### PR TITLE
GH#30557: fix: preserve multiline secret injection

### DIFF
--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -78,9 +78,8 @@ resolve_credential_files() {
 	return 0
 }
 
-# Get a secret value from gopass.
-# Used by cmd_get (direct output) and build_secret_env (subprocess injection).
-# Callers are responsible for deciding whether to expose the value to stdout.
+# Get the scalar password value from gopass.
+# Used only by cmd_get, which preserves the historical first-line contract.
 get_secret_value() {
 	local name="$1"
 	if has_gopass; then
@@ -103,6 +102,15 @@ get_secret_value() {
 	return 0
 }
 
+# Get the complete raw gopass entry for subprocess injection.
+# Bash command substitution consistently removes trailing newlines; embedded
+# newlines are preserved byte-for-byte and encoded safely by build_secret_env.
+get_gopass_entry_value() {
+	local secret_path="$1"
+	gopass show -n "$secret_path" 2>/dev/null || true
+	return 0
+}
+
 # Collect all secret values for redaction as NUL-delimited literal data.
 collect_secret_values() {
 	local -a values=()
@@ -112,10 +120,15 @@ collect_secret_values() {
 		secrets=$(gopass ls --flat "${GOPASS_PREFIX}/" 2>/dev/null || true)
 		while IFS= read -r secret_path; do
 			[[ -z "$secret_path" ]] && continue
-			local val
-			val=$(gopass show -o "$secret_path" 2>/dev/null || true)
-			if [[ -n "$val" && ${#val} -ge 4 ]]; then
-				values+=("$val")
+			local scalar_val=""
+			local entry_val=""
+			scalar_val=$(gopass show -o "$secret_path" 2>/dev/null || true)
+			entry_val=$(get_gopass_entry_value "$secret_path")
+			if [[ -n "$scalar_val" && ${#scalar_val} -ge 4 ]]; then
+				values+=("$scalar_val")
+			fi
+			if [[ -n "$entry_val" && ${#entry_val} -ge 4 && "$entry_val" != "$scalar_val" ]]; then
+				values+=("$entry_val")
 			fi
 		done <<<"$secrets"
 	fi
@@ -226,19 +239,40 @@ redact_available(pending, final=True)
 	return "$exit_code"
 }
 
-# Build environment from gopass secrets
+# Return success when a secret name was already emitted.
+secret_env_name_emitted() {
+	local expected_name="$1"
+	shift
+	local emitted_name=""
+	for emitted_name in "$@"; do
+		[[ "$emitted_name" == "$expected_name" ]] && return 0
+	done
+	return 1
+}
+
+# Emit one NUL-delimited environment record. Environment values cannot contain
+# NUL bytes, making NUL a safe record delimiter while preserving newlines.
+emit_secret_env_record() {
+	local name="$1"
+	local value="$2"
+	printf '%s=%s\0' "$name" "$value"
+	return 0
+}
+
+# Build a NUL-delimited environment from gopass secrets.
 build_secret_env() {
 	local -a specific_names=("$@")
-	local env_vars=""
+	local -a emitted_names=()
 
 	if has_gopass; then
 		if [[ ${#specific_names[@]} -gt 0 ]]; then
 			# Inject only specific secrets
 			for name in "${specific_names[@]}"; do
 				local val
-				val=$(gopass show -o "${GOPASS_PREFIX}/${name}" 2>/dev/null || true)
+				val=$(get_gopass_entry_value "${GOPASS_PREFIX}/${name}")
 				if [[ -n "$val" ]]; then
-					env_vars="${env_vars}${name}=${val}\n"
+					emit_secret_env_record "$name" "$val"
+					emitted_names+=("$name")
 				fi
 			done
 		else
@@ -249,9 +283,10 @@ build_secret_env() {
 				[[ -z "$secret_path" ]] && continue
 				local name="${secret_path#"${GOPASS_PREFIX}"/}"
 				local val
-				val=$(gopass show -o "$secret_path" 2>/dev/null || true)
+				val=$(get_gopass_entry_value "$secret_path")
 				if [[ -n "$val" ]]; then
-					env_vars="${env_vars}${name}=${val}\n"
+					emit_secret_env_record "$name" "$val"
+					emitted_names+=("$name")
 				fi
 			done <<<"$secrets"
 		fi
@@ -268,14 +303,14 @@ build_secret_env() {
 				val="${val#\"}"
 				val="${val%\"}"
 				# Only add if not already set by gopass
-				if ! printf '%b' "$env_vars" | grep -q "^${name}="; then
-					env_vars="${env_vars}${name}=${val}\n"
+				if ! secret_env_name_emitted "$name" "${emitted_names[@]}"; then
+					emit_secret_env_record "$name" "$val"
+					emitted_names+=("$name")
 				fi
 			fi
 		done <"$cred_file"
 	done < <(resolve_credential_files)
 
-	printf '%b' "$env_vars"
 	return 0
 }
 
@@ -594,7 +629,7 @@ cmd_run() {
 	local exit_code=0
 	(
 		# Load secrets into subprocess environment
-		while IFS='=' read -r key val; do
+		while IFS='=' read -r -d '' key val; do
 			[[ -z "$key" ]] && continue
 			export "$key=$val"
 		done <"$env_file"
@@ -644,7 +679,7 @@ cmd_run_specific() {
 	# Execute command with secrets in environment, redact output
 	local exit_code=0
 	(
-		while IFS='=' read -r key val; do
+		while IFS='=' read -r -d '' key val; do
 			[[ -z "$key" ]] && continue
 			export "$key=$val"
 		done <"$env_file"

--- a/.agents/scripts/tests/test-secret-helper.sh
+++ b/.agents/scripts/tests/test-secret-helper.sh
@@ -57,15 +57,26 @@ case "$cmd" in
 			if [[ -n "${AIDEVOPS_TEST_SECRET:-}" ]]; then
 				printf '%s\n' 'aidevops/REDACTION_KEY'
 			fi
+			if [[ "${AIDEVOPS_TEST_MULTILINE:-}" == "true" ]]; then
+				printf '%s\n' 'aidevops/MULTILINE_KEY'
+			fi
 		fi
 		exit 0
 		;;
 	show)
-		if [[ "${1:-}" == "-o" ]]; then
+		mode="${1:-}"
+		if [[ "$mode" == "-o" || "$mode" == "-n" ]]; then
 			shift
 		fi
 		case "${1:-}" in
 			aidevops/REDACTION_KEY) printf '%s' "${AIDEVOPS_TEST_SECRET:-}" ;;
+			aidevops/MULTILINE_KEY)
+				if [[ "$mode" == "-n" ]]; then
+					printf 'header-line\nbody-line\n\n'
+				else
+					printf 'header-line'
+				fi
+				;;
 			*) exit 1 ;;
 		esac
 		exit 0
@@ -147,7 +158,35 @@ teardown() {
 		rm -rf "$TEST_DIR"
 	fi
 	TEST_DIR=""
-	unset AIDEVOPS_TEST_DIR AIDEVOPS_TEST_SECRET || true
+	unset AIDEVOPS_TEST_DIR AIDEVOPS_TEST_SECRET AIDEVOPS_TEST_MULTILINE || true
+	return 0
+}
+
+test_multiline_gopass_injection_preserves_embedded_newlines() {
+	setup
+	trap 'teardown' RETURN
+	export AIDEVOPS_TEST_MULTILINE=true
+	local output=""
+	local exit_code=0
+
+	output=$(HOME="$TEST_DIR/home" bash "$HELPER" MULTILINE_KEY -- python3 -c '
+import os
+import sys
+
+value = os.environ.get("MULTILINE_KEY", "")
+if value != "header-line\nbody-line":
+    raise SystemExit(23)
+sys.stdout.write(value)
+') || exit_code=$?
+
+	local scalar=""
+	scalar=$(HOME="$TEST_DIR/home" bash "$HELPER" get MULTILINE_KEY)
+	if [[ "$exit_code" -eq 0 && "$output" == "[REDACTED]" && "$scalar" == "header-line" ]]; then
+		print_result "multiline injection preserves embedded newlines and normalizes trailing newlines" 0
+	else
+		print_result "multiline injection preserves embedded newlines and normalizes trailing newlines" 1 \
+			"Expected full redacted injection and scalar get compatibility"
+	fi
 	return 0
 }
 
@@ -280,6 +319,7 @@ main() {
 	test_set_rejects_command_literal_input
 	test_run_redacts_sed_significant_literal_values
 	test_run_fails_closed_when_redactor_cannot_start
+	test_multiline_gopass_injection_preserves_embedded_newlines
 	test_inventory_is_names_only_deterministic_json
 	test_inventory_rejects_malformed_gopass_name
 	test_inventory_requires_owner_only_credentials


### PR DESCRIPTION
## Summary

Preserve embedded newlines in gopass values injected into child processes while keeping secret get scalar-compatible and redacting both full and first-line forms.

## Files Changed

.agents/scripts/secret-helper.sh, .agents/scripts/tests/test-secret-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Secret-helper regression suite (9/9), secret-read guards (6/6), ShellCheck, secretlint, Bash 3.2/portability/complexity gates, and local linters passed.

Resolves #30557


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.286 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 3h 30m and 1,321,806 tokens on this with the user in an interactive session.