### PR TITLE
GH#30583: fix: trust native PR body closing targets

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -2031,14 +2031,14 @@ process_pr() {
 }
 
 #######################################
-# Extract linked issue number from a GitHub-native closing clause in the PR body.
-# A "GH#NNN:" title may confirm that identity but may never override it.
+# Extract linked issue number from a same-repository GitHub-native closing clause
+# in the PR body. PR title metadata is not issue identity.
 #
 # Close keyword matching (GH#18098): only GitHub-native keywords trigger auto-close —
 # bare GH#NNN references in "Related" sections do NOT.  GitHub's full keyword list:
 # close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved (case-insensitive).
-# GH#NNN matching is restricted to the PR title to avoid treating informational body
-# references as closing keywords.
+# Cross-repository references use owner/repo#NNN and do not match the local #NNN
+# shape below.
 #
 # Args: $1=PR number, $2=repo slug
 # Returns: issue number on stdout, or empty if none found
@@ -2046,11 +2046,7 @@ process_pr() {
 _extract_linked_issue() {
 	local pr_number="$1"
 	local repo_slug="$2"
-	local pr_title="" pr_body=""
-	if ! pr_title=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json title --jq '.title // empty' 2>/dev/null); then
-		echo "[pulse-wrapper] _extract_linked_issue: PR #${pr_number} in ${repo_slug} title metadata unavailable — no routing target" >>"$LOGFILE"
-		return 1
-	fi
+	local pr_body=""
 	if ! pr_body=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json body --jq '.body // empty' 2>/dev/null); then
 		echo "[pulse-wrapper] _extract_linked_issue: PR #${pr_number} in ${repo_slug} body metadata unavailable — no routing target" >>"$LOGFILE"
 		return 1
@@ -2061,15 +2057,12 @@ _extract_linked_issue() {
 	# Does NOT match bare GH#NNN, "Related #NNN", "For #NNN", "Ref #NNN", or other
 	# non-closing references. (GH#18098 + t2108)
 	#
-	# The body keyword is AUTHORITATIVE. The title fallback below only fires when
-	# the body has a closing keyword AND the title also names a number — it picks
-	# WHICH issue from the body matches when there are multiple. It is NEVER an
-	# override that creates a match where the body intentionally has none. (t2108)
-	local body_issues="" body_issue="" title_issue=""
+	# The body keyword is AUTHORITATIVE. A project-specific GH#NNN title prefix
+	# must not override or contradict a single native closing target. (t2108)
+	local body_issues="" body_issue=""
 	body_issues=$(printf '%s' "$pr_body" \
 		| grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]+#[0-9]+' \
 		| grep -oE '[0-9]+' | sort -u) || body_issues=""
-	title_issue=$(printf '%s' "$pr_title" | grep -oE 'GH#[0-9]+' | head -1 | grep -oE '[0-9]+') || title_issue=""
 
 	# No closing keyword in the body → return empty. The PR is intentionally
 	# not closing any issue (planning-only PR, multi-PR roadmap, "For #NNN"
@@ -2084,12 +2077,6 @@ _extract_linked_issue() {
 	fi
 	body_issue="$body_issues"
 
-	# A title identity is corroborating evidence only. A mismatch means target
-	# identity is ambiguous and destructive callers must fail closed.
-	if [[ -n "$title_issue" && "$title_issue" != "$body_issue" ]]; then
-		echo "[pulse-wrapper] _extract_linked_issue: PR #${pr_number} in ${repo_slug} title issue #${title_issue} disagrees with closing issue #${body_issue} — no routing target" >>"$LOGFILE"
-		return 1
-	fi
 	printf '%s' "$body_issue"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh
+++ b/.agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh
@@ -3,9 +3,8 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
 # Tests for t2108 / GH#19051: pulse-merge.sh _extract_linked_issue
-# must treat the PR body keyword as AUTHORITATIVE. The PR-title fallback
-# (GH#NNN: prefix) may only return an issue number when the PR body ALSO
-# contains a GitHub-native closing keyword (Closes/Fixes/Resolves + #NNN).
+# must treat a single same-repository PR-body closing target as AUTHORITATIVE.
+# A project-specific GH#NNN title prefix is not GitHub issue identity.
 #
 # Root cause: every PR in this repo follows the canonical title format
 # "GH#NNN: description". _extract_linked_issue fell back to that title
@@ -25,12 +24,13 @@
 #      (regression guard for the t2105 incident)
 #   2. "Resolves #NNN" body + GH#NNN title → issue number
 #      (normal leaf close path still works)
-#   3. "Closes #99999" body + GH#19042 title → empty
-#      (mismatched identities fail closed)
+#   3. "Closes #99999" body + unrelated GH#19042 title → #99999
+#      (the single native closing target is authoritative)
 #   4. "Ref #NNN" body (no closing keyword) + tNNN title → empty
 #      (tNNN: title format has no GH# — both gates fail)
 #   5. Multiple distinct closing identities → empty
-#   6. Failed title/body metadata reads → empty
+#   6. Cross-repository closing reference → empty
+#   7. Failed body metadata read → empty; unavailable title metadata is irrelevant
 
 set -euo pipefail
 
@@ -176,14 +176,14 @@ test_closing_keyword_accepts_tab_whitespace() {
 	return 0
 }
 
-# Scenario 3: title/body mismatch is ambiguous and must not select either issue.
-test_title_mismatch_returns_empty() {
+# Scenario 3: a project-specific GH# title cannot contradict the single native target.
+test_unrelated_title_keeps_body_target() {
 	export TEST_PR_TITLE="GH#19042: cross-issue"
 	export TEST_PR_BODY="Closes #99999
 
 Also references #19042."
-	assert_returns "" \
-		"scenario3: mismatched title and closing issue return empty"
+	assert_returns "99999" \
+		"scenario3: unrelated GH# title does not override native closing target"
 	return 0
 }
 
@@ -195,13 +195,21 @@ test_multiple_closing_issues_return_empty() {
 	return 0
 }
 
+test_cross_repo_closing_reference_returns_empty() {
+	export TEST_PR_TITLE="GH#19042: external tracker identity"
+	export TEST_PR_BODY="Resolves other/repo#19042"
+	assert_returns "" \
+		"scenario6: cross-repository closing reference is not a local issue target"
+	return 0
+}
+
 test_metadata_failure_returns_empty() {
 	export TEST_PR_TITLE="GH#19042: fix bug"
 	export TEST_PR_BODY="Resolves #19042"
 	export TEST_FAIL_METADATA="title"
-	assert_returns "" "scenario6a: failed title metadata read returns empty"
+	assert_returns "19042" "scenario7a: unavailable title metadata does not block body target"
 	export TEST_FAIL_METADATA="body"
-	assert_returns "" "scenario6b: failed body metadata read returns empty"
+	assert_returns "" "scenario7b: failed body metadata read returns empty"
 	export TEST_FAIL_METADATA=""
 	return 0
 }
@@ -231,9 +239,10 @@ main() {
 	test_for_ref_body_no_close_returns_empty
 	test_resolves_body_returns_issue
 	test_closing_keyword_accepts_tab_whitespace
-	test_title_mismatch_returns_empty
+	test_unrelated_title_keeps_body_target
 	test_ref_body_tnnn_title_returns_empty
 	test_multiple_closing_issues_return_empty
+	test_cross_repo_closing_reference_returns_empty
 	test_metadata_failure_returns_empty
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Make a single same-repository closing-keyword target in the PR body authoritative. Ignore project-specific GH# title prefixes, keep multiple native targets fail-closed, and reject cross-repository references.

## Files Changed

.agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-merge-extract-linked-issue.sh; bash .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh; bash .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh; bash .agents/scripts/tests/test-pulse-merge-interactive-handover.sh; shellcheck changed shell files; .agents/scripts/linters-local.sh

Resolves #30583


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 9h 16m and 2,241,364 tokens on this with the user in an interactive session.