### PR TITLE
fix: skip deleted shell files in release preflight

### DIFF
--- a/.agents/scripts/tests/test-version-manager-linked-release.sh
+++ b/.agents/scripts/tests/test-version-manager-linked-release.sh
@@ -31,6 +31,8 @@ print_success() { return 0; }
 export SCRIPT_DIR REPO_ROOT="$REPO"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/version-manager-git.sh"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/version-manager-preflight.sh"
 
 force_flag=1
 if assert_release_linked_worktree >/dev/null 2>&1; then
@@ -58,5 +60,24 @@ if (cd "$LINKED" && PRE_EDIT_OWNER_PID="$$" bash "$PRE_EDIT" >/dev/null 2>&1); t
 	printf 'PASS pre-edit accepts detached linked release worktree\n'
 else
 	printf 'FAIL pre-edit rejected detached linked release worktree\n'
+	exit 1
+fi
+
+SHELLCHECK_LOG="${ROOT}/shellcheck.log"
+shellcheck() {
+	printf '%s\n' "$*" >>"$SHELLCHECK_LOG"
+	return 0
+}
+printf '#!/usr/bin/env bash\n' >"${LINKED}/current.sh"
+if (cd "$LINKED" && _run_shellcheck_on_changed_files v1.0.0 $'current.sh\ndeleted.sh\nREADME.md'); then
+	if grep -qx -- '--severity=warning current.sh' "$SHELLCHECK_LOG" &&
+		! grep -q 'deleted.sh' "$SHELLCHECK_LOG"; then
+		printf 'PASS release preflight excludes deleted shell files from ShellCheck\n'
+	else
+		printf 'FAIL release preflight passed an unexpected changed file to ShellCheck\n'
+		exit 1
+	fi
+else
+	printf 'FAIL release preflight rejected a changed-file list containing a deletion\n'
 	exit 1
 fi

--- a/.agents/scripts/version-manager-preflight.sh
+++ b/.agents/scripts/version-manager-preflight.sh
@@ -290,7 +290,8 @@ _run_shellcheck_on_changed_files() {
 		[[ -n "$changed_file" ]] || continue
 		case "$changed_file" in
 		*.sh)
-			changed_shell_files+=("$changed_file")
+			# Diff name lists include deletions; ShellCheck only current files.
+			[[ -f "$REPO_ROOT/$changed_file" ]] && changed_shell_files+=("$changed_file")
 			;;
 		esac
 	done <<<"$changed_files"


### PR DESCRIPTION
## Summary

- Exclude deleted `.sh` paths from patch-release ShellCheck inputs, matching the existing secretlint changed-file behavior.
- Add regression coverage using a mixed current/deleted/non-shell changed-file list in a detached release worktree.

## Problem

Patch release preflight derives names from `git diff`, which includes deleted files. Secretlint already filters paths that do not exist in the release tree, but ShellCheck attempted to open them and blocked the authorized release before version or tag mutation.

Observed failure:

`test-historical-replay-benchmark.sh: openBinaryFile: does not exist`

## Safety

Only absent paths are excluded. Existing changed shell files continue through the same per-file ShellCheck severity gate.

## Testing

- `bash .agents/scripts/tests/test-version-manager-linked-release.sh`
- `shellcheck .agents/scripts/version-manager-preflight.sh .agents/scripts/tests/test-version-manager-linked-release.sh`
- `git diff --check`

## Runtime Testing

Risk: high. Runtime-verified through the detached-release test harness with a real changed-file list containing both an existing shell file and a deleted shell path.

Ref #30622

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1d 4h and 7,357,006 tokens on this with the user in an interactive session.