### PR TITLE
GH#30579: clarify review-thread scanner commands

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -58,7 +58,7 @@ PRRTS_VALUE_UNKNOWN="unknown"
 PRRTS_TSV_FIELD_SEPARATOR=$'\034'
 # Increment when the worker prompt or launch contract changes so escalated
 # same-fingerprint state receives one fresh bounded remediation pass.
-PRRTS_WORKER_CONTRACT_VERSION="8"
+PRRTS_WORKER_CONTRACT_VERSION="9"
 # Targeted callers distinguish productive dispatch deduplication from a hard
 # launch failure so an already-remediating PR is preserved.
 PRRTS_RC_DISPATCH_DEFERRED=10
@@ -1737,9 +1737,9 @@ Thread preview: ${safe_preview}
    you have verified the finding is addressed or no longer applies.
    Write each reply to a local temporary file and pass that path as <body_file>.
    Select <thread_id> from the assigned thread IDs listed above.
-   Review-thread read/reply/resolve operations are GraphQL-only in this helper;
-   use the scanner commands above or 'gh api graphql'. The resolveReviewThread
-   mutation has no REST endpoint, so do not try 'gh api repos/...' for resolve.
+   The scanner has no 'read' subcommand. Fetch review threads with 'gh api graphql'.
+   Only reply and resolve use the scanner commands above; thread operations are GraphQL-only.
+   The resolveReviewThread mutation has no REST endpoint; do not use 'gh api repos/...' for resolve.
 4. For each assigned review thread, classify it as actionable or praise-only:
    - Actionable means the thread requests a code, documentation, configuration,
      or follow-up change. Verify the premise in the cited file and context.

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -1321,7 +1321,10 @@ test_dispatch_prompt_mentions_graphql_only_thread_operations() {
 	setup_test_env
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
 	wait_for_headless_log || true
-	if grep -q 'Review-thread read/reply/resolve operations are GraphQL-only' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+	if grep -q "The scanner has no 'read' subcommand" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		grep -q "Fetch review threads with 'gh api graphql'" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		grep -q 'Only reply and resolve use the scanner commands above' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		! grep -q 'Review-thread read/reply/resolve operations are GraphQL-only' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
 		grep -q 'resolveReviewThread' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
 		grep -q 'has no REST endpoint' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
 		grep -q 'Completion requires each verified-addressed assigned thread to be resolved' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
@@ -1349,13 +1352,13 @@ test_dispatch_prompt_requires_machine_readable_completion_state() {
 	return 0
 }
 
-test_dispatch_prompt_requires_contract_v8_remediation_role_and_praise_only_resolution() {
+test_dispatch_prompt_requires_contract_v9_remediation_role_and_praise_only_resolution() {
 	setup_test_env
 	local stable_scanner="${HOME}/.aidevops/agents/scripts/pr-review-thread-response-scanner.sh"
 	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
 	wait_for_headless_log || true
-	if grep -q '^worker_contract_version=8$' "$state_file" 2>/dev/null &&
+	if grep -q '^worker_contract_version=9$' "$state_file" 2>/dev/null &&
 		grep -Fq 'For each assigned review thread, classify it as actionable or praise-only' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
 		grep -Fq 'Praise-only means positive feedback or an observation with no requested' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
 		grep -Fq 'Perform one bounded remediation pass' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
@@ -1363,9 +1366,9 @@ test_dispatch_prompt_requires_contract_v8_remediation_role_and_praise_only_resol
 		grep -Fq 'fix actionable defects in the linked worktree' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
 		! grep -Fq 'PR-loop review model' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
 		grep -Fq "${stable_scanner} resolve owner/repo <thread_id>" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
-		print_result "dispatch prompt requires contract-v8 remediation role and praise-only resolution" 0
+		print_result "dispatch prompt requires contract-v9 remediation role and praise-only resolution" 0
 	else
-		print_result "dispatch prompt requires contract-v8 remediation role and praise-only resolution" 1 \
+		print_result "dispatch prompt requires contract-v9 remediation role and praise-only resolution" 1 \
 			"state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf ''), prompt=$(tr '\n' ' ' <"$HEADLESS_PROMPT_CAPTURE" 2>/dev/null || printf '')"
 	fi
 	teardown_test_env
@@ -1800,9 +1803,9 @@ test_dispatch_retries_escalated_previous_worker_contract() {
 	wait_for_headless_log || true
 	if [[ -s "$HEADLESS_LOG" ]] &&
 		grep -q '^attempt_count=1$' "$state_file" 2>/dev/null &&
-		grep -q '^worker_contract_version=8$' "$state_file" 2>/dev/null &&
+		grep -q '^worker_contract_version=9$' "$state_file" 2>/dev/null &&
 		! grep -q '^maintainer_attention=true$' "$state_file" 2>/dev/null &&
-		grep -q 'retrying stale same-fingerprint escalation under worker contract 8 (stored=2)' "$LOGFILE" 2>/dev/null; then
+		grep -q 'retrying stale same-fingerprint escalation under worker contract 9 (stored=2)' "$LOGFILE" 2>/dev/null; then
 		print_result "dispatch retries escalation created under previous worker contract" 0
 	else
 		print_result "dispatch retries escalation created under previous worker contract" 1 \
@@ -2530,7 +2533,7 @@ main() {
 	test_dispatch_prompt_uses_stable_deployed_scanner_path
 	test_dispatch_prompt_mentions_graphql_only_thread_operations
 	test_dispatch_prompt_requires_machine_readable_completion_state
-	test_dispatch_prompt_requires_contract_v8_remediation_role_and_praise_only_resolution
+	test_dispatch_prompt_requires_contract_v9_remediation_role_and_praise_only_resolution
 	test_dispatch_prompt_requires_exactly_one_terminal_call
 	test_dispatch_prompt_explains_shell_redirection_constraint
 	test_dispatch_prompt_declares_precreated_worktree_contract


### PR DESCRIPTION
## Summary

Remove the nonexistent read-command implication from the bounded review-thread worker prompt, direct fetching to gh api graphql, and reserve scanner commands for reply and resolve.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — All 89 focused scanner tests passed; ShellCheck, shfmt, complexity ratchets, and local repository linters passed.

Resolves #30579


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 5h 8m and 1,281,700 tokens on this with the user in an interactive session.