### PR TITLE
GH#30580: reduce dependency graph parsing in one jq pass

### DIFF
--- a/.agents/scripts/pulse-dep-graph-reduce.jq
+++ b/.agents/scripts/pulse-dep-graph-reduce.jq
@@ -1,0 +1,79 @@
+def task_id_pattern:
+  "(?:t[1-9][0-9]{0,17}(?:\\.[1-9][0-9]{0,17}){0,8}|to[0-7][0-9a-hjkmnp-tv-z]{25}-[1-9][0-9]{0,17}(?:\\.[1-9][0-9]{0,17}){0,8})";
+
+def text_value:
+  if . == null then "" elif type == "string" then . else tostring end;
+
+def valid_task_id:
+  type == "string" and test("^" + task_id_pattern + "$");
+
+def task_id_from_title:
+  text_value
+  | ((try capture("^(?<id>" + task_id_pattern + "):"; "").id catch "") // "");
+
+def without_task_brief_paths:
+  gsub("(^|[^[:alnum:]./])todo/tasks/" + task_id_pattern + "-brief\\.md(?=$|[^[:alnum:].])"; " ");
+
+def malformed_task_candidate:
+  without_task_brief_paths
+  | [scan("(^|[^[:alnum:].])([tT][0-9][[:alnum:].-]*|t[A-Z][[:alnum:].-]*|[tT][oO][[:alnum:]]{26}-[[:alnum:].-]+)(?=$|[^[:alnum:].])") | .[1]]
+  | any(.[]; (valid_task_id | not));
+
+def extracted_task_ids:
+  [scan("(^|[^[:alnum:].])(" + task_id_pattern + ")(?=$|[^[:alnum:].])") | .[1]];
+
+def blocker_text:
+  [scan("blocked[- ]by[^\\r\\n]*"; "i")] | join("\n");
+
+def defer_marker:
+  test("defer until|do[-[:space:]]not[-[:space:]]dispatch|on[-[:space:]]hold|HUMAN_UNBLOCK_REQUIRED|hold for |paused[[:space:]:]"; "i");
+
+def issue_number:
+  if type == "number" and . >= 0 and floor == . then .
+  elif type == "string" and test("^[0-9]+$") then tonumber
+  else null
+  end;
+
+def label_names:
+  [(.labels // [])[]? | .name? // empty | strings];
+
+def parsed_issue:
+  (.number | issue_number) as $number
+  | if $number == null then null else
+      (.title | task_id_from_title) as $task_id
+      | (.body | text_value) as $body
+      | ($body | blocker_text) as $blocker_text
+      | ($blocker_text | if malformed_task_candidate then ["__malformed__"] else extracted_task_ids end) as $body_task_ids
+      | (label_names) as $labels
+      | ([$labels[] | select(startswith("blocked-by:")) | ltrimstr("blocked-by:")
+          | if valid_task_id then . elif malformed_task_candidate then "__malformed__" else empty end]) as $label_task_ids
+      | (($body_task_ids + $label_task_ids) | unique | map(select(. != $task_id))) as $task_ids
+      | ([$blocker_text | scan("#[0-9]+") | ltrimstr("#")]) as $body_issue_nums
+      | ([$labels[] | select(test("^blocked-by:#[0-9]+$")) | ltrimstr("blocked-by:#")]) as $label_issue_nums
+      | (($body_issue_nums + $label_issue_nums) | unique | map(select(. != ($number | tostring)))) as $issue_nums
+      | ($body | defer_marker) as $defer
+      | {
+          number: $number,
+          state: ((.state // "OPEN") | text_value | ascii_upcase),
+          task_id: $task_id,
+          task_ids: $task_ids,
+          issue_nums: $issue_nums,
+          defer: $defer,
+          has_blockers: (($task_ids | length) > 0 or ($issue_nums | length) > 0)
+        }
+    end;
+
+reduce (.[] | parsed_issue | select(. != null)) as $issue (
+  {open_issues: [], closed_issues: [], known_issues: [], task_to_issue: {}, blocked_by: {}, defer_flags: {}};
+  .known_issues += [$issue.number]
+  | if $issue.state == "CLOSED" then .closed_issues += [$issue.number] else .open_issues += [$issue.number] end
+  | if $issue.task_id != "" then .task_to_issue[$issue.task_id] = $issue.number else . end
+  | if $issue.has_blockers and $issue.state != "CLOSED" then
+      .blocked_by[($issue.number | tostring)] = {
+        task_ids: $issue.task_ids,
+        issue_nums: $issue.issue_nums,
+        has_defer_marker: $issue.defer
+      }
+    else . end
+  | if $issue.defer then .defer_flags[($issue.number | tostring)] = true else . end
+)

--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -38,6 +38,7 @@ _pulse_dep_graph_dir="${BASH_SOURCE[0]%/*}"
 source "${_pulse_dep_graph_dir}/task-identity-lib.sh"
 # shellcheck source=./issue-hold-marker-lib.sh
 source "${_pulse_dep_graph_dir}/issue-hold-marker-lib.sh"
+DEP_GRAPH_REDUCE_FILTER="${PULSE_DEP_GRAPH_REDUCE_FILTER:-${_pulse_dep_graph_dir}/pulse-dep-graph-reduce.jq}"
 unset _pulse_dep_graph_dir
 
 #######################################
@@ -202,26 +203,48 @@ _dep_graph_prune_circular_edges() {
 # _dep_graph_process_issue_json is retained for unit testing and as a
 # reference implementation.
 #
-# Arguments: $1 - repo slug (owner/repo)
-# Output:    one JSON object on stdout
+# Arguments: $1 - issue-list JSON array
+# Output:    one unpruned JSON object on stdout
 #######################################
-_dep_graph_build_repo_data() {
-	local slug="$1"
-	local issues_json
-	if ! issues_json=$(gh_issue_list --repo "$slug" --state all --limit 500 \
-		--json number,title,body,labels,state 2>/dev/null); then
-		echo "[pulse-wrapper] dep-graph-cache: failed to list open issues for ${slug}; preserving previous repo cache when available" >>"$LOGFILE"
-		return 1
-	fi
-
+_dep_graph_build_repo_data_reference() {
+	local issues_json="$1"
 	local acc='{"open_nums":[],"closed_nums":[],"known_nums":[],"task_to_issue":{},"blocked_by_map":{},"defer_flags_map":{}}'
 	local issue_json=""
 	while IFS= read -r issue_json; do
 		[[ -n "$issue_json" ]] || continue
 		acc=$(_dep_graph_process_issue_json "$issue_json" "$acc") || return 1
 	done < <(printf '%s' "$issues_json" | jq -c '.[]' 2>/dev/null)
+	printf '%s' "$acc" | jq -c '{open_issues:.open_nums,closed_issues:.closed_nums,known_issues:.known_nums,task_to_issue:.task_to_issue,blocked_by:.blocked_by_map,defer_flags:.defer_flags_map}' || return 1
+	return 0
+}
+
+#######################################
+# Reduce one bounded issue-list response without per-issue subprocesses.
+#######################################
+_dep_graph_reduce_issues_json() {
+	local issues_json="$1"
+	[[ -f "$DEP_GRAPH_REDUCE_FILTER" ]] || return 1
+	printf '%s' "$issues_json" | jq -c -f "$DEP_GRAPH_REDUCE_FILTER" 2>/dev/null || return 1
+	return 0
+}
+
+#######################################
+# Fetch and build one repository graph through the bounded jq fast path.
+# The shell-loop implementation remains available above for parity tests.
+# Arguments: $1 - repo slug (owner/repo)
+# Output:    one pruned JSON object on stdout
+#######################################
+_dep_graph_build_repo_data() {
+	local slug="$1"
+	local issues_json=""
+	if ! issues_json=$(gh_issue_list --repo "$slug" --state all --limit 500 \
+		--json number,title,body,labels,state 2>/dev/null); then
+		echo "[pulse-wrapper] dep-graph-cache: failed to list open issues for ${slug}; preserving previous repo cache when available" >>"$LOGFILE"
+		return 1
+	fi
+
 	local parsed_repo_data=""
-	parsed_repo_data=$(printf '%s' "$acc" | jq -c '{open_issues:.open_nums,closed_issues:.closed_nums,known_issues:.known_nums,task_to_issue:.task_to_issue,blocked_by:.blocked_by_map,defer_flags:.defer_flags_map}') || return 1
+	parsed_repo_data=$(_dep_graph_reduce_issues_json "$issues_json") || return 1
 	_dep_graph_prune_circular_edges "$parsed_repo_data" || return 1
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-dep-graph-reduce.sh
+++ b/.agents/scripts/tests/test-pulse-dep-graph-reduce.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEP_GRAPH="${SCRIPT_DIR}/../pulse-dep-graph.sh"
+
+# shellcheck source=../pulse-dep-graph.sh
+source "$DEP_GRAPH"
+
+# shellcheck disable=SC2016 # JSON fixture is intentionally literal.
+fixture='[
+  {"number":1,"title":"t1: root","body":"","labels":[],"state":"OPEN"},
+  {"number":2,"title":"t2.1: child","body":"**Blocked by:** `t1`, #1\nDefer until next cycle","labels":[],"state":"OPEN"},
+  {"number":3,"title":"Not a task","body":"blocked-by:t2.1,t999","labels":[{"name":"blocked-by:#2"}],"state":"OPEN"},
+  {"number":4,"title":"to0aaaaaaaaaaaaaaaaaaaaaaaaa-12.3: namespaced","body":"BLOCKED BY t1","labels":[],"state":"CLOSED"},
+  {"number":5,"title":"t5: self edge","body":"blocked-by:t5,#5","labels":[{"name":"blocked-by:t1"}],"state":"OPEN"},
+  {"number":6,"title":"t6: malformed body","body":"blocked-by:t001","labels":[],"state":"OPEN"},
+  {"number":7,"title":"t7: malformed label","body":"","labels":[{"name":"blocked-by:t001"}],"state":"OPEN"},
+  {"number":"8","title":"t8: string number","body":"paused: awaiting decision","labels":[{"name":"blocked-by:#2"}],"state":"open"},
+  {"number":"invalid","title":"t9: ignored","body":"blocked-by:t1","labels":[],"state":"OPEN"},
+  {"number":10,"title":"t10: closed hold","body":"on hold","labels":[],"state":"CLOSED"},
+  {"number":11,"title":"t1: duplicate task mapping","body":"blocked-by:#2,#2","labels":[],"state":"OPEN"},
+  {"number":12,"title":"t12: adjacent brief paths","body":"blocked-by:todo/tasks/t1-brief.md,todo/tasks/t2.1-brief.md","labels":[],"state":"OPEN"}
+]'
+
+reference=$(_dep_graph_build_repo_data_reference "$fixture" | jq -S -c .)
+reduced=$(_dep_graph_reduce_issues_json "$fixture" | jq -S -c .)
+
+if [[ "$reference" != "$reduced" ]]; then
+	printf 'FAIL dependency graph jq reduce differs from reference\n' >&2
+	printf 'reference=%s\nreduced=%s\n' "$reference" "$reduced" >&2
+	exit 1
+fi
+
+if [[ "${PULSE_DEP_GRAPH_BENCHMARK:-0}" == "1" ]]; then
+	large_fixture=$(jq -cn '[range(1; 501) as $n | {
+		number: $n,
+		title: ("t" + ($n | tostring) + ": benchmark"),
+		body: (if $n > 1 then "blocked-by:t1,#1" else "" end),
+		labels: [],
+		state: "OPEN"
+	}]')
+	reference_start=$(date +%s)
+	_dep_graph_build_repo_data_reference "$large_fixture" >/dev/null
+	reference_seconds=$(($(date +%s) - reference_start))
+	reduced_start=$(date +%s)
+	_dep_graph_reduce_issues_json "$large_fixture" >/dev/null
+	reduced_seconds=$(($(date +%s) - reduced_start))
+	printf 'BENCHMARK issues=500 reference_seconds=%s reduce_seconds=%s\n' "$reference_seconds" "$reduced_seconds"
+fi
+
+printf 'PASS dependency graph jq reduce matches reference\n'
+exit 0


### PR DESCRIPTION
## Summary

Replace the per-issue shell and jq subprocess loop with one bounded jq reducer while retaining the shell implementation as parity evidence.

## Files Changed

.agents/scripts/pulse-dep-graph-reduce.jq, .agents/scripts/pulse-dep-graph.sh, .agents/scripts/tests/test-pulse-dep-graph-reduce.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Parity fixture passes across task IDs, blockers, issue state, defer markers, malformed values, duplicate mappings, self-edges, and adjacent brief paths; all existing dependency-graph tests and local linters pass; a 500-issue benchmark measured 39 seconds for the reference loop and less than one second for the reducer.

Resolves #30580


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 6h and 1,514,204 tokens on this with the user in an interactive session.