### PR TITLE
GH#30605: fix: surface model replay egress failures

### DIFF
--- a/.agents/scripts/model-replay-cell.mjs
+++ b/.agents/scripts/model-replay-cell.mjs
@@ -3,7 +3,7 @@
 
 import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { readFileSync, rmSync } from "node:fs";
+import { copyFileSync, readFileSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
 import {
   assertNoSymlinks,
@@ -62,16 +62,18 @@ function gradeCapturedPatch({ loadedCase, catalog, workRoot, patchPath }) {
       verificationWorkspace,
       workRoot,
     );
-    const applied = execute(
-      ["git", "apply", "--binary", "--whitespace=nowarn", patchPath],
-      {
-        cwd: synthetic.workspace,
-        env: workspaceExecutionEnvironment(synthetic.workspace),
-        timeoutMs: 120000,
-      },
-    );
-    if (applied.status !== 0) {
-      throw new Error(`Captured benchmark patch cannot be replayed: ${applied.stderr || applied.stdout}`);
+    if (readFileSync(patchPath).length > 0) {
+      const applied = execute(
+        ["git", "apply", "--binary", "--whitespace=nowarn", patchPath],
+        {
+          cwd: synthetic.workspace,
+          env: workspaceExecutionEnvironment(synthetic.workspace),
+          timeoutMs: 120000,
+        },
+      );
+      if (applied.status !== 0) {
+        throw new Error(`Captured benchmark patch cannot be replayed: ${applied.stderr || applied.stdout}`);
+      }
     }
     assertNoSymlinks(synthetic.workspace);
     return gradeWorkspace(loadedCase, synthetic.workspace);
@@ -85,6 +87,53 @@ function artifactRecords(paths) {
     path: `artifacts/${basename(path)}`,
     sha256: sha256File(path),
   }]));
+}
+
+function writeInfrastructureAttempt({
+  cell,
+  plan,
+  sealed,
+  experimentDir,
+  runtime,
+  evidence,
+  logPath,
+  patchPath,
+  metricsSnapshotPath,
+}) {
+  const attemptID = randomUUID().replaceAll("-", "").slice(0, 12);
+  const preservedLogPath = join(
+    experimentDir,
+    "artifacts",
+    `${cell.cell_id}.infrastructure-${attemptID}.runtime.log`,
+  );
+  const attemptPath = join(
+    experimentDir,
+    "artifacts",
+    `${cell.cell_id}.infrastructure-${attemptID}.json`,
+  );
+  copyFileSync(logPath, preservedLogPath);
+  writeJson(attemptPath, {
+    schema_version: "aidevops-model-replay-infrastructure-attempt/v1",
+    experiment_id: plan.experiment_id,
+    cell_id: cell.cell_id,
+    model: cell.model,
+    candidate_tier: cell.candidate_tier,
+    requested_effort: cell.requested_effort,
+    failure_class: "provider_request_unverified",
+    runtime_status: runtime.status,
+    runtime_signal: runtime.signal,
+    timed_out: runtime.timedOut,
+    runtime_error: runtime.error,
+    provider_request_observed: evidence.requestObserved,
+    resource_metric_observed: evidence.resourceObserved,
+    runtime_result: String(evidence.metric.result || ""),
+    log: artifactRecords({ log: preservedLogPath }).log,
+    patch_sha256: sha256File(patchPath),
+    metrics_sha256: sha256File(metricsSnapshotPath),
+    prediction_seal_sha256: sealed.seal_sha256,
+    recorded_at: new Date().toISOString(),
+  });
+  return attemptPath;
 }
 
 function runtimeArguments({ helper, sessionKey, workspace, promptPath, cell }) {
@@ -273,12 +322,6 @@ export function executeCell({ cell, plan, sealed, corpusDir, catalog, experiment
     writePrivateFile(logPath, `${run.stdout || ""}${run.stderr || ""}`, 0o600);
     assertNoSymlinks(workspace);
     capturePatch(workspace, synthetic.syntheticCommit, patchPath);
-    const grade = gradeCapturedPatch({
-      loadedCase: verified.loadedCase,
-      catalog,
-      workRoot,
-      patchPath,
-    });
     const evidence = runtimeEvidence({
       sessionKey,
       cell,
@@ -292,6 +335,28 @@ export function executeCell({ cell, plan, sealed, corpusDir, catalog, experiment
       runtime_metric: evidence.metric,
       request_usage: evidence.usage,
       resource_metric: evidence.resource,
+    });
+    if (!evidence.requestObserved) {
+      const attemptPath = writeInfrastructureAttempt({
+        cell,
+        plan,
+        sealed,
+        experimentDir,
+        runtime,
+        evidence,
+        logPath,
+        patchPath,
+        metricsSnapshotPath,
+      });
+      throw new Error(
+        `Model replay infrastructure failed before a verified provider request (status=${runtime.status ?? "unavailable"}); evidence: artifacts/${basename(attemptPath)}`,
+      );
+    }
+    const grade = gradeCapturedPatch({
+      loadedCase: verified.loadedCase,
+      catalog,
+      workRoot,
+      patchPath,
     });
     const artifacts = artifactRecords({
       prompt: promptPath,

--- a/.agents/scripts/model-replay-runner.mjs
+++ b/.agents/scripts/model-replay-runner.mjs
@@ -21,7 +21,10 @@ import {
 import { loadSealedPredictions } from "./model-replay-predictions.mjs";
 import { createReport, reportHash } from "./model-replay-report.mjs";
 import { acquireRunLock, validatedResultRecords } from "./model-replay-results.mjs";
-import { createRuntimeWorkRoot } from "./model-replay-runtime.mjs";
+import {
+  assertModelReplayEgressConfigured,
+  createRuntimeWorkRoot,
+} from "./model-replay-runtime.mjs";
 
 function pendingCells(plan, results) {
   const completed = new Set(results.map((record) => record.cell_id));
@@ -115,8 +118,10 @@ export function runExperiment({ experimentDir, corpusDir, catalogPath, dryRun = 
       return record;
     }
     const lockedResults = validatedResultRecords(experimentDir, plan, sealed);
+    const executableCells = pendingCells(plan, lockedResults);
+    if (executableCells.length > 0) assertModelReplayEgressConfigured();
     const results = executePendingCells({
-      cells: pendingCells(plan, lockedResults),
+      cells: executableCells,
       plan,
       sealed,
       corpusDir,

--- a/.agents/scripts/model-replay-runtime.mjs
+++ b/.agents/scripts/model-replay-runtime.mjs
@@ -3,15 +3,18 @@
 
 import { spawnSync } from "node:child_process";
 import {
+  accessSync,
   chmodSync,
+  constants,
   existsSync,
   lstatSync,
   mkdirSync,
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeJson, writePrivateFile } from "./model-replay-core.mjs";
 
@@ -29,6 +32,26 @@ function ensureOwnedDirectory(path) {
   mkdirSync(path, { recursive: true, mode: 0o700 });
   chmodSync(path, 0o700);
   return realpathSync(path);
+}
+
+function isExecutableAbsoluteFile(path) {
+  if (!path || !isAbsolute(path)) return false;
+  try {
+    accessSync(path, constants.X_OK);
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function assertModelReplayEgressConfigured() {
+  const backend = process.env.AIDEVOPS_WORKER_EGRESS_BACKEND || "";
+  if (!isExecutableAbsoluteFile(backend)) {
+    throw new Error(
+      "Real model replay requires AIDEVOPS_WORKER_EGRESS_BACKEND to be an executable absolute file",
+    );
+  }
+  return backend;
 }
 
 export function prepareModelReplayRuntime(workRoot) {

--- a/.agents/scripts/tests/model-replay-benchmark-fixture.mjs
+++ b/.agents/scripts/tests/model-replay-benchmark-fixture.mjs
@@ -55,6 +55,10 @@ case "$AIDEVOPS_HEADLESS_RUNTIME_DIR" in "$AIDEVOPS_WORKTREE_BASE_DIR"/*) ;; *) 
 case "$AIDEVOPS_HEADLESS_METRICS_FILE" in "$AIDEVOPS_WORKTREE_BASE_DIR"/*) ;; *) exit 21 ;; esac
 case "$AIDEVOPS_RESOURCE_METRICS_FILE" in "$AIDEVOPS_WORKTREE_BASE_DIR"/*) ;; *) exit 22 ;; esac
 case "$AIDEVOPS_OAUTH_POOL_FILE" in "$AIDEVOPS_WORKTREE_BASE_DIR"/*) ;; *) exit 23 ;; esac
+if [ "\${AIDEVOPS_TEST_RUNTIME_FAILURE:-}" = "1" ]; then
+  printf '%s\n' 'simulated pre-provider infrastructure failure' >&2
+  exit 126
+fi
 export MR_WORK_DIR="$work_dir" MR_SESSION_KEY="$session_key" MR_MODEL="$model" MR_VARIANT="$variant" MR_TIER="$tier"
 "$AIDEVOPS_TEST_NODE" -e '
 const fs = require("node:fs");
@@ -154,6 +158,7 @@ function fixturePaths(sandbox) {
     sensitiveTemp: join(sandbox, "sensitive-temp"),
     testHome: join(sandbox, "home"),
     fakeOpenCode: join(sandbox, "fake-opencode.sh"),
+    fakeEgressBackend: join(sandbox, "fake-egress-backend.sh"),
   };
 }
 
@@ -236,6 +241,8 @@ function writeRuntimeFixtures(paths) {
   chmodSync(paths.promptGuard, 0o700);
   writeFileSync(paths.fakeOpenCode, "#!/bin/sh\nprintf '%s\\n' 'fixture-opencode 1.0'\n", { mode: 0o700 });
   chmodSync(paths.fakeOpenCode, 0o700);
+  writeFileSync(paths.fakeEgressBackend, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+  chmodSync(paths.fakeEgressBackend, 0o700);
   writeFileSync(paths.fakeRuntime, FAKE_RUNTIME, { mode: 0o700 });
   chmodSync(paths.fakeRuntime, 0o700);
 }
@@ -256,6 +263,7 @@ function fixtureEnvironment(paths) {
     AIDEVOPS_TEST_NODE: process.execPath,
     AIDEVOPS_HEADLESS_VARIANT: "xhigh",
     AIDEVOPS_HEADLESS_VARIANT_SIMPLE: "high",
+    AIDEVOPS_WORKER_EGRESS_BACKEND: paths.fakeEgressBackend,
     OPENCODE_BIN: paths.fakeOpenCode,
     OPENCODE_SERVER_PASSWORD: "test-only-password",
   };

--- a/.agents/scripts/tests/model-replay-benchmark-fixture.mjs
+++ b/.agents/scripts/tests/model-replay-benchmark-fixture.mjs
@@ -62,8 +62,10 @@ fi
 export MR_WORK_DIR="$work_dir" MR_SESSION_KEY="$session_key" MR_MODEL="$model" MR_VARIANT="$variant" MR_TIER="$tier"
 "$AIDEVOPS_TEST_NODE" -e '
 const fs = require("node:fs");
-fs.writeFileSync(process.env.MR_WORK_DIR + "/value.txt", "fixed\\n");
-fs.writeFileSync(process.env.MR_WORK_DIR + "/created.txt", "x".repeat(3000) + "PATCH_END_MARKER\\n");
+if (process.env.AIDEVOPS_TEST_NO_CHANGE !== "1") {
+  fs.writeFileSync(process.env.MR_WORK_DIR + "/value.txt", "fixed\\n");
+  fs.writeFileSync(process.env.MR_WORK_DIR + "/created.txt", "x".repeat(3000) + "PATCH_END_MARKER\\n");
+}
 const now = Math.floor(Date.now() / 1000);
 const mixedEvidence = process.env.AIDEVOPS_TEST_MIXED_EVIDENCE === "1";
 const observedModel = mixedEvidence ? process.env.MR_MODEL + ",openai/replay-other" : process.env.MR_MODEL;

--- a/.agents/scripts/tests/test-model-replay-benchmark.mjs
+++ b/.agents/scripts/tests/test-model-replay-benchmark.mjs
@@ -383,6 +383,32 @@ try {
   );
   git(repository, "replace", "-d", baseSHA);
 
+  for (const invalidBackend of ["", "relative/backend"]) {
+    expectFailure(
+      { ...environment, AIDEVOPS_WORKER_EGRESS_BACKEND: invalidBackend },
+      /requires AIDEVOPS_WORKER_EGRESS_BACKEND to be an executable absolute file/u,
+      "run", "--experiment", experiment, "--corpus", corpus, "--catalog", catalog,
+    );
+  }
+  assert.equal(existsSync(runtimeMarker), false);
+
+  expectFailure(
+    { ...environment, AIDEVOPS_TEST_RUNTIME_FAILURE: "1" },
+    /infrastructure failed before a verified provider request.*evidence: artifacts\//u,
+    "run", "--experiment", experiment, "--corpus", corpus, "--catalog", catalog,
+  );
+  const infrastructureArtifact = readdirSync(join(experiment, "artifacts"))
+    .find((name) => name.includes(".infrastructure-") && name.endsWith(".json"));
+  assert.ok(infrastructureArtifact);
+  const infrastructureAttempt = JSON.parse(readFileSync(
+    join(experiment, "artifacts", infrastructureArtifact),
+    "utf8",
+  ));
+  assert.equal(infrastructureAttempt.runtime_status, 126);
+  assert.equal(infrastructureAttempt.provider_request_observed, false);
+  assert.equal(existsSync(join(experiment, infrastructureAttempt.log.path)), true);
+  assert.equal(existsSync(runtimeMarker), false);
+
   const run = invokeRequired(
     environment,
     "run", "--experiment", experiment, "--corpus", corpus, "--catalog", catalog,

--- a/.agents/scripts/tests/test-model-replay-benchmark.mjs
+++ b/.agents/scripts/tests/test-model-replay-benchmark.mjs
@@ -364,6 +364,19 @@ try {
     environment,
     "seal", "--experiment", prescriptiveExperiment, "--input", prescriptivePredictions,
   );
+  const noChangeExperiment = join(sandbox, "experiment-no-change");
+  const noChangePlan = invokeRequired(
+    environment,
+    "plan", "--corpus", corpus, "--candidates", candidates,
+    "--experiment", noChangeExperiment, "--experiment-id", "fixture-no-change",
+    "--suite", "quick", "--stage", "primary", "--mode", "autonomous",
+  );
+  const noChangePredictions = join(sandbox, "predictions-no-change.json");
+  writeJson(noChangePredictions, completedPredictions(noChangeExperiment));
+  invokeRequired(
+    environment,
+    "seal", "--experiment", noChangeExperiment, "--input", noChangePredictions,
+  );
 
   const runLock = join(experiment, "run.lock");
   writeFileSync(runLock, "fixture\n", { mode: 0o600 });
@@ -408,6 +421,21 @@ try {
   assert.equal(infrastructureAttempt.provider_request_observed, false);
   assert.equal(existsSync(join(experiment, infrastructureAttempt.log.path)), true);
   assert.equal(existsSync(runtimeMarker), false);
+
+  const noChangeRun = invokeRequired(
+    { ...environment, AIDEVOPS_TEST_NO_CHANGE: "1" },
+    "run", "--experiment", noChangeExperiment, "--corpus", corpus, "--catalog", catalog,
+  );
+  assert.equal(noChangeRun.results[0].outcome, "fail");
+  assert.equal(noChangeRun.results[0].provider_request_observed, true);
+  assert.equal(noChangeRun.results[0].verification.functional_passed, false);
+  assert.equal(
+    readFileSync(
+      join(noChangeExperiment, "artifacts", `${noChangePlan.cells[0].cell_id}.patch`),
+      "utf8",
+    ),
+    "",
+  );
 
   const run = invokeRequired(
     environment,

--- a/.agents/workflows/optimize-tiers.md
+++ b/.agents/workflows/optimize-tiers.md
@@ -176,6 +176,11 @@ an isolated sandbox, and enforced provider-only whole-process egress. A pass als
 requires a concrete structured provider-request record and resource metric. The
 captured patch is reapplied to another clean synthetic base and regraded; prompt,
 log, metrics, and patch hashes remain bound to the append-only result record.
+Dry runs never contact providers and do not require an egress backend. Before a
+real run, set `AIDEVOPS_WORKER_EGRESS_BACKEND` to an absolute executable that
+implements the v1 kernel/equivalent contract documented by
+`sandbox-exec-helper.sh`; model replay fails before provider execution when this
+trusted operator prerequisite is absent. Never use a test fixture backend.
 Each deterministic check receives a disposable patch snapshot in a separate
 filesystem-deny sandbox, so check-time writes cannot affect later checks. The
 current enforcing backend is macOS Seatbelt; qualification fails closed on hosts


### PR DESCRIPTION
## Summary

Preflight required egress before real cells, preserve pre-provider runtime failures as durable infrastructure artifacts, and grade provider-observed empty patches normally.

## Files Changed

.agents/scripts/model-replay-cell.mjs, .agents/scripts/model-replay-runner.mjs, .agents/scripts/model-replay-runtime.mjs, .agents/scripts/tests/model-replay-benchmark-fixture.mjs, .agents/scripts/tests/test-model-replay-benchmark.mjs, .agents/workflows/optimize-tiers.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused model replay benchmark tests, Biome checks, local linters, whitespace validation, and the Qlty regression gate all pass.

Resolves #30605


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 22h 44m and 5,189,283 tokens on this with the user in an interactive session.