### PR TITLE
GH#30555: clarify empty required-check waits

### DIFF
--- a/.agents/scripts/gh-checks-wait-helper.sh
+++ b/.agents/scripts/gh-checks-wait-helper.sh
@@ -170,10 +170,15 @@ emit_transitions() {
 
 classify_state() {
 	local checks="$1"
+	local required_only="$2"
 	local count=""
 	count=$(printf '%s' "$checks" | jq 'length')
 	if [[ "$count" -eq 0 ]]; then
-		printf 'success\n'
+		if [[ "$required_only" -eq 1 ]]; then
+			printf 'no-required\n'
+		else
+			printf 'no-checks\n'
+		fi
 		return 0
 	fi
 	if printf '%s' "$checks" | jq -e --arg pass "$_GCW_BUCKET_PASS" --arg pending "$_GCW_BUCKET_PENDING" --arg skipping "$_GCW_BUCKET_SKIPPING" \
@@ -293,13 +298,13 @@ wait_for_checks() {
 			next_heartbeat=$((now_epoch + heartbeat_interval))
 		fi
 
-		classification=$(classify_state "$current")
+		classification=$(classify_state "$current" "$required_only")
 		case "$classification" in
 		failure)
 			emit_failure_details "$current"
 			return 1
 			;;
-		success)
+		success | no-required | no-checks)
 			final_head=$(read_head_sha "$pr_number" "$repo" 2>/dev/null || true)
 			if [[ -z "$final_head" ]]; then
 				printf 'INDETERMINATE: PR head could not be verified after required checks completed\n' >&2
@@ -313,7 +318,21 @@ wait_for_checks() {
 				poll_sleep "$interval"
 				continue
 			fi
-			printf 'PASS: required checks completed in %ss (%s)\n' "$elapsed" "$(state_counts "$current")"
+			case "$classification" in
+			no-required)
+				printf 'PASS: verified no required checks; optional checks were not evaluated (use --all to wait for all checks) in %ss (%s)\n' "$elapsed" "$(state_counts "$current")"
+				;;
+			no-checks)
+				printf 'PASS: verified no checks reported in %ss (%s)\n' "$elapsed" "$(state_counts "$current")"
+				;;
+			success)
+				if [[ "$required_only" -eq 1 ]]; then
+					printf 'PASS: required checks completed in %ss (%s)\n' "$elapsed" "$(state_counts "$current")"
+				else
+					printf 'PASS: all checks completed in %ss (%s)\n' "$elapsed" "$(state_counts "$current")"
+				fi
+				;;
+			esac
 			return 0
 			;;
 		pending | indeterminate) ;;

--- a/.agents/scripts/gh-checks-wait-helper.sh
+++ b/.agents/scripts/gh-checks-wait-helper.sh
@@ -203,6 +203,29 @@ emit_failure_details() {
 	return 0
 }
 
+emit_success_details() {
+	local classification="$1"
+	local required_only="$2"
+	local elapsed="$3"
+	local checks="$4"
+	case "$classification" in
+	no-required)
+		printf 'PASS: verified no required checks; optional checks were not evaluated (use --all to wait for all checks) in %ss (%s)\n' "$elapsed" "$(state_counts "$checks")"
+		;;
+	no-checks)
+		printf 'PASS: verified no checks reported in %ss (%s)\n' "$elapsed" "$(state_counts "$checks")"
+		;;
+	success)
+		if [[ "$required_only" -eq 1 ]]; then
+			printf 'PASS: required checks completed in %ss (%s)\n' "$elapsed" "$(state_counts "$checks")"
+		else
+			printf 'PASS: all checks completed in %ss (%s)\n' "$elapsed" "$(state_counts "$checks")"
+		fi
+		;;
+	esac
+	return 0
+}
+
 read_head_sha() {
 	local pr_number="$1"
 	local repo="$2"
@@ -318,21 +341,7 @@ wait_for_checks() {
 				poll_sleep "$interval"
 				continue
 			fi
-			case "$classification" in
-			no-required)
-				printf 'PASS: verified no required checks; optional checks were not evaluated (use --all to wait for all checks) in %ss (%s)\n' "$elapsed" "$(state_counts "$current")"
-				;;
-			no-checks)
-				printf 'PASS: verified no checks reported in %ss (%s)\n' "$elapsed" "$(state_counts "$current")"
-				;;
-			success)
-				if [[ "$required_only" -eq 1 ]]; then
-					printf 'PASS: required checks completed in %ss (%s)\n' "$elapsed" "$(state_counts "$current")"
-				else
-					printf 'PASS: all checks completed in %ss (%s)\n' "$elapsed" "$(state_counts "$current")"
-				fi
-				;;
-			esac
+			emit_success_details "$classification" "$required_only" "$elapsed" "$current"
 			return 0
 			;;
 		pending | indeterminate) ;;

--- a/.agents/scripts/tests/test-gh-checks-wait-helper.sh
+++ b/.agents/scripts/tests/test-gh-checks-wait-helper.sh
@@ -73,7 +73,18 @@ pending_count=$(printf '%s\n' "$transition_output" | grep -c '^  Complexity: pen
 empty_dir="${TMPDIR_TEST}/empty"
 write_fixture "$empty_dir" 1 '[]'
 empty_output=$(run_fixture_wait "$empty_dir")
-assert_contains "no required checks is terminal success" "PASS: required checks completed" "$empty_output"
+assert_contains "no required checks is explicit terminal success" "PASS: verified no required checks; optional checks were not evaluated (use --all to wait for all checks)" "$empty_output"
+
+all_checks_dir="${TMPDIR_TEST}/all-checks"
+write_fixture "$all_checks_dir" 1 '[{"name":"Preview","workflow":"Deploy","state":"PENDING","bucket":"pending","link":""}]'
+write_fixture "$all_checks_dir" 2 '[{"name":"Preview","workflow":"Deploy","state":"SUCCESS","bucket":"pass","link":""}]'
+all_checks_output=$(run_fixture_wait "$all_checks_dir" --all)
+assert_contains "all-check mode observes pending optional checks" "Preview: pending" "$all_checks_output"
+assert_contains "all-check mode waits for the transition" "+ Preview: pending -> pass" "$all_checks_output"
+assert_contains "all-check mode reports scoped terminal success" "PASS: all checks completed" "$all_checks_output"
+
+all_empty_output=$(run_fixture_wait "$empty_dir" --all)
+assert_contains "empty all-check selection is explicit terminal success" "PASS: verified no checks reported" "$all_empty_output"
 
 live_bin="${TMPDIR_TEST}/live-bin"
 mkdir -p "$live_bin"
@@ -101,7 +112,7 @@ chmod +x "${live_bin}/gh"
 
 live_no_required_output=$(PATH="${live_bin}:$PATH" AIDEVOPS_GH_CHECKS_TEST_NO_SLEEP=1 \
 	"$HELPER" wait 123 --repo example/repo --timeout 0 2>&1)
-assert_contains "canonical no-required message is terminal success" "PASS: required checks completed" "$live_no_required_output"
+assert_contains "canonical no-required message is explicit terminal success" "PASS: verified no required checks; optional checks were not evaluated" "$live_no_required_output"
 
 set +e
 live_api_error_output=$(PATH="${live_bin}:$PATH" GH_TEST_MODE=api-error AIDEVOPS_GH_CHECKS_TEST_NO_SLEEP=1 \


### PR DESCRIPTION
## Summary

Distinguish verified empty required-check selections from completed checks and make all-check waits explicit.

## Files Changed

.agents/scripts/gh-checks-wait-helper.sh, .agents/scripts/tests/test-gh-checks-wait-helper.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — 29 focused wait-helper assertions passed; ShellCheck and local quality gates passed; pending optional checks transition to success under --all.

Resolves #30555


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.285 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 23m and 207,013 tokens on this with the user in an interactive session.