### PR TITLE
GH#30561: Trust active release signer for source access

### DIFF
--- a/.agents/scripts/setup/modules/source-access.sh
+++ b/.agents/scripts/setup/modules/source-access.sh
@@ -15,7 +15,12 @@ _SOURCE_ACCESS_HELPER_SOURCE=".agents/scripts/source-access-helper.py"
 _SOURCE_ACCESS_SETUP_SOURCE=".agents/scripts/setup/modules/source-access.sh"
 _SOURCE_ACCESS_RAW_BASE="https://raw.githubusercontent.com/marcusquinn/aidevops"
 _SOURCE_ACCESS_RELEASE_SIGNER_IDENTITY="6428977+marcusquinn@users.noreply.github.com"
-_SOURCE_ACCESS_RELEASE_SIGNER_KEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMnXVft9/hT5P2dIICJMMmXeg6HUnKGCvR4VzkKpyJza"
+_SOURCE_ACCESS_CURRENT_RELEASE_SIGNER_KEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOSJYsC+NrAcX6kM/VDfwMLzoASLVzv0tdDvj4MWz1e/"
+_SOURCE_ACCESS_HISTORICAL_RELEASE_SIGNER_KEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMnXVft9/hT5P2dIICJMMmXeg6HUnKGCvR4VzkKpyJza"
+_SOURCE_ACCESS_RELEASE_SIGNER_KEYS=(
+	"$_SOURCE_ACCESS_CURRENT_RELEASE_SIGNER_KEY"
+	"$_SOURCE_ACCESS_HISTORICAL_RELEASE_SIGNER_KEY"
+)
 
 _source_access_git() {
 	GIT_NO_REPLACE_OBJECTS=1 /usr/bin/git "$@"
@@ -27,14 +32,18 @@ _source_access_verify_release_tag() {
 	local tag_object="$2"
 	local allowed_signers=""
 	local verification_rc=0
+	local signer_key=""
 
 	allowed_signers=$(/usr/bin/mktemp "${TMPDIR:-/tmp}/aidevops-source-access-signers.XXXXXX") || return 1
-	if ! printf '%s %s\n' \
-		"$_SOURCE_ACCESS_RELEASE_SIGNER_IDENTITY" \
-		"$_SOURCE_ACCESS_RELEASE_SIGNER_KEY" >"$allowed_signers"; then
-		/bin/rm -f "$allowed_signers"
-		return 1
-	fi
+	: >"$allowed_signers" || return 1
+	for signer_key in "${_SOURCE_ACCESS_RELEASE_SIGNER_KEYS[@]}"; do
+		if ! printf '%s %s\n' \
+			"$_SOURCE_ACCESS_RELEASE_SIGNER_IDENTITY" \
+			"$signer_key" >>"$allowed_signers"; then
+			/bin/rm -f "$allowed_signers"
+			return 1
+		fi
+	done
 	/bin/chmod 0600 "$allowed_signers" || {
 		/bin/rm -f "$allowed_signers"
 		return 1

--- a/.agents/scripts/tests/test-setup-source-access-broker.sh
+++ b/.agents/scripts/tests/test-setup-source-access-broker.sh
@@ -20,7 +20,8 @@ print_warning() {
 # shellcheck source=../setup/modules/source-access.sh
 source "$SOURCE_ACCESS_MODULE"
 production_release_signer_identity="$_SOURCE_ACCESS_RELEASE_SIGNER_IDENTITY"
-production_release_signer_key="$_SOURCE_ACCESS_RELEASE_SIGNER_KEY"
+production_current_release_signer_key="$_SOURCE_ACCESS_CURRENT_RELEASE_SIGNER_KEY"
+production_historical_release_signer_key="$_SOURCE_ACCESS_HISTORICAL_RELEASE_SIGNER_KEY"
 
 fixture_repo="$TEST_DIR/repo"
 mkdir -p "$fixture_repo/.agents/scripts/setup/modules"
@@ -41,15 +42,22 @@ git -C "$fixture_repo" add VERSION .agents/scripts/source_access_core.py \
 	.agents/scripts/source-access-helper.py .agents/scripts/setup/modules/source-access.sh
 git -C "$fixture_repo" -c commit.gpgsign=false commit -q -m "fixture release"
 git -C "$fixture_repo" tag -s v1.2.3 -m "fixture tag"
-IFS= read -r _SOURCE_ACCESS_RELEASE_SIGNER_KEY <"${release_key}.pub"
-_SOURCE_ACCESS_RELEASE_SIGNER_KEY="${_SOURCE_ACCESS_RELEASE_SIGNER_KEY% setup-test-release}"
+IFS= read -r fixture_release_signer_key <"${release_key}.pub"
+fixture_release_signer_key="${fixture_release_signer_key% setup-test-release}"
+IFS= read -r fixture_untrusted_signer_key <"${untrusted_key}.pub"
+fixture_untrusted_signer_key="${fixture_untrusted_signer_key% setup-test-untrusted}"
+_SOURCE_ACCESS_RELEASE_SIGNER_KEYS=("$fixture_untrusted_signer_key" "$fixture_release_signer_key")
 _SOURCE_ACCESS_RELEASE_SIGNER_IDENTITY="setup-test@example.invalid"
 
 if ! grep -qF "readonly TRUSTED_EMAIL=\"${production_release_signer_identity}\"" \
 	"$REPO_ROOT/.agents/scripts/signing-setup.sh" ||
-	! grep -qF "readonly TRUSTED_KEY=\"${production_release_signer_key} " \
+	! grep -qF "readonly TRUSTED_KEY=\"${production_historical_release_signer_key} " \
 		"$REPO_ROOT/.agents/scripts/signing-setup.sh"; then
-	printf 'FAIL: source-access release trust anchor drifted from signing-setup.sh\n' >&2
+	printf 'FAIL: historical source-access release trust anchor drifted from signing-setup.sh\n' >&2
+	exit 1
+fi
+if [[ "$production_current_release_signer_key" == "$production_historical_release_signer_key" ]]; then
+	printf 'FAIL: current and historical release trust anchors are not distinct\n' >&2
 	exit 1
 fi
 
@@ -126,14 +134,13 @@ if _source_access_broker_current "$fixture_repo" "$resolved_commit"; then
 	exit 1
 fi
 
-trusted_release_key="$_SOURCE_ACCESS_RELEASE_SIGNER_KEY"
-IFS= read -r _SOURCE_ACCESS_RELEASE_SIGNER_KEY <"${untrusted_key}.pub"
-_SOURCE_ACCESS_RELEASE_SIGNER_KEY="${_SOURCE_ACCESS_RELEASE_SIGNER_KEY% setup-test-untrusted}"
+trusted_release_keys=("${_SOURCE_ACCESS_RELEASE_SIGNER_KEYS[@]}")
+_SOURCE_ACCESS_RELEASE_SIGNER_KEYS=("$fixture_untrusted_signer_key")
 if _source_access_release_commit "$fixture_repo" >/dev/null 2>&1; then
 	printf 'FAIL: unverified release tag was accepted\n' >&2
 	exit 1
 fi
-_SOURCE_ACCESS_RELEASE_SIGNER_KEY="$trusted_release_key"
+_SOURCE_ACCESS_RELEASE_SIGNER_KEYS=("${trusted_release_keys[@]}")
 
 rm -rf "$_SOURCE_ACCESS_BROKER_DIR"
 INSTALL_DIR="$fixture_repo"


### PR DESCRIPTION
## Summary

Allow source-access setup to verify tags signed by the active headless release key while retaining the historical maintainer trust anchor.

## Files Changed

.agents/scripts/setup/modules/source-access.sh, .agents/scripts/tests/test-setup-source-access-broker.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Source-access broker test passed; v3.32.285 resolves through the updated verifier; ShellCheck and changed-file local linters passed.

Resolves #30561


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.285 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1h 17m and 647,171 tokens on this with the user in an interactive session.