### PR TITLE
GH#30581: scope mirror provenance to helper workflows

### DIFF
--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -463,11 +463,24 @@ _extract_ref_pin() {
 	return 0
 }
 
+# Return success only for reusable workflows that fetch framework helpers from
+# the configured aidevops repository. Self-contained workflows must not inherit
+# helper provenance inputs merely because they expose an aidevops_ref input for
+# API consistency.
+_workflow_fetches_framework_helpers() {
+	local _workflow_name="$1"
+	case "$_workflow_name" in
+	issue-sync | review-bot-gate | loc-badge) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
 # Render the caller template with a target reusable repo/ref, writing to stdout.
 _render_template_with_target() {
 	local _template="$1"
 	local _repo="$2"
 	local _ref="$3"
+	local _workflow_name="$4"
 	# Escape sed replacement special chars (&, |) before interpolation.
 	local _repo_escaped _ref_escaped
 	_repo_escaped=$(_escape_sed_replacement "$_repo")
@@ -481,11 +494,12 @@ _render_template_with_target() {
 		-e 's|marcusquinn/aidevops(/\.github/workflows/[^[:space:]]+)|'"$_repo_escaped"'\1|g' \
 		-e 's|^(      aidevops_ref:).*$|\1 '"$_ref_escaped"'|' \
 		"$_template")
-	# Existing pinned reusable versions already accept aidevops_ref. The new
-	# repository input is emitted only for configured mirrors, which must update
-	# their reusable workflow before callers are resynced.
+	# Helper-bearing reusable workflows must bind helper checkout provenance to
+	# the configured mirror. Self-contained workflows keep their original caller
+	# contract even when they expose an aidevops_ref input for API consistency.
 	if [[ "$_repo" != "$_DEFAULT_WORKFLOW_REUSABLE_REPO" ]] && \
-		printf '%s\n' "$_rendered" | grep -qE '^      aidevops_ref:'; then
+		_workflow_fetches_framework_helpers "$_workflow_name"; then
+		printf '%s\n' "$_rendered" | grep -qE '^      aidevops_ref:' || return 1
 		_rendered=$(printf '%s\n' "$_rendered" | sed -E \
 			's|^(      aidevops_ref:.*)$|      aidevops_repository: '"$_repo_escaped"'\n\1|'
 		)
@@ -1222,14 +1236,16 @@ _sync_open_pr() {
 	return 0
 }
 
-# _render_sync_target <template> <target-repo> <effective-ref> <slug>
+# _render_sync_target <template> <target-repo> <effective-ref> <slug> <workflow-name>
 _render_sync_target() {
 	local _template="$1"
 	local _target_repo="$2"
 	local _effective_ref="$3"
 	local _slug="$4"
+	local _workflow_name="$5"
 	local _content
-	_content=$(_render_template_with_target "$_template" "$_target_repo" "$_effective_ref") || return 1
+	_content=$(_render_template_with_target \
+		"$_template" "$_target_repo" "$_effective_ref" "$_workflow_name") || return 1
 	local _runner_override
 	_runner_override=$(_read_runner_field "$_slug")
 	if [[ -n "$_runner_override" ]]; then
@@ -1369,7 +1385,7 @@ _sync_one_repo() {
 	local _effective_ref
 	_effective_ref=$(_resolve_effective_ref "$_status" "$_workflow" "$_target_ref" "$_force_ref")
 	local _target_content
-	if ! _target_content=$(_render_sync_target "$_template" "$_target_repo" "$_effective_ref" "$_slug"); then
+	if ! _target_content=$(_render_sync_target "$_template" "$_target_repo" "$_effective_ref" "$_slug" "$_workflow_name"); then
 		printf '%s\t%s\t%s\ttemplate render failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
 		return 1
 	fi
@@ -1532,7 +1548,7 @@ _process_rows() {
 		_effective_ref=$(_resolve_effective_ref \
 			"$_status" "$_path/$_workflow_relpath" "$_target_ref_arg" "$_OPT_FORCE_REF")
 		if [[ "$_target_repo" != "$_DEFAULT_WORKFLOW_REUSABLE_REPO" ]] && \
-			grep -qE '^      aidevops_ref:' "$_template" && \
+			_workflow_fetches_framework_helpers "$_workflow_name" && \
 			! _mirror_supports_helper_provenance "$_target_repo" "$_workflow_name" "$_effective_ref"; then
 			_result="${_slug}"$'\t'"${_status}"$'\t'"${_STATUS_FAILED}"$'\t'"configured mirror must be registered and updated at ${_effective_ref} before caller sync"
 			_any_failed=1

--- a/.agents/scripts/tests/test-sync-workflows-mirror-provenance.sh
+++ b/.agents/scripts/tests/test-sync-workflows-mirror-provenance.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Focused mirror helper-provenance capability tests (GH#30581).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/../sync-workflows-helper.sh"
+TEMPLATES="$SCRIPT_DIR/../../templates/workflows"
+PASS=0
+FAIL=0
+
+assert_case() {
+	local description="$1"
+	local expected_rc="$2"
+	local actual_rc="$3"
+	local output="$4"
+	local expected_text="$5"
+	if [[ "$actual_rc" -eq "$expected_rc" && "$output" == *"$expected_text"* ]]; then
+		printf 'PASS %s\n' "$description"
+		PASS=$((PASS + 1))
+	else
+		printf 'FAIL %s: rc=%s expected=%s output=%s\n' \
+			"$description" "$actual_rc" "$expected_rc" "$output" >&2
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+init_mirror() {
+	local root="$1"
+	local workflow_name="$2"
+	local content="$3"
+	local mirror="$root/mirror"
+	mkdir -p "$mirror/.github/workflows"
+	git -C "$mirror" init -q
+	git -C "$mirror" config user.email test@example.com
+	git -C "$mirror" config user.name Test
+	git -C "$mirror" config commit.gpgsign false
+	git -C "$mirror" symbolic-ref HEAD refs/heads/main
+	printf '%s\n' "$content" >"$mirror/.github/workflows/${workflow_name}-reusable.yml"
+	git -C "$mirror" add -A
+	git -C "$mirror" commit -q -m "mirror fixture"
+	return 0
+}
+
+write_repos_json() {
+	local root="$1"
+	local target_slug="$2"
+	local target_path="$3"
+	mkdir -p "$root/.config/aidevops"
+	printf '%s\n' \
+		"{\"workflow_reusable_repo\":\"ORG/.github\",\"initialized_repos\":[{\"path\":\"$target_path\",\"slug\":\"$target_slug\"},{\"path\":\"$root/mirror\",\"slug\":\"ORG/.github\"}]}" > \
+		"$root/.config/aidevops/repos.json"
+	return 0
+}
+
+TEST_ROOT="$(mktemp -d)" || exit 1
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+HELPER_ROOT="$TEST_ROOT/helper"
+HELPER_TARGET="$HELPER_ROOT/target"
+mkdir -p "$HELPER_TARGET/.github/workflows"
+printf '%s\n' 'name: legacy issue sync' >"$HELPER_TARGET/.github/workflows/issue-sync.yml"
+init_mirror "$HELPER_ROOT" "issue-sync" "name: stale helper-bearing reusable"
+write_repos_json "$HELPER_ROOT" "owner/helper-target" "$HELPER_TARGET"
+helper_output=$(HOME="$HELPER_ROOT" bash "$HELPER" \
+	--repo owner/helper-target --workflow issue-sync 2>&1)
+helper_rc=$?
+assert_case "helper-bearing mirror remains fail-closed" 1 "$helper_rc" "$helper_output" \
+	"configured mirror must be registered and updated"
+
+SELF_ROOT="$TEST_ROOT/self-contained"
+SELF_TARGET="$SELF_ROOT/target"
+mkdir -p "$SELF_TARGET/.github/workflows" \
+	"$SELF_ROOT/.aidevops/agents/templates/workflows"
+printf '%s\n' 'name: legacy maintainer gate' > \
+	"$SELF_TARGET/.github/workflows/maintainer-gate.yml"
+# Presence of an aidevops_ref input must not imply a helper checkout.
+sed '/^    secrets: inherit$/i\
+    with:\
+      aidevops_ref: main' "$TEMPLATES/maintainer-gate-caller.yml" > \
+	"$SELF_ROOT/.aidevops/agents/templates/workflows/maintainer-gate-caller.yml"
+init_mirror "$SELF_ROOT" "maintainer-gate" \
+	"name: self-contained reusable without helper provenance"
+write_repos_json "$SELF_ROOT" "owner/self-contained-target" "$SELF_TARGET"
+self_output=$(HOME="$SELF_ROOT" bash "$HELPER" \
+	--repo owner/self-contained-target --workflow maintainer-gate 2>&1)
+self_rc=$?
+assert_case "self-contained mirror remains syncable" 0 "$self_rc" "$self_output" "PLANNED"
+
+printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Replace aidevops_ref inference with an explicit helper-fetch capability contract so self-contained mirrored workflows can sync without impossible provenance fields.

## Files Changed

.agents/scripts/sync-workflows-helper.sh, .agents/scripts/tests/test-sync-workflows-mirror-provenance.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused mirror fixtures pass for self-contained maintainer-gate sync and fail-closed stale issue-sync provenance; workflow classifier suites pass 66 checks; ShellCheck, complexity ratchets, and local linters pass.

Resolves #30581


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 7h 19m and 1,673,085 tokens on this with the user in an interactive session.