### PR TITLE
GH#30578: bound post-label pulse refill

### DIFF
--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -387,6 +387,43 @@ _preflight_early_dispatch() {
 }
 
 #######################################
+# Return whether the post-label refill has enough measured wall-clock budget
+# to start. The refill retains candidate-level timeouts; this admission gate
+# prevents a second full dispatch pass from starting near the cycle ceiling.
+#######################################
+_preflight_post_label_refill_wall_clock_allows() {
+	local start_epoch="${PULSE_START_EPOCH:-}"
+	local ceiling_seconds="${PULSE_STALE_THRESHOLD:-}"
+	local required_seconds="${PULSE_POST_LABEL_REFILL_MIN_REMAINING_SECONDS:-${PRE_RUN_STAGE_TIMEOUT:-600}}"
+	local now_epoch=""
+	now_epoch=$(date +%s 2>/dev/null) || now_epoch=""
+
+	if [[ ! "$start_epoch" =~ ^[0-9]+$ || ! "$ceiling_seconds" =~ ^[1-9][0-9]*$ ||
+		! "$required_seconds" =~ ^[1-9][0-9]*$ || ! "$now_epoch" =~ ^[0-9]+$ ||
+		"$now_epoch" -lt "$start_epoch" ]]; then
+		echo "[pulse-wrapper] Post-label dispatch_max skipped: wall-clock budget unavailable (start=${start_epoch:-?}, now=${now_epoch:-?}, ceiling=${ceiling_seconds:-?}, required=${required_seconds:-?})" >>"$LOGFILE"
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "pulse_post_label_refill_wall_clock_skipped" 2>/dev/null || true
+		fi
+		_PULSE_BUDGET_STAGE_DEFERRED=1
+		return 1
+	fi
+
+	local elapsed_seconds=$((now_epoch - start_epoch))
+	local remaining_seconds=$((ceiling_seconds - elapsed_seconds))
+	[[ "$remaining_seconds" -lt 0 ]] && remaining_seconds=0
+	if [[ "$remaining_seconds" -lt "$required_seconds" ]]; then
+		echo "[pulse-wrapper] Post-label dispatch_max skipped: insufficient wall-clock budget (remaining=${remaining_seconds}s, required=${required_seconds}s, elapsed=${elapsed_seconds}s, ceiling=${ceiling_seconds}s)" >>"$LOGFILE"
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "pulse_post_label_refill_wall_clock_skipped" 2>/dev/null || true
+		fi
+		_PULSE_BUDGET_STAGE_DEFERRED=1
+		return 1
+	fi
+	return 0
+}
+
+#######################################
 # Refill after label maintenance without repeating routine-comment responses.
 # Invalidate the cycle-scoped candidate snapshot first so apply_dispatch_max
 # sees labels changed by maintenance while preserving the existing claim,
@@ -396,6 +433,7 @@ _preflight_post_label_refill() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag present — skipping post-label dispatch_max" >>"$LOGFILE"
 	else
+		_preflight_post_label_refill_wall_clock_allows || return 0
 		if ! _dispatch_invalidate_candidate_snapshot "label_maintenance_complete"; then
 			echo "[pulse-wrapper] Post-label dispatch_max skipped: unable to invalidate candidate snapshot" >>"$LOGFILE"
 			return 0

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -108,6 +108,9 @@ assert_refill_runtime_contract() {
 			STOP_FLAG=""
 			LOGFILE="/dev/null"
 			PRE_RUN_STAGE_TIMEOUT=7
+			PULSE_START_EPOCH=$(date +%s)
+			PULSE_STALE_THRESHOLD=1800
+			PULSE_POST_LABEL_REFILL_MIN_REMAINING_SECONDS=600
 
 			_dispatch_invalidate_candidate_snapshot() {
 				local reason="$1"
@@ -147,6 +150,63 @@ assert_refill_runtime_contract() {
 			_preflight_post_label_refill
 			STOP_FLAG="$PREFLIGHT_LIB"
 			_preflight_post_label_refill
+			printf '%s\n' "$REFILL_EVENTS"
+		)
+	)
+	if [[ "$actual_events" == "$expected_events" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected events: $expected_events"
+		echo "  actual events:   ${actual_events:-none}"
+	fi
+	return 0
+}
+
+assert_refill_wall_clock_budget_contract() {
+	local label="$1"
+	local actual_events="" expected_events="counter:pulse_post_label_refill_wall_clock_skipped;skipped:1;"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	actual_events=$(
+		(
+			unset _PULSE_DISPATCH_PREFLIGHT_LIB_LOADED
+			# shellcheck source=../pulse-dispatch-preflight-lib.sh
+			source "$PREFLIGHT_LIB"
+			REFILL_EVENTS=""
+			STOP_FLAG=""
+			LOGFILE="/dev/null"
+			PRE_RUN_STAGE_TIMEOUT=600
+			PULSE_START_EPOCH=1000
+			PULSE_STALE_THRESHOLD=1800
+			PULSE_POST_LABEL_REFILL_MIN_REMAINING_SECONDS=600
+
+			date() {
+				local format="${1:-}"
+				[[ "$format" == "+%s" ]] || return 1
+				printf '2300\n'
+				return 0
+			}
+
+			pulse_stats_increment() {
+				local counter_name="$1"
+				REFILL_EVENTS="${REFILL_EVENTS}counter:${counter_name};"
+				return 0
+			}
+
+			_dispatch_invalidate_candidate_snapshot() {
+				local reason="$1"
+				REFILL_EVENTS="${REFILL_EVENTS}invalidate:${reason};"
+				return 0
+			}
+
+			apply_dispatch_max() {
+				REFILL_EVENTS="${REFILL_EVENTS}dispatch;"
+				return 0
+			}
+
+			_preflight_post_label_refill
+			REFILL_EVENTS="${REFILL_EVENTS}skipped:${_PULSE_BUDGET_STAGE_DEFERRED:-0};"
 			printf '%s\n' "$REFILL_EVENTS"
 		)
 	)
@@ -439,6 +499,8 @@ assert_match_count \
 	"$PREFLIGHT_LIB"
 assert_refill_runtime_contract \
 	"9l: trusted NMR reconciliation completes before the normalized refill"
+assert_refill_wall_clock_budget_contract \
+	"9l1: refill skips with telemetry when remaining cycle budget is insufficient"
 assert_routine_comment_rest_block_contract \
 	"9l2: blocked REST evidence suppresses the routine-comment API scan"
 assert_label_maintenance_rest_block_contract \


### PR DESCRIPTION
## Summary

Admit the second post-label dispatch pass only when measured remaining cycle time meets the preflight budget, otherwise emit skip telemetry and preserve the existing candidate-level timeouts.

## Files Changed

.agents/scripts/pulse-dispatch-preflight-lib.sh, .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 54 dispatch stage-wiring tests passed; GraphQL budget-priority test passed; Linux systemd timeout fixture passed; ShellCheck, shfmt, and local repository linters passed.

Resolves #30578


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 2h 45m and 1,039,425 tokens on this with the user in an interactive session.