### PR TITLE
GH#30577: keep pulse remediations on owned surfaces

### DIFF
--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -228,6 +228,28 @@ _resolve_apply_repo() {
 	return 0
 }
 
+_framework_write_surface_paths() {
+	printf '%s\n' \
+		'.agents/scripts/pulse-check-queue-scan.py' \
+		'.agents/scripts/pulse-check-report.jq' \
+		'.agents/scripts/pulse-check-helper.sh' \
+		'.agents/scripts/tests/test-pulse-check-helper.sh'
+	return 0
+}
+
+_repo_owns_framework_write_surface() {
+	local slug="$1"
+	local path=""
+	while IFS= read -r path; do
+		[[ -n "$path" ]] || continue
+		if ! gh api "repos/${slug}/contents/${path}" --jq '.type' >/dev/null 2>&1; then
+			print_error "pulse-check: refusing framework remediation issue in ${slug}; repository does not own ${path}"
+			return 1
+		fi
+	done < <(_framework_write_surface_paths)
+	return 0
+}
+
 _existing_open_issue_for_finding() {
 	local slug="$1"
 	local finding_id="$2"
@@ -603,6 +625,7 @@ _apply_findings() {
 		print_warning "pulse-check: skipping issue writes while GitHub API cooldown or dispatch API block is active"
 		return 0
 	fi
+	_repo_owns_framework_write_surface "$slug" || return 1
 
 	local applied_count=0
 	while IFS= read -r finding_json; do

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -191,6 +191,14 @@ if [[ " $* " == *" api "*"/labels?per_page=100"* ]]; then
   printf '%s\n' "${PULSE_CHECK_EXISTING_LABELS_JSON:-[]}"
   exit "${PULSE_CHECK_LABEL_LIST_EXIT:-0}"
 fi
+if [[ " $* " == *" api repos/"*"/contents/.agents/scripts/"* ]]; then
+  if [[ " $* " == *"repos/owner/aidevops/contents/"* ]]; then
+    printf 'file\n'
+    exit 0
+  fi
+  printf 'not found\n' >&2
+  exit 1
+fi
 if [[ " $* " == *" label create "* ]]; then
   label_name="${3:-}"
   printf 'label-create=%s\n' "$label_name" >>"${PULSE_CHECK_CAPTURE}"
@@ -498,6 +506,11 @@ FAILED_LABEL_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_FAIL_LABEL=source:pulse-c
 FAILED_LABEL_CAPTURE=$(<"${TEST_ROOT}/capture.txt")
 assert_contains "required label failure is reported" "failed to ensure label source:pulse-check" "$FAILED_LABEL_OUT"
 assert_not_contains "required label failure prevents issue creation" "repo=owner/aidevops" "$FAILED_LABEL_CAPTURE"
+
+rm -f "${TEST_ROOT}/capture.txt" "${TEST_ROOT}/capture.txt.body"
+FOREIGN_REPO_OUT=$(env "${COMMON_ENV[@]}" "$HELPER" apply --repo owner/product 2>&1)
+assert_contains "foreign repo is rejected before issue creation" "repository does not own .agents/scripts/pulse-check-queue-scan.py" "$FOREIGN_REPO_OUT"
+assert_not_contains "foreign repo receives no remediation issue" "pulse-check: filed" "$FOREIGN_REPO_OUT"
 
 # shellcheck source=../routines/core-routines.sh
 CORE_OUTPUT=$(source "$CORE_ROUTINES" && get_core_routine_entries)


### PR DESCRIPTION
## Summary

Verify every framework-owned pulse remediation path exists in the destination repository before deduplication, label, issue, or reconciliation writes.

## Files Changed

.agents/scripts/pulse-check-helper.sh, .agents/scripts/tests/test-pulse-check-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck passed; focused pulse-check suite passed 73 tests; local repository linters passed.

Resolves #30577


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1h 54m and 915,434 tokens on this with the user in an interactive session.