### PR TITLE
GH#30610: fix: bound GitHub hot-path operations

### DIFF
--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -13,6 +13,16 @@
 #     Check whether an issue already has open or merged PR evidence.
 #     Exit 0 = PR evidence exists (do NOT dispatch), exit 1 = no evidence.
 
+_ddpr_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 #######################################
 # Read the current issue body from the canonical dispatch metadata bundle.
 #
@@ -101,7 +111,7 @@ _ddpr_graphql_open_siblings() {
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="dispatch-dedup-open-siblings-exact-cost" \
-		gh api graphql -F queryString="$search_query" -f query='
+		_ddpr_gh_read gh api graphql -F queryString="$search_query" -f query='
 		query($queryString: String!) {
 			search(type: ISSUE, query: $queryString, first: 20) {
 				nodes {
@@ -175,7 +185,7 @@ _ddpr_graphql_open_commits() {
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="dispatch-dedup-open-commits-exact-cost" \
-		gh api graphql -f owner="$owner" -f name="$repo" -f query='
+		_ddpr_gh_read gh api graphql -f owner="$owner" -f name="$repo" -f query='
 		query($owner: String!, $name: String!) {
 			repository(owner: $owner, name: $name) {
 				pullRequests(

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -78,6 +78,16 @@ _DSI_JSON_TRUE="true"
 _DSI_DEFAULT_CANARY_TIMEOUT_SECONDS=180
 _DSI_READY_PREPARATION_ALLOWANCE_SECONDS=60
 _DSI_CLAIM_WON=0
+
+_dsi_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
 _DSI_CLAIM_COMMENT_ID=""
 _DSI_TARGET_JSON=""
 _DSI_GIT_AUTH_TOKEN_FILE=""
@@ -1545,7 +1555,7 @@ _dsi_resolve_runner_login() {
 		return 0
 	fi
 
-	runner_login=$(gh api graphql \
+	runner_login=$(_dsi_gh_read gh api graphql \
 		-f 'query=query { viewer { login } }' \
 		--jq '.data.viewer.login // ""' 2>/dev/null || true)
 	if [[ "$runner_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -30,6 +30,16 @@ _FULL_LOOP_MERGE_LIB_LOADED=1
 FULL_LOOP_MERGE_SUBJECT_FLAG="--subject"
 FULL_LOOP_MERGE_BODY_FILE_FLAG="--body-file"
 
+_flm_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	_lib_path="${BASH_SOURCE[0]%/*}"
@@ -265,7 +275,7 @@ _merge_confirmed_closing_issue_numbers() {
 	local result=""
 	[[ "$repo" == */* && "$pr_number" =~ ^[0-9]+$ ]] || return 1
 	# shellcheck disable=SC2016
-	result=$(gh api graphql -f query='
+	result=$(_flm_gh_read gh api graphql -f query='
 query($owner:String!,$name:String!,$number:Int!) {
   repository(owner:$owner,name:$name) {
     nameWithOwner

--- a/.agents/scripts/gh-api-aggregate.awk
+++ b/.agents/scripts/gh-api-aggregate.awk
@@ -16,6 +16,9 @@ BEGIN {
 	logical_events = 0
 	cache_events = 0
 	evidence_events = 0
+	timeout_events = 0
+	timeout_elapsed_ms = 0
+	unknown_timeout_elapsed_events = 0
 	legacy_events = 0
 	attempted_requests = 0
 	opaque_paginated_attempts = 0
@@ -83,6 +86,9 @@ function emit_group(title, group,    pair, parts, values, n, i, value) {
 		printf "      \"logical_events\": %d,\n", metric_get(group, value, "logical_events")
 		printf "      \"cache_events\": %d,\n", metric_get(group, value, "cache_events")
 		printf "      \"evidence_events\": %d,\n", metric_get(group, value, "evidence_events")
+		printf "      \"timeout_events\": %d,\n", metric_get(group, value, "timeout_events")
+		printf "      \"timeout_elapsed_ms\": %d,\n", metric_get(group, value, "timeout_elapsed_ms")
+		printf "      \"unknown_timeout_elapsed_events\": %d,\n", metric_get(group, value, "unknown_timeout_elapsed_events")
 		printf "      \"legacy_events\": %d,\n", metric_get(group, value, "legacy_events")
 		printf "      \"attempted_requests\": %d,\n", metric_get(group, value, "attempted_requests")
 		printf "      \"opaque_paginated_attempts\": %d,\n", metric_get(group, value, "opaque_paginated_attempts")
@@ -216,6 +222,19 @@ $1 !~ /^[0-9]+$/ || NF < 3 {
 		metric_add_dimensions(caller, path, auth, pool, decision, "evidence_events", 1)
 		next
 	}
+	if (kind == "timeout") {
+		timeout_events++
+		metric_add_dimensions(caller, path, auth, pool, decision, "timeout_events", 1)
+		metric_add("outcome", outcome, "timeout_events", 1)
+		if (elapsed_ms ~ /^[0-9]+$/) {
+			timeout_elapsed_ms += elapsed_ms
+			metric_add_dimensions(caller, path, auth, pool, decision, "timeout_elapsed_ms", elapsed_ms)
+		} else {
+			unknown_timeout_elapsed_events++
+			metric_add_dimensions(caller, path, auth, pool, decision, "unknown_timeout_elapsed_events", 1)
+		}
+		next
+	}
 
 	if (kind != "attempt") {
 		total_calls++
@@ -329,6 +348,9 @@ END {
 	printf "    \"logical_events\": %d,\n", logical_events
 	printf "    \"cache_events\": %d,\n", cache_events
 	printf "    \"evidence_events\": %d,\n", evidence_events
+	printf "    \"timeout_events\": %d,\n", timeout_events
+	printf "    \"timeout_elapsed_ms\": %d,\n", timeout_elapsed_ms
+	printf "    \"unknown_timeout_elapsed_events\": %d,\n", unknown_timeout_elapsed_events
 	printf "    \"legacy_events\": %d,\n", legacy_events
 	printf "    \"attempted_requests\": %d,\n", attempted_requests
 	printf "    \"opaque_paginated_attempts\": %d,\n", opaque_paginated_attempts + 0

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -599,6 +599,32 @@ gh_record_attempt() {
 	return 0
 }
 
+# --- gh_record_timeout <path> <caller> <elapsed_ms> <operation_class> ----
+# Record one parent-owned timeout terminal event. This is deliberately not an
+# attempt row: the child transport may already have emitted an attempt during
+# shutdown, and the timeout-owning parent cannot prove an additional request.
+# Arguments are bounded metadata only; command argv and request values are
+# never accepted by this interface.
+gh_record_timeout() {
+	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
+	local path="$1"
+	local caller="$2"
+	local elapsed_ms="$3"
+	local operation_class="${4:-read}"
+	local api_pool="${AIDEVOPS_GH_API_POOL:-}"
+	local auth_mode="${AIDEVOPS_GH_AUTH_MODE:-}"
+	local route_decision="${AIDEVOPS_GH_ROUTE_DECISION:-bounded-${operation_class}}"
+	local budget_remaining="${AIDEVOPS_GH_BUDGET_REMAINING:-${_GH_LAST_GRAPHQL_REMAINING:-}}"
+	local logical_id="${AIDEVOPS_GH_LOGICAL_ID:-}"
+	[[ "$elapsed_ms" =~ ^[0-9]+$ ]] || elapsed_ms=0
+	[[ -n "$api_pool" ]] || api_pool=$(_gh_default_pool "$path")
+	[[ -n "$auth_mode" ]] || auth_mode=$(_gh_default_auth "$api_pool")
+	[[ -n "$logical_id" ]] || logical_id=$(gh_new_logical_id)
+	_gh_append_v2 timeout "$caller" "$path" "$auth_mode" "$api_pool" "$route_decision" \
+		"$budget_remaining" "$logical_id" "" "" "" timeout "" "$elapsed_ms" ""
+	return 0
+}
+
 # --- gh_run_transport_attempt <path> <caller> <logical> <page> <retry> -- cmd
 # Execute one native transport command with unmodified stdout and status. Normal
 # mode appends one process-level attempt; exact capture may append one record per

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -72,6 +72,16 @@
 #   Under this model the worker reads the section header, greps the
 #   helper, closes with "premise falsified — no write path exists" — done
 #   in minutes, with zero human touches.
+
+_pmrsc_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
 #
 # Prior art for the false-premise risk: AGENTS.md "AI-Generated Issue Quality"
 # (AI-generated issue quality, GH#17832-17835). The AGENTS.md
@@ -268,7 +278,7 @@ fetch_review_threads_json() {
 	# shellcheck disable=SC2016
 	resp=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="post-merge-review-threads-exact-cost" \
-		gh api graphql \
+		_pmrsc_gh_read gh api graphql \
 		-F owner="$owner" -F name="$name" -F pr="$pr" \
 		-f query='
 			query($owner: String!, $name: String!, $pr: Int!) {

--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -85,6 +85,18 @@ PRRTS_WORKTREE_EXPECTED_OWNER_TASK=""
 PRRTS_WORKTREE_EXPECTED_OWNER_CREATED_AT=""
 PRRTS_WORKER_OUTCOME_ID=""
 
+_prrts_gh_call() {
+	local operation="$1"
+	shift
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout "$operation" "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 _prrts_ensure_dirs() {
 	local log_dir=""
 	log_dir="$(dirname "$LOGFILE")"
@@ -254,7 +266,7 @@ _prrts_normalise_blocked_by() {
 
 _prrts_graphql_rate_limit_ok() {
 	local remaining=""
-	remaining=$(gh api rate_limit --jq '.resources.graphql.remaining // .resources.core.remaining // 0' 2>/dev/null) || remaining="0"
+	remaining=$(_prrts_gh_call read gh api rate_limit --jq '.resources.graphql.remaining // .resources.core.remaining // 0' 2>/dev/null) || remaining="0"
 	[[ "$remaining" =~ ^[0-9]+$ ]] || remaining=0
 	if [[ "$remaining" -lt 10 ]]; then
 		_prrts_log "write: skipped — GraphQL/API rate-limit remaining=${remaining}"
@@ -265,7 +277,7 @@ _prrts_graphql_rate_limit_ok() {
 
 _prrts_graphql_remaining() {
 	local remaining=""
-	remaining=$(gh api rate_limit --jq '.resources.graphql.remaining // 0' 2>/dev/null) || remaining="$PRRTS_VALUE_UNKNOWN"
+	remaining=$(_prrts_gh_call read gh api rate_limit --jq '.resources.graphql.remaining // 0' 2>/dev/null) || remaining="$PRRTS_VALUE_UNKNOWN"
 	[[ -n "$remaining" ]] || remaining="$PRRTS_VALUE_UNKNOWN"
 	printf '%s\n' "$remaining"
 	return 0
@@ -288,7 +300,7 @@ _prrts_thread_has_marker() {
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="review-thread-marker-exact-cost" \
-		gh api graphql \
+		_prrts_gh_call read gh api graphql \
 		-F thread="$thread_id" -f query='
 			query($thread: ID!) {
 				node(id: $thread) {
@@ -327,7 +339,7 @@ _prrts_thread_author_login() {
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="review-thread-author-exact-cost" \
-		gh api graphql \
+		_prrts_gh_call read gh api graphql \
 		-F thread="$thread_id" -f query='
 			query($thread: ID!) {
 				node(id: $thread) {
@@ -439,7 +451,7 @@ cmd_reply() {
 	# shellcheck disable=SC2016
 	if ! response=$(AIDEVOPS_GH_QUOTA_COST=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="review-thread-reply-exact-cost" \
-		gh api graphql \
+		_prrts_gh_call write gh api graphql \
 		-F thread="$thread_id" -f body="$body" \
 		-f query='
 			mutation($thread: ID!, $body: String!) {
@@ -480,7 +492,7 @@ cmd_resolve() {
 	# shellcheck disable=SC2016
 	if ! response=$(AIDEVOPS_GH_QUOTA_COST=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="review-thread-resolve-exact-cost" \
-		gh api graphql \
+		_prrts_gh_call write gh api graphql \
 		-F thread="$thread_id" \
 		-f query='
 			mutation($thread: ID!) {
@@ -505,7 +517,7 @@ _prrts_list_open_prs() {
 	local repo_slug="$1"
 	local limit=""
 	limit="$(_prrts_normalise_int "$PR_REVIEW_THREAD_RESPONSE_PR_LIMIT" "50" "1")"
-	gh pr list --repo "$repo_slug" --state open --limit "$limit" \
+	_prrts_gh_call read gh pr list --repo "$repo_slug" --state open --limit "$limit" \
 		--json number,title,isDraft,labels,headRefName,headRefOid,author \
 		--jq '.[] | [.number, (.title // "" | gsub("[\t\r\n]"; " ")), (.isDraft | tostring), ([.labels[].name] | join(",")), (.headRefName // ""), (.headRefOid // ""), (.author.login // "")] | @tsv'
 	return $?
@@ -519,7 +531,7 @@ _prrts_fetch_review_threads_json() {
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="review-thread-scan-exact-cost" \
-		gh api graphql \
+		_prrts_gh_call read gh api graphql \
 		-F owner="$owner" -F name="$name" -F pr="$pr_number" \
 		-f query='
 			query($owner: String!, $name: String!, $pr: Int!) {
@@ -583,7 +595,7 @@ _prrts_recent_change_request_comments() {
 	local repo_slug="$1"
 	local pr_number="$2"
 	local response="" rc=0
-	response=$(gh pr view "$pr_number" --repo "$repo_slug" \
+	response=$(_prrts_gh_call read gh pr view "$pr_number" --repo "$repo_slug" \
 		--json latestReviews,comments 2>/dev/null) || rc=$?
 	if [[ "$rc" -ne 0 ]]; then
 		_prrts_log "prompt: reviewer comment fetch unavailable for ${repo_slug}#${pr_number}"
@@ -671,7 +683,7 @@ cmd_scan_pr() {
 		_prrts_usage >&2
 		return 2
 	}
-	metadata=$(gh pr view "$pr_number" --repo "$repo_slug" \
+	metadata=$(_prrts_gh_call read gh pr view "$pr_number" --repo "$repo_slug" \
 		--json title,headRefName,headRefOid,author \
 		--jq '[(.title // "" | gsub("[\t\r\n]"; " ")), (.headRefName // ""), (.headRefOid // ""), (.author.login // "")] | @tsv' \
 		2>/dev/null || true)
@@ -1834,7 +1846,7 @@ _prrts_validate_worker_head() {
 	fi
 	pr_repo_json=$(AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="review-thread-head-repository-rest" \
-		gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || {
+		_prrts_gh_call read gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || {
 		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — could not verify PR head repository"
 		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_HEAD_REPOSITORY_UNVERIFIED"
 		return 1
@@ -1970,13 +1982,13 @@ _prrts_worker_login() {
 	# #aidevops:trust-boundary — ordinary PR repair binds ownership to the
 	# authenticated gh viewer. Checkpoint continuation overrides this function
 	# with its independently verified linked-issue assignee contract.
-	worker_login=$(gh api user --jq '.login // ""' 2>/dev/null || true)
+	worker_login=$(_prrts_gh_call read gh api user --jq '.login // ""' 2>/dev/null || true)
 	if [[ "$worker_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
 		printf '%s' "$worker_login"
 		return 0
 	fi
 
-	worker_login=$(gh api graphql \
+	worker_login=$(_prrts_gh_call read gh api graphql \
 		-f 'query=query { viewer { login } }' \
 		--jq '.data.viewer.login // ""' 2>/dev/null || true)
 	if [[ "$worker_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then

--- a/.agents/scripts/pr-supersession-helper.sh
+++ b/.agents/scripts/pr-supersession-helper.sh
@@ -10,6 +10,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 # shellcheck source=shared-constants.sh
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
+_psh_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 _psh_log() {
 	local msg="$1"
 	printf '[pr-supersession] %s\n' "$msg" >&2
@@ -320,7 +330,7 @@ _psh_find_merged_closer_for_closed_issue() {
 	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub.
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="pulse-supersession-closing-pr-exact-cost" \
-		gh api graphql -F owner="$owner" -F name="$name" -F number="$issue_number" -f query='
+		_psh_gh_read gh api graphql -F owner="$owner" -F name="$name" -F number="$issue_number" -f query='
 		query($owner: String!, $name: String!, $number: Int!) {
 			repository(owner: $owner, name: $name) {
 				nameWithOwner

--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -38,6 +38,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 
+_pdv_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 : "${REPOS_JSON:=${HOME}/.config/aidevops/repos.json}"
 
 if [[ -f "${SCRIPT_DIR}/shared-gh-collaborator-permission.sh" ]]; then
@@ -227,7 +237,7 @@ _validator_complexity_stall_sweep() {
 		return 20
 	fi
 
-	recent_closures=$(gh api graphql \
+	recent_closures=$(_pdv_gh_read gh api graphql \
 		-f query="query { search(query:\"repo:${slug} label:function-complexity-debt is:issue is:closed closed:>${since_date}\", type:ISSUE) { issueCount } }" \
 		--jq '.data.search.issueCount' 2>/dev/null) || {
 		_log "WARN" "complexity-stall-sweep validator: recent-closure lookup failed"

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -53,6 +53,16 @@ _PULSE_MERGE_FEEDBACK_LOADED=1
 
 _CI_REPAIR_OUTCOME_SUMMARY=""
 
+_pmf_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 _feedback_finalizer_path="${BASH_SOURCE[0]%/*}/pulse-merge-feedback-finalizer.sh"
 if [[ -r "$_feedback_finalizer_path" ]]; then
 	# shellcheck source=./pulse-merge-feedback-finalizer.sh
@@ -1407,7 +1417,7 @@ _ci_repair_resolve_runner_login() {
 		return 0
 	fi
 
-	runner_login=$(gh api graphql \
+	runner_login=$(_pmf_gh_read gh api graphql \
 		-f 'query=query { viewer { login } }' \
 		--jq '.data.viewer.login // ""' 2>/dev/null || true)
 	if [[ "$runner_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -49,6 +49,16 @@ source "${_PULSE_MERGE_DIR:-${BASH_SOURCE[0]%/*}}/trusted-dependabot-lib.sh"
 
 # --- Functions ---
 
+_pmg_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 _pulse_is_trusted_issue_sync_pr() {
 	local pr_number="$1"
 	local repo_slug="$2"
@@ -172,7 +182,7 @@ _pulse_merge_admin_pr_json_graphql() {
 	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub.
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="pulse-admin-authority-exact-cost" \
-		gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
+		_pmg_gh_read gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
 		query($owner: String!, $name: String!, $pr: Int!) {
 			repository(owner: $owner, name: $name) {
 				pullRequest(number: $pr) {

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -71,6 +71,16 @@ NMR_CLASS_GENUINE_AUTHORITY="genuine-authority"
 NMR_CLASS_TEMPORARY="temporary"
 NMR_SOURCE_DEFAULT="default"
 NMR_STATUS_HUMAN_AUTHORITY="human-authority-required"
+
+_nmr_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
 NMR_REASON_ACTION_CONTINUE="continue"
 NMR_REASON_ACTION_AUTO="auto"
 NMR_REASON_ACTION_DEFER="defer"
@@ -1614,7 +1624,7 @@ _find_qualifying_pr_for_stale_recovery() {
 	local response="" reported_cost="" pr_json="[]"
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_GH_ROUTE_DECISION="pulse-nmr-pr-search-exact-cost" \
-		gh api graphql -F queryString="$query_string" -f query='
+		_nmr_gh_read gh api graphql -F queryString="$query_string" -f query='
 		query($queryString: String!) {
 			search(type: ISSUE, query: $queryString, first: 10) {
 				nodes {

--- a/.agents/scripts/pulse-wrapper-bootstrap.sh
+++ b/.agents/scripts/pulse-wrapper-bootstrap.sh
@@ -37,6 +37,16 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+_pwb_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 # ---------------------------------------------------------------------------
 # _pulse_handle_self_check
 #
@@ -448,7 +458,7 @@ _resolve_linked_pr_for_issue() {
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="pulse-linked-pr-exact-cost" \
-		gh api graphql -F owner="$owner" -F name="$name" -F number="$issue_num" -f query='
+		_pwb_gh_read gh api graphql -F owner="$owner" -F name="$name" -F number="$issue_num" -f query='
 			query($owner: String!, $name: String!, $number: Int!) {
 				repository(owner: $owner, name: $name) {
 					issue(number: $number) {

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -412,12 +412,69 @@ _gh_record_cooldown_response_if_needed() {
 	return 0
 }
 
+_gh_timeout_path_from_args() {
+	local command_name="${1:-}"
+	local subcommand="${2:-}"
+	local endpoint="${3:-}"
+	case "${command_name}:${subcommand}:${endpoint}" in
+	gh:api:graphql) printf 'graphql\n' ;;
+	gh:api:*) printf 'rest\n' ;;
+	gh:search:*) printf 'search-graphql\n' ;;
+	gh:*:*) printf 'graphql\n' ;;
+	*) printf 'other\n' ;;
+	esac
+	return 0
+}
+
+_gh_record_timeout_if_needed() {
+	local rc="$1"
+	local start_ms="$2"
+	local caller="$3"
+	local path="$4"
+	local operation_class="$5"
+	local end_ms=""
+	local elapsed_ms=0
+	[[ "$rc" -eq 124 ]] || return 0
+	declare -f gh_record_timeout >/dev/null 2>&1 || return 0
+	if declare -f _gh_now_ms >/dev/null 2>&1; then
+		end_ms=$(_gh_now_ms) || end_ms=""
+	fi
+	if [[ "$start_ms" =~ ^[0-9]+$ && "$end_ms" =~ ^[0-9]+$ && "$end_ms" -ge "$start_ms" ]]; then
+		elapsed_ms=$((end_ms - start_ms))
+	fi
+	gh_record_timeout "$path" "$caller" "$elapsed_ms" "$operation_class" 2>/dev/null || true
+	return 0
+}
+
+_gh_timeout_logical_id() {
+	local logical_id="${AIDEVOPS_GH_LOGICAL_ID:-}"
+	if [[ -z "$logical_id" ]] &&
+		declare -f gh_new_logical_id >/dev/null 2>&1; then
+		logical_id=$(gh_new_logical_id) || logical_id=""
+	fi
+	printf '%s\n' "$logical_id"
+	return 0
+}
+
 _gh_with_timeout() {
 	local op_class="${1:-read}"
 	shift
+	local timeout_caller="${BASH_SOURCE[1]:-${0}}"
+	local timeout_path="" timeout_start_ms="" AIDEVOPS_GH_LOGICAL_ID=""
+	AIDEVOPS_GH_LOGICAL_ID=$(_gh_timeout_logical_id)
+	[[ -z "$AIDEVOPS_GH_LOGICAL_ID" ]] || export AIDEVOPS_GH_LOGICAL_ID
+	timeout_path=$(_gh_timeout_path_from_args "$@")
+	if declare -f _gh_now_ms >/dev/null 2>&1; then
+		timeout_start_ms=$(_gh_now_ms) || timeout_start_ms=""
+	fi
 	_gh_cooldown_context_from_args "$op_class" "$@"
 	if command -v _gh_secondary_cooldown_preflight >/dev/null 2>&1; then
-		_gh_secondary_cooldown_preflight "$op_class" || return $?
+		local preflight_rc=0
+		_gh_secondary_cooldown_preflight "$op_class" || preflight_rc=$?
+		if [[ "$preflight_rc" -ne 0 ]]; then
+			_gh_record_timeout_if_needed "$preflight_rc" "$timeout_start_ms" "$timeout_caller" "$timeout_path" "$op_class"
+			return "$preflight_rc"
+		fi
 	fi
 	local secs
 	case "$op_class" in
@@ -428,9 +485,15 @@ _gh_with_timeout() {
 	local deadline_epoch="${AIDEVOPS_GH_DEADLINE_EPOCH:-}"
 	local now_epoch="" remaining_secs=""
 	if [[ "$deadline_epoch" =~ ^[0-9]+$ ]]; then
-		now_epoch=$(date +%s 2>/dev/null) || return 124
+		if ! now_epoch=$(date +%s 2>/dev/null); then
+			_gh_record_timeout_if_needed 124 "$timeout_start_ms" "$timeout_caller" "$timeout_path" "$op_class"
+			return 124
+		fi
 		remaining_secs=$((deadline_epoch - now_epoch))
-		[[ "$remaining_secs" -gt 0 ]] || return 124
+		if [[ "$remaining_secs" -le 0 ]]; then
+			_gh_record_timeout_if_needed 124 "$timeout_start_ms" "$timeout_caller" "$timeout_path" "$op_class"
+			return 124
+		fi
 		[[ "$remaining_secs" -ge "$secs" ]] || secs="$remaining_secs"
 	fi
 	# Invocation-scoped diagnostics may provide a pre-created counter file.
@@ -445,12 +508,14 @@ _gh_with_timeout() {
 	local rc=0
 	if [[ -n "$cmd" ]] && declare -f "$cmd" >/dev/null; then
 		err_file=$(mktemp -t aidevops-gh-secondary.XXXXXX) || {
-			"$@"
-			return $?
+			"$@" || rc=$?
+			_gh_record_timeout_if_needed "$rc" "$timeout_start_ms" "$timeout_caller" "$timeout_path" "$op_class"
+			return "$rc"
 		}
 		out_file=$(mktemp -t aidevops-gh-response.XXXXXX) || {
 			"$@" 2>"$err_file"
 			rc=$?
+			_gh_record_timeout_if_needed "$rc" "$timeout_start_ms" "$timeout_caller" "$timeout_path" "$op_class"
 			cat "$err_file" >&2 2>/dev/null || true
 			rm -f "$err_file"
 			return $rc
@@ -461,6 +526,7 @@ _gh_with_timeout() {
 			"$@" >"$out_file" 2>"$err_file"
 		fi
 		rc=$?
+		_gh_record_timeout_if_needed "$rc" "$timeout_start_ms" "$timeout_caller" "$timeout_path" "$op_class"
 		cat "$out_file" 2>/dev/null || true
 		cat "$err_file" >&2 2>/dev/null || true
 		_gh_record_cooldown_response_if_needed "$rc" "$out_file" "$err_file" "$@"
@@ -482,6 +548,7 @@ _gh_with_timeout() {
 		_gh_run_bounded_command "$secs" "$@"
 		rc=$?
 	fi
+	_gh_record_timeout_if_needed "$rc" "$timeout_start_ms" "$timeout_caller" "$timeout_path" "$op_class"
 	if [[ -n "$err_file" && -n "$out_file" ]]; then
 		cat "$out_file" 2>/dev/null || true
 		cat "$err_file" >&2 2>/dev/null || true

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -193,12 +193,108 @@ unset _SHARED_GH_WRAPPERS_LOADED _SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED _GH_AP
 # shellcheck source=../shared-gh-wrappers.sh
 source "${PARENT_DIR}/shared-gh-wrappers.sh"
 
+# Timeout ownership tests exercise instrumentation, not host-global cooldown
+# state. Keep their preflight deterministic and isolated from operator state.
+_gh_secondary_cooldown_preflight() { return 0; }
+_gh_secondary_cooldown_record_if_needed() { return 0; }
+
 if type -t gh_record_call >/dev/null 2>&1; then
 	echo "  PASS: gh_record_call defined after sourcing shared-gh-wrappers.sh"
 	PASS=$((PASS + 1))
 else
 	echo "  FAIL: gh_record_call NOT defined after sourcing shared-gh-wrappers.sh"
 	FAIL=$((FAIL + 1))
+fi
+
+# --- Test 5b: timeout owner emits a terminal event without an attempt -----
+slow_timeout_probe() {
+	sleep 3
+	return 0
+}
+
+gh_clear_log
+set +e
+AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) + 1 )) \
+	_gh_with_timeout read slow_timeout_probe \
+	'private-repository' 'Authorization: bearer private-token' >/dev/null 2>&1
+timeout_status=$?
+set -e
+assert_eq "bounded function preserves timeout status" "124" "$timeout_status"
+gh_aggregate_calls
+assert_eq "timeout owner emits one terminal event" "1" "$(jq -r '._meta.timeout_events' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "timeout terminal is not a transport attempt" "0" "$(jq -r '._meta.attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "timeout terminal is not a logical route call" "0" "$(jq -r '._meta.total_calls' "$AIDEVOPS_GH_API_REPORT")"
+if [[ "$(jq -r '._meta.timeout_elapsed_ms >= 500' "$AIDEVOPS_GH_API_REPORT")" == "true" ]]; then
+	echo "  PASS: timeout terminal retains elapsed duration"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: timeout terminal lost elapsed duration"
+	FAIL=$((FAIL + 1))
+fi
+if grep -Eq 'private-repository|private-token|Authorization' "$AIDEVOPS_GH_API_LOG"; then
+	echo "  FAIL: timeout telemetry exposed command arguments"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: timeout telemetry excludes command arguments"
+	PASS=$((PASS + 1))
+fi
+
+# --- Test 5c: parent and child share one logical operation on timeout ------
+timeout_command_bin="$TMPDIR/timeout-command-bin"
+mkdir -p "$timeout_command_bin"
+cat >"${timeout_command_bin}/gh" <<'TIMEOUT_COMMAND'
+#!/usr/bin/env bash
+source "${TEST_INSTRUMENT:?}"
+gh_record_call graphql timeout-child gh-pat graphql timeout-child-route 4999
+gh_record_attempt graphql timeout-child "${AIDEVOPS_GH_LOGICAL_ID:-}" "" 1 0 success 200 10 1 gh-pat graphql timeout-child-route 4999
+sleep 3
+TIMEOUT_COMMAND
+chmod +x "${timeout_command_bin}/gh"
+export TEST_INSTRUMENT="${PARENT_DIR}/gh-api-instrument.sh"
+unset AIDEVOPS_GH_LOGICAL_ID
+gh_clear_log
+set +e
+PATH="${timeout_command_bin}:$PATH" AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) + 1 )) \
+	_gh_with_timeout read gh api graphql -f 'query=private-timeout-query' >/dev/null 2>&1
+external_timeout_status=$?
+set -e
+assert_eq "bounded external command preserves timeout status" "124" "$external_timeout_status"
+gh_aggregate_calls
+assert_eq "timeout parent reuses child logical operation" "1" "$(jq -r '._meta.logical_operations' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "timeout parent does not duplicate child attempt" "1" "$(jq -r '._meta.attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "external timeout emits one terminal event" "1" "$(jq -r '._meta.timeout_events' "$AIDEVOPS_GH_API_REPORT")"
+if grep -q 'private-timeout-query' "$AIDEVOPS_GH_API_LOG"; then
+	echo "  FAIL: external timeout telemetry exposed command arguments"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: external timeout telemetry excludes command arguments"
+	PASS=$((PASS + 1))
+fi
+
+# --- Test 5d: function-backed gh calls share the parent logical ID ----------
+function_timeout_probe() {
+	gh api graphql -f 'query=private-function-timeout-query'
+	return $?
+}
+
+unset AIDEVOPS_GH_LOGICAL_ID
+gh_clear_log
+set +e
+PATH="${timeout_command_bin}:$PATH" AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) + 1 )) \
+	_gh_with_timeout read function_timeout_probe >/dev/null 2>&1
+function_timeout_status=$?
+set -e
+assert_eq "bounded gh-calling function preserves timeout status" "124" "$function_timeout_status"
+gh_aggregate_calls
+assert_eq "function timeout parent reuses child logical operation" "1" "$(jq -r '._meta.logical_operations' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "function timeout parent does not duplicate child attempt" "1" "$(jq -r '._meta.attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "function timeout emits one terminal event" "1" "$(jq -r '._meta.timeout_events' "$AIDEVOPS_GH_API_REPORT")"
+if grep -q 'private-function-timeout-query' "$AIDEVOPS_GH_API_LOG"; then
+	echo "  FAIL: function timeout telemetry exposed command arguments"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: function timeout telemetry excludes command arguments"
+	PASS=$((PASS + 1))
 fi
 
 # --- Test 6: disable env var makes record a no-op ---------------------

--- a/.agents/scripts/tests/test-gh-graphql-page-bounds.sh
+++ b/.agents/scripts/tests/test-gh-graphql-page-bounds.sh
@@ -180,6 +180,36 @@ else
 	fail "API retries expose final failure diagnostics" "expected 3 attempts, incomplete api_error result, and final stderr/error details"
 fi
 
+# Guard the reviewed merge/dispatch/approval inventory. These files have no
+# intentional executable bare-GraphQL exceptions: documentation mentions are
+# allowed, while command-shaped occurrences must name a bounded module adapter.
+guarded_graphql_sources=(
+	"${REPO_ROOT}/.agents/scripts/pr-review-thread-response-scanner.sh"
+	"${REPO_ROOT}/.agents/scripts/pulse-merge-gates.sh"
+	"${REPO_ROOT}/.agents/scripts/pulse-merge-feedback.sh"
+	"${REPO_ROOT}/.agents/scripts/dispatch-dedup-pr.sh"
+	"${REPO_ROOT}/.agents/scripts/dispatch-single-issue-helper.sh"
+	"${REPO_ROOT}/.agents/scripts/pulse-wrapper-bootstrap.sh"
+	"${REPO_ROOT}/.agents/scripts/pr-supersession-helper.sh"
+	"${REPO_ROOT}/.agents/scripts/pre-dispatch-validator-helper.sh"
+	"${REPO_ROOT}/.agents/scripts/trusted-dependabot-lib.sh"
+	"${REPO_ROOT}/.agents/scripts/full-loop-helper-merge.sh"
+	"${REPO_ROOT}/.agents/scripts/post-merge-review-scanner.sh"
+	"${REPO_ROOT}/.agents/scripts/pulse-nmr-approval.sh"
+)
+guard_failed=0
+for guarded_source in "${guarded_graphql_sources[@]}"; do
+	while IFS= read -r graphql_line; do
+		if [[ ! "$graphql_line" =~ _[a-z0-9_]+_gh_(read|call)([[:space:]]+(read|write))?[[:space:]]+gh[[:space:]]+api[[:space:]]+graphql ]]; then
+			fail "hot-path GraphQL calls use bounded adapters" "${guarded_source}: ${graphql_line}"
+			guard_failed=1
+		fi
+	done < <(grep -E 'gh api graphql([[:space:]]+\\|[[:space:]]+-)' "$guarded_source" || true)
+done
+if [[ "$guard_failed" -eq 0 ]]; then
+	pass "hot-path GraphQL calls use bounded adapters"
+fi
+
 printf '\nRan %s tests, %s failed.\n' "$((PASS + FAIL))" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then
 	exit 1

--- a/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
@@ -162,6 +162,12 @@ fi
 # the direct function-dispatch path.
 
 {
+	extract_function _gh_timeout_path_from_args "$WRAPPERS_FILE"
+	printf '\n'
+	extract_function _gh_record_timeout_if_needed "$WRAPPERS_FILE"
+	printf '\n'
+	extract_function _gh_timeout_logical_id "$WRAPPERS_FILE"
+	printf '\n'
 	extract_function _gh_with_timeout "$WRAPPERS_FILE"
 	printf '\n'
 	printf '%s\n' '_gh_cooldown_context_from_args(){ return 0; }'

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -130,6 +130,10 @@ GH_STUB
 append_fake_gh_thread_modes() {
 	cat >>"${TEST_ROOT}/bin/gh" <<'GH_STUB'
 	case "${STUB_THREADS_MODE:-unresolved}" in
+	hang)
+		sleep "${STUB_HANG_SECONDS:-5}"
+		exit 1
+		;;
 	rate_limit|error)
 		printf 'GraphQL failure\n' >&2
 		exit 1
@@ -417,7 +421,7 @@ WORKTREE_STUB
 }
 
 setup_test_env() {
-	unset STUB_PR_LIST STUB_PR_VIEW STUB_THREADS_MODE STUB_GRAPHQL_COST_MODE STUB_PR_REPOSITORY_MODE STUB_REMOTE_HEAD STUB_GH_LOGIN
+	unset STUB_PR_LIST STUB_PR_VIEW STUB_THREADS_MODE STUB_HANG_SECONDS STUB_GRAPHQL_COST_MODE STUB_PR_REPOSITORY_MODE STUB_REMOTE_HEAD STUB_GH_LOGIN
 	unset STUB_GH_REST_FAIL STUB_GH_GRAPHQL_FAIL STUB_GH_GRAPHQL_LOGIN
 	unset STUB_GIT_INVALID_BRANCH STUB_GIT_FETCH_FAIL STUB_GIT_CANONICAL_FETCH_FAIL
 	unset STUB_REMOTE_HEAD_INITIAL STUB_REMOTE_HEAD_AFTER_FETCH STUB_WORKTREE_ACTUAL_HEAD STUB_WORKTREE_HELPER_FAIL
@@ -475,6 +479,25 @@ setup_test_env() {
 	: >"$DETACH_LAUNCH_LOG"
 	: >"$GIT_FETCH_CWD_LOG"
 	rm -f "$GIT_FETCHED_HEAD_STATE"
+	return 0
+}
+
+test_scan_pr_bounds_hanging_graphql_read() {
+	setup_test_env
+	export STUB_THREADS_MODE="hang"
+	export STUB_HANG_SECONDS=5
+	export AIDEVOPS_GH_READ_TIMEOUT=1
+	local started_at="" elapsed=0 scan_rc=0
+	started_at=$(date +%s)
+	$SCANNER scan-pr owner/repo 1 >/dev/null 2>&1 || scan_rc=$?
+	elapsed=$(( $(date +%s) - started_at ))
+	if [[ "$scan_rc" -eq 2 && "$elapsed" -le 3 ]]; then
+		print_result "scan-pr bounds a hanging GraphQL review-thread read" 0
+	else
+		print_result "scan-pr bounds a hanging GraphQL review-thread read" 1 "rc=${scan_rc}, elapsed=${elapsed}s"
+	fi
+	unset AIDEVOPS_GH_READ_TIMEOUT
+	teardown_test_env
 	return 0
 }
 
@@ -2574,6 +2597,7 @@ main() {
 	test_dispatch_pr_preserves_indeterminate_young_lock_until_age_fallback
 	test_dispatch_reports_graphql_budget_exhaustion_when_scan_blind
 	test_dispatch_reports_fetch_errors_when_scan_blind
+	test_scan_pr_bounds_hanging_graphql_read
 	test_dispatch_rotates_candidates_with_repo_cursor
 	test_dispatch_stale_cursor_falls_back_to_original_order
 	test_reply_and_resolve_use_graphql_mutations

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -458,7 +458,7 @@ define_process_helper() {
 
 define_feedback_helpers() {
 	local fns=(
-		_build_ci_feedback_section
+		_pmf_gh_read _build_ci_feedback_section
 		_ci_check_url_has_infra_failure_log
 		_ci_actionable_failed_checks_markdown
 		_ci_check_evidence_role

--- a/.agents/scripts/tests/test-pulse-nmr-approval.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-approval.sh
@@ -218,7 +218,10 @@ define_helper_under_test() {
 	# shellcheck disable=SC1090
 	source "$checks_lib"
 
-	local finder_src notify_src ever_notify_src
+	local gh_read_src finder_src notify_src ever_notify_src
+	gh_read_src=$(awk '
+		/^_nmr_gh_read\(\) \{/,/^}$/ { print }
+	' "$NMR_SCRIPT")
 	finder_src=$(awk '
 		/^_find_qualifying_pr_for_stale_recovery\(\) \{/,/^}$/ { print }
 	' "$NMR_SCRIPT")
@@ -228,10 +231,12 @@ define_helper_under_test() {
 	ever_notify_src=$(awk '
 		/^notify_ever_nmr_without_approval\(\) \{/,/^}$/ { print }
 	' "$NMR_SCRIPT")
-	if [[ -z "$finder_src" || -z "$notify_src" || -z "$ever_notify_src" || ! -f "$RECONCILE_SCRIPT" ]]; then
+	if [[ -z "$gh_read_src" || -z "$finder_src" || -z "$notify_src" || -z "$ever_notify_src" || ! -f "$RECONCILE_SCRIPT" ]]; then
 		printf 'ERROR: could not extract helpers from %s and %s\n' "$NMR_SCRIPT" "$RECONCILE_SCRIPT" >&2
 		return 1
 	fi
+	# shellcheck disable=SC1090
+	eval "$gh_read_src"
 	# shellcheck disable=SC1090
 	eval "$finder_src"
 	# shellcheck disable=SC1090

--- a/.agents/scripts/trusted-dependabot-lib.sh
+++ b/.agents/scripts/trusted-dependabot-lib.sh
@@ -17,6 +17,16 @@ _TRUSTED_DEPENDABOT_LAST_REPO=""
 _TRUSTED_DEPENDABOT_LAST_PR=""
 _TRUSTED_DEPENDABOT_LAST_HEAD=""
 
+_td_gh_read() {
+	local rc=0
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
 _trusted_dependabot_log() {
 	local message="$1"
 	if [[ -n "${LOGFILE:-}" ]]; then
@@ -208,7 +218,7 @@ _trusted_dependabot_pr_json_graphql() {
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="$route_decision" \
-		gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
+		_td_gh_read gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
 		query($owner: String!, $name: String!, $pr: Int!) {
 			repository(owner: $owner, name: $name) {
 				pullRequest(number: $pr) {


### PR DESCRIPTION
## Summary

Bound scanner and residual merge, dispatch, and approval GitHub operations; added timeout-terminal telemetry without double-counting attempts. Also implements #30611 and #30612.

## Files Changed

.agents/scripts/dispatch-dedup-pr.sh, .agents/scripts/dispatch-single-issue-helper.sh, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/gh-api-aggregate.awk, .agents/scripts/gh-api-instrument.sh, .agents/scripts/post-merge-review-scanner.sh, .agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/pr-supersession-helper.sh, .agents/scripts/pre-dispatch-validator-helper.sh, .agents/scripts/pulse-merge-feedback.sh, .agents/scripts/pulse-merge-gates.sh, .agents/scripts/pulse-nmr-approval.sh, .agents/scripts/pulse-wrapper-bootstrap.sh, .agents/scripts/shared-gh-wrappers.sh, .agents/scripts/tests/test-gh-api-instrument.sh, .agents/scripts/tests/test-gh-graphql-page-bounds.sh, .agents/scripts/tests/test-gh-wrapper-zsh-compat.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh, .agents/scripts/tests/test-pulse-nmr-approval.sh, .agents/scripts/trusted-dependabot-lib.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Local linters; scanner 90/90; zsh 4/4; stats timeout 5/5; GraphQL guard 9/9; focused merge, dispatch, approval, and telemetry suites.

Resolves #30610


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1h 54m and 1,223,791 tokens on this with the user in an interactive session.