### PR TITLE
GH#30576: retain permission blocker capability context

### DIFF
--- a/.agents/scripts/tests/test-worker-permission-helper.sh
+++ b/.agents/scripts/tests/test-worker-permission-helper.sh
@@ -35,13 +35,29 @@ cat >"$capture_file" <<'JSON'
     "patterns": ["~/.qlty/bin/*"],
     "tool": "read",
     "intent": "Locate the Qlty executable",
-    "risk": {"level": "medium", "grantable": true, "reason": "external boundary"},
+    "risk": {"level": "high", "grantable": false, "reason": "external boundary"},
     "opencode": {"request_id": "oc-2", "session_id": "ses-1"}
   }]
 }
 JSON
 
 permission_validate_capture "$capture_file" 123 owner/repo
+capability_summary=$(permission_blocker_capability_json "$capture_file")
+jq -e 'select(
+  .permission == "external_directory×2"
+  and .tool == "read×2"
+  and .risk_level == "high"
+  and .grantable == false
+)' <<<"$capability_summary" >/dev/null
+single_capture="${test_root}/single-capture.json"
+jq '.requests = [.requests[0]]' "$capture_file" >"$single_capture"
+single_capability_summary=$(permission_blocker_capability_json "$single_capture")
+jq -e 'select(
+  .permission == "external_directory"
+  and .tool == "read"
+  and .risk_level == "medium"
+  and .grantable == true
+)' <<<"$single_capability_summary" >/dev/null
 envelope=$(permission_build_envelope "$capture_file" 123 owner/repo issue-123 "$PWD" '{"auto_dispatch":true}')
 expected_worktree_digest=$(permission_sha256_text "$PWD")
 jq -e '
@@ -142,7 +158,26 @@ if ! jq -e 'select(.issue == 123 and .session == "issue-123" and (.request_id | 
 	exit 1
 fi
 jq -e 'select(.event == "permission_awaiting_approval" and .reason == "needs_maintainer_permissions" and .blocking == true
-  and .issue_number == 123 and .repo_slug == "owner/repo" and .session_key == "issue-123")' \
+  and .issue_number == 123 and .repo_slug == "owner/repo" and .session_key == "issue-123"
+  and .permission == "external_directory×2" and .tool == "read×2"
+  and .risk_level == "high" and .grantable == false)' \
 	"$AIDEVOPS_WORKER_BLOCKER_LOG_FILE" >/dev/null
+permission_record_blocker "permission_capability_true_fixture" "blocked" "permission_required" "true" \
+	123 "owner/repo" "issue-123" "perm-true" "Boolean transport fixture" \
+	"external_directory" "read" "medium" "true"
+jq -e 'select(.event == "permission_capability_true_fixture" and .grantable == true)' \
+	"$AIDEVOPS_WORKER_BLOCKER_LOG_FILE" >/dev/null
+activity_summary=$(WAH_BLOCKER_LOG_FILE="$AIDEVOPS_WORKER_BLOCKER_LOG_FILE" \
+	WAH_METRICS_FILE="${test_root}/missing-metrics.jsonl" \
+	WAH_PULSE_STATS_FILE="${test_root}/missing-pulse-stats.json" \
+	WAH_DISPATCH_LEDGER_FILE="${test_root}/missing-dispatch-ledger.jsonl" \
+	"${SCRIPT_DIR}/worker-activity-helper.sh" summary --since 24h --json --no-pr-check)
+jq -e '.progress_blockers.active_blockers[] | select(
+  .event == "permission_awaiting_approval"
+  and .permission == "external_directory×2"
+  and .tool == "read×2"
+  and .risk_level == "high"
+  and .grantable == false
+)' <<<"$activity_summary" >/dev/null
 
 printf 'worker permission helper tests passed\n'

--- a/.agents/scripts/worker-blocker-cli.mjs
+++ b/.agents/scripts/worker-blocker-cli.mjs
@@ -17,6 +17,9 @@ function parseCliArguments(argv) {
     if (flag === "--blocking") {
       event.blocking = value !== "false";
       index++;
+    } else if (flag === "--grantable") {
+      event.grantable = value === "true" ? true : value === "false" ? false : null;
+      index++;
     } else if (flag === "--log-file") {
       options.logPath = value;
       index++;

--- a/.agents/scripts/worker-permission-helper.sh
+++ b/.agents/scripts/worker-permission-helper.sh
@@ -24,20 +24,29 @@ permission_record_blocker() {
 	local session_key="$7"
 	local request_id="${8:-}"
 	local detail="${9:-}"
+	local permission="${10:-}"
+	local tool="${11:-}"
+	local risk_level="${12:-}"
+	local grantable="${13:-}"
 	local logger="${SCRIPT_DIR}/worker-blocker-log.mjs"
 	[[ -f "$logger" ]] || return 0
 	command -v node >/dev/null 2>&1 || return 0
-	node "$logger" append \
-		--event "$event" \
-		--status "$status" \
-		--reason "$reason" \
-		--blocking "$blocking" \
-		--source "worker-permission-helper" \
-		--issue-number "$issue_number" \
-		--repo-slug "$repo_slug" \
-		--session-key "$session_key" \
-		--request-id "$request_id" \
-		--detail "$detail" >/dev/null 2>&1 || true
+	local blocker_args=(append
+		--event "$event"
+		--status "$status"
+		--reason "$reason"
+		--blocking "$blocking"
+		--source "worker-permission-helper"
+		--issue-number "$issue_number"
+		--repo-slug "$repo_slug"
+		--session-key "$session_key"
+		--request-id "$request_id"
+		--permission "$permission"
+		--tool "$tool"
+		--risk-level "$risk_level"
+		--detail "$detail")
+	[[ -z "$grantable" ]] || blocker_args+=(--grantable "$grantable")
+	node "$logger" "${blocker_args[@]}" >/dev/null 2>&1 || true
 	return 0
 }
 
@@ -87,6 +96,31 @@ permission_validate_capture() {
 	return $?
 }
 
+# Summarize validated requests without exposing patterns, intent, or raw tool
+# metadata. Counts retain multiplicity while scalar fields stay schema-safe.
+permission_blocker_capability_json() {
+	local capture_file="$1"
+	jq -c '
+		def counted:
+			map(strings | select(length > 0))
+			| sort
+			| group_by(.)
+			| map(.[0] + if length > 1 then "×\(length)" else "" end)
+			| join(",")
+			| .[0:100];
+		.requests as $requests
+		| {
+			permission: ([$requests[].permission] | counted),
+			tool: ([$requests[].tool // ""] | counted),
+			risk_level: (["critical", "high", "medium", "low"]
+				| map(. as $level | select(any($requests[]; .risk.level == $level)))
+				| .[0]),
+			grantable: all($requests[]; .risk.grantable == true)
+		}
+	' "$capture_file"
+	return $?
+}
+
 permission_changed_files_json() {
 	local work_dir="$1"
 	if [[ -z "$work_dir" || ! -d "$work_dir" ]]; then
@@ -98,8 +132,8 @@ permission_changed_files_json() {
 		printf '[]\n'
 		return 0
 	fi
-	printf '%s\n' "$status_output" \
-		| jq -Rsc 'split("\n") | map(select(length >= 4) | .[3:]) | map(select(length > 0)) | .[:20]'
+	printf '%s\n' "$status_output" |
+		jq -Rsc 'split("\n") | map(select(length >= 4) | .[3:]) | map(select(length > 0)) | .[:20]'
 	return 0
 }
 
@@ -282,16 +316,34 @@ permission_apply_block() {
 
 cmd_request() {
 	local capture_file="" issue_number="" repo_slug="" session_key="" work_dir=""
-	local request_id=""
+	local request_id="" capability_json="" permission="" tool="" risk_level="" grantable=""
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		case "$arg" in
-		--file) capture_file="${2:-}"; shift 2 ;;
-		--issue) issue_number="${2:-}"; shift 2 ;;
-		--repo) repo_slug="${2:-}"; shift 2 ;;
-		--session) session_key="${2:-}"; shift 2 ;;
-		--work-dir) work_dir="${2:-}"; shift 2 ;;
-		*) printf 'Unknown option: %s\n' "$arg" >&2; return 1 ;;
+		--file)
+			capture_file="${2:-}"
+			shift 2
+			;;
+		--issue)
+			issue_number="${2:-}"
+			shift 2
+			;;
+		--repo)
+			repo_slug="${2:-}"
+			shift 2
+			;;
+		--session)
+			session_key="${2:-}"
+			shift 2
+			;;
+		--work-dir)
+			work_dir="${2:-}"
+			shift 2
+			;;
+		*)
+			printf 'Unknown option: %s\n' "$arg" >&2
+			return 1
+			;;
 		esac
 	done
 	[[ -f "$capture_file" && "$issue_number" =~ ^[0-9]+$ && "$repo_slug" == */* ]] || return 1
@@ -301,6 +353,11 @@ cmd_request() {
 			"Captured permission request failed validation"
 		return 1
 	fi
+	capability_json="$(permission_blocker_capability_json "$capture_file")" || return 1
+	permission="$(jq -r '.permission' <<<"$capability_json")"
+	tool="$(jq -r '.tool' <<<"$capability_json")"
+	risk_level="$(jq -r '.risk_level' <<<"$capability_json")"
+	grantable="$(jq -r '.grantable' <<<"$capability_json")"
 	if ! request_id=$(permission_post_request "$capture_file" "$issue_number" "$repo_slug" "$session_key" "$work_dir"); then
 		permission_record_blocker "$PERMISSION_PERSISTENCE_FAILED_EVENT" "$PERMISSION_BLOCKER_STATUS" \
 			"github_request_comment_failed" "$PERMISSION_BLOCKER_TRUE" "$issue_number" "$repo_slug" "$session_key" "" \
@@ -332,7 +389,8 @@ cmd_request() {
 	fi
 	permission_record_blocker "permission_awaiting_approval" "$PERMISSION_BLOCKER_STATUS" \
 		"needs_maintainer_permissions" "$PERMISSION_BLOCKER_TRUE" "$issue_number" "$repo_slug" "$session_key" "$request_id" \
-		"Worker paused until the exact scoped permission request is approved"
+		"Worker paused until the exact scoped permission request is approved" \
+		"$permission" "$tool" "$risk_level" "$grantable"
 	return 0
 }
 
@@ -341,7 +399,10 @@ main() {
 	shift 2>/dev/null || true
 	case "$command" in
 	request) cmd_request "$@" ;;
-	*) printf 'Usage: worker-permission-helper.sh request --file FILE --issue N --repo OWNER/REPO --session KEY --work-dir PATH\n' >&2; return 1 ;;
+	*)
+		printf 'Usage: worker-permission-helper.sh request --file FILE --issue N --repo OWNER/REPO --session KEY --work-dir PATH\n' >&2
+		return 1
+		;;
 	esac
 	return $?
 }


### PR DESCRIPTION
## Summary

- propagate bounded capability context into `permission_awaiting_approval` blocker events
- summarize multiple validated requests with counts, highest risk, and an all-request grantability decision
- preserve `grantable` as a JSON boolean across the shell-to-Node CLI boundary
- keep patterns, intents, credentials, and raw tool metadata out of blocker logs

## Verification

- `.agents/scripts/linters-local.sh`
- `.agents/scripts/tests/test-worker-permission-helper.sh`
- `node --test .agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs`
- covered single- and multi-request summaries, highest-risk selection, boolean `true`/`false` transport, and `worker-activity-helper.sh summary --json` rendering

Resolves #30576

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1h 33m and 715,697 tokens on this with the user in an interactive session.