### PR TITLE
GH#30585: fix(backfill): skip Renovate Dependency Dashboards

### DIFF
--- a/.agents/scripts/backfill-status-available.sh
+++ b/.agents/scripts/backfill-status-available.sh
@@ -35,6 +35,8 @@ source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || {
 	printf 'ERROR: cannot source shared-constants.sh\n' >&2
 	exit 1
 }
+# shellcheck source=renovate-dependency-dashboard-helper.sh
+source "${SCRIPT_DIR}/renovate-dependency-dashboard-helper.sh"
 
 # --- Constants ----------------------------------------------------------------
 
@@ -206,7 +208,7 @@ process_repo() {
 		--state open \
 		--limit 200 \
 		--search "$search_query" \
-		--json number,title,labels 2>/dev/null) || issues_json="[]"
+		--json number,title,labels,author 2>/dev/null) || issues_json="[]"
 	issues_json=$(normalize_issues_json "$issues_json") || issues_json="[]"
 
 	local count
@@ -220,7 +222,12 @@ process_repo() {
 	# Process each candidate
 	local i=0
 	while [[ "$i" -lt "$count" ]]; do
-		local num title labels_json add_tier
+		local issue_json num title labels_json add_tier
+		issue_json=$(printf '%s' "$issues_json" | jq -c ".[$i]")
+		if _is_renovate_dependency_dashboard_issue "$issue_json"; then
+			i=$((i + 1))
+			continue
+		fi
 		num=$(printf '%s' "$issues_json" | jq -r ".[$i].number")
 		title=$(printf '%s' "$issues_json" | jq -r ".[$i].title | .[0:80]")
 		labels_json=$(printf '%s' "$issues_json" | jq -c "[.[$i].labels[].name]")

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -73,6 +73,8 @@ _PULSE_DISPATCH_COLLABORATOR_ASSOCIATION="COLLABORATOR"
 
 # shellcheck source=disk-capacity-lib.sh
 source "${BASH_SOURCE[0]%/*}/disk-capacity-lib.sh"
+# shellcheck source=renovate-dependency-dashboard-helper.sh
+source "${BASH_SOURCE[0]%/*}/renovate-dependency-dashboard-helper.sh"
 
 # Extracted modules — sourced in load order.
 # shellcheck source=pulse-dispatch-dedup-layers.sh
@@ -1114,30 +1116,6 @@ _dispatch_target_is_pull_request() {
 		return 1
 	fi
 	return 2
-}
-
-#######################################
-# Return success when issue metadata identifies a Renovate Dependency Dashboard
-# meta-issue. These are maintenance tracking issues, not implementation work.
-#
-# Args:
-#   $1 - issue_meta_json (pre-fetched JSON with .author and .title)
-# Returns:
-#   0 - renovate[bot] Dependency Dashboard issue
-#   1 - not a Renovate Dependency Dashboard issue
-#######################################
-_is_renovate_dependency_dashboard_issue() {
-	local issue_meta_json="$1"
-	local author_login="" issue_title="" title_lower=""
-
-	[[ -n "$issue_meta_json" ]] || return 1
-	author_login=$(printf '%s' "$issue_meta_json" | jq -r '.author.login // empty' 2>/dev/null | tr '[:upper:]' '[:lower:]') || author_login=""
-	issue_title=$(printf '%s' "$issue_meta_json" | jq -r '.title // empty' 2>/dev/null) || issue_title=""
-	title_lower=$(printf '%s' "$issue_title" | tr '[:upper:]' '[:lower:]')
-
-	[[ "$author_login" == "renovate[bot]" ]] || return 1
-	[[ "$title_lower" == *"dependency dashboard"* ]] || return 1
-	return 0
 }
 
 #######################################

--- a/.agents/scripts/renovate-dependency-dashboard-helper.sh
+++ b/.agents/scripts/renovate-dependency-dashboard-helper.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Shared classification for Renovate Dependency Dashboard tracking issues.
+
+[[ -n "${_RENOVATE_DEPENDENCY_DASHBOARD_HELPER_LOADED:-}" ]] && return 0
+_RENOVATE_DEPENDENCY_DASHBOARD_HELPER_LOADED=1
+
+# Return success only for Renovate's metadata-only Dependency Dashboard issue.
+# Args: $1 = issue JSON containing .author.login and .title
+_is_renovate_dependency_dashboard_issue() {
+	local issue_meta_json="$1"
+	local author_login="" issue_title="" title_lower=""
+
+	[[ -n "$issue_meta_json" ]] || return 1
+	author_login=$(printf '%s' "$issue_meta_json" | jq -r '.author.login // empty' 2>/dev/null | tr '[:upper:]' '[:lower:]') || author_login=""
+	issue_title=$(printf '%s' "$issue_meta_json" | jq -r '.title // empty' 2>/dev/null) || issue_title=""
+	title_lower=$(printf '%s' "$issue_title" | tr '[:upper:]' '[:lower:]')
+
+	[[ "$author_login" == "renovate[bot]" ]] || return 1
+	[[ "$title_lower" == *"dependency dashboard"* ]] || return 1
+	return 0
+}
+
+return 0

--- a/.agents/scripts/tests/test-backfill-status-available-normalizes-gh-output.sh
+++ b/.agents/scripts/tests/test-backfill-status-available-normalizes-gh-output.sh
@@ -33,7 +33,7 @@ setup_test_env() {
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
-	printf '[{"number":2,"title":"candidate","labels":[{"name":"auto-dispatch"}]}]\n[]\n'
+	printf '[{"number":1,"title":"ordinary candidate","author":{"login":"reporter"},"labels":[{"name":"auto-dispatch"}]},{"number":2,"title":"Dependency Dashboard","author":{"login":"renovate[bot]"},"labels":[{"name":"auto-dispatch"}]},{"number":3,"title":"chore(deps): update jq","author":{"login":"renovate[bot]"},"labels":[{"name":"auto-dispatch"}]},{"number":4,"title":"Dependency Dashboard help","author":{"login":"reporter"},"labels":[{"name":"auto-dispatch"}]}]\n[]\n'
 	exit 0
 fi
 
@@ -53,9 +53,16 @@ main() {
 	if [[ "$output" == *"syntax error in expression"* ]]; then
 		fail "arithmetic syntax error leaked for multi-document gh output"
 	fi
-	if [[ "$output" != *"Dry-run summary: 1 candidate(s) found"* ]]; then
+	if [[ "$output" != *"Dry-run summary: 3 candidate(s) found"* ]]; then
 		printf '%s\n' "$output" >&2
-		fail "expected one normalized candidate in dry-run summary"
+		fail "expected dashboard exclusion and three dispatchable candidates"
+	fi
+	if [[ "$output" == *"owner/repo#2"* ]]; then
+		fail "expected Renovate Dependency Dashboard to be excluded"
+	fi
+	if [[ "$output" != *"owner/repo#1"* || "$output" != *"owner/repo#3"* || "$output" != *"owner/repo#4"* ]]; then
+		printf '%s\n' "$output" >&2
+		fail "expected ordinary, actionable Renovate, and non-bot dashboard-title issues"
 	fi
 
 	printf 'PASS backfill-status-available normalizes gh output\n'

--- a/.agents/scripts/tests/test-pulse-dispatch-core-renovate-dashboard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-renovate-dashboard.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+HELPER_SCRIPT="${SCRIPT_DIR}/../renovate-dependency-dashboard-helper.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -39,9 +39,9 @@ define_helper_under_test() {
 	local helper_src
 	helper_src=$(awk '
 		/^_is_renovate_dependency_dashboard_issue\(\) \{/,/^}$/ { print }
-	' "$CORE_SCRIPT")
+	' "$HELPER_SCRIPT")
 	if [[ -z "$helper_src" ]]; then
-		printf 'ERROR: could not extract _is_renovate_dependency_dashboard_issue from %s\n' "$CORE_SCRIPT" >&2
+		printf 'ERROR: could not extract _is_renovate_dependency_dashboard_issue from %s\n' "$HELPER_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090


### PR DESCRIPTION
## Summary

Implementation for issue #30585.

## Files Changed

.agents/scripts/backfill-status-available.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/renovate-dependency-dashboard-helper.sh, .agents/scripts/tests/test-backfill-status-available-normalizes-gh-output.sh, .agents/scripts/tests/test-pulse-dispatch-core-renovate-dashboard.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30585


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 10h 8m and 2,540,620 tokens on this with the user in an interactive session.