### PR TITLE
GH#30598: redact Google OAuth client secrets

### DIFF
--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -14,6 +14,7 @@ This is Layer 4 of t2458 credential sanitization:
 
 Token prefix families scrubbed (mirrors shared-constants.sh scrub_credentials):
   sk-       OpenAI / Anthropic API keys
+  GOCSPX-   Google OAuth client secrets
   ghp_      GitHub personal access tokens
   gho_      GitHub OAuth tokens
   ghs_      GitHub server-to-server tokens
@@ -45,7 +46,7 @@ import sys
 import time
 
 # Regex mirrors shared-constants.sh scrub_credentials sed pattern exactly.
-# Group 1: token prefix family (one of the 9 families).
+# Group 1: token prefix family (one of the 10 families).
 # Suffix: 10+ alphanumeric / dash / underscore chars (token body).
 #
 # Word-boundary anchor `(?:^|(?<=[^A-Za-z0-9_-]))` prevents false positives
@@ -55,7 +56,7 @@ import time
 # into `ta[redacted-credential]` and similar (see GH#21026 / t2892 for the
 # canonical incident on example-repo/develop).
 CREDENTIAL_PATTERN = re.compile(
-    r"(?:^|(?<=[^A-Za-z0-9_-]))(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}",
+    r"(?:^|(?<=[^A-Za-z0-9_-]))(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}",
     re.ASCII,
 )
 

--- a/.agents/plugins/opencode-aidevops/plugin-console.mjs
+++ b/.agents/plugins/opencode-aidevops/plugin-console.mjs
@@ -16,7 +16,7 @@ const MAX_LOG_BYTES = 5 * 1024 * 1024;
 const MAX_ENTRY_LENGTH = 4000;
 const MAX_ROTATED_LOGS = 3;
 const CREDENTIAL_PATTERN =
-  /(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
+  /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 
 function formatArgument(arg) {
   if (arg instanceof Error) return arg.stack || arg.message;

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -39,7 +39,7 @@ export { checkSecretReadGate, isReadTool } from "./quality-hooks-secret-read.mjs
 // ---------------------------------------------------------------------------
 
 const CREDENTIAL_PATTERN =
-  /(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
+  /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 
 const REDACTION_TOKEN = "[redacted-credential]";
 const OPERATION_TITLE_MAX_LENGTH = 500;

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -12,8 +12,11 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { scrubCredentials } from "../quality-hooks.mjs";
+import { createQualityHooks, scrubCredentials } from "../quality-hooks.mjs";
 
 const REDACTION_TOKEN = "[redacted-credential]";
 
@@ -54,5 +57,35 @@ describe("credential transcript scrub boundary", () => {
 
   test("redacts credential after parenthesis boundary", () => {
     assertScrub(`(${"xoxp-"}${"e".repeat(10)})`, `(${REDACTION_TOKEN})`, 1);
+  });
+
+  test("redacts Google OAuth client secret after equals boundary", () => {
+    const secret = `GOCSPX-${"f".repeat(28)}`;
+    assertScrub(`client_secret=${secret}`, `client_secret=${REDACTION_TOKEN}`, 1);
+  });
+
+  test("does not redact Google OAuth prefix embedded mid-word", () => {
+    const embedded = `vendor-GOCSPX-${"g".repeat(28)}`;
+    assertScrub(embedded, embedded, 0);
+  });
+
+  test("toolExecuteAfter scrubs Google OAuth secrets before returning output", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "aidevops-google-oauth-scrub-"));
+    const secret = `GOCSPX-${"h".repeat(28)}`;
+    const output = {
+      output: { stdout: `client_secret=${secret}`, exitCode: 0 },
+      metadata: {},
+    };
+
+    try {
+      const hooks = createQualityHooks({ scriptsDir: tempDir, logsDir: tempDir });
+      await hooks.toolExecuteAfter({ tool: "grep", callID: "" }, output);
+      assert.deepEqual(output.output, {
+        stdout: `client_secret=${REDACTION_TOKEN}`,
+        exitCode: 0,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/.agents/scripts/contributor-insight-helper.sh
+++ b/.agents/scripts/contributor-insight-helper.sh
@@ -104,7 +104,7 @@ sanitize_text() {
 	# Word-boundary anchor — see shared-constants.sh::scrub_credentials for the
 	# t2892 rationale. Mid-word matches like `task-failure-handler` must not be
 	# corrupted into `ta[redacted-credential]`.
-	text=$(printf '%s' "$text" | sed -E 's/(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g')
+	text=$(printf '%s' "$text" | sed -E 's/(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g')
 
 	# 4. Strip email addresses
 	text=$(printf '%s' "$text" | sed -E 's/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/[email]/g')

--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -50,7 +50,7 @@ PRIVACY_SCAN_GLOBS=(
 PRIVACY_SCAN_GLOBS_TEXT="${PRIVACY_SCAN_GLOBS_TEXT:-}"
 # Require a left token boundary so credential-looking substrings inside words or
 # filenames (for example, task-coordinator.sh) are not treated as secrets.
-PRIVACY_CREDENTIAL_PREFIX_ERE='(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'
+PRIVACY_CREDENTIAL_PREFIX_ERE='(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}'
 
 # =============================================================================
 # Logging

--- a/.agents/scripts/runtime-events-payload.mjs
+++ b/.agents/scripts/runtime-events-payload.mjs
@@ -13,7 +13,7 @@ const MAX_STRING_LENGTH = 2048;
 const SECRET_KEY_PATTERN = /^(auth|authorization|cookie|set_cookie|credentials?|password|passwd|secret|token|[a-z0-9]+_token|api_key|client_secret|private_key|database_url|dsn)$/i;
 const PATH_KEY_PATTERN = /(^|_)(cwd|dir|directory|file|path|root|worktree)(_|$)/i;
 const REPOSITORY_KEY_PATTERN = /^(project_name|repo|repository|repo_slug|repository_slug)$/i;
-const CREDENTIAL_PATTERN = /(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
+const CREDENTIAL_PATTERN = /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 const AWS_ACCESS_KEY_PATTERN = /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g;
 const AWS_SECRET_KEY_PATTERN = /\b[A-Za-z0-9/+=]{40}\b/g;
 const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g;

--- a/.agents/scripts/session-distill-helper.sh
+++ b/.agents/scripts/session-distill-helper.sh
@@ -90,7 +90,7 @@ init_session_dir() {
 privacy_redact() {
 	local text="$1"
 	text=$(printf '%s' "$text" | sed -E 's|/Users/[^ ]*|[local-path]|g; s|/home/[^ ]*|[local-path]|g; s|/private/var/[^ ]*|[local-path]|g; s|/var/folders/[^ ]*|[local-path]|g; s|~/Git/[^ ]*|[local-path]|g')
-	text=$(printf '%s' "$text" | sed -E 's/(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g')
+	text=$(printf '%s' "$text" | sed -E 's/(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g')
 	text=$(printf '%s' "$text" | sed -E 's/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/[email]/g')
 	printf '%s' "$text"
 	return 0

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -581,7 +581,7 @@ readonly TASK_SIBLING_NON_ACTIVE_STATES_SQL="'verified','cancelled','deployed','
 # surface in pasted bug reports.
 #
 # Two layers:
-#   scrub_credentials  — strips known token prefixes (sk-, ghp_, gho_, ghs_,
+#   scrub_credentials  — strips known token prefixes (sk-, GOCSPX-, ghp_, gho_, ghs_,
 #                        ghu_, github_pat_, glpat-, xoxb-, xoxp-) from any
 #                        text passed to it. Pure regex, no network.
 #   sanitize_url       — strips the `user:pass@` or `token@` authority from
@@ -606,7 +606,7 @@ scrub_credentials() {
 	# but is NOT a credential. macOS BSD sed has no `\b`, so we capture the
 	# preceding boundary character and restore it via \1 in the replacement.
 	# (t2892, GH#21026)
-	printf '%s' "$text" | sed -E 's/(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g'
+	printf '%s' "$text" | sed -E 's/(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g'
 	return 0
 }
 

--- a/.agents/scripts/tests/test-credential-sanitizer.sh
+++ b/.agents/scripts/tests/test-credential-sanitizer.sh
@@ -101,7 +101,7 @@ _assert_notcontains "glpat- in query string scrubbed" \
 
 echo ""
 echo "[test] scrub_credentials — token prefix matrix"
-for prefix in "sk-" "ghp_" "gho_" "ghs_" "ghu_" "github_pat_" "glpat-" "xoxb-" "xoxp-"; do
+for prefix in "sk-" "GOCSPX-" "ghp_" "gho_" "ghs_" "ghu_" "github_pat_" "glpat-" "xoxb-" "xoxp-"; do
 	fake_token="${prefix}abcdefghij1234567890"
 	input="prefix: ${fake_token} suffix"
 	result=$(scrub_credentials "$input")

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -80,7 +80,7 @@ d = json.load(sys.stdin)
 resp = d.get('tool_response', '')
 # Check that no raw token prefix family appears in the output
 import re
-pat = re.compile(r'(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}')
+pat = re.compile(r'(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}')
 if isinstance(resp, str):
     assert not pat.search(resp), f'token still present: {resp}'
 elif isinstance(resp, dict):
@@ -133,7 +133,7 @@ if ! command -v python3 &>/dev/null; then
 fi
 printf '  Hook: %s\n\n' "$HOOK_SCRIPT"
 
-# ── Token-family tests (1–9) ───────────────────────────────────────────────
+# ── Token-family tests (1–10) ──────────────────────────────────────────────
 
 printf '%s\n' "${TEST_BLUE}Token family coverage${TEST_NC}"
 
@@ -164,23 +164,27 @@ assert_redacted "8. xoxb- token" \
 assert_redacted "9. xoxp- token" \
 	'{"tool_response": "Slack user: xoxp-ABCDEFGHIJKLM-1234567890-abcdefghij"}'
 
+GOOGLE_OAUTH_SECRET="GOCSPX-$(printf 'a%.0s' {1..28})"
+assert_redacted "10. GOCSPX- token" \
+	"{\"tool_response\": \"client_secret=${GOOGLE_OAUTH_SECRET}\"}"
+
 # ── Edge cases ─────────────────────────────────────────────────────────────
 
 printf '\n%s\n' "${TEST_BLUE}Edge cases${TEST_NC}"
 
-assert_no_output "10. Clean input produces no output" \
+assert_no_output "11. Clean input produces no output" \
 	'{"tool_response": "git status: clean working tree"}'
 
-assert_no_output "11. Token body shorter than 10 chars not redacted" \
+assert_no_output "12. Token body shorter than 10 chars not redacted" \
 	'{"tool_response": "gho_SHORT123"}'
 
-assert_redacted "12. Multiple tokens all redacted" \
+assert_redacted "13. Multiple tokens all redacted" \
 	'{"tool_response": "key1=ghp_ABCDEFGHIJ1234567890 key2=gho_ABCDEFGHIJ1234567890"}'
 
-# Test 13: nested JSON object
+# Test 14: nested JSON object
 NESTED_PAYLOAD='{"tool_response": {"stdout": "token: ghs_ABCDEFGHIJ1234567890", "stderr": "", "exit_code": 0}}'
-output13=$(run_hook "$NESTED_PAYLOAD")
-if echo "$output13" | python3 -c "
+output14=$(run_hook "$NESTED_PAYLOAD")
+if echo "$output14" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
 assert d.get('redacted_credential') is True, 'not redacted'
@@ -188,13 +192,13 @@ resp = d.get('tool_response', {})
 assert isinstance(resp, dict), 'tool_response not dict'
 assert '[redacted-credential]' in resp.get('stdout', ''), 'token not scrubbed in stdout'
 " 2>/dev/null; then
-	pass "13. Nested dict tool_response scrubbed recursively"
+	pass "14. Nested dict tool_response scrubbed recursively"
 else
-	fail "13. Nested dict tool_response scrubbed recursively — got: $output13"
+	fail "14. Nested dict tool_response scrubbed recursively — got: $output14"
 fi
 
-# Test 14: malformed JSON exits 0
-assert_exit_zero "14. Malformed JSON exits 0 (fail-open)" \
+# Test 15: malformed JSON exits 0
+assert_exit_zero "15. Malformed JSON exits 0 (fail-open)" \
 	"not-valid-json"
 
 # ── Word-boundary anchor regression (t2892, GH#21026) ──────────────────────
@@ -262,7 +266,7 @@ BENCH_MS=$(python3 -c "
 import re, time, json
 
 CREDENTIAL_PATTERN = re.compile(
-    r'(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}',
+    r'(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}',
     re.ASCII,
 )
 filler = 'x' * 9900
@@ -280,9 +284,9 @@ print(round(avg_ms, 4))
 printf '  In-process regex per 10KB (%d runs): %sms\n' 500 "$BENCH_MS"
 
 if python3 -c "import sys; sys.exit(0 if float('$BENCH_MS') < 5 else 1)" 2>/dev/null; then
-	pass "15. Performance: ${BENCH_MS}ms per 10KB in-process (budget: <5ms)"
+	pass "23. Performance: ${BENCH_MS}ms per 10KB in-process (budget: <5ms)"
 else
-	fail "15. Performance: ${BENCH_MS}ms per 10KB in-process exceeds 5ms budget"
+	fail "23. Performance: ${BENCH_MS}ms per 10KB in-process exceeds 5ms budget"
 fi
 printf '  Note: subprocess launch adds ~50ms Python startup; in-process cost shown above.\n'
 

--- a/.agents/scripts/worker-blocker-log.mjs
+++ b/.agents/scripts/worker-blocker-log.mjs
@@ -30,7 +30,7 @@ export const DEFAULT_WORKER_BLOCKER_LOG_MAX_BYTES = 5 * 1024 * 1024;
 const MIN_LOG_MAX_BYTES = 512;
 const MAX_DETAIL_LENGTH = 500;
 const MAX_FIELD_LENGTH = 200;
-const CREDENTIAL_PATTERN = /(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
+const CREDENTIAL_PATTERN = /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 
 function cleanText(value, maxLength, options = {}) {
   if (value === null || value === undefined) return "";


### PR DESCRIPTION
## Summary

Redact GOCSPX-prefixed Google OAuth client secrets before OpenCode tool output, plugin logs, runtime events, worker blockers, session distillation, contributor insights, privacy scans, or Claude transcript hooks persist them.

## Files Changed

.agents/hooks/credential-transcript-scrub.py, .agents/plugins/opencode-aidevops/plugin-console.mjs, .agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs, .agents/scripts/contributor-insight-helper.sh, .agents/scripts/privacy-guard-helper.sh, .agents/scripts/runtime-events-payload.mjs, .agents/scripts/session-distill-helper.sh, .agents/scripts/shared-constants.sh, .agents/scripts/tests/test-credential-sanitizer.sh, .agents/scripts/tests/test-credential-transcript-scrub.sh, .agents/scripts/worker-blocker-log.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — OpenCode scrub 10/10, shell sanitizer 31/31, Python transcript hook 37/37, runtime/worker/plugin 36/36, privacy 27/27, contributor insight 35/35, session distillation, ShellCheck, and Node syntax checks pass.

Resolves #30598


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 2h 49m and 1,073,728 tokens on this with the user in an interactive session.