### PR TITLE
GH#30582: fix: admit trusted review repair candidates

### DIFF
--- a/.agents/scripts/label-sync-helper.sh
+++ b/.agents/scripts/label-sync-helper.sh
@@ -152,6 +152,7 @@ SOURCE_LABELS=(
 	"source:health-dashboard|C2E0C6|Auto-created by stats-functions.sh health dashboard"
 	"source:quality-sweep|C2E0C6|Auto-created by stats-functions.sh quality sweep"
 	"source:review-feedback|C2E0C6|Auto-created by quality-feedback-helper.sh"
+	"source:review-repair|C2E0C6|Verified head-bound PR review repair routed by pulse"
 	"source:review-scanner|C2E0C6|Auto-created by post-merge-review-scanner"
 	"source:ci-failure-miner|C2E0C6|Auto-created by gh-failure-miner-helper.sh"
 	"source:circuit-breaker|C2E0C6|Auto-created by circuit-breaker-helper.sh"

--- a/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
+++ b/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
@@ -10,6 +10,87 @@
 [[ -n "${_PULSE_DISPATCH_CURRENT_STATE_GUARDRAILS_LOADED:-}" ]] && return 0
 _PULSE_DISPATCH_CURRENT_STATE_GUARDRAILS_LOADED=1
 
+_dispatch_review_repair_issue_body() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	if declare -F gh_issue_view >/dev/null 2>&1; then
+		gh_issue_view "$issue_number" --repo "$repo_slug" --json body --jq '.body'
+		return $?
+	fi
+	gh issue view "$issue_number" --repo "$repo_slug" --json body --jq '.body'
+	return $?
+}
+
+_dispatch_review_repair_pr_json() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	if declare -F gh_pr_view >/dev/null 2>&1; then
+		gh_pr_view "$pr_number" --repo "$repo_slug" \
+			--json state,headRefOid,labels,closingIssuesReferences
+		return $?
+	fi
+	gh pr view "$pr_number" --repo "$repo_slug" \
+		--json state,headRefOid,labels,closingIssuesReferences
+	return $?
+}
+
+_dispatch_review_repair_live_evidence_fingerprint() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	declare -F _review_feedback_fetch_evidence >/dev/null 2>&1 || return 1
+	declare -F _review_feedback_evidence_fingerprint >/dev/null 2>&1 || return 1
+	_review_feedback_fetch_evidence "$pr_number" "$repo_slug" || return 1
+	_review_feedback_evidence_fingerprint \
+		"$_PULSE_REVIEW_FEEDBACK_REVIEWS_JSON" "$_PULSE_REVIEW_FEEDBACK_INLINE_JSON"
+	return $?
+}
+
+#######################################
+# Verify that review-repair provenance is bound to a closed PR generation and
+# to the candidate issue. Labels or issue text alone never grant an exemption.
+#
+# Args:
+#   $1 - repository slug
+#   $2 - issue number
+# Returns: 0 only for verified head-bound review repair provenance.
+#######################################
+_dispatch_review_repair_candidate_is_verified() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	local issue_body="" marker_json="" pr_number="" expected_head="" expected_evidence=""
+	local live_evidence="" pr_json=""
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
+
+	issue_body=$(_dispatch_review_repair_issue_body "$repo_slug" "$issue_number" 2>/dev/null) || return 1
+	marker_json=$(jq -Rn --arg body "$issue_body" '
+		[$body | scan("<!-- feedback-route:complete:review:PR([0-9]+):SHA([0-9A-Za-z]{7,64}):EVIDENCE([0-9a-f]{64}) -->")]
+		| last // empty
+	' 2>/dev/null) || return 1
+	pr_number=$(jq -r '.[0] // empty' <<<"$marker_json" 2>/dev/null) || return 1
+	expected_head=$(jq -r '.[1] // empty' <<<"$marker_json" 2>/dev/null) || return 1
+	expected_evidence=$(jq -r '.[2] // empty' <<<"$marker_json" 2>/dev/null) || return 1
+	[[ "$pr_number" =~ ^[0-9]+$ && "$expected_head" =~ ^[0-9A-Za-z]{7,64}$ \
+		&& "$expected_evidence" =~ ^[0-9a-f]{64}$ ]] || return 1
+	live_evidence=$(_dispatch_review_repair_live_evidence_fingerprint "$repo_slug" "$pr_number" 2>/dev/null) || return 1
+	[[ "$live_evidence" == "$expected_evidence" ]] || return 1
+
+	pr_json=$(_dispatch_review_repair_pr_json "$repo_slug" "$pr_number" 2>/dev/null) || return 1
+	jq -e --arg expected_head "$expected_head" --arg repo_slug "$repo_slug" \
+		--argjson issue_number "$issue_number" '
+		.state == "CLOSED"
+		and .headRefOid == $expected_head
+		and any(.labels[]?; (.name // .) == "review-routed-to-issue")
+		and any(.closingIssuesReferences[]?;
+			.number == $issue_number
+			and (
+				(.repository.nameWithOwner // "") == $repo_slug
+				or (((.repository.owner.login // "") + "/" + (.repository.name // "")) == $repo_slug)
+			)
+		)
+	' <<<"$pr_json" >/dev/null 2>&1
+	return $?
+}
+
 #######################################
 # Filter ordinary candidates when their repository has reached its open-PR cap.
 #
@@ -48,7 +129,26 @@ _dispatch_filter_repo_pr_backlog_candidates() {
 		(($labels | index("quality-debt")) != null and ($labels | index("source:review-feedback")) != null)
 		or ($labels | index("source:ci-feedback")) != null
 		or ($labels | index("source:conflict-feedback")) != null
-	)]' <<<"$candidates_json" 2>/dev/null) || filtered_json="$candidates_json"
+	)]' <<<"$candidates_json" 2>/dev/null) || filtered_json='[]'
+
+	local repair_candidates="" repair_candidate="" repair_issue=""
+	repair_candidates=$(jq -c '.[] |
+		((.labels // []) | map(.name? // .)) as $labels |
+		select(
+			($labels | index("source:review-repair")) != null
+			and ((($labels | index("quality-debt")) != null and ($labels | index("source:review-feedback")) != null) | not)
+			and (($labels | index("source:ci-feedback")) == null)
+			and (($labels | index("source:conflict-feedback")) == null)
+		)
+	' <<<"$candidates_json" 2>/dev/null) || repair_candidates=""
+	while IFS= read -r repair_candidate; do
+		[[ -n "$repair_candidate" ]] || continue
+		repair_issue=$(jq -r '.number // empty' <<<"$repair_candidate" 2>/dev/null) || continue
+		if _dispatch_review_repair_candidate_is_verified "$repo_slug" "$repair_issue"; then
+			filtered_json=$(jq -cn --argjson current "$filtered_json" --argjson candidate "$repair_candidate" \
+				'$current + [$candidate]' 2>/dev/null) || true
+		fi
+	done <<<"$repair_candidates"
 	candidate_count=$(jq 'length' <<<"$candidates_json" 2>/dev/null) || candidate_count=0
 	filtered_count=$(jq 'length' <<<"$filtered_json" 2>/dev/null) || filtered_count="$candidate_count"
 	echo "[pulse-wrapper] Repository PR backlog guardrail: repo=${repo_slug} open_prs=${open_prs} threshold=${pr_threshold} ordinary_candidates_suppressed=$((candidate_count - filtered_count)) exempt_candidates=${filtered_count}" >>"$LOGFILE"

--- a/.agents/scripts/pulse-merge-feedback-finalizer.sh
+++ b/.agents/scripts/pulse-merge-feedback-finalizer.sh
@@ -569,6 +569,7 @@ _feedback_route_transition_and_verify() {
 	local pr_number="${5:-}"
 	local kind="${6:-}"
 	local expected_head="${7:-}"
+	local companion_source_label="${8:-}"
 
 	if [[ "$clear_hold" == "1" ]]; then
 		[[ "$pr_number" =~ ^[0-9]+$ && -n "$kind" && -n "$expected_head" ]] || return 1
@@ -579,7 +580,8 @@ _feedback_route_transition_and_verify() {
 			return 1
 		fi
 	fi
-	if ! _transition_issue_for_redispatch "$linked_issue" "$repo_slug" "$source_label" "$clear_hold"; then
+	if ! _transition_issue_for_redispatch "$linked_issue" "$repo_slug" "$source_label" "$clear_hold" \
+		"$companion_source_label"; then
 		if [[ "$clear_hold" == "1" ]]; then
 			_feedback_route_restore_unverified_hold "$pr_number" "$repo_slug" "$linked_issue" \
 				"issue transition failed while clearing an automation hold" || true
@@ -1033,6 +1035,7 @@ _finalize_feedback_route() {
 	local close_comment="${11}"
 	local legacy_match="${12:-$legacy_marker}"
 	local evidence_fingerprint="${13:-}"
+	local companion_source_label="${14:-}"
 	local start_marker=""
 	local completion_marker=""
 	local snapshot=""
@@ -1086,7 +1089,7 @@ _finalize_feedback_route() {
 		"$expected_head" "$pr_state" "$issue_body" "$start_marker" "$legacy_marker" \
 		"$feedback_section" "$caller" "$legacy_match" || return $?
 	if ! _feedback_route_transition_and_verify "$linked_issue" "$repo_slug" "$source_label" \
-		"$clear_automation_hold" "$pr_number" "$kind" "$expected_head"; then
+		"$clear_automation_hold" "$pr_number" "$kind" "$expected_head" "$companion_source_label"; then
 		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "${kind} issue transition was not fully verified"
 		return $?
 	fi

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -50,6 +50,7 @@ _PULSE_MERGE_FEEDBACK_LOADED=1
 : "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
 : "${PULSE_REVIEW_FEEDBACK_ITEM_LIMIT:=4000}"
 : "${PULSE_REVIEW_FEEDBACK_SECTION_LIMIT:=12000}"
+PULSE_REVIEW_REPAIR_SOURCE_LABEL="source:review-repair"
 
 _CI_REPAIR_OUTCOME_SUMMARY=""
 
@@ -322,12 +323,14 @@ ${feedback_section}"
 #   $2 - repo_slug     (owner/repo)
 #   $3 - source_label  (e.g. "source:ci-feedback")
 #   $4 - clear_hold    (optional: 1 removes hold-for-review on recovery)
+#   $5 - companion_source_label (optional compatibility provenance)
 #######################################
 _transition_issue_for_redispatch() {
 	local linked_issue="$1"
 	local repo_slug="$2"
 	local source_label="$3"
 	local clear_hold="${4:-0}"
+	local companion_source_label="${5:-}"
 	local _assignees=""
 	_assignees=$(gh issue view "$linked_issue" --repo "$repo_slug" --json assignees --jq '.assignees[].login' 2>/dev/null) || _assignees=""
 
@@ -336,6 +339,9 @@ _transition_issue_for_redispatch() {
 		--remove-label "origin:interactive"
 		--remove-label "origin:worker-takeover"
 	)
+	if [[ -n "$companion_source_label" && "$companion_source_label" != "$source_label" ]]; then
+		_redispatch_flags+=(--add-label "$companion_source_label")
+	fi
 	local _assignee
 	while IFS= read -r _assignee; do
 		[[ -n "$_assignee" ]] && _redispatch_flags+=(--remove-assignee "$_assignee")
@@ -2398,6 +2404,9 @@ _dispatch_pr_fix_worker() {
 	_feedback_route_gh_write label create "source:review-feedback" --repo "$repo_slug" --color "C2E0C6" \
 		--description "Issue carries review feedback routed from a closed worker PR" \
 		--force >/dev/null 2>&1 || true
+	_feedback_route_gh_write label create "$PULSE_REVIEW_REPAIR_SOURCE_LABEL" --repo "$repo_slug" --color "C2E0C6" \
+		--description "Verified head-bound PR review repair" \
+		--force >/dev/null 2>&1 || true
 
 	if ! _review_feedback_fetch_evidence "$pr_number" "$repo_slug"; then
 		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
@@ -2431,9 +2440,9 @@ PR as an active claim), the deterministic merge pass has:
 1. Extracted the review feedback (top-level reviews + file:line inline comments) and
    appended it to the linked issue body as a \"Review Feedback\" section.
 2. Closed this PR so the dispatch queue can re-pick the linked issue.
-3. Transitioned issue #${linked_issue} to \`status:available\` and tagged it
-   \`source:review-feedback\` so the next pulse cycle dispatches a fresh worker with
-   the feedback in its prompt.
+3. Transitioned issue #${linked_issue} to \`status:available\` and tagged it with
+   verified \`source:review-repair\` provenance plus \`source:review-feedback\`.
+   The next pulse cycle can dispatch a fresh worker with the feedback in its prompt.
 
 The next worker will see the updated issue body, address the review findings, and
 open a fresh PR against issue #${linked_issue}.
@@ -2441,8 +2450,9 @@ open a fresh PR against issue #${linked_issue}.
 _Closed by deterministic merge pass (pulse-merge.sh, t2093)._"
 	local finalize_rc=0
 	_finalize_feedback_route "review" "$pr_number" "$repo_slug" "$linked_issue" "$expected_head" \
-		"source:review-feedback" "review-routed-to-issue" "$marker" "$feedback_section" \
-		"_dispatch_pr_fix_worker" "$close_comment" "$legacy_match" "$evidence_fingerprint" || finalize_rc=$?
+		"$PULSE_REVIEW_REPAIR_SOURCE_LABEL" "review-routed-to-issue" "$marker" "$feedback_section" \
+		"_dispatch_pr_fix_worker" "$close_comment" "$legacy_match" "$evidence_fingerprint" \
+		"source:review-feedback" || finalize_rc=$?
 	if [[ "$finalize_rc" -eq 0 ]]; then
 		echo "[pulse-wrapper] _dispatch_pr_fix_worker: routed review feedback from PR #${pr_number} to issue #${linked_issue} in ${repo_slug} (t2093)" >>"$LOGFILE"
 	fi

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -243,9 +243,45 @@ JSON
 		local limit="$2"
 		printf '%s' "$limit" >/dev/null
 		case "$repo_slug" in
-			owner/repo-a) printf '%s\n' '[{"number":1,"labels":[{"name":"bug"}]},{"number":2,"labels":[{"name":"quality-debt"},{"name":"source:review-feedback"}]},{"number":3,"labels":[{"name":"source:ci-feedback"}]},{"number":4,"labels":[{"name":"source:conflict-feedback"}]}]' ;;
+			owner/repo-a) printf '%s\n' '[{"number":1,"labels":[{"name":"bug"}]},{"number":2,"labels":[{"name":"quality-debt"},{"name":"source:review-feedback"}]},{"number":3,"labels":[{"name":"source:ci-feedback"}]},{"number":4,"labels":[{"name":"source:conflict-feedback"}]},{"number":6,"labels":[{"name":"source:review-feedback"}]},{"number":7,"labels":[{"name":"source:review-feedback"},{"name":"source:review-repair"}]},{"number":8,"labels":[{"name":"source:review-repair"}]},{"number":9,"labels":[{"name":"source:review-repair"}]},{"number":10,"labels":[{"name":"source:review-repair"}]}]' ;;
 			owner/repo-b) printf '%s\n' '[{"number":5,"labels":[{"name":"bug"}]}]' ;;
 			*) printf '[]\n' ;;
+		esac
+		return 0
+	}
+	_dispatch_review_repair_issue_body() {
+		local repo_slug="$1"
+		local issue_number="$2"
+		printf '%s' "$repo_slug" >/dev/null
+		case "$issue_number" in
+			7) printf '%s\n' '<!-- feedback-route:complete:review:PR107:SHAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:EVIDENCEaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->' ;;
+			8) printf '%s\n' '<!-- feedback-route:complete:review:PR108:SHAbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:EVIDENCEbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb -->' ;;
+			10) printf '%s\n' '<!-- feedback-route:complete:review:PR110:SHAcccccccccccccccccccccccccccccccccccccccc:EVIDENCEcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc -->' ;;
+			*) printf '%s\n' 'externally supplied label without route evidence' ;;
+		esac
+		return 0
+	}
+	_dispatch_review_repair_pr_json() {
+		local repo_slug="$1"
+		local pr_number="$2"
+		printf '%s' "$repo_slug" >/dev/null
+		case "$pr_number" in
+			107) printf '%s\n' '{"state":"CLOSED","headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","labels":[{"name":"review-routed-to-issue"}],"closingIssuesReferences":[{"number":7,"repository":{"nameWithOwner":"owner/repo-a"}}]}' ;;
+			108) printf '%s\n' '{"state":"OPEN","headRefOid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","labels":[{"name":"review-routed-to-issue"}],"closingIssuesReferences":[{"number":8,"repository":{"nameWithOwner":"owner/repo-a"}}]}' ;;
+			110) printf '%s\n' '{"state":"CLOSED","headRefOid":"cccccccccccccccccccccccccccccccccccccccc","labels":[{"name":"review-routed-to-issue"}],"closingIssuesReferences":[{"number":10,"repository":{"nameWithOwner":"owner/repo-a"}}]}' ;;
+			*) return 1 ;;
+		esac
+		return 0
+	}
+	_dispatch_review_repair_live_evidence_fingerprint() {
+		local repo_slug="$1"
+		local pr_number="$2"
+		printf '%s' "$repo_slug" >/dev/null
+		case "$pr_number" in
+			107) printf '%s\n' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ;;
+			108) printf '%s\n' 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' ;;
+			110) printf '%s\n' 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd' ;;
+			*) return 1 ;;
 		esac
 		return 0
 	}
@@ -254,10 +290,10 @@ JSON
 	ranked=$(build_ranked_dispatch_candidates_json 10)
 	repo_a_numbers=$(jq -r '[.[] | select(.repo_slug == "owner/repo-a") | .number] | join(",")' <<<"$ranked")
 	repo_b_numbers=$(jq -r '[.[] | select(.repo_slug == "owner/repo-b") | .number] | join(",")' <<<"$ranked")
-	if [[ "$repo_a_numbers" == "2,3,4" && "$repo_b_numbers" == "5" ]]; then
-		print_result "guardrail: repo backlog exempts review debt and verified CI/conflict repair lineages" 0
+	if [[ "$repo_a_numbers" == "2,3,4,7" && "$repo_b_numbers" == "5" ]]; then
+		print_result "guardrail: repo backlog admits only trusted review-repair provenance" 0
 	else
-		print_result "guardrail: repo backlog exempts review debt and verified CI/conflict repair lineages" 1 "repo_a=${repo_a_numbers} repo_b=${repo_b_numbers}"
+		print_result "guardrail: repo backlog admits only trusted review-repair provenance" 1 "repo_a=${repo_a_numbers} repo_b=${repo_b_numbers}"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -587,6 +587,13 @@ test_dispatch_appends_to_issue_body_and_closes_pr() {
 			"Expected 'source:review-feedback' label add in call log"
 		return 0
 	fi
+	# Verify the head-bound finalizer adds dedicated trusted repair provenance.
+	if ! grep -qF 'source:review-repair' "$GH_LOG" \
+		|| [[ ",$(<"${TEST_ROOT}/issue-labels.txt")," != *",source:review-repair,"* ]]; then
+		print_result "dispatch adds trusted review-repair provenance to issue" 1 \
+			"Expected source:review-repair in issue transition"
+		return 0
+	fi
 	# Verify status transition to available (clears active claim labels).
 	if ! grep -qF 'status:available' "$GH_LOG"; then
 		print_result "dispatch transitions issue status to available" 1 \
@@ -710,6 +717,8 @@ review_route_is_complete() {
 	[[ "$start_count" -eq 1 && "$completion_count" -eq 1 ]] || return 1
 	[[ "$(<"${TEST_ROOT}/pr-state.txt")" == "CLOSED" ]] || return 1
 	[[ ",$(<"${TEST_ROOT}/pr-labels.txt")," == *",review-routed-to-issue,"* ]] || return 1
+	[[ ",$(<"${TEST_ROOT}/issue-labels.txt")," == *",source:review-feedback,"* ]] || return 1
+	[[ ",$(<"${TEST_ROOT}/issue-labels.txt")," == *",source:review-repair,"* ]] || return 1
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Apply a dedicated source:review-repair label only through head-bound review finalization, retain source:review-feedback compatibility, and exempt only the trusted repair signal from the repository PR backlog cap.

## Files Changed

.agents/scripts/label-sync-helper.sh, .agents/scripts/pulse-dispatch-current-state-guardrails.sh, .agents/scripts/pulse-merge-feedback-finalizer.sh, .agents/scripts/pulse-merge-feedback.sh, .agents/scripts/tests/test-pulse-current-state-guardrails.sh, .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh; bash .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh; bash .agents/scripts/tests/test-label-invariants.sh; shellcheck changed shell files; .agents/scripts/linters-local.sh

Resolves #30582


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 8h 44m and 2,092,157 tokens on this with the user in an interactive session.