### PR TITLE
GH#30595: exempt CI and conflict repairs from PR backlog cap

### DIFF
--- a/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
+++ b/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
@@ -42,7 +42,12 @@ _dispatch_filter_repo_pr_backlog_candidates() {
 
 	filtered_json=$(jq -c '[.[] | select(
 		((.labels // []) | map(.name? // .)) as $labels |
+		# Feedback finalization verifies the source PR head and closes that PR
+		# before these candidates are redispatched. CI/conflict candidates therefore
+		# repair an existing PR lineage instead of adding ordinary backlog.
 		(($labels | index("quality-debt")) != null and ($labels | index("source:review-feedback")) != null)
+		or ($labels | index("source:ci-feedback")) != null
+		or ($labels | index("source:conflict-feedback")) != null
 	)]' <<<"$candidates_json" 2>/dev/null) || filtered_json="$candidates_json"
 	candidate_count=$(jq 'length' <<<"$candidates_json" 2>/dev/null) || candidate_count=0
 	filtered_count=$(jq 'length' <<<"$filtered_json" 2>/dev/null) || filtered_count="$candidate_count"

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -243,8 +243,8 @@ JSON
 		local limit="$2"
 		printf '%s' "$limit" >/dev/null
 		case "$repo_slug" in
-			owner/repo-a) printf '%s\n' '[{"number":1,"labels":[{"name":"bug"}]},{"number":2,"labels":[{"name":"quality-debt"},{"name":"source:review-feedback"}]}]' ;;
-			owner/repo-b) printf '%s\n' '[{"number":3,"labels":[{"name":"bug"}]}]' ;;
+			owner/repo-a) printf '%s\n' '[{"number":1,"labels":[{"name":"bug"}]},{"number":2,"labels":[{"name":"quality-debt"},{"name":"source:review-feedback"}]},{"number":3,"labels":[{"name":"source:ci-feedback"}]},{"number":4,"labels":[{"name":"source:conflict-feedback"}]}]' ;;
+			owner/repo-b) printf '%s\n' '[{"number":5,"labels":[{"name":"bug"}]}]' ;;
 			*) printf '[]\n' ;;
 		esac
 		return 0
@@ -254,10 +254,10 @@ JSON
 	ranked=$(build_ranked_dispatch_candidates_json 10)
 	repo_a_numbers=$(jq -r '[.[] | select(.repo_slug == "owner/repo-a") | .number] | join(",")' <<<"$ranked")
 	repo_b_numbers=$(jq -r '[.[] | select(.repo_slug == "owner/repo-b") | .number] | join(",")' <<<"$ranked")
-	if [[ "$repo_a_numbers" == "2" && "$repo_b_numbers" == "3" ]]; then
-		print_result "guardrail: repo A backlog does not throttle repo B and trusted review debt is exempt" 0
+	if [[ "$repo_a_numbers" == "2,3,4" && "$repo_b_numbers" == "5" ]]; then
+		print_result "guardrail: repo backlog exempts review debt and verified CI/conflict repair lineages" 0
 	else
-		print_result "guardrail: repo A backlog does not throttle repo B and trusted review debt is exempt" 1 "repo_a=${repo_a_numbers} repo_b=${repo_b_numbers}"
+		print_result "guardrail: repo backlog exempts review debt and verified CI/conflict repair lineages" 1 "repo_a=${repo_a_numbers} repo_b=${repo_b_numbers}"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Allow verified source:ci-feedback and source:conflict-feedback repair candidates through the repository open-PR backlog guardrail while continuing to suppress ordinary backlog.

## Files Changed

.agents/scripts/pulse-dispatch-current-state-guardrails.sh, .agents/scripts/tests/test-pulse-current-state-guardrails.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused current-state guardrail suite passes 23/23; ShellCheck and git diff validation pass.

Resolves #30595


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 2h 37m and 839,781 tokens on this with the user in an interactive session.