### PR TITLE
GH#30575: restore local model upstream compatibility

### DIFF
--- a/.agents/scripts/local-model-db.sh
+++ b/.agents/scripts/local-model-db.sh
@@ -89,7 +89,7 @@ load_config() {
 		LLAMA_PORT="$(jq -r '.port // 8080' "$LOCAL_CONFIG_FILE" 2>/dev/null || echo "8080")"
 		LLAMA_HOST="$(jq -r '.host // "127.0.0.1"' "$LOCAL_CONFIG_FILE" 2>/dev/null || echo "127.0.0.1")"
 		LLAMA_CTX_SIZE="$(jq -r '.ctx_size // 8192' "$LOCAL_CONFIG_FILE" 2>/dev/null || echo "8192")"
-		LLAMA_GPU_LAYERS="$(jq -r '.gpu_layers // 99' "$LOCAL_CONFIG_FILE" 2>/dev/null || echo "99")"
+		LLAMA_GPU_LAYERS="$(jq -r '.gpu_layers // "auto"' "$LOCAL_CONFIG_FILE" 2>/dev/null || echo "auto")"
 		LLAMA_FLASH_ATTN="$(jq -r '.flash_attn // true' "$LOCAL_CONFIG_FILE" 2>/dev/null || echo "true")"
 	fi
 	return 0
@@ -104,7 +104,7 @@ write_default_config() {
 			  "host": "127.0.0.1",
 			  "ctx_size": 8192,
 			  "threads": "auto",
-			  "gpu_layers": 99,
+			  "gpu_layers": "auto",
 			  "flash_attn": true
 			}
 		CONFIGEOF

--- a/.agents/scripts/local-model-helper.sh
+++ b/.agents/scripts/local-model-helper.sh
@@ -9,7 +9,7 @@
 # Usage: local-model-helper.sh [command] [options]
 #
 # Commands:
-#   install [--update]            Install/update llama.cpp + huggingface-cli (alias: setup)
+#   install [--update]            Install/update llama.cpp + Hugging Face CLI (alias: setup)
 #   serve [--model M] [options]   Start llama-server localhost:8080 (alias: start)
 #   stop                          Stop running llama-server
 #   status                        Show server status and loaded model
@@ -29,7 +29,7 @@
 #   --port N        Server port (default: 8080)
 #   --ctx-size N    Context window size (default: 8192)
 #   --threads N     CPU threads (default: auto-detect performance cores)
-#   --gpu-layers N  GPU layers to offload (default: 99 = all)
+#   --gpu-layers N  GPU layers to offload (default: auto)
 #   --json          Output in JSON format
 #   --quiet         Suppress informational output
 #
@@ -44,7 +44,7 @@
 # Exit codes:
 #   0 - Success
 #   1 - General error
-#   2 - Dependency missing (llama.cpp, huggingface-cli)
+#   2 - Dependency missing (llama.cpp, Hugging Face CLI)
 #   3 - Model not found
 #   4 - Server already running / not running
 #
@@ -69,6 +69,7 @@ readonly LOCAL_CONFIG_FILE="${LOCAL_MODELS_DIR}/config.json"
 readonly LOCAL_PID_FILE="${LOCAL_MODELS_DIR}/llama-server.pid"
 readonly LLAMA_SERVER_BIN="${LOCAL_BIN_DIR}/llama-server"
 readonly LLAMA_CLI_BIN="${LOCAL_BIN_DIR}/llama-cli"
+readonly LOCAL_HF_VENV_DIR="${LOCAL_MODELS_DIR}/hf-cli-env"
 
 # Usage/inventory database (t1338.5) — stored with other framework SQLite DBs
 readonly LOCAL_MODELS_DB_DIR="${HOME}/.aidevops/.agent-workspace/memory"
@@ -84,13 +85,14 @@ readonly STALE_NUDGE_THRESHOLD_BYTES=5368709120
 LLAMA_PORT=8080
 LLAMA_HOST="127.0.0.1"
 LLAMA_CTX_SIZE=8192
-LLAMA_GPU_LAYERS=99
+LLAMA_GPU_LAYERS="auto"
 LLAMA_FLASH_ATTN="true"
 STALE_THRESHOLD_DAYS=30
 
 # GitHub release API for llama.cpp
 readonly LLAMA_CPP_REPO="ggml-org/llama.cpp"
-readonly LLAMA_CPP_API="https://api.github.com/repos/${LLAMA_CPP_REPO}/releases/latest"
+readonly LLAMA_CPP_RELEASES_API="https://api.github.com/repos/${LLAMA_CPP_REPO}/releases"
+readonly LLAMA_CPP_API="${LLAMA_CPP_RELEASES_API}/latest"
 
 # HuggingFace API
 readonly HF_API="https://huggingface.co/api"
@@ -370,10 +372,13 @@ cmd_update() {
 	print_info "Checking latest llama.cpp release..."
 
 	local release_json
-	release_json="$(curl -sL "$LLAMA_CPP_API")" || {
+	release_json="$(curl -fsSL "$LLAMA_CPP_API")" || {
 		print_error "Failed to fetch llama.cpp release info from GitHub"
 		return 1
 	}
+	local platform=""
+	platform="$(detect_platform)" || return 1
+	release_json="$(_setup_resolve_release_json "$platform" "$release_json")" || return $?
 
 	local latest_tag
 	latest_tag="$(echo "$release_json" | jq -r '.tag_name // empty')"
@@ -389,9 +394,9 @@ cmd_update() {
 	local update_available=false
 
 	if [[ -x "$LLAMA_SERVER_BIN" ]]; then
-		current_version="$("$LLAMA_SERVER_BIN" --version 2>/dev/null | head -1 || echo "unknown")"
-		# Compare: if current version string does not contain the latest tag, update is available
-		if ! echo "$current_version" | grep -qF "$latest_tag"; then
+		current_version="$(_setup_read_version "$LLAMA_SERVER_BIN")"
+		# Nightly tags use bNNNN while --version reports "build NNNN".
+		if ! _setup_version_matches_tag "$current_version" "$latest_tag"; then
 			update_available=true
 		fi
 	else
@@ -428,7 +433,7 @@ cmd_help() {
 		  local-model-helper.sh <command> [options]
 
 		COMMANDS:
-		  install [--update]            Install/update llama.cpp + huggingface-cli (alias: setup)
+		  install [--update]            Install/update llama.cpp + Hugging Face CLI (alias: setup)
 		  serve [--model M] [options]   Start llama-server localhost:8080 (alias: start)
 		  stop                          Stop running llama-server
 		  status [--json]               Show server status and loaded model
@@ -449,7 +454,7 @@ cmd_help() {
 		  --port <N>         Server port (default: 8080)
 		  --host <addr>      Bind address (default: 127.0.0.1)
 		  --ctx-size <N>     Context window (default: 8192)
-		  --gpu-layers <N>   GPU layers to offload (default: 99)
+		  --gpu-layers <N>   GPU layers to offload (default: auto)
 		  --threads <N>      CPU threads (default: auto)
 		  --no-flash-attn    Disable Flash Attention
 

--- a/.agents/scripts/local-model-models.sh
+++ b/.agents/scripts/local-model-models.sh
@@ -5,7 +5,7 @@
 # Local Model Models Library — Listing, Download & Search
 # =============================================================================
 # List downloaded GGUF models with metadata, download models from HuggingFace
-# via huggingface-cli, and search the HuggingFace API for GGUF repos.
+# via the Hugging Face CLI, and search the HuggingFace API for GGUF repos.
 #
 # Usage: source "${SCRIPT_DIR}/local-model-models.sh"
 #
@@ -13,7 +13,7 @@
 #   - shared-constants.sh (print_error, print_info, print_success, etc.)
 #   - local-model-db.sh (sql_escape, register_model_inventory)
 #   - curl, jq (for HuggingFace API calls)
-#   - huggingface-cli (for downloads)
+#   - hf or huggingface-cli (for downloads)
 #
 # Part of aidevops framework: https://aidevops.sh
 
@@ -254,9 +254,9 @@ cmd_download() {
 
 	ensure_dirs
 
-	# Check for huggingface-cli
-	if ! suppress_stderr command -v huggingface-cli; then
-		print_error "huggingface-cli not found. Run: local-model-helper.sh setup"
+	local hf_cli=""
+	if ! hf_cli="$(_local_model_hf_cli)"; then
+		print_error "Hugging Face CLI not found. Run: local-model-helper.sh setup"
 		return 2
 	fi
 
@@ -269,10 +269,14 @@ cmd_download() {
 	print_info "Downloading ${filename} from ${repo}..."
 	print_info "Destination: ${LOCAL_MODELS_STORE}/"
 
-	# Use huggingface-cli for download (supports resume)
-	if ! huggingface-cli download "$repo" "$filename" \
-		--local-dir "$LOCAL_MODELS_STORE" \
-		--local-dir-use-symlinks False 2>&1; then
+	# Current `hf` removed --local-dir-use-symlinks; retain it only when a
+	# legacy CLI advertises support so older installations keep their behavior.
+	local download_args=(download "$repo" "$filename" --local-dir "$LOCAL_MODELS_STORE")
+	if [[ "$hf_cli" == "huggingface-cli" ]] &&
+		"$hf_cli" download --help 2>&1 | grep -q -- '--local-dir-use-symlinks'; then
+		download_args+=(--local-dir-use-symlinks False)
+	fi
+	if ! "$hf_cli" "${download_args[@]}" 2>&1; then
 		print_error "Download failed"
 		return 1
 	fi

--- a/.agents/scripts/local-model-server.sh
+++ b/.agents/scripts/local-model-server.sh
@@ -93,7 +93,7 @@ _start_server_process() {
 	)
 
 	if [[ "$flash_attn" == "true" ]]; then
-		server_args+=("--flash-attn")
+		server_args+=("--flash-attn" "on")
 	fi
 
 	print_info "Starting llama-server..."
@@ -393,7 +393,7 @@ cmd_status() {
 	# Show installed binary version
 	if [[ -x "$LLAMA_SERVER_BIN" ]]; then
 		local version
-		version="$("$LLAMA_SERVER_BIN" --version 2>/dev/null | head -1 || echo "installed")"
+		version="$(_setup_read_version "$LLAMA_SERVER_BIN" "installed")"
 		echo "Binary: ${version}"
 	else
 		echo "Binary: not installed (run: local-model-helper.sh setup)"

--- a/.agents/scripts/local-model-setup.sh
+++ b/.agents/scripts/local-model-setup.sh
@@ -5,7 +5,7 @@
 # Local Model Setup Library — Hardware Detection & Installation
 # =============================================================================
 # Platform/GPU/memory detection, llama.cpp release download helpers,
-# huggingface-cli installer, and the cmd_setup entry point.
+# Hugging Face CLI installer, and the cmd_setup entry point.
 #
 # Usage: source "${SCRIPT_DIR}/local-model-setup.sh"
 #
@@ -165,6 +165,83 @@ get_release_asset_pattern() {
 # Installation Helpers
 # =============================================================================
 
+# Resolve the installed Hugging Face CLI, preferring the current `hf` command.
+_local_model_hf_cli() {
+	local candidate=""
+	for candidate in hf "${LOCAL_HF_VENV_DIR}/bin/hf" huggingface-cli; do
+		if suppress_stderr command -v "$candidate" >/dev/null && "$candidate" --help >/dev/null 2>&1; then
+			printf '%s' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Resolve stable llama.cpp pointer releases to their binary-bearing nightly tag.
+_setup_resolve_release_json() {
+	local platform="$1"
+	local release_json="$2"
+	local asset_pattern=""
+	asset_pattern="$(get_release_asset_pattern "$platform")" || return 1
+
+	if jq -e --arg pat "$asset_pattern" \
+		'.assets[]? | select(.name | test($pat))' <<<"$release_json" >/dev/null 2>&1; then
+		printf '%s' "$release_json"
+		return 0
+	fi
+
+	local pointer_url=""
+	pointer_url="$(printf '%s' "$release_json" | jq -r \
+		'.assets[]? | select(.name == "nightly-tag.txt") | .browser_download_url // empty' 2>/dev/null | head -1)"
+	if [[ -z "$pointer_url" ]]; then
+		print_error "Release contains neither a matching binary nor nightly-tag.txt" >&2
+		return 1
+	fi
+
+	local nightly_tag=""
+	nightly_tag="$(curl -fsSL "$pointer_url" 2>/dev/null | tr -d '[:space:]')" || nightly_tag=""
+	if [[ ! "$nightly_tag" =~ ^b[0-9]+$ ]]; then
+		print_error "Invalid llama.cpp nightly tag pointer" >&2
+		return 1
+	fi
+
+	local nightly_json=""
+	nightly_json="$(curl -fsSL "${LLAMA_CPP_RELEASES_API}/tags/${nightly_tag}" 2>/dev/null)" || nightly_json=""
+	if [[ -z "$nightly_json" ]] || ! jq -e --arg pat "$asset_pattern" \
+		'.assets[]? | select(.name | test($pat))' <<<"$nightly_json" >/dev/null 2>&1; then
+		print_error "Nightly release ${nightly_tag} has no matching binary for ${platform}" >&2
+		return 1
+	fi
+
+	print_info "Resolved stable release pointer to nightly ${nightly_tag}" >&2
+	printf '%s' "$nightly_json"
+	return 0
+}
+
+# Compare a llama.cpp tag with either historical or current --version output.
+_setup_version_matches_tag() {
+	local version="$1"
+	local tag="$2"
+	[[ -n "$version" && "$tag" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
+	printf '%s' "$version" | grep -qF "$tag" && return 0
+	if [[ "$tag" =~ ^b([0-9]+)$ ]]; then
+		local build_number="${BASH_REMATCH[1]}"
+		printf '%s' "$version" | grep -Eq "build[[:space:]]+${build_number}([^0-9]|$)" && return 0
+	fi
+	return 1
+}
+
+# llama.cpp currently writes version details to stderr; normalize the first
+# line so setup, status, and update checks share one compatibility path.
+_setup_read_version() {
+	local binary="$1"
+	local fallback="${2:-unknown}"
+	local version=""
+	version="$("$binary" --version 2>&1 | head -1)" || version=""
+	printf '%s' "${version:-$fallback}"
+	return 0
+}
+
 # Resolve download URL for a llama.cpp release asset
 _setup_find_asset_url() {
 	local platform="$1"
@@ -201,7 +278,7 @@ _setup_extract_archive() {
 	local tmp_archive="${tmp_dir}/${asset_name}"
 
 	print_info "Downloading ${asset_name}..."
-	if ! curl -sL -o "$tmp_archive" "$download_url"; then
+	if ! curl -fsSL -o "$tmp_archive" "$download_url"; then
 		print_error "Download failed: ${download_url}"
 		return 1
 	fi
@@ -226,7 +303,8 @@ _setup_extract_archive() {
 	return 0
 }
 
-# Install llama-server (and optionally llama-cli) from extracted dir
+# Atomically install the complete binary directory so sibling shared libraries
+# remain available to executables that use an origin-relative runtime path.
 _setup_install_binaries() {
 	local extracted_dir="$1"
 
@@ -243,18 +321,38 @@ _setup_install_binaries() {
 		return 1
 	fi
 
-	cp "$server_bin" "$LLAMA_SERVER_BIN"
-	chmod +x "$LLAMA_SERVER_BIN"
+	local server_dir="${server_bin%/*}"
+	local staging_dir="${LOCAL_MODELS_DIR}/.bin-staging-$$"
+	local backup_dir="${LOCAL_MODELS_DIR}/.bin-backup-$$"
+	local had_existing=0
+	rm -rf "$staging_dir" "$backup_dir"
+	mkdir -p "$staging_dir" || return 1
+	if ! cp -R "${server_dir}/." "$staging_dir/"; then
+		print_error "Failed to stage llama.cpp release directory"
+		rm -rf "$staging_dir"
+		return 1
+	fi
+	chmod +x "${staging_dir}/llama-server"
+	[[ ! -f "${staging_dir}/llama-cli" ]] || chmod +x "${staging_dir}/llama-cli"
 
-	# Also copy llama-cli if present
-	local cli_bin
-	cli_bin="$(find "$extracted_dir" -name "llama-cli" -type f | head -1)"
-	if [[ -n "$cli_bin" ]]; then
-		cp "$cli_bin" "$LLAMA_CLI_BIN"
-		chmod +x "$LLAMA_CLI_BIN"
+	if [[ -e "$LOCAL_BIN_DIR" ]]; then
+		mv "$LOCAL_BIN_DIR" "$backup_dir" || {
+			rm -rf "$staging_dir"
+			return 1
+		}
+		had_existing=1
+	fi
+	if mv "$staging_dir" "$LOCAL_BIN_DIR" && "$LLAMA_SERVER_BIN" --version >/dev/null 2>&1; then
+		rm -rf "$backup_dir"
+		return 0
 	fi
 
-	return 0
+	print_error "Installed llama-server failed validation; restoring previous binaries"
+	rm -rf "$LOCAL_BIN_DIR" "$staging_dir"
+	if [[ "$had_existing" -eq 1 ]]; then
+		mv "$backup_dir" "$LOCAL_BIN_DIR" || print_error "Previous binary directory requires manual recovery: ${backup_dir}"
+	fi
+	return 1
 }
 
 # Download and extract llama.cpp release
@@ -299,31 +397,44 @@ _setup_download_llama() {
 	rm -rf "$tmp_dir"
 
 	local installed_version
-	installed_version="$("$LLAMA_SERVER_BIN" --version 2>/dev/null | head -1 || echo "${tag_name}")"
+	installed_version="$(_setup_read_version "$LLAMA_SERVER_BIN" "$tag_name")"
 	print_success "llama-server installed: ${installed_version}"
 	return 0
 }
 
-# Install huggingface-cli
+# Install the Hugging Face CLI (`hf`; legacy `huggingface-cli` also supported).
 _setup_install_hf_cli() {
-	if ! suppress_stderr command -v huggingface-cli; then
-		print_info "Installing huggingface-cli..."
-		if suppress_stderr command -v pip3; then
-			log_stderr "pip install" pip3 install --quiet "huggingface_hub[cli]" || {
-				print_warning "Failed to install huggingface-cli via pip3"
-				print_info "Install manually: pip3 install 'huggingface_hub[cli]'"
-			}
-		elif suppress_stderr command -v pip; then
-			log_stderr "pip install" pip install --quiet "huggingface_hub[cli]" || {
-				print_warning "Failed to install huggingface-cli via pip"
-				print_info "Install manually: pip install 'huggingface_hub[cli]'"
-			}
-		else
-			print_warning "pip not found — install huggingface-cli manually"
-			print_info "Install: pip3 install 'huggingface_hub[cli]'"
+	local hf_cli=""
+	if ! hf_cli="$(_local_model_hf_cli)"; then
+		print_info "Installing Hugging Face CLI in an isolated environment..."
+		local python_bin=""
+		local candidate=""
+		for candidate in python3 python; do
+			if suppress_stderr command -v "$candidate" >/dev/null; then
+				python_bin="$candidate"
+				break
+			fi
+		done
+		if [[ -z "$python_bin" ]]; then
+			print_warning "Python not found — cannot install the Hugging Face CLI"
+			print_info "Install manually: uv tool install huggingface_hub"
+			return 2
 		fi
+
+		rm -rf "$LOCAL_HF_VENV_DIR"
+		if ! log_stderr "Hugging Face CLI environment" "$python_bin" -m venv "$LOCAL_HF_VENV_DIR" ||
+			! log_stderr "Hugging Face CLI install" "${LOCAL_HF_VENV_DIR}/bin/python" -m pip install --quiet huggingface_hub; then
+			print_warning "Failed to install the Hugging Face CLI in an isolated environment"
+			print_info "Install manually: uv tool install huggingface_hub"
+			return 1
+		fi
+		hf_cli="$(_local_model_hf_cli)" || {
+			print_warning "Hugging Face CLI installation did not provide a working hf command"
+			return 1
+		}
+		print_success "Hugging Face CLI installed: ${hf_cli}"
 	else
-		print_info "huggingface-cli: already installed"
+		print_info "Hugging Face CLI (${hf_cli}): already installed"
 	fi
 	return 0
 }
@@ -362,7 +473,7 @@ cmd_setup() {
 	# Check if llama-server already exists
 	if [[ -f "$LLAMA_SERVER_BIN" ]] && [[ "$update_mode" == "false" ]]; then
 		local current_version
-		current_version="$("$LLAMA_SERVER_BIN" --version 2>/dev/null | head -1 || echo "unknown")"
+		current_version="$(_setup_read_version "$LLAMA_SERVER_BIN")"
 		print_info "llama-server already installed: ${current_version}"
 		print_info "Use 'local-model-helper.sh setup --update' to update"
 	else
@@ -370,16 +481,17 @@ cmd_setup() {
 		print_info "Fetching latest llama.cpp release..."
 
 		local release_json
-		release_json="$(curl -sL "$LLAMA_CPP_API")" || {
+		release_json="$(curl -fsSL "$LLAMA_CPP_API")" || {
 			print_error "Failed to fetch llama.cpp release info"
 			return 1
 		}
+		release_json="$(_setup_resolve_release_json "$platform" "$release_json")" || return $?
 
 		_setup_download_llama "$platform" "$release_json" || return $?
 	fi
 
-	# Install huggingface-cli if not present
-	_setup_install_hf_cli
+	# Install the Hugging Face CLI if not present
+	_setup_install_hf_cli || return $?
 
 	# Write default config
 	write_default_config

--- a/.agents/tools/local-models/huggingface.md
+++ b/.agents/tools/local-models/huggingface.md
@@ -21,8 +21,8 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Find, evaluate, and download GGUF models from HuggingFace for local inference via llama.cpp
-- **CLI**: `huggingface-cli download <repo> <file> --local-dir <path>` (resume-capable)
-- **Install**: `pip install "huggingface_hub[cli]"` (or pipx). Token: `~/.cache/huggingface/token`
+- **CLI**: `hf download <repo> <file> --local-dir <path>` (resume-capable; legacy `huggingface-cli` remains supported)
+- **Install**: `local-model-helper.sh setup` (isolated environment), or `uv tool install huggingface_hub`. Token: `~/.cache/huggingface/token`
 - **Format**: GGUF — single file (weights + tokenizer + metadata), llama.cpp native. Naming: `{model}-{size}-{quant}.gguf`
 - **Helper**: `local-model-helper.sh search|download|models|recommend|setup`
 - **Browse**: `https://huggingface.co/models?library=gguf&sort=trending`
@@ -73,12 +73,12 @@ local-model-helper.sh search "qwen3 8b"
 local-model-helper.sh search "llama 3.1" --max-size 10G
 
 # Direct download
-huggingface-cli download Qwen/Qwen3-8B-GGUF qwen3-8b-q4_k_m.gguf \
+hf download Qwen/Qwen3-8B-GGUF qwen3-8b-q4_k_m.gguf \
   --local-dir ~/.aidevops/local-models/models/
 
 # Gated models (Llama, etc.) — login first, accept license on HF page
-huggingface-cli login
-huggingface-cli download meta-llama/Llama-3.1-8B-Instruct-GGUF \
+hf auth login
+hf download meta-llama/Llama-3.1-8B-Instruct-GGUF \
   llama-3.1-8b-instruct-q4_k_m.gguf --local-dir ~/.aidevops/local-models/models/
 ```
 
@@ -87,7 +87,7 @@ huggingface-cli download meta-llama/Llama-3.1-8B-Instruct-GGUF \
 | Issue | Solution |
 |-------|----------|
 | Download interrupted | Re-run same command — resumes automatically |
-| "Access denied" | `huggingface-cli login` + accept license on HF page |
+| "Access denied" | `hf auth login` + accept license on HF page |
 | Model too slow | Lower quantization or smaller model |
 | Gibberish output | Re-download (corruption), use instruct/chat variant |
 | Can't find GGUF | Search `bartowski/{model-name}-GGUF` |

--- a/.agents/tools/local-models/local-models.md
+++ b/.agents/tools/local-models/local-models.md
@@ -100,10 +100,10 @@ cp build/bin/llama-server ~/.aidevops/local-models/bin/
 ## Installation
 
 ```bash
-local-model-helper.sh setup   # detects platform, downloads binary, installs huggingface-cli, initialises SQLite DB
+local-model-helper.sh setup   # detects platform, downloads binary + shared libraries, installs `hf`, initialises SQLite DB
 ```
 
-Directory layout: `~/.aidevops/local-models/{bin/llama-server,models/,config.json}` · DB: `~/.aidevops/.agent-workspace/memory/local-models.db`
+Directory layout: `~/.aidevops/local-models/{bin/,hf-cli-env/,models/,config.json}` · DB: `~/.aidevops/.agent-workspace/memory/local-models.db`
 
 ## Hardware & Model Selection
 
@@ -204,7 +204,7 @@ local-model-helper.sh search "qwen3 8b"
 local-model-helper.sh download Qwen/Qwen3-8B-GGUF --quant Q4_K_M
 
 # Start/stop
-local-model-helper.sh start --model qwen3-8b-q4_k_m.gguf [--port 8080] [--ctx-size 8192] [--threads 8] [--gpu-layers 99]
+local-model-helper.sh start --model qwen3-8b-q4_k_m.gguf [--port 8080] [--ctx-size 8192] [--threads 8] [--gpu-layers auto]
 local-model-helper.sh stop
 local-model-helper.sh status   # PID, model, API URL, uptime, requests
 
@@ -219,7 +219,7 @@ curl http://localhost:8080/v1/embeddings -H "Content-Type: application/json" \
 curl http://localhost:8080/health
 ```
 
-Server defaults (`~/.aidevops/local-models/config.json`): port 8080, host 127.0.0.1, ctx_size 8192, threads auto (perf cores), gpu_layers 99, flash_attn true.
+Server defaults (`~/.aidevops/local-models/config.json`): port 8080, host 127.0.0.1, ctx_size 8192, threads auto (perf cores), gpu_layers auto, flash_attn true.
 
 ## aidevops Integration
 
@@ -249,7 +249,7 @@ local-model-helper.sh benchmark --model <file>        # tok/s, time-to-first-tok
 |-------|----------|
 | `setup` fails on Linux | Check glibc (`ldd --version`); ROCm: ensure runtime installed; try `setup --update` |
 | Slow inference | Verify `gpu_layers` set; check Metal/CUDA detected via `status` |
-| Download interrupted | Re-run `download` — huggingface-cli resumes automatically |
+| Download interrupted | Re-run `download` — `hf` resumes automatically |
 | Out of memory | Use Q4_K_M or smaller model; check `recommend` |
 | Port in use | `start --port 8081` or `stop` existing |
 | Context crash | Reduce `--ctx-size`; larger contexts need more RAM |


### PR DESCRIPTION
## Summary

- resolve llama.cpp stable pointer releases to their binary-bearing nightly tag
- atomically install the complete release directory, retaining required shared libraries and restoring the prior directory on validation failure
- support the current `hf` CLI in an isolated environment while retaining legacy CLI compatibility
- normalize current version output, download flags, Flash Attention syntax, and automatic GPU-layer defaults
- update local-model documentation for the current runtime and CLI layout

## Verification

- `.agents/scripts/linters-local.sh`
- focused release-resolution, version-matching, complete-directory install, and rollback fixtures
- clean temporary-home setup installed nightly `b10566` and the isolated `hf` CLI
- downloaded `TinyMistral-248M-v2-Instruct.Q4_K_M.gguf`, started `llama-server`, completed a real `/v1/chat/completions` request, and stopped cleanly
- `setup --update` replaced the complete llama.cpp directory while preserving the working isolated `hf` environment

Resolves #30575

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1h 1m and 558,863 tokens on this with the user in an interactive session.