### PR TITLE
GH#30619: persist footprint overlap deferrals

### DIFF
--- a/.agents/scripts/dispatch-dedup-footprint.sh
+++ b/.agents/scripts/dispatch-dedup-footprint.sh
@@ -35,12 +35,303 @@ _FOOTPRINT_CACHE_REPO=""
 _FOOTPRINT_CACHE_DATA=""
 _FOOTPRINT_CACHE_EPOCH=0
 
+# Cross-cycle defer state. The live overlap check remains authoritative; this
+# state only suppresses unchanged reconsideration until a bounded wake event.
+_FOOTPRINT_DEFER_STATE_DIR="${AIDEVOPS_FOOTPRINT_DEFER_STATE_DIR:-${HOME}/.aidevops/cache/footprint-defers}"
+_FOOTPRINT_DEFER_TTL_SECONDS="${AIDEVOPS_FOOTPRINT_DEFER_TTL_SECONDS:-1800}"
+[[ "$_FOOTPRINT_DEFER_TTL_SECONDS" =~ ^[1-9][0-9]*$ ]] || _FOOTPRINT_DEFER_TTL_SECONDS=1800
+_FOOTPRINT_DEFER_SCHEMA="aidevops-footprint-defer/v1"
+
 # Maximum age of the footprint cache in seconds. After this, rebuild.
 # 30s: long enough to catch concurrent same-file dispatch races (the
 # original use-case), short enough to limit blast radius when issues
 # close mid-window. See invalidate_footprint_cache_for_issue() for
 # immediate eviction on known-close events (t2927/GH#21103).
 _FOOTPRINT_CACHE_TTL=30
+
+#######################################
+# Compute a portable SHA-256 digest for text.
+# Args: $1 = text
+# Output: lowercase hex digest
+# Exit: 0 on success, 1 when no digest implementation is available
+#######################################
+_footprint_hash_text() {
+	local value="$1"
+	local digest=""
+	if command -v sha256sum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$value" | sha256sum | awk '{print $1}') || return 1
+	elif command -v shasum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$value" | shasum -a 256 | awk '{print $1}') || return 1
+	elif command -v openssl >/dev/null 2>&1; then
+		digest=$(printf '%s' "$value" | openssl dgst -sha256 | awk '{print $NF}') || return 1
+	else
+		return 1
+	fi
+	[[ "$digest" =~ ^[a-fA-F0-9]{64}$ ]] || return 1
+	printf '%s\n' "$digest" | tr '[:upper:]' '[:lower:]'
+	return 0
+}
+
+#######################################
+# Prepare the private defer-state directory.
+# Exit: 0 when safe, 1 otherwise
+#######################################
+_footprint_defer_prepare_dir() {
+	local state_dir="$_FOOTPRINT_DEFER_STATE_DIR"
+	if [[ ! -e "$state_dir" && ! -L "$state_dir" ]]; then
+		(umask 077 && mkdir -p "$state_dir") || return 1
+	fi
+	[[ -d "$state_dir" && ! -L "$state_dir" && -O "$state_dir" ]] || return 1
+	chmod 0700 "$state_dir" 2>/dev/null || return 1
+	return 0
+}
+
+#######################################
+# Resolve the state path for a repository candidate without exposing the slug
+# in the filename.
+# Args: $1 = repo slug, $2 = candidate issue
+# Output: absolute state path
+#######################################
+_footprint_defer_state_path() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	local repo_hash=""
+	local normalized_repo=""
+	normalized_repo=$(printf '%s' "$repo_slug" | tr '[:upper:]' '[:lower:]')
+	repo_hash=$(_footprint_hash_text "$normalized_repo") || return 1
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
+	printf '%s/%s-%s.json\n' "$_FOOTPRINT_DEFER_STATE_DIR" "$repo_hash" "$issue_number"
+	return 0
+}
+
+#######################################
+# Atomically write one validated defer-state object.
+# Args: $1 = destination path, $2 = JSON object
+#######################################
+_footprint_defer_write_json() {
+	local state_path="$1"
+	local state_json="$2"
+	local temp_path=""
+	command -v jq >/dev/null 2>&1 || return 1
+	printf '%s' "$state_json" | jq -e --arg schema "$_FOOTPRINT_DEFER_SCHEMA" '.schema == $schema' >/dev/null 2>&1 || return 1
+	_footprint_defer_prepare_dir || return 1
+	temp_path=$(mktemp "${_FOOTPRINT_DEFER_STATE_DIR}/.defer.XXXXXX" 2>/dev/null) || return 1
+	if ! printf '%s\n' "$state_json" >"$temp_path"; then
+		rm -f "$temp_path" 2>/dev/null || true
+		return 1
+	fi
+	chmod 0600 "$temp_path" 2>/dev/null || {
+		rm -f "$temp_path" 2>/dev/null || true
+		return 1
+	}
+	if ! mv -f "$temp_path" "$state_path"; then
+		rm -f "$temp_path" 2>/dev/null || true
+		return 1
+	fi
+	return 0
+}
+
+#######################################
+# Read one structurally valid defer record.
+# Args: $1 = state path
+# Output: compact JSON
+#######################################
+_footprint_defer_read_json() {
+	local state_path="$1"
+	[[ -f "$state_path" && ! -L "$state_path" && -O "$state_path" ]] || return 1
+	jq -ce --arg schema "$_FOOTPRINT_DEFER_SCHEMA" '
+		select(.schema == $schema)
+		| select([.candidate_issue, .blocking_issue, .expires_at] | all(type == "number"))
+		| select((.candidate_hash | type) == "string")
+		| select((.blocker_hash | type) == "string")
+	' "$state_path" 2>/dev/null
+	return $?
+}
+
+#######################################
+# Persist a wake/tombstone so diagnostics can explain why suppression ended.
+# Args: $1 = state path, $2 = current JSON, $3 = wake reason
+#######################################
+_footprint_defer_wake() {
+	local state_path="$1"
+	local state_json="$2"
+	local wake_reason="$3"
+	local now_epoch=""
+	local updated_json=""
+	now_epoch=$(date +%s)
+	updated_json=$(printf '%s' "$state_json" | jq -c \
+		--arg reason "$wake_reason" --argjson now "$now_epoch" \
+		'.active = false | .wake_reason = $reason | .wake_at = $now') || return 1
+	_footprint_defer_write_json "$state_path" "$updated_json" || return 1
+	if [[ -n "${LOGFILE:-}" ]]; then
+		local candidate_issue=""
+		local repo_slug=""
+		local blocking_issue=""
+		candidate_issue=$(printf '%s' "$updated_json" | jq -r '.candidate_issue')
+		repo_slug=$(printf '%s' "$updated_json" | jq -r '.repo_slug')
+		blocking_issue=$(printf '%s' "$updated_json" | jq -r '.blocking_issue')
+		printf '[footprint-defer] event=wake issue=#%s repo=%s blocker=#%s wake_reason=%s ts=%s\n' \
+			"$candidate_issue" "$repo_slug" "$blocking_issue" "$wake_reason" "$now_epoch" >>"$LOGFILE"
+	fi
+	return 0
+}
+
+#######################################
+# Record a newly confirmed live overlap. This runs inside the overlap command
+# substitution, so only filesystem/log side effects are used.
+# Args: candidate issue, repo slug, candidate files, inflight data,
+#       blocking issue, overlapping files
+#######################################
+_footprint_defer_record_overlap() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local candidate_files="$3"
+	local inflight_data="$4"
+	local blocking_issue="$5"
+	local overlapping_files="$6"
+	local blocker_files=""
+	local candidate_hash="" blocker_hash="" state_path="" existing_json=""
+	local now_epoch="" expires_at=""
+	local state_json=""
+	command -v jq >/dev/null 2>&1 || return 0
+	blocker_files=$(printf '%s\n' "$inflight_data" | awk -F '|' -v issue="$blocking_issue" '$2 == issue {print $1}' | sort -u)
+	[[ -n "$blocker_files" ]] || return 0
+	candidate_hash=$(_footprint_hash_text "$candidate_files") || return 0
+	blocker_hash=$(_footprint_hash_text "$blocker_files") || return 0
+	state_path=$(_footprint_defer_state_path "$repo_slug" "$issue_number") || return 0
+	if existing_json=$(_footprint_defer_read_json "$state_path"); then
+		if printf '%s' "$existing_json" | jq -e \
+			--arg candidate "$candidate_hash" --arg blocker "$blocker_hash" --argjson blocking "$blocking_issue" \
+			'.active == true and .candidate_hash == $candidate and .blocker_hash == $blocker and .blocking_issue == $blocking' >/dev/null 2>&1; then
+			return 0
+		fi
+	fi
+	now_epoch=$(date +%s)
+	expires_at=$((now_epoch + _FOOTPRINT_DEFER_TTL_SECONDS))
+	state_json=$(jq -cn \
+		--arg schema "$_FOOTPRINT_DEFER_SCHEMA" \
+		--arg repo "$repo_slug" \
+		--arg candidate_hash "$candidate_hash" \
+		--arg blocker_hash "$blocker_hash" \
+		--arg overlapping_files "$overlapping_files" \
+		--argjson candidate_issue "$issue_number" \
+		--argjson blocking_issue "$blocking_issue" \
+		--argjson created_at "$now_epoch" \
+		--argjson expires_at "$expires_at" \
+		'{schema:$schema,repo_slug:$repo,candidate_issue:$candidate_issue,blocking_issue:$blocking_issue,candidate_hash:$candidate_hash,blocker_hash:$blocker_hash,overlapping_files:$overlapping_files,created_at:$created_at,expires_at:$expires_at,suppressed_count:0,active:true,wake_reason:"none",wake_at:0}') || return 0
+	_footprint_defer_write_json "$state_path" "$state_json" || return 0
+	if [[ -n "${LOGFILE:-}" ]]; then
+		printf '[footprint-defer] event=deferred issue=#%s repo=%s blocker=#%s expires_at=%s suppressed=0 wake_reason=none\n' \
+			"$issue_number" "$repo_slug" "$blocking_issue" "$expires_at" >>"$LOGFILE"
+	fi
+	return 0
+}
+
+#######################################
+# Return success when an unchanged durable overlap should suppress this cycle.
+# Missing/corrupt/stale state falls through to the authoritative live check.
+# Args: $1 = candidate issue, $2 = repo slug, $3 = candidate JSON
+# Exit: 0 suppress, 1 reconsider normally
+#######################################
+_footprint_defer_should_suppress() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local candidate_json="$3"
+	local state_path=""
+	local state_json=""
+	local candidate_body="" candidate_files="" candidate_hash=""
+	local now_epoch="" expires_at=""
+	local blocking_issue="" blocker_json="" blocker_state=""
+	local blocker_files="" blocker_hash="" updated_json="" suppressed_count=""
+	state_path=$(_footprint_defer_state_path "$repo_slug" "$issue_number") || return 1
+	if ! state_json=$(_footprint_defer_read_json "$state_path"); then
+		[[ -e "$state_path" || -L "$state_path" ]] && rm -f "$state_path" 2>/dev/null || true
+		return 1
+	fi
+	printf '%s' "$state_json" | jq -e '.active == true' >/dev/null 2>&1 || return 1
+	if printf '%s' "$candidate_json" | jq -e '[(.labels // [])[]? | if type == "object" then .name else . end] | index("force-dispatch") != null' >/dev/null 2>&1; then
+		_footprint_defer_wake "$state_path" "$state_json" "operator_reconsideration" || true
+		return 1
+	fi
+	candidate_body=$(printf '%s' "$candidate_json" | jq -r '.body // ""' 2>/dev/null) || candidate_body=""
+	candidate_files=$(_footprint_extract_paths "$candidate_body")
+	[[ -n "$candidate_files" ]] || {
+		_footprint_defer_wake "$state_path" "$state_json" "candidate_footprint_changed" || true
+		return 1
+	}
+	candidate_hash=$(_footprint_hash_text "$candidate_files") || return 1
+	if ! printf '%s' "$state_json" | jq -e --arg hash "$candidate_hash" '.candidate_hash == $hash' >/dev/null 2>&1; then
+		_footprint_defer_wake "$state_path" "$state_json" "candidate_footprint_changed" || true
+		return 1
+	fi
+	now_epoch=$(date +%s)
+	expires_at=$(printf '%s' "$state_json" | jq -r '.expires_at')
+	if [[ ! "$expires_at" =~ ^[0-9]+$ || "$now_epoch" -ge "$expires_at" ]]; then
+		_footprint_defer_wake "$state_path" "$state_json" "cooldown_expired" || true
+		return 1
+	fi
+	blocking_issue=$(printf '%s' "$state_json" | jq -r '.blocking_issue')
+	if declare -F gh_issue_view >/dev/null 2>&1; then
+		blocker_json=$(gh_issue_view "$blocking_issue" --repo "$repo_slug" --json number,state,labels,body 2>/dev/null) || blocker_json=""
+	else
+		blocker_json=$(gh issue view "$blocking_issue" --repo "$repo_slug" --json number,state,labels,body 2>/dev/null) || blocker_json=""
+	fi
+	if [[ -n "$blocker_json" ]]; then
+		blocker_state=$(printf '%s' "$blocker_json" | jq -r '.state // ""' | tr '[:lower:]' '[:upper:]')
+		if [[ "$blocker_state" != "OPEN" ]] || ! printf '%s' "$blocker_json" | jq -e \
+			'[(.labels // [])[]? | if type == "object" then .name else . end] | any(. == "status:in-progress" or . == "status:in-review" or . == "status:claimed")' >/dev/null 2>&1; then
+			_footprint_defer_wake "$state_path" "$state_json" "blocker_lifecycle_changed" || true
+			return 1
+		fi
+		blocker_files=$(_footprint_extract_paths "$(printf '%s' "$blocker_json" | jq -r '.body // ""')")
+		blocker_hash=$(_footprint_hash_text "$blocker_files") || blocker_hash=""
+		if [[ -z "$blocker_hash" ]] || ! printf '%s' "$state_json" | jq -e --arg hash "$blocker_hash" '.blocker_hash == $hash' >/dev/null 2>&1; then
+			_footprint_defer_wake "$state_path" "$state_json" "blocker_footprint_changed" || true
+			return 1
+		fi
+	fi
+	suppressed_count=$(printf '%s' "$state_json" | jq -r '.suppressed_count // 0')
+	[[ "$suppressed_count" =~ ^[0-9]+$ ]] || suppressed_count=0
+	suppressed_count=$((suppressed_count + 1))
+	updated_json=$(printf '%s' "$state_json" | jq -c --argjson count "$suppressed_count" --argjson checked "$now_epoch" \
+		'.suppressed_count = $count | .last_checked_at = $checked') || updated_json=""
+	[[ -n "$updated_json" ]] && _footprint_defer_write_json "$state_path" "$updated_json" || true
+	return 0
+}
+
+#######################################
+# Return the current/tombstoned defer record for diagnostics.
+# Args: $1 = issue number, $2 = repo slug
+# Output: compact JSON (or an inactive empty object)
+#######################################
+_footprint_defer_empty_status_json() {
+	local wake_reason="$1"
+	jq -cn --arg reason "$wake_reason" '{active:false,wake_reason:$reason}' 2>/dev/null || printf '{}\n'
+	return 0
+}
+
+_footprint_defer_status_json() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local state_path=""
+	local state_json=""
+	local now_epoch=""
+	state_path=$(_footprint_defer_state_path "$repo_slug" "$issue_number") || {
+		_footprint_defer_empty_status_json "unavailable"
+		return 0
+	}
+	if ! state_json=$(_footprint_defer_read_json "$state_path"); then
+		_footprint_defer_empty_status_json "none"
+		return 0
+	fi
+	now_epoch=$(date +%s)
+	printf '%s' "$state_json" | jq -c --argjson now "$now_epoch" '
+		. + {
+			age_seconds: ([$now - (.created_at // $now), 0] | max),
+			cooldown_remaining_seconds: ([.expires_at - $now, 0] | max)
+		}' 2>/dev/null || _footprint_defer_empty_status_json "parse_error"
+	return 0
+}
 
 #######################################
 # Extract file paths from an issue body.
@@ -262,6 +553,8 @@ _footprint_check_overlap() {
 	if [[ -n "$overlapping_files" && -n "$blocking_issue" ]]; then
 		# Trim trailing ", "
 		overlapping_files="${overlapping_files%, }"
+		_footprint_defer_record_overlap "$issue_number" "$repo_slug" "$candidate_files" \
+			"$inflight_data" "$blocking_issue" "$overlapping_files"
 		printf 'FOOTPRINT_OVERLAP (issue=#%s files=%s)\n' "$blocking_issue" "$overlapping_files"
 		return 0
 	fi
@@ -290,19 +583,41 @@ _footprint_check_overlap() {
 invalidate_footprint_cache_for_issue() {
 	local issue_num="$1"
 	[[ -n "$issue_num" ]] || return 0
-	[[ -n "$_FOOTPRINT_CACHE_DATA" ]] || return 0
 
 	# Rebuild cache without entries for this issue.
 	# Cache stores "file_path|issue_num\n" (literal \n separators).
 	# printf '%b' expands \n to actual newlines for line-by-line filtering.
 	local _new_cache_data=""
 	local _cache_entry _cache_issue
-	while IFS= read -r _cache_entry; do
-		[[ -n "$_cache_entry" ]] || continue
-		_cache_issue="${_cache_entry##*|}"
-		[[ "$_cache_issue" == "$issue_num" ]] && continue
-		_new_cache_data="${_new_cache_data}${_cache_entry}\n"
-	done <<<"$(printf '%b' "$_FOOTPRINT_CACHE_DATA")"
-	_FOOTPRINT_CACHE_DATA="$_new_cache_data"
+	if [[ -n "$_FOOTPRINT_CACHE_DATA" ]]; then
+		while IFS= read -r _cache_entry; do
+			[[ -n "$_cache_entry" ]] || continue
+			_cache_issue="${_cache_entry##*|}"
+			[[ "$_cache_issue" == "$issue_num" ]] && continue
+			_new_cache_data="${_new_cache_data}${_cache_entry}\n"
+		done <<<"$(printf '%b' "$_FOOTPRINT_CACHE_DATA")"
+		_FOOTPRINT_CACHE_DATA="$_new_cache_data"
+	fi
+
+	# Wake any durable record where this issue is either candidate or blocker.
+	# The caller does not always know the repository, so conservatively scan the
+	# private bounded state directory; issue-number collisions only cause a safe
+	# extra live overlap check.
+	local state_path=""
+	local state_json=""
+	local candidate_issue=""
+	local blocking_issue=""
+	if [[ -d "$_FOOTPRINT_DEFER_STATE_DIR" && ! -L "$_FOOTPRINT_DEFER_STATE_DIR" ]]; then
+		for state_path in "$_FOOTPRINT_DEFER_STATE_DIR"/*.json; do
+			[[ -f "$state_path" && ! -L "$state_path" ]] || continue
+			state_json=$(_footprint_defer_read_json "$state_path") || continue
+			printf '%s' "$state_json" | jq -e '.active == true' >/dev/null 2>&1 || continue
+			candidate_issue=$(printf '%s' "$state_json" | jq -r '.candidate_issue')
+			blocking_issue=$(printf '%s' "$state_json" | jq -r '.blocking_issue')
+			if [[ "$candidate_issue" == "$issue_num" || "$blocking_issue" == "$issue_num" ]]; then
+				_footprint_defer_wake "$state_path" "$state_json" "lifecycle_invalidation" || true
+			fi
+		done
+	fi
 	return 0
 }

--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -44,6 +44,13 @@ source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || {
 }
 set -euo pipefail
 
+# GH#30619: read local durable footprint-defer state for issue reports.
+# shellcheck source=dispatch-dedup-footprint.sh
+if [[ -f "${SCRIPT_DIR}/dispatch-dedup-footprint.sh" ]]; then
+	# shellcheck disable=SC1091
+	source "${SCRIPT_DIR}/dispatch-dedup-footprint.sh"
+fi
+
 # =============================================================================
 # Constants
 # =============================================================================
@@ -146,6 +153,8 @@ pmc-close-conflicting-generic|pulse-merge-conflict.sh|734|Deterministic merge: c
 pmc-false-positive-heuristic|pulse-merge-conflict.sh|656|Deterministic merge: task ID match.*no implementation file overlap.*false-positive|Task ID match with no file overlap — false-positive heuristic, PR left open for rebase
 pmc-carry-diff|pulse-merge-conflict.sh|904|_carry_forward_pr_diff: appended diff from PR #|Carried forward PR diff to linked issue before close
 pmc-carry-diff-skip|pulse-merge-conflict.sh|859|_carry_forward_pr_diff: issue.*already has diff marker|Diff carry-forward skipped — already has diff marker for this PR
+pfd-deferred|dispatch-dedup-footprint.sh|220|\[footprint-defer\] event=deferred issue=#|Footprint overlap persisted as a bounded cross-cycle defer
+pfd-wake|dispatch-dedup-footprint.sh|170|\[footprint-defer\] event=wake issue=#|Footprint overlap defer woke after lifecycle, footprint, cooldown, or operator change
 dps-classify|pulse-dirty-pr-sweep.sh|788|PR #.*decision=|Dirty PR sweep classification decision
 dps-rebase-ok|pulse-dirty-pr-sweep.sh|615|PR #.*rebased \+ pushed|Dirty PR rebased and force-pushed successfully
 dps-rebase-cooldown|pulse-dirty-pr-sweep.sh|535|PR #.*rebase skipped.*cooldown|Rebase skipped — cooldown active
@@ -1841,6 +1850,25 @@ _render_issue_blockers_text() {
 	return 0
 }
 
+# Render the current or most recent durable footprint-overlap defer.
+# Args: issue_number repo_slug
+_render_issue_footprint_defer_text() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local defer_json='{"active":false,"wake_reason":"unavailable"}'
+	if declare -F _footprint_defer_status_json >/dev/null 2>&1; then
+		defer_json=$(_footprint_defer_status_json "$issue_number" "$repo_slug")
+	fi
+	printf 'Footprint overlap defer:\n'
+	printf '  Active: %s\n' "$(printf '%s' "$defer_json" | jq -r '.active // false' 2>/dev/null || printf 'false')"
+	printf '  Blocking issue: %s\n' "$(printf '%s' "$defer_json" | jq -r 'if .blocking_issue then "#" + (.blocking_issue | tostring) else "none" end' 2>/dev/null || printf 'none')"
+	printf '  Suppressed retries: %s\n' "$(printf '%s' "$defer_json" | jq -r '.suppressed_count // 0' 2>/dev/null || printf '0')"
+	printf '  Age seconds: %s\n' "$(printf '%s' "$defer_json" | jq -r '.age_seconds // 0' 2>/dev/null || printf '0')"
+	printf '  Cooldown remaining seconds: %s\n' "$(printf '%s' "$defer_json" | jq -r '.cooldown_remaining_seconds // 0' 2>/dev/null || printf '0')"
+	printf '  Wake reason: %s\n\n' "$(printf '%s' "$defer_json" | jq -r '.wake_reason // "none"' 2>/dev/null || printf 'unavailable')"
+	return 0
+}
+
 # Render the human-readable issue correlation report.
 # Args: issue_number repo_slug issue_json comments_json pr_numbers logfile logdir verbose attempt_summary_json issue_log_lines blocker_summary_json
 _render_issue_text() {
@@ -1868,6 +1896,7 @@ _render_issue_text() {
 
 	_render_issue_lifecycle_comments "$comments_json"
 	_render_issue_blockers_text "$blocker_summary_json"
+	_render_issue_footprint_defer_text "$issue_number" "$repo_slug"
 	_render_issue_attempts_text "$attempt_summary_json" "$issue_log_lines" "$verbose"
 	_render_issue_linked_prs "$repo_slug" "$pr_numbers" "$logfile" "$logdir" "$verbose"
 	return 0
@@ -1932,6 +1961,13 @@ _render_issue_json() {
 	printf ',\n'
 	printf '  "progress_blockers": '
 	printf '%s' "$blocker_summary_json" | jq -c '.' 2>/dev/null || printf '{}'
+	printf ',\n'
+	printf '  "footprint_defer": '
+	if declare -F _footprint_defer_status_json >/dev/null 2>&1; then
+		_footprint_defer_status_json "$issue_number" "$repo_slug"
+	else
+		printf '{"active":false,"wake_reason":"unavailable"}\n'
+	fi
 	printf ',\n'
 
 	printf '  "linked_prs": [\n'

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -1296,6 +1296,22 @@ _dispatch_skip_for_benign_block() {
 }
 
 #######################################
+# Skip a candidate covered by an unchanged durable footprint-overlap defer.
+# State errors and wake conditions fall through to the authoritative live gate.
+# Arguments: issue number, repo slug, prefetched candidate JSON
+# Returns: 0 to skip, 1 to continue
+#######################################
+_dispatch_skip_for_footprint_defer() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local candidate_json="$3"
+	declare -F _footprint_defer_should_suppress >/dev/null 2>&1 || return 1
+	_footprint_defer_should_suppress "$issue_number" "$repo_slug" "$candidate_json" || return 1
+	_dispatch_stats_increment "dispatch_candidate_footprint_defer_suppressed"
+	return 0
+}
+
+#######################################
 # Skip candidates with terminal blockers.
 #
 # Arguments:
@@ -1912,6 +1928,11 @@ _dispatch_process_candidate() {
 	fi
 
 	pulse_dispatch_debug_log "processing #${issue_number} (${repo_slug}) labels=[${labels_csv}]"
+
+	# GH#30619: suppress unchanged overlap before expensive candidate ceremony.
+	if _dispatch_skip_for_footprint_defer "$issue_number" "$repo_slug" "$candidate_json"; then
+		return 1
+	fi
 
 	if _dispatch_should_skip_candidate "$issue_number" "$repo_slug"; then
 		return 1

--- a/.agents/scripts/tests/test-dispatch-footprint-overlap.sh
+++ b/.agents/scripts/tests/test-dispatch-footprint-overlap.sh
@@ -249,6 +249,14 @@ TEST_BIN="${TEST_ROOT}/bin"
 mkdir -p "$TEST_BIN"
 cat >"${TEST_BIN}/gh" <<'MOCK_GH'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+	[[ "${MOCK_BLOCKER_FAIL:-0}" == "1" ]] && exit 1
+	printf '{"number":401,"state":"%s","body":"## Files to Modify\\n- `EDIT: %s`","labels":[{"name":"%s"}]}\n' \
+		"${MOCK_BLOCKER_STATE:-OPEN}" "${MOCK_BLOCKER_PATH:-.agents/scripts/pulse-wrapper.sh}" \
+		"${MOCK_BLOCKER_LABEL:-status:in-review}"
+	exit 0
+fi
+
 label=""
 while [[ "$#" -gt 0 ]]; do
 	case "${1:-}" in
@@ -282,6 +290,157 @@ if printf '%s' "$result" | grep -q "pulse-wrapper.sh|401" &&
 else
 	print_result "get_inflight: excludes parent-task coordination footprints" 1 "(got: ${result})"
 fi
+
+# =============================================================================
+# Test 12 — durable defer suppresses unchanged overlap across cycles
+# =============================================================================
+_FOOTPRINT_DEFER_STATE_DIR="${TEST_ROOT}/footprint-defers"
+_FOOTPRINT_DEFER_TTL_SECONDS=1800
+LOGFILE="${TEST_ROOT}/pulse.log"
+export PATH="${TEST_BIN}:$OLD_PATH"
+# shellcheck disable=SC2016 # Markdown backticks are literal fixture content.
+candidate_body='## Files to Modify
+- `EDIT: .agents/scripts/pulse-wrapper.sh:100-120` — same file'
+inflight_data='.agents/scripts/pulse-wrapper.sh|401'
+_footprint_defer_record_overlap "500" "test/repo" \
+	"$(_footprint_extract_paths "$candidate_body")" "$inflight_data" "401" ".agents/scripts/pulse-wrapper.sh"
+candidate_json=$(jq -cn --arg body "$candidate_body" '{body:$body,labels:[{"name":"auto-dispatch"}]}')
+if _footprint_defer_should_suppress "500" "test/repo" "$candidate_json"; then
+	status_json=$(_footprint_defer_status_json "500" "test/repo")
+	suppressed_count=$(printf '%s' "$status_json" | jq -r '.suppressed_count // 0')
+	if [[ "$suppressed_count" == "1" && "$(printf '%s' "$status_json" | jq -r '.active')" == "true" ]]; then
+		print_result "durable defer: suppresses unchanged active overlap" 0
+	else
+		print_result "durable defer: suppresses unchanged active overlap" 1 "(state=${status_json})"
+	fi
+else
+	print_result "durable defer: suppresses unchanged active overlap" 1 "(unexpected reconsideration)"
+fi
+
+# =============================================================================
+# Test 13 — candidate footprint changes wake the defer
+# =============================================================================
+# shellcheck disable=SC2016 # Markdown backticks are literal fixture content.
+changed_body='## Files to Modify
+- `EDIT: .agents/scripts/other.sh` — changed file'
+changed_json=$(jq -cn --arg body "$changed_body" '{body:$body,labels:[{"name":"auto-dispatch"}]}')
+if _footprint_defer_should_suppress "500" "test/repo" "$changed_json"; then
+	print_result "durable defer: candidate footprint change wakes reconsideration" 1 "(still suppressed)"
+else
+	status_json=$(_footprint_defer_status_json "500" "test/repo")
+	wake_reason=$(printf '%s' "$status_json" | jq -r '.wake_reason // ""')
+	if [[ "$wake_reason" == "candidate_footprint_changed" ]]; then
+		print_result "durable defer: candidate footprint change wakes reconsideration" 0
+	else
+		print_result "durable defer: candidate footprint change wakes reconsideration" 1 "(state=${status_json})"
+	fi
+fi
+
+# =============================================================================
+# Test 14 — blocker lifecycle changes wake the defer
+# =============================================================================
+_footprint_defer_record_overlap "501" "test/repo" \
+	"$(_footprint_extract_paths "$candidate_body")" "$inflight_data" "401" ".agents/scripts/pulse-wrapper.sh"
+MOCK_BLOCKER_STATE=CLOSED
+export MOCK_BLOCKER_STATE
+if _footprint_defer_should_suppress "501" "test/repo" "$candidate_json"; then
+	print_result "durable defer: blocker close wakes reconsideration" 1 "(still suppressed)"
+else
+	status_json=$(_footprint_defer_status_json "501" "test/repo")
+	wake_reason=$(printf '%s' "$status_json" | jq -r '.wake_reason // ""')
+	if [[ "$wake_reason" == "blocker_lifecycle_changed" ]]; then
+		print_result "durable defer: blocker close wakes reconsideration" 0
+	else
+		print_result "durable defer: blocker close wakes reconsideration" 1 "(state=${status_json})"
+	fi
+fi
+unset MOCK_BLOCKER_STATE
+
+# =============================================================================
+# Test 15 — malformed state falls through to the live overlap check
+# =============================================================================
+state_path=$(_footprint_defer_state_path "test/repo" "502")
+mkdir -p "${state_path%/*}"
+printf '{malformed\n' >"$state_path"
+if _footprint_defer_should_suppress "502" "test/repo" "$candidate_json"; then
+	print_result "durable defer: malformed state fails through to live check" 1 "(unsafe suppression)"
+else
+	print_result "durable defer: malformed state fails through to live check" 0
+fi
+
+# =============================================================================
+# Test 16 — blocker footprint changes wake the defer
+# =============================================================================
+_footprint_defer_record_overlap "503" "test/repo" \
+	"$(_footprint_extract_paths "$candidate_body")" "$inflight_data" "401" ".agents/scripts/pulse-wrapper.sh"
+MOCK_BLOCKER_PATH=.agents/scripts/changed.sh
+export MOCK_BLOCKER_PATH
+if _footprint_defer_should_suppress "503" "test/repo" "$candidate_json"; then
+	print_result "durable defer: blocker footprint change wakes reconsideration" 1 "(still suppressed)"
+else
+	status_json=$(_footprint_defer_status_json "503" "test/repo")
+	wake_reason=$(printf '%s' "$status_json" | jq -r '.wake_reason // ""')
+	if [[ "$wake_reason" == "blocker_footprint_changed" ]]; then
+		print_result "durable defer: blocker footprint change wakes reconsideration" 0
+	else
+		print_result "durable defer: blocker footprint change wakes reconsideration" 1 "(state=${status_json})"
+	fi
+fi
+unset MOCK_BLOCKER_PATH
+
+# =============================================================================
+# Test 17 — force-dispatch explicitly wakes but does not authorize overlap
+# =============================================================================
+_footprint_defer_record_overlap "504" "test/repo" \
+	"$(_footprint_extract_paths "$candidate_body")" "$inflight_data" "401" ".agents/scripts/pulse-wrapper.sh"
+force_json=$(jq -cn --arg body "$candidate_body" '{body:$body,labels:[{"name":"force-dispatch"}]}')
+if _footprint_defer_should_suppress "504" "test/repo" "$force_json"; then
+	print_result "durable defer: operator reconsideration wakes live check" 1 "(still suppressed)"
+else
+	status_json=$(_footprint_defer_status_json "504" "test/repo")
+	wake_reason=$(printf '%s' "$status_json" | jq -r '.wake_reason // ""')
+	if [[ "$wake_reason" == "operator_reconsideration" ]]; then
+		print_result "durable defer: operator reconsideration wakes live check" 0
+	else
+		print_result "durable defer: operator reconsideration wakes live check" 1 "(state=${status_json})"
+	fi
+fi
+
+# =============================================================================
+# Test 18 — bounded cooldown expiry wakes the live check
+# =============================================================================
+_footprint_defer_record_overlap "505" "test/repo" \
+	"$(_footprint_extract_paths "$candidate_body")" "$inflight_data" "401" ".agents/scripts/pulse-wrapper.sh"
+state_path=$(_footprint_defer_state_path "test/repo" "505")
+state_json=$(_footprint_defer_read_json "$state_path")
+state_json=$(printf '%s' "$state_json" | jq -c '.expires_at = 0')
+_footprint_defer_write_json "$state_path" "$state_json"
+if _footprint_defer_should_suppress "505" "test/repo" "$candidate_json"; then
+	print_result "durable defer: cooldown expiry wakes reconsideration" 1 "(still suppressed)"
+else
+	status_json=$(_footprint_defer_status_json "505" "test/repo")
+	wake_reason=$(printf '%s' "$status_json" | jq -r '.wake_reason // ""')
+	if [[ "$wake_reason" == "cooldown_expired" ]]; then
+		print_result "durable defer: cooldown expiry wakes reconsideration" 0
+	else
+		print_result "durable defer: cooldown expiry wakes reconsideration" 1 "(state=${status_json})"
+	fi
+fi
+
+# =============================================================================
+# Test 19 — blocker refresh failure remains safely suppressed
+# =============================================================================
+_footprint_defer_record_overlap "506" "test/repo" \
+	"$(_footprint_extract_paths "$candidate_body")" "$inflight_data" "401" ".agents/scripts/pulse-wrapper.sh"
+MOCK_BLOCKER_FAIL=1
+export MOCK_BLOCKER_FAIL
+if _footprint_defer_should_suppress "506" "test/repo" "$candidate_json"; then
+	print_result "durable defer: blocker refresh failure remains fail-closed" 0
+else
+	print_result "durable defer: blocker refresh failure remains fail-closed" 1 "(unsafe reconsideration)"
+fi
+unset MOCK_BLOCKER_FAIL
+PATH="$OLD_PATH"
 
 # =============================================================================
 # Summary

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -826,6 +826,35 @@ printf '\nTest 20: help output includes issue subcommand\n'
 output=$("$HELPER" help 2>&1) || true
 assert_contains "help shows issue subcommand" "issue <N>" "$output"
 
+# --- Test 20b: issue report surfaces durable footprint defer state ---
+printf '\nTest 20b: durable footprint defer diagnostics\n'
+DIAG_FOOTPRINT_STATE_DIR="${TMPDIR_TEST}/footprint-defers"
+AIDEVOPS_FOOTPRINT_DEFER_STATE_DIR="$DIAG_FOOTPRINT_STATE_DIR" bash -c '
+	source "$1"
+	_footprint_defer_record_overlap "21860" "marcusquinn/aidevops" \
+		".agents/scripts/pulse-wrapper.sh" \
+		".agents/scripts/pulse-wrapper.sh|401" \
+		"401" ".agents/scripts/pulse-wrapper.sh"
+' _ "${SCRIPT_DIR}/../dispatch-dedup-footprint.sh"
+output=$(AIDEVOPS_FOOTPRINT_DEFER_STATE_DIR="$DIAG_FOOTPRINT_STATE_DIR" \
+	PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	PATH="${TMPDIR_TEST}:${PATH}" \
+	"$HELPER" issue 21860 --repo marcusquinn/aidevops 2>&1) || true
+assert_contains "issue text shows footprint defer heading" "Footprint overlap defer:" "$output"
+assert_contains "issue text shows footprint blocker" "Blocking issue: #401" "$output"
+assert_contains "issue text shows active footprint defer" "Active: true" "$output"
+
+output=$(AIDEVOPS_FOOTPRINT_DEFER_STATE_DIR="$DIAG_FOOTPRINT_STATE_DIR" \
+	PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	PATH="${TMPDIR_TEST}:${PATH}" \
+	"$HELPER" issue 21860 --repo marcusquinn/aidevops --json 2>&1) || true
+json_footprint_blocker=$(printf '%s' "$output" | jq -r '.footprint_defer.blocking_issue // 0' 2>/dev/null || printf '0')
+assert_eq "JSON footprint defer blocker" "401" "$json_footprint_blocker"
+json_footprint_active=$(printf '%s' "$output" | jq -r '.footprint_defer.active // false' 2>/dev/null || printf 'false')
+assert_eq "JSON footprint defer active" "true" "$json_footprint_active"
+
 # --- Test 21: api-budget compact sanitized summary ---
 printf '\nTest 21: api-budget compact sanitized summary\n'
 output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \


### PR DESCRIPTION
## Summary

Persist blocker-aware footprint-overlap deferrals, suppress unchanged reconsideration before candidate ceremony, wake on lifecycle/footprint/cooldown/operator changes, and expose defer state in issue diagnostics.

## Files Changed

.agents/scripts/dispatch-dedup-footprint.sh, .agents/scripts/pulse-diagnose-helper.sh, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/tests/test-dispatch-footprint-overlap.sh, .agents/scripts/tests/test-pulse-diagnose-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Local linters passed; footprint overlap suite passed 19/19; pulse diagnose suite passed 151/151; dispatch stage wiring passed 54/54; guardrail and failure-reason suites passed.

Resolves #30619


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 38m and 487,651 tokens on this with the user in an interactive session.