### PR TITLE
fix: allow explicit reserved release migration

### DIFF
--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -250,6 +250,24 @@ _full_loop_recovery_validate_receipt() {
 	return 1
 }
 
+#aidevops:trust-boundary
+_full_loop_recovery_validate_reserved_receipt() {
+	local repo="$1"
+	local source_pr="$2"
+	local receipt_path=""
+	local status=""
+	# This path is reachable only from a fresh explicit release command. Before
+	# any tag exists, that command may replace prior not-requested evidence.
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$source_pr") || return 1
+	[[ -f "$receipt_path" ]] && IFS= read -r status <"$receipt_path" || true
+	case "$status" in
+	"" | "$_FULL_LOOP_PHASE_FAILED" | "$_FULL_LOOP_RELEASE_NOT_REQUESTED") return 0 ;;
+	esac
+	printf 'Reserved release authorization migration refused: release receipt is terminal (%s)\n' \
+		"$status" >&2
+	return 1
+}
+
 _full_loop_recovery_validate_existing_tag() {
 	local repo="$1"
 	local source_pr="$2"
@@ -515,7 +533,7 @@ _full_loop_recovery_expand_reserved_authorization() {
 	local current_auth=""
 	local observed_auth=""
 	local existing_tag_rc=0
-	_full_loop_recovery_validate_receipt "$repo" "$source_pr" || return 1
+	_full_loop_recovery_validate_reserved_receipt "$repo" "$source_pr" || return 1
 	_full_loop_release_find_tag_for_pr "$repo" "$source_pr" || existing_tag_rc=$?
 	[[ "$existing_tag_rc" -eq 2 ]] || return 1
 	_full_loop_recovery_prepare_aggregate "$repo" "$source_pr" "$expected_sources" || return 1

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -115,9 +115,16 @@ if _full_loop_recovery_validate_receipt test/repo 42 v1.2.3 '{"source_pr":42}' >
 	printf 'FAIL recovery accepted release:not-requested without matching publication intent\n'
 	exit 1
 fi
+_full_loop_recovery_validate_reserved_receipt test/repo 42
+printf 'published\n' >"${TEST_ROOT}/release.status"
+if _full_loop_recovery_validate_reserved_receipt test/repo 42 >/dev/null 2>&1; then
+	printf 'FAIL reserved authorization migration accepted a published receipt\n'
+	exit 1
+fi
 printf 'failed\n' >"${TEST_ROOT}/release.status"
 _full_loop_recovery_validate_receipt test/repo 42
-printf 'PASS recovery accepts authorized release:not-requested and rejects other terminal receipts\n'
+_full_loop_recovery_validate_reserved_receipt test/repo 42
+printf 'PASS recovery distinguishes explicit pre-tag migration from terminal aggregate recovery\n'
 
 STATE_LOG="${TEST_ROOT}/state.log"
 : >"$STATE_LOG"
@@ -848,7 +855,7 @@ printf 'PASS persisted replacement-tag recovery recreates its detached tag workt
 	root_authorization_record=$(jq -cn --arg merge 2222222222222222222222222222222222222222 \
 		'{schema_version:1,repository:"test/repo",requested_pr:42,
 		  expected_sources:[{pr:42,merge:$merge}],recorded_at:"2026-08-09T00:00:00Z"}')
-	_full_loop_recovery_validate_receipt() { return 0; }
+	printf 'not-requested\n' >"${TEST_ROOT}/release.status"
 	_full_loop_release_find_tag_for_pr() { return 2; }
 	_full_loop_recovery_prepare_aggregate() {
 		_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$expanded_manifest"


### PR DESCRIPTION
## Summary

- Allow a fresh explicit release command to migrate a reserved authorization after an earlier `release:not-requested` receipt.
- Keep published, superseded, and unknown terminal receipts blocked.
- Exercise the real receipt validator in reserved-lane regression coverage instead of masking it with a stub.

## Problem

A reserved lane created before reviewed exact-tip aggregation called the tag-recovery receipt validator without tag context. That validator necessarily rejected `release:not-requested`, even though the fresh `aidevops release` invocation was the explicit publication intent. This blocked the authorized release for #30622 before any tag mutation.

## Safety

The relaxed rule is isolated to fresh pre-tag reserved-lane migration. Aggregate tag recovery still requires publication intent bound to the exact tag/source context, and terminal receipts remain immutable.

## Testing

- `bash .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh`
- `bash .agents/scripts/tests/test-full-loop-release-helper.sh`
- `shellcheck .agents/scripts/full-loop-release-aggregate-recovery.sh .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh`
- `git diff --check`

## Runtime Testing

Risk: high. Runtime-verified through the existing shell state-machine harness using the real `not-requested` receipt path; no publication side effect was performed by the tests.

Ref #30622

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1d 3h and 7,239,189 tokens on this with the user in an interactive session.