### PR TITLE
GH#30614: feat: add trusted-local model replay posture

### DIFF
--- a/.agents/scripts/headless-runtime-invoke.sh
+++ b/.agents/scripts/headless-runtime-invoke.sh
@@ -209,7 +209,11 @@ _invoke_opencode_prepare_child_command() {
 		if [[ "$requested_egress_mode" == "off" ]]; then
 			print_warning "Public triage ignores egress mode off; effective mode=${egress_mode}"
 		elif [[ "$egress_mode" == "$HEADLESS_EGRESS_MODE_AUTO" ]]; then
-			print_warning "Public triage whole-process egress backend unavailable; continuing with the no-tools isolated runtime (egress=logical-isolation)"
+			if [[ "$runtime_role" == "${HEADLESS_ROLE_MODEL_REPLAY:-model-replay}" ]]; then
+				print_warning "Model replay is using the explicit trusted-local posture without process-tree egress enforcement"
+			else
+				print_warning "Public triage whole-process egress backend unavailable; continuing with the no-tools isolated runtime (egress=logical-isolation)"
+			fi
 		fi
 		egress_policy_profile="provider:${_invoke_provider}"
 		sandbox_home_args=(--home-dir "$isolated_home_dir")

--- a/.agents/scripts/headless-runtime-launch.sh
+++ b/.agents/scripts/headless-runtime-launch.sh
@@ -454,11 +454,38 @@ _model_replay_runtime_profile_is_valid() {
 	return 1
 }
 
+_validate_model_replay_execution_posture() {
+	local execution_posture="$1"
+	local egress_mode="$2"
+	local egress_backend="$3"
+
+	case "$execution_posture" in
+	enforced)
+		if [[ "$egress_mode" != "required" ]]; then
+			print_error "Enforced model replay requires provider-only process-tree egress"
+			return 1
+		fi
+		;;
+	trusted-local)
+		if [[ "$egress_mode" != "auto" || -n "$egress_backend" ]]; then
+			print_error "Trusted-local model replay requires auto egress mode without a process-tree backend"
+			return 1
+		fi
+		;;
+	*)
+		print_error "Model replay received an invalid execution posture"
+		return 1
+		;;
+	esac
+	return 0
+}
+
 _validate_model_replay_args() {
 	[[ "${role:-}" == "$_HEADLESS_MODEL_REPLAY_ROLE" ]] || return 0
 	local expected_provider="${model_override%%/*}"
 	local config_dir_canonical=""
 	local config_parent_canonical=""
+	local execution_posture="${AIDEVOPS_MODEL_REPLAY_EXECUTION_POSTURE:-enforced}"
 	local worktree_base_canonical=""
 	local work_dir_canonical=""
 	local required_toggle=""
@@ -488,13 +515,16 @@ _validate_model_replay_args() {
 		return 1
 	fi
 	if [[ "${headless_runtime:-opencode}" != "opencode" ||
-		"${AIDEVOPS_WORKER_EGRESS_MODE:-}" != "required" ||
 		"${AIDEVOPS_HEADLESS_APPEND_CONTRACT:-}" != "0" ||
 		"${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-0}" == "1" ||
 		-n "${AIDEVOPS_WORKER_PREWARM_DIR:-}" ]]; then
-		print_error "Model replay requires OpenCode with the isolated sandbox and enforced provider-only egress"
+		print_error "Model replay requires OpenCode with its isolated sandbox contract"
 		return 1
 	fi
+	_validate_model_replay_execution_posture \
+		"$execution_posture" \
+		"${AIDEVOPS_WORKER_EGRESS_MODE:-}" \
+		"${AIDEVOPS_WORKER_EGRESS_BACKEND:-}" || return 1
 	if [[ ! -d "${work_dir:-}" || -L "${work_dir:-}" ||
 		! -d "${AIDEVOPS_WORKTREE_BASE_DIR:-}" || -L "${AIDEVOPS_WORKTREE_BASE_DIR:-}" ]]; then
 		print_error "Model replay requires real owned worktree directories"

--- a/.agents/scripts/model-replay-analysis.mjs
+++ b/.agents/scripts/model-replay-analysis.mjs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
-import { modelReplayExecutionPosture } from "./model-replay-contracts.mjs";
-
 function configurationKey(result) {
   return `${result.model}@${result.requested_effort}`;
 }
@@ -160,9 +158,6 @@ function confirmationRecommendation(plan, dominant) {
 }
 
 export function budgetRecommendation(plan, configurations, pairwise, completedCells) {
-  if (modelReplayExecutionPosture(plan) === "trusted-local") {
-    return recommendation("quarantine", "trusted_local_egress_unenforced");
-  }
   if (plan.integrity.non_fresh_cells.length > 0) {
     return recommendation("quarantine", "non_fresh_cells_excluded");
   }

--- a/.agents/scripts/model-replay-analysis.mjs
+++ b/.agents/scripts/model-replay-analysis.mjs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
+import { modelReplayExecutionPosture } from "./model-replay-contracts.mjs";
+
 function configurationKey(result) {
   return `${result.model}@${result.requested_effort}`;
 }
@@ -158,6 +160,9 @@ function confirmationRecommendation(plan, dominant) {
 }
 
 export function budgetRecommendation(plan, configurations, pairwise, completedCells) {
+  if (modelReplayExecutionPosture(plan) === "trusted-local") {
+    return recommendation("quarantine", "trusted_local_egress_unenforced");
+  }
   if (plan.integrity.non_fresh_cells.length > 0) {
     return recommendation("quarantine", "non_fresh_cells_excluded");
   }

--- a/.agents/scripts/model-replay-benchmark.mjs
+++ b/.agents/scripts/model-replay-benchmark.mjs
@@ -31,6 +31,7 @@ function commandPlan(options) {
     suite: options.suite || "quick",
     stage: options.stage || "primary",
     mode: options.mode || "autonomous",
+    executionPosture: options.execution_posture || "enforced",
     allowContaminated: Boolean(options.allow_contaminated),
   });
 }

--- a/.agents/scripts/model-replay-cell.mjs
+++ b/.agents/scripts/model-replay-cell.mjs
@@ -6,6 +6,10 @@ import { randomUUID } from "node:crypto";
 import { copyFileSync, readFileSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
 import {
+  modelReplayExecutionPosture,
+  RESULT_SCHEMA,
+} from "./model-replay-contracts.mjs";
+import {
   assertNoSymlinks,
   createSyntheticWorkspace,
   execute,
@@ -18,7 +22,6 @@ import {
   writeJson,
   writePrivateFile,
 } from "./model-replay-core.mjs";
-import { RESULT_SCHEMA } from "./model-replay-contracts.mjs";
 import { classifyFailure, runtimeEvidence } from "./model-replay-evidence.mjs";
 import { resultDigest, validateResult } from "./model-replay-results.mjs";
 import {
@@ -89,6 +92,11 @@ function artifactRecords(paths) {
   }]));
 }
 
+function processTreeEgressEnforcement(executionPosture, requestObserved) {
+  if (executionPosture === "trusted-local") return false;
+  return requestObserved ? true : null;
+}
+
 function writeInfrastructureAttempt({
   cell,
   plan,
@@ -100,6 +108,7 @@ function writeInfrastructureAttempt({
   patchPath,
   metricsSnapshotPath,
 }) {
+  const executionPosture = modelReplayExecutionPosture(plan);
   const attemptID = randomUUID().replaceAll("-", "").slice(0, 12);
   const preservedLogPath = join(
     experimentDir,
@@ -115,6 +124,11 @@ function writeInfrastructureAttempt({
   writeJson(attemptPath, {
     schema_version: "aidevops-model-replay-infrastructure-attempt/v1",
     experiment_id: plan.experiment_id,
+    execution_posture: executionPosture,
+    process_tree_egress_enforced: processTreeEgressEnforcement(
+      executionPosture,
+      evidence.requestObserved,
+    ),
     cell_id: cell.cell_id,
     model: cell.model,
     candidate_tier: cell.candidate_tier,
@@ -148,7 +162,14 @@ function runtimeArguments({ helper, sessionKey, workspace, promptPath, cell }) {
   return args;
 }
 
-function runtimeEnvironment(workRoot, runtimeConfig, candidates, timeoutSeconds, runtimePaths) {
+function runtimeEnvironment(
+  workRoot,
+  runtimeConfig,
+  candidates,
+  timeoutSeconds,
+  runtimePaths,
+  executionPosture,
+) {
   const environment = { ...process.env };
   for (const name of [
     "AIDEVOPS_OPENCODE_SESSION_ID",
@@ -172,9 +193,12 @@ function runtimeEnvironment(workRoot, runtimeConfig, candidates, timeoutSeconds,
     AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST: candidates.allowed_providers.join(","),
     AIDEVOPS_HEADLESS_RUNTIME_DIR: runtimePaths.state,
     AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT: String(timeoutSeconds),
+    AIDEVOPS_MODEL_REPLAY_EXECUTION_POSTURE: executionPosture,
     AIDEVOPS_OAUTH_POOL_FILE: runtimePaths.oauthPool,
     AIDEVOPS_RESOURCE_METRICS_FILE: runtimePaths.resources,
-    AIDEVOPS_WORKER_EGRESS_MODE: "required",
+    AIDEVOPS_WORKER_EGRESS_BACKEND: executionPosture === "trusted-local"
+      ? "" : environment.AIDEVOPS_WORKER_EGRESS_BACKEND,
+    AIDEVOPS_WORKER_EGRESS_MODE: executionPosture === "trusted-local" ? "auto" : "required",
     AIDEVOPS_WORKTREE_BASE_DIR: workRoot,
     OPENCODE_CONFIG: runtimeConfig.configPath,
     OPENCODE_CONFIG_DIR: runtimeConfig.configDirectory,
@@ -211,6 +235,7 @@ function outcomeFor(runtime, functionalPass, verifiedCompletion, identityVerifie
 }
 
 function resultRecord({ cell, plan, sealed, runtime, grade, evidence, artifacts }) {
+  const executionPosture = modelReplayExecutionPosture(plan);
   const functionalPass = grade.functional_passed;
   const completed = runtime.status === 0 && !runtime.timedOut;
   const identityVerified = evidence.modelMatched && evidence.tierMatched && evidence.effortSupported;
@@ -218,6 +243,11 @@ function resultRecord({ cell, plan, sealed, runtime, grade, evidence, artifacts 
   return {
     schema_version: RESULT_SCHEMA,
     experiment_id: plan.experiment_id,
+    execution_posture: executionPosture,
+    process_tree_egress_enforced: processTreeEgressEnforcement(
+      executionPosture,
+      evidence.requestObserved,
+    ),
     cell_id: cell.cell_id,
     case_id: cell.case_id,
     case_hash: cell.case_hash,
@@ -260,6 +290,7 @@ function resultRecord({ cell, plan, sealed, runtime, grade, evidence, artifacts 
 }
 
 export function executeCell({ cell, plan, sealed, corpusDir, catalog, experimentDir, candidates }) {
+  const executionPosture = modelReplayExecutionPosture(plan);
   const verified = verifyQualification(corpusDir, cell.case_id);
   const plannedCase = plan.cases.find((candidate) => candidate.case_id === cell.case_id);
   if (verified.qualification.case_hash !== cell.case_hash
@@ -312,6 +343,7 @@ export function executeCell({ cell, plan, sealed, corpusDir, catalog, experiment
         candidates,
         cell.timeout_seconds,
         runtimePaths,
+        executionPosture,
       ),
       timeout: (cell.timeout_seconds + 60) * 1000,
       maxBuffer: 50 * 1024 * 1024,
@@ -332,6 +364,11 @@ export function executeCell({ cell, plan, sealed, corpusDir, catalog, experiment
     });
     writeJson(metricsSnapshotPath, {
       session_key: sessionKey,
+      execution_posture: executionPosture,
+      process_tree_egress_enforced: processTreeEgressEnforcement(
+        executionPosture,
+        evidence.requestObserved,
+      ),
       runtime_metric: evidence.metric,
       request_usage: evidence.usage,
       resource_metric: evidence.resource,

--- a/.agents/scripts/model-replay-cell.mjs
+++ b/.agents/scripts/model-replay-cell.mjs
@@ -162,14 +162,14 @@ function runtimeArguments({ helper, sessionKey, workspace, promptPath, cell }) {
   return args;
 }
 
-function runtimeEnvironment(
+function runtimeEnvironment({
   workRoot,
   runtimeConfig,
   candidates,
   timeoutSeconds,
   runtimePaths,
   executionPosture,
-) {
+}) {
   const environment = { ...process.env };
   for (const name of [
     "AIDEVOPS_OPENCODE_SESSION_ID",
@@ -337,14 +337,14 @@ export function executeCell({ cell, plan, sealed, corpusDir, catalog, experiment
     const startedAt = Date.now();
     const run = spawnSync(args[0], args.slice(1), {
       encoding: "utf8",
-      env: runtimeEnvironment(
+      env: runtimeEnvironment({
         workRoot,
         runtimeConfig,
         candidates,
-        cell.timeout_seconds,
+        timeoutSeconds: cell.timeout_seconds,
         runtimePaths,
         executionPosture,
-      ),
+      }),
       timeout: (cell.timeout_seconds + 60) * 1000,
       maxBuffer: 50 * 1024 * 1024,
       stdio: ["ignore", "pipe", "pipe"],

--- a/.agents/scripts/model-replay-cli-options.mjs
+++ b/.agents/scripts/model-replay-cli-options.mjs
@@ -24,7 +24,7 @@ const COMMAND_OPTIONS = {
   ],
   plan: [
     "corpus", "candidates", "experiment", "experiment_id", "suite", "stage", "mode",
-    "allow_contaminated",
+    "execution_posture", "allow_contaminated",
   ],
   seal: ["experiment", "input"],
   run: ["experiment", "corpus", "catalog", "dry_run"],
@@ -46,7 +46,8 @@ Usage:
     [--repetitions N] [--allow-reconstructed] [--allow-prompt-warnings]
   brief-tier-test-helper.sh plan --corpus DIR --candidates FILE --experiment DIR \\
     --experiment-id ID [--suite quick|full] [--stage canary|primary|sweep|confirm] \\
-    [--mode autonomous|prescriptive] [--allow-contaminated]
+    [--mode autonomous|prescriptive] [--execution-posture enforced|trusted-local] \\
+    [--allow-contaminated]
   brief-tier-test-helper.sh seal --experiment DIR --input FILE
   brief-tier-test-helper.sh run --experiment DIR --corpus DIR --catalog FILE [--dry-run]
   brief-tier-test-helper.sh report --experiment DIR

--- a/.agents/scripts/model-replay-contracts.mjs
+++ b/.agents/scripts/model-replay-contracts.mjs
@@ -8,4 +8,16 @@ export const PLAN_SCHEMA = "aidevops-model-replay-plan/v1";
 export const PREDICTION_SCHEMA = "aidevops-model-replay-predictions/v1";
 export const RESULT_SCHEMA = "aidevops-model-replay-result/v1";
 export const REPORT_SCHEMA = "aidevops-model-replay-report/v1";
+export const DEFAULT_EXECUTION_POSTURE = "enforced";
+export const EXECUTION_POSTURES = Object.freeze([DEFAULT_EXECUTION_POSTURE, "trusted-local"]);
 export const TIER_RANK = Object.fromEntries(TIERS.map((tier, index) => [tier, index]));
+
+export function modelReplayExecutionPosture(plan) {
+  const posture = Object.hasOwn(plan, "execution_posture")
+    ? plan.execution_posture
+    : DEFAULT_EXECUTION_POSTURE;
+  if (!EXECUTION_POSTURES.includes(posture)) {
+    throw new Error(`Unsupported model replay execution posture: ${posture}`);
+  }
+  return posture;
+}

--- a/.agents/scripts/model-replay-plan.mjs
+++ b/.agents/scripts/model-replay-plan.mjs
@@ -3,19 +3,23 @@
 
 import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { contaminationFor, loadCandidates } from "./model-replay-candidates.mjs";
 import {
-  MODES,
+  EXECUTION_POSTURES,
+  modelReplayExecutionPosture,
+  PLAN_SCHEMA,
+} from "./model-replay-contracts.mjs";
+import {
   assertSafeID,
   loadCase,
   loadCorpus,
+  MODES,
   readJson,
   sha256,
   stableJson,
   verifyQualification,
   writeJson,
 } from "./model-replay-core.mjs";
-import { contaminationFor, loadCandidates } from "./model-replay-candidates.mjs";
-import { PLAN_SCHEMA } from "./model-replay-contracts.mjs";
 import {
   frameworkIdentity,
   resolveExperimentDirectory,
@@ -51,6 +55,7 @@ export function loadVerifiedPlan(experimentDir) {
   if (plan.schema_version !== PLAN_SCHEMA || planDigest(plan) !== plan.plan_sha256) {
     throw new Error("Experiment plan integrity check failed");
   }
+  modelReplayExecutionPosture(plan);
   return plan;
 }
 
@@ -159,13 +164,16 @@ function buildCells({ cases, candidateConfig, corpusDir, stage, mode, allowConta
   return { cells, contamination };
 }
 
-function validatePlanOptions({ experimentID, suite, stage, mode }) {
+function validatePlanOptions({ experimentID, suite, stage, mode, executionPosture }) {
   assertSafeID(experimentID, "experiment_id");
   if (!["quick", "full"].includes(suite)) throw new Error("Suite must be quick or full");
   if (!["canary", "primary", "sweep", "confirm"].includes(stage)) {
     throw new Error("Stage must be canary, primary, sweep, or confirm");
   }
   if (!MODES.includes(mode)) throw new Error("Mode must be autonomous or prescriptive");
+  if (!EXECUTION_POSTURES.includes(executionPosture)) {
+    throw new Error("Execution posture must be enforced or trusted-local");
+  }
 }
 
 function persistPlan(experimentDir, plan, candidateConfig) {
@@ -185,10 +193,11 @@ export function createPlan({
   suite = "quick",
   stage = "primary",
   mode = "autonomous",
+  executionPosture = "enforced",
   allowContaminated = false,
 }) {
   experimentDir = resolveExperimentDirectory(experimentDir, true);
-  validatePlanOptions({ experimentID, suite, stage, mode });
+  validatePlanOptions({ experimentID, suite, stage, mode, executionPosture });
   if (existsSync(join(experimentDir, "plan.json"))) {
     throw new Error("Experiment plan already exists; use a new experiment directory");
   }
@@ -213,6 +222,7 @@ export function createPlan({
     suite,
     stage,
     mode,
+    execution_posture: executionPosture,
     framework: frameworkIdentity(candidateConfig),
     candidate_config_sha256: sha256(stableJson(candidateConfig)),
     allowed_providers: candidateConfig.allowed_providers,

--- a/.agents/scripts/model-replay-report.mjs
+++ b/.agents/scripts/model-replay-report.mjs
@@ -4,17 +4,20 @@
 import { chmodSync } from "node:fs";
 import { join } from "node:path";
 import {
-  sha256File,
-  writeJson,
-  writePrivateFile,
-} from "./model-replay-core.mjs";
-import {
   budgetRecommendation,
   configurationStats,
   pairwiseSeparation,
 } from "./model-replay-analysis.mjs";
 import { predictionCalibration } from "./model-replay-calibration.mjs";
-import { REPORT_SCHEMA } from "./model-replay-contracts.mjs";
+import {
+  modelReplayExecutionPosture,
+  REPORT_SCHEMA,
+} from "./model-replay-contracts.mjs";
+import {
+  sha256File,
+  writeJson,
+  writePrivateFile,
+} from "./model-replay-core.mjs";
 import { resolveExperimentDirectory } from "./model-replay-framework.mjs";
 import {
   loadExperimentCandidates,
@@ -54,6 +57,9 @@ function markdownReport(report) {
     `- Experiment: \`${report.experiment_id}\``,
     `- Suite/stage: ${report.suite} / ${report.stage}`,
     `- Replay mode: ${report.mode}`,
+    `- Execution posture: ${report.execution_posture}`,
+    `- Process-tree egress enforced: ${report.process_tree_egress_enforced === null ? "not observed" : report.process_tree_egress_enforced ? "yes" : "no"}`,
+    `- Automatic routing from this posture: ${report.execution_posture_allows_automatic_routing ? "allowed" : "excluded"}`,
     `- Completed cells: ${report.integrity.completed_cells}/${report.integrity.planned_cells}`,
     "",
     "## Integrity",
@@ -62,6 +68,7 @@ function markdownReport(report) {
     `- Non-fresh cells admitted by override: ${report.integrity.non_fresh_cells}`,
     `- Unknown effective effort: ${report.integrity.unknown_effect_cells}`,
     `- Unverified model identity: ${report.integrity.unverified_model_cells}`,
+    `- Cells without process-tree egress enforcement: ${report.integrity.unenforced_egress_cells}`,
     `- Unknown cost: ${report.integrity.unknown_cost_cells}`,
     "",
     "## Configuration results",
@@ -105,6 +112,7 @@ export function createReport({ experimentDir }) {
   const sealed = loadSealedPredictions(experimentDir, plan);
   loadExperimentCandidates(experimentDir, plan);
   const results = validatedResultRecords(experimentDir, plan, sealed);
+  const executionPosture = modelReplayExecutionPosture(plan);
   const configurations = configurationStats(results);
   const pairwise = pairwiseSeparation(results);
   const report = {
@@ -115,6 +123,11 @@ export function createReport({ experimentDir }) {
     suite: plan.suite,
     stage: plan.stage,
     mode: plan.mode,
+    execution_posture: executionPosture,
+    process_tree_egress_enforced: results.length > 0
+      ? results.every((result) => result.process_tree_egress_enforced !== false)
+      : null,
+    execution_posture_allows_automatic_routing: executionPosture === "enforced",
     plan_sha256: plan.plan_sha256,
     prediction_seal_sha256: sealed.seal_sha256,
     integrity: {
@@ -125,6 +138,9 @@ export function createReport({ experimentDir }) {
       contamination_override: plan.integrity.contamination_override,
       unknown_effect_cells: results.filter((result) => result.effective_effort === "unknown").length,
       unverified_model_cells: results.filter((result) => result.model_matched !== true).length,
+      unenforced_egress_cells: results.filter(
+        (result) => result.process_tree_egress_enforced === false,
+      ).length,
       unknown_cost_cells: results.filter((result) => !Number.isFinite(result.cost_usd)).length,
     },
     configurations,

--- a/.agents/scripts/model-replay-report.mjs
+++ b/.agents/scripts/model-replay-report.mjs
@@ -145,7 +145,13 @@ export function createReport({ experimentDir }) {
     },
     configurations,
     pairwise_separation: pairwise,
-    budget_recommendation: budgetRecommendation(plan, configurations, pairwise, results.length),
+    budget_recommendation: executionPosture === "trusted-local"
+      ? {
+        action: "quarantine",
+        reason: "trusted_local_egress_unenforced",
+        dominant_configuration: "",
+      }
+      : budgetRecommendation(plan, configurations, pairwise, results.length),
     prediction_calibration: predictionCalibration(plan, sealed, results),
   };
   writeJson(join(experimentDir, "report.json"), report);

--- a/.agents/scripts/model-replay-results.mjs
+++ b/.agents/scripts/model-replay-results.mjs
@@ -10,12 +10,16 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import {
+  DEFAULT_EXECUTION_POSTURE,
+  modelReplayExecutionPosture,
+  RESULT_SCHEMA,
+} from "./model-replay-contracts.mjs";
+import {
   pathInside,
   sha256,
   sha256File,
   stableJson,
 } from "./model-replay-core.mjs";
-import { RESULT_SCHEMA } from "./model-replay-contracts.mjs";
 
 export function resultRecords(experimentDir) {
   const path = join(experimentDir, "results.jsonl");
@@ -75,6 +79,22 @@ function validateResultArtifacts(result, cell, experimentDir) {
   }
 }
 
+function resultContainmentMatches(result, plan) {
+  const expectedPosture = modelReplayExecutionPosture(plan);
+  if (Object.hasOwn(plan, "execution_posture")) {
+    if (typeof result.execution_posture !== "string"
+      || typeof result.process_tree_egress_enforced !== "boolean") return false;
+  }
+  const resultPosture = Object.hasOwn(result, "execution_posture")
+    ? result.execution_posture
+    : DEFAULT_EXECUTION_POSTURE;
+  const processTreeEgressEnforced = Object.hasOwn(result, "process_tree_egress_enforced")
+    ? result.process_tree_egress_enforced
+    : true;
+  return resultPosture === expectedPosture
+    && processTreeEgressEnforced === (expectedPosture === "enforced");
+}
+
 function resultIdentityMatches(result, cell, plan, sealed) {
   const expected = {
     schema_version: RESULT_SCHEMA,
@@ -93,7 +113,8 @@ function resultIdentityMatches(result, cell, plan, sealed) {
     mode: plan.mode,
     prediction_seal_sha256: sealed.seal_sha256,
   };
-  return Object.entries(expected).every(([field, value]) => result[field] === value);
+  return Object.entries(expected).every(([field, value]) => result[field] === value)
+    && resultContainmentMatches(result, plan);
 }
 
 function verificationState(result, plannedCase) {

--- a/.agents/scripts/model-replay-runner.mjs
+++ b/.agents/scripts/model-replay-runner.mjs
@@ -3,6 +3,8 @@
 
 import { rmSync } from "node:fs";
 import { join } from "node:path";
+import { executeCell } from "./model-replay-cell.mjs";
+import { modelReplayExecutionPosture } from "./model-replay-contracts.mjs";
 import {
   appendJsonLine,
   createSyntheticWorkspace,
@@ -11,8 +13,7 @@ import {
   verifyQualification,
   writeJson,
 } from "./model-replay-core.mjs";
-import { executeCell } from "./model-replay-cell.mjs";
-import { validateRuntimeContract, resolveExperimentDirectory } from "./model-replay-framework.mjs";
+import { resolveExperimentDirectory, validateRuntimeContract } from "./model-replay-framework.mjs";
 import {
   loadExperimentCandidates,
   loadVerifiedPlan,
@@ -61,6 +62,7 @@ function createDryRunRecord({ experimentDir, plan, sealed, pending }) {
   return {
     schema_version: "aidevops-model-replay-dry-run/v1",
     experiment_id: plan.experiment_id,
+    execution_posture: modelReplayExecutionPosture(plan),
     plan_sha256: plan.plan_sha256,
     prediction_seal_sha256: sealed.seal_sha256,
     pending_cells: pending.map((cell) => ({
@@ -119,7 +121,9 @@ export function runExperiment({ experimentDir, corpusDir, catalogPath, dryRun = 
     }
     const lockedResults = validatedResultRecords(experimentDir, plan, sealed);
     const executableCells = pendingCells(plan, lockedResults);
-    if (executableCells.length > 0) assertModelReplayEgressConfigured();
+    if (executableCells.length > 0 && modelReplayExecutionPosture(plan) === "enforced") {
+      assertModelReplayEgressConfigured();
+    }
     const results = executePendingCells({
       cells: executableCells,
       plan,
@@ -129,7 +133,11 @@ export function runExperiment({ experimentDir, corpusDir, catalogPath, dryRun = 
       experimentDir,
       candidates,
     });
-    return { experiment_id: plan.experiment_id, results };
+    return {
+      experiment_id: plan.experiment_id,
+      execution_posture: modelReplayExecutionPosture(plan),
+      results,
+    };
   } finally {
     releaseLock();
   }

--- a/.agents/scripts/tests/model-replay-benchmark-fixture.mjs
+++ b/.agents/scripts/tests/model-replay-benchmark-fixture.mjs
@@ -46,7 +46,11 @@ done
 [ -f "$OPENCODE_CONFIG" ] || exit 12
 case "$work_dir" in "$AIDEVOPS_WORKTREE_BASE_DIR"/*) ;; *) exit 13 ;; esac
 [ "$AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT" = "60" ] || exit 14
-[ "$AIDEVOPS_WORKER_EGRESS_MODE" = "required" ] || exit 15
+case "$AIDEVOPS_MODEL_REPLAY_EXECUTION_POSTURE:$AIDEVOPS_WORKER_EGRESS_MODE" in
+  enforced:required) ;;
+  trusted-local:auto) [ -z "\${AIDEVOPS_WORKER_EGRESS_BACKEND:-}" ] || exit 24 ;;
+  *) exit 15 ;;
+esac
 [ "$tier" = "simple" ] || exit 16
 [ -z "\${OPENCODE_SERVER_PASSWORD:-}" ] || exit 17
 [ -z "\${AIDEVOPS_HEADLESS_VARIANT:-}\${AIDEVOPS_HEADLESS_VARIANT_SIMPLE:-}" ] || exit 18

--- a/.agents/scripts/tests/test-headless-runtime-provider-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-provider-tests.sh
@@ -472,6 +472,8 @@ JSON
 	local AIDEVOPS_HEADLESS_APPEND_CONTRACT=0
 	local AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST="openai"
 	local AIDEVOPS_HEADLESS_SANDBOX_DISABLED=0
+	local AIDEVOPS_MODEL_REPLAY_EXECUTION_POSTURE=""
+	local AIDEVOPS_WORKER_EGRESS_BACKEND=""
 	local AIDEVOPS_WORKER_EGRESS_MODE="required"
 	local AIDEVOPS_WORKTREE_BASE_DIR="$replay_root"
 	local OPENCODE_CONFIG="${config_dir}/opencode.json"
@@ -489,21 +491,37 @@ JSON
 	local OPENCODE_DISABLE_SHARE=1
 	local OPENCODE_PURE=1
 	local -a extra_args=()
-	local valid_status=0 invalid_status=0 prewarm_status=0
+	local valid_status=0 trusted_status=0 backend_status=0 mismatch_status=0 invalid_posture_status=0
+	local invalid_status=0 prewarm_status=0
 
 	_validate_model_replay_args >/dev/null 2>&1 || valid_status=$?
+	AIDEVOPS_MODEL_REPLAY_EXECUTION_POSTURE="trusted-local"
+	AIDEVOPS_WORKER_EGRESS_MODE="auto"
+	_validate_model_replay_args >/dev/null 2>&1 || trusted_status=$?
+	AIDEVOPS_WORKER_EGRESS_BACKEND="/configured/backend"
+	_validate_model_replay_args >/dev/null 2>&1 || backend_status=$?
+	AIDEVOPS_WORKER_EGRESS_BACKEND=""
+	AIDEVOPS_WORKER_EGRESS_MODE="required"
+	_validate_model_replay_args >/dev/null 2>&1 || mismatch_status=$?
+	AIDEVOPS_MODEL_REPLAY_EXECUTION_POSTURE="invalid"
+	AIDEVOPS_WORKER_EGRESS_MODE="auto"
+	_validate_model_replay_args >/dev/null 2>&1 || invalid_posture_status=$?
+	AIDEVOPS_MODEL_REPLAY_EXECUTION_POSTURE=""
+	AIDEVOPS_WORKER_EGRESS_MODE="required"
 	local AIDEVOPS_WORKER_PREWARM_DIR="${TEST_ROOT}/stale-model-replay-prewarm"
 	_validate_model_replay_args >/dev/null 2>&1 || prewarm_status=$?
 	unset AIDEVOPS_WORKER_PREWARM_DIR
 	session_key="issue-30560"
 	_validate_model_replay_args >/dev/null 2>&1 || invalid_status=$?
-	if [[ "$valid_status" -eq 0 && "$prewarm_status" -ne 0 && "$invalid_status" -ne 0 ]]; then
+	if [[ "$valid_status" -eq 0 && "$trusted_status" -eq 0 && "$backend_status" -ne 0 &&
+		"$mismatch_status" -ne 0 &&
+		"$invalid_posture_status" -ne 0 && "$prewarm_status" -ne 0 && "$invalid_status" -ne 0 ]]; then
 		print_result "model replay requires its fresh trusted runtime profile" 0
 		return 0
 	fi
 
 	print_result "model replay requires its fresh trusted runtime profile" 1 \
-		"valid_status=$valid_status prewarm_status=$prewarm_status invalid_status=$invalid_status"
+		"valid=$valid_status trusted=$trusted_status backend=$backend_status mismatch=$mismatch_status posture=$invalid_posture_status prewarm=$prewarm_status invalid=$invalid_status"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-model-replay-benchmark.mjs
+++ b/.agents/scripts/tests/test-model-replay-benchmark.mjs
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { modelReplayExecutionPosture } from "../model-replay-contracts.mjs";
 import {
   completedPredictions,
   createReplayFixture,
@@ -28,6 +29,11 @@ const fixture = createReplayFixture();
 const { sandbox } = fixture;
 
 try {
+  assert.equal(modelReplayExecutionPosture({}), "enforced");
+  assert.throws(
+    () => modelReplayExecutionPosture({ execution_posture: "" }),
+    /Unsupported model replay execution posture/u,
+  );
   const {
     repository,
     inputs,
@@ -253,6 +259,14 @@ try {
     "--experiment", join(sandbox, "claude-runtime-experiment"),
     "--experiment-id", "claude-runtime", "--suite", "quick",
   );
+  expectFailure(
+    environment,
+    /Execution posture must be enforced or trusted-local/u,
+    "plan", "--corpus", corpus, "--candidates", candidates,
+    "--experiment", join(sandbox, "invalid-posture-experiment"),
+    "--experiment-id", "invalid-posture", "--suite", "quick",
+    "--execution-posture", "invalid",
+  );
 
   const experiment = join(sandbox, "experiment-autonomous");
   const plan = invokeRequired(
@@ -262,6 +276,7 @@ try {
     "--suite", "quick", "--stage", "primary", "--mode", "autonomous",
   );
   assert.equal(plan.cells.length, 1);
+  assert.equal(plan.execution_posture, "enforced");
   const predictionInput = join(sandbox, "predictions-autonomous.json");
   writeJson(predictionInput, completedPredictions(experiment));
   invokeRequired(environment, "seal", "--experiment", experiment, "--input", predictionInput);
@@ -286,6 +301,7 @@ try {
     "run", "--experiment", experiment, "--corpus", corpus, "--catalog", catalog, "--dry-run",
   );
   assert.equal(dryRun.provider_calls_made, 0);
+  assert.equal(dryRun.execution_posture, "enforced");
   assert.equal(existsSync(runtimeMarker), false);
   assert.equal(existsSync(join(experiment, "report.json")), true);
   invokeRequired(environment, "report", "--experiment", experiment);
@@ -377,6 +393,32 @@ try {
     environment,
     "seal", "--experiment", noChangeExperiment, "--input", noChangePredictions,
   );
+  const trustedLocalExperiment = join(sandbox, "experiment-trusted-local");
+  const trustedLocalPlan = invokeRequired(
+    environment,
+    "plan", "--corpus", corpus, "--candidates", candidates,
+    "--experiment", trustedLocalExperiment, "--experiment-id", "fixture-trusted-local",
+    "--suite", "quick", "--stage", "primary", "--mode", "autonomous",
+    "--execution-posture", "trusted-local",
+  );
+  assert.equal(trustedLocalPlan.execution_posture, "trusted-local");
+  const trustedLocalPredictions = join(sandbox, "predictions-trusted-local.json");
+  writeJson(trustedLocalPredictions, completedPredictions(trustedLocalExperiment));
+  invokeRequired(
+    environment,
+    "seal", "--experiment", trustedLocalExperiment, "--input", trustedLocalPredictions,
+  );
+  const trustedLocalPlanPath = join(trustedLocalExperiment, "plan.json");
+  const originalTrustedLocalPlan = readFileSync(trustedLocalPlanPath, "utf8");
+  const tamperedTrustedLocalPlan = JSON.parse(originalTrustedLocalPlan);
+  tamperedTrustedLocalPlan.execution_posture = "enforced";
+  writeJson(trustedLocalPlanPath, tamperedTrustedLocalPlan);
+  expectFailure(
+    environment,
+    /plan integrity check failed/u,
+    "report", "--experiment", trustedLocalExperiment,
+  );
+  writeFileSync(trustedLocalPlanPath, originalTrustedLocalPlan, { mode: 0o600 });
 
   const runLock = join(experiment, "run.lock");
   writeFileSync(runLock, "fixture\n", { mode: 0o600 });
@@ -418,9 +460,31 @@ try {
     "utf8",
   ));
   assert.equal(infrastructureAttempt.runtime_status, 126);
+  assert.equal(infrastructureAttempt.execution_posture, "enforced");
+  assert.equal(infrastructureAttempt.process_tree_egress_enforced, null);
   assert.equal(infrastructureAttempt.provider_request_observed, false);
   assert.equal(existsSync(join(experiment, infrastructureAttempt.log.path)), true);
   assert.equal(existsSync(runtimeMarker), false);
+
+  const trustedLocalRun = invokeRequired(
+    environment,
+    "run", "--experiment", trustedLocalExperiment, "--corpus", corpus,
+    "--catalog", catalog,
+  );
+  assert.equal(trustedLocalRun.execution_posture, "trusted-local");
+  assert.equal(trustedLocalRun.results[0].outcome, "pass");
+  assert.equal(trustedLocalRun.results[0].execution_posture, "trusted-local");
+  assert.equal(trustedLocalRun.results[0].process_tree_egress_enforced, false);
+  const trustedLocalReport = invokeRequired(
+    environment,
+    "report", "--experiment", trustedLocalExperiment,
+  );
+  assert.equal(trustedLocalReport.execution_posture, "trusted-local");
+  assert.equal(trustedLocalReport.process_tree_egress_enforced, false);
+  assert.equal(trustedLocalReport.execution_posture_allows_automatic_routing, false);
+  assert.equal(trustedLocalReport.integrity.unenforced_egress_cells, 1);
+  assert.equal(trustedLocalReport.budget_recommendation.action, "quarantine");
+  assert.equal(trustedLocalReport.budget_recommendation.reason, "trusted_local_egress_unenforced");
 
   const noChangeRun = invokeRequired(
     { ...environment, AIDEVOPS_TEST_NO_CHANGE: "1" },
@@ -443,6 +507,8 @@ try {
   );
   assert.equal(run.results.length, 1);
   assert.equal(run.results[0].outcome, "pass");
+  assert.equal(run.results[0].execution_posture, "enforced");
+  assert.equal(run.results[0].process_tree_egress_enforced, true);
   assert.equal(run.results[0].concrete_model, "openai/replay-fixture");
   assert.equal(run.results[0].routing_tier, "simple");
   assert.equal(run.results[0].tier_matched, true);
@@ -469,6 +535,10 @@ try {
 
   const finalReport = invokeRequired(environment, "report", "--experiment", experiment);
   assert.equal(finalReport.integrity.completed_cells, 1);
+  assert.equal(finalReport.execution_posture, "enforced");
+  assert.equal(finalReport.process_tree_egress_enforced, true);
+  assert.equal(finalReport.execution_posture_allows_automatic_routing, true);
+  assert.equal(finalReport.integrity.unenforced_egress_cells, 0);
   assert.equal(finalReport.integrity.unknown_cost_cells, 0);
   assert.equal(finalReport.configurations[0].completed_pass_rate, 1);
 
@@ -482,6 +552,16 @@ try {
   const resultModule = await import(
     pathToFileURL(join(scriptDirectory, "model-replay-results.mjs")).href
   );
+  const forgedContainment = structuredClone(run.results[0]);
+  forgedContainment.process_tree_egress_enforced = false;
+  forgedContainment.result_sha256 = resultModule.resultDigest(forgedContainment);
+  writeFileSync(resultsPath, `${JSON.stringify(forgedContainment)}\n`, { mode: 0o600 });
+  expectFailure(
+    environment,
+    /Result identity mismatch/u,
+    "report", "--experiment", experiment,
+  );
+  writeFileSync(resultsPath, originalResults, { mode: 0o600 });
   const wrongTierResult = structuredClone(run.results[0]);
   wrongTierResult.routing_tier = "standard";
   wrongTierResult.tier_matched = false;

--- a/.agents/workflows/optimize-tiers.md
+++ b/.agents/workflows/optimize-tiers.md
@@ -132,8 +132,14 @@ The modes must never be aggregated.
   --experiment-id quick-primary-autonomous \
   --suite quick \
   --stage primary \
-  --mode autonomous
+  --mode autonomous \
+  --execution-posture enforced
 ```
+
+The default `enforced` posture requires verified provider-only process-tree
+egress. For a curated V1 experiment on an operator-controlled machine, select
+`--execution-posture trusted-local` explicitly. The posture is sealed into the
+plan and cannot be changed later; create a new experiment to change it.
 
 Fill every field in `prediction-template.json` before any provider call, then
 seal it. The CLI will not replace or reseal an existing prediction ledger.
@@ -171,16 +177,23 @@ similarity and LLM grading are excluded. Reports compare completion, functional
 correctness, model/effort evidence, duration, cost when observed, failure class,
 pairwise separation, and sealed-prediction calibration.
 
-Model execution requires the restricted OpenCode profile, scoped provider auth,
-an isolated sandbox, and enforced provider-only whole-process egress. A pass also
-requires a concrete structured provider-request record and resource metric. The
-captured patch is reapplied to another clean synthetic base and regraded; prompt,
-log, metrics, and patch hashes remain bound to the append-only result record.
-Dry runs never contact providers and do not require an egress backend. Before a
-real run, set `AIDEVOPS_WORKER_EGRESS_BACKEND` to an absolute executable that
-implements the v1 kernel/equivalent contract documented by
-`sandbox-exec-helper.sh`; model replay fails before provider execution when this
+Every execution posture requires the restricted OpenCode profile, scoped
+provider auth, isolated sandbox, disabled MCP/subagents/shell/network tools, and
+concrete provider-request plus resource evidence. The captured patch is reapplied
+to another clean synthetic base and regraded; prompt, log, metrics, and patch
+hashes remain bound to the append-only result record.
+
+Dry runs never contact providers and do not require an egress backend. Before an
+`enforced` real run, set `AIDEVOPS_WORKER_EGRESS_BACKEND` to an absolute
+executable that implements the v1 kernel/equivalent contract documented by
+`sandbox-exec-helper.sh`; the run fails before provider execution when this
 trusted operator prerequisite is absent. Never use a test fixture backend.
+
+`trusted-local` deliberately records that process-tree egress was not enforced.
+It is only for curated local experiments on an operator-controlled machine. Its
+correctness, cost, duration, identity, and resource observations remain visible,
+but reports quarantine them from automatic routing or release recommendations.
+It never weakens public triage, worker, or other runtime roles.
 Each deterministic check receives a disposable patch snapshot in a separate
 filesystem-deny sandbox, so check-time writes cannot affect later checks. The
 current enforcing backend is macOS Seatbelt; qualification fails closed on hosts


### PR DESCRIPTION
## Summary

Implementation for issue #30614.

## Files Changed

.agents/scripts/headless-runtime-invoke.sh, .agents/scripts/headless-runtime-launch.sh, .agents/scripts/model-replay-benchmark.mjs, .agents/scripts/model-replay-cell.mjs, .agents/scripts/model-replay-cli-options.mjs, .agents/scripts/model-replay-contracts.mjs, .agents/scripts/model-replay-plan.mjs, .agents/scripts/model-replay-report.mjs, .agents/scripts/model-replay-results.mjs, .agents/scripts/model-replay-runner.mjs, .agents/scripts/tests/model-replay-benchmark-fixture.mjs, .agents/scripts/tests/test-headless-runtime-provider-tests.sh, .agents/scripts/tests/test-model-replay-benchmark.mjs, .agents/workflows/optimize-tiers.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30614


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1d and 5,844,057 tokens on this with the user in an interactive session.