### PR TITLE
GH#30586: fix(pulse): preserve substantive review decisions

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -1301,21 +1301,47 @@ _check_ruleset_required_reviews_passing() {
 		echo "[pulse-merge] _check_ruleset_required_reviews_passing: review fetch failed for PR #${pr_number} in ${repo_slug} with ruleset requiring ${required_count} approval(s) — failing closed (GH#24577)" >>"$LOGFILE"
 		return 1
 	fi
+	# #aidevops:trust-boundary — count only each reviewer's latest substantive
+	# decision. COMMENTED submissions do not change GitHub's approval state, while
+	# malformed state-changing reviews must keep ruleset admission fail-closed.
 	approved_count=$(jq -er --arg author "$pr_author" --arg empty "$empty_string" \
-		--arg array_type "$PMRC_JSON_ARRAY" --arg object_type "$PMRC_JSON_OBJECT" '
+		--arg array_type "$PMRC_JSON_ARRAY" --arg object_type "$PMRC_JSON_OBJECT" \
+		--arg number_type "$PMRC_JSON_NUMBER" --arg string_type "$PMRC_JSON_STRING" '
+		def normalized_state:
+			(.state // $empty) | if type == $string_type then ascii_upcase else error("invalid review state") end;
+		def state_changing:
+			. == "APPROVED" or . == "CHANGES_REQUESTED" or . == "DISMISSED";
+		def known_state:
+			state_changing or . == "COMMENTED" or . == "PENDING";
+		($author | ascii_downcase) as $author_login |
 		if type != $array_type or any(.[]; type != $array_type) or any(.[][]?; type != $object_type) then
 			error("invalid paginated reviews response")
+		elif any(.[][]?;
+			((normalized_state | known_state) | not)
+			or ((normalized_state | state_changing) and (
+				(.user | type) != $object_type
+				or (.user.login | type) != $string_type
+				or (.user.login | length) == 0
+				or (.submitted_at | type) != $string_type
+				or (.submitted_at | length) == 0
+				or ((try (.submitted_at | fromdateiso8601) catch null) == null)
+				or (.id | type) != $number_type
+				or .id <= 0
+				or (.id | floor) != .id
+			))
+		) then
+			error("malformed state-changing review")
 		else
 			[.[][]? | {
-				login: (.user.login // $empty),
-				state: (.state // $empty),
-				submitted_at: (.submitted_at // $empty),
+				login: ((.user.login // $empty) | ascii_downcase),
+				state: normalized_state,
+				submitted_epoch: ((.submitted_at // $empty) | fromdateiso8601),
 				id: (.id // 0)
-			} | select(.login != $empty)]
+			} | select(.state | state_changing) | select(.login != $empty)]
 			| group_by(.login)
-			| map(max_by([.submitted_at, .id]))
-			| map(select(.login != $author))
-			| map(select((.state | ascii_upcase) == "APPROVED"))
+			| map(max_by([.submitted_epoch, .id]))
+			| map(select(.login != $author_login))
+			| map(select(.state == "APPROVED"))
 			| length
 		end
 	' <<<"$reviews_pages" 2>/dev/null) || approved_count=""

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -1294,6 +1294,10 @@ _check_ruleset_required_reviews_passing() {
 	required_count=$(_ruleset_required_review_count_for_default_branch "$repo_slug" "$default_branch") || return 1
 	[[ "$required_count" =~ ^[0-9]+$ ]] || required_count=0
 	[[ "$required_count" -eq 0 ]] && return 0
+	if [[ -z "$pr_author" ]]; then
+		echo "[pulse-merge] _check_ruleset_required_reviews_passing: PR #${pr_number} in ${repo_slug} has no verifiable author — failing closed (GH#30586)" >>"$LOGFILE"
+		return 1
+	fi
 
 	local reviews_pages="" approved_count="" empty_string=""
 	reviews_pages=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}/reviews?per_page=100" --paginate --slurp 2>/dev/null) || reviews_pages=""
@@ -1307,8 +1311,8 @@ _check_ruleset_required_reviews_passing() {
 	approved_count=$(jq -er --arg author "$pr_author" --arg empty "$empty_string" \
 		--arg array_type "$PMRC_JSON_ARRAY" --arg object_type "$PMRC_JSON_OBJECT" \
 		--arg number_type "$PMRC_JSON_NUMBER" --arg string_type "$PMRC_JSON_STRING" '
-		def normalized_state:
-			(.state // $empty) | if type == $string_type then ascii_upcase else error("invalid review state") end;
+		def review_state:
+			(.state // $empty) | if type == $string_type then . else error("invalid review state") end;
 		def state_changing:
 			. == "APPROVED" or . == "CHANGES_REQUESTED" or . == "DISMISSED";
 		def known_state:
@@ -1317,8 +1321,8 @@ _check_ruleset_required_reviews_passing() {
 		if type != $array_type or any(.[]; type != $array_type) or any(.[][]?; type != $object_type) then
 			error("invalid paginated reviews response")
 		elif any(.[][]?;
-			((normalized_state | known_state) | not)
-			or ((normalized_state | state_changing) and (
+			((review_state | known_state) | not)
+			or ((review_state | state_changing) and (
 				(.user | type) != $object_type
 				or (.user.login | type) != $string_type
 				or (.user.login | length) == 0
@@ -1332,12 +1336,12 @@ _check_ruleset_required_reviews_passing() {
 		) then
 			error("malformed state-changing review")
 		else
-			[.[][]? | {
+			[.[][]? | review_state as $state | select($state | state_changing) | {
 				login: ((.user.login // $empty) | ascii_downcase),
-				state: normalized_state,
+				state: $state,
 				submitted_epoch: ((.submitted_at // $empty) | fromdateiso8601),
 				id: (.id // 0)
-			} | select(.state | state_changing) | select(.login != $empty)]
+			} | select(.login != $empty)]
 			| group_by(.login)
 			| map(max_by([.submitted_epoch, .id]))
 			| map(select(.login != $author_login))

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
 MERGE_PROCESS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
+REQUIRED_CHECKS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-required-checks.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -222,6 +223,11 @@ _pmp_review_decision_is_unknown() {
 }
 
 PULSE_UNKNOWN_STATE="UNKNOWN"
+PULSE_MERGE_BOOL_TRUE="true"
+PMRC_JSON_ARRAY="array"
+PMRC_JSON_NUMBER="number"
+PMRC_JSON_OBJECT="object"
+PMRC_JSON_STRING="string"
 _resolve_pr_mergeable_status() { return 0; }
 _extract_linked_issue() { printf '123'; return 0; }
 _check_pr_merge_gates() { return 0; }
@@ -230,6 +236,7 @@ approve_collaborator_pr() { return 0; }
 _check_ruleset_required_reviews_passing() { return 0; }
 _extract_merge_summary() { printf 'summary'; return 0; }
 _retarget_stacked_children() { return 0; }
+_pmp_is_protected_release_pr() { return 1; }
 _pulse_merge_admin_safety_check() { return 0; }
 _pulse_merge_final_trust_gate() {
 	_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE=0
@@ -263,6 +270,91 @@ _handle_post_merge_actions() {
 }
 _pulse_merge_ready_pr_json_fields() {
 	printf 'number,state,mergeable,reviewDecision,author,title,updatedAt,headRefOid,headRefName,baseRefName,labels,isDraft'
+	return 0
+}
+
+RULESET_REVIEWS_JSON="[]"
+
+_pmrc_gh_read() {
+	local command_name="$1"
+	shift
+	if [[ "$command_name" == "gh" && "$*" == *"repos/owner/repo --jq .default_branch"* ]]; then
+		printf 'main\n'
+		return 0
+	fi
+	if [[ "$command_name" == "gh" && "$*" == *"repos/owner/repo/pulls/77/reviews?per_page=100"* ]]; then
+		printf '%s\n' "$RULESET_REVIEWS_JSON"
+		return 0
+	fi
+	return 1
+}
+
+_ruleset_required_review_count_for_default_branch() {
+	local repo_slug="$1"
+	local default_branch="$2"
+	[[ "$repo_slug" == "owner/repo" && "$default_branch" == "main" ]] || return 1
+	printf '1\n'
+	return 0
+}
+
+define_ruleset_review_function_under_test() {
+	local helper_src=""
+	helper_src=$(awk '
+		/^_check_ruleset_required_reviews_passing\(\) \{/,/^\}$/ { print }
+	' "$REQUIRED_CHECKS_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract ruleset review helper from %s\n' "$REQUIRED_CHECKS_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$helper_src"
+	return 0
+}
+
+assert_ruleset_review_sequence() {
+	local test_name="$1"
+	local reviews_json="$2"
+	local expected_rc="$3"
+	local actual_rc=0
+	RULESET_REVIEWS_JSON="$reviews_json"
+	_check_ruleset_required_reviews_passing "owner/repo" "77" "author" || actual_rc=$?
+	if [[ "$actual_rc" -eq "$expected_rc" ]]; then
+		print_result "$test_name" 0
+		return 0
+	fi
+	print_result "$test_name" 1 "expected rc=${expected_rc}, actual rc=${actual_rc}"
+	return 0
+}
+
+test_ruleset_required_review_decision_sequences() {
+	setup_test_env
+	define_ruleset_review_function_under_test || {
+		teardown_test_env
+		return 0
+	}
+
+	assert_ruleset_review_sequence "APPROVED then COMMENTED preserves approval" \
+		'[[{"id":1,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"},{"id":2,"user":{"login":"reviewer"},"state":"COMMENTED","submitted_at":"2026-08-23T11:00:00Z"}]]' 0
+	assert_ruleset_review_sequence "CHANGES_REQUESTED then COMMENTED remains unapproved" \
+		'[[{"id":3,"user":{"login":"reviewer"},"state":"CHANGES_REQUESTED","submitted_at":"2026-08-23T10:00:00Z"},{"id":4,"user":{"login":"reviewer"},"state":"COMMENTED","submitted_at":"2026-08-23T11:00:00Z"}]]' 1
+	assert_ruleset_review_sequence "APPROVED then CHANGES_REQUESTED remains unapproved" \
+		'[[{"id":5,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"},{"id":6,"user":{"login":"reviewer"},"state":"CHANGES_REQUESTED","submitted_at":"2026-08-23T11:00:00Z"}]]' 1
+	assert_ruleset_review_sequence "APPROVED then DISMISSED remains unapproved" \
+		'[[{"id":7,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"},{"id":8,"user":{"login":"reviewer"},"state":"DISMISSED","submitted_at":"2026-08-23T11:00:00Z"}]]' 1
+	assert_ruleset_review_sequence "PR author approval remains excluded" \
+		'[[{"id":9,"user":{"login":"author"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"}]]' 1
+	assert_ruleset_review_sequence "malformed substantive review fails closed" \
+		'[[{"id":10,"user":{"login":"reviewer"},"state":"APPROVED"}]]' 1
+	assert_ruleset_review_sequence "unknown review state fails closed" \
+		'[[{"id":11,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"},{"id":12,"user":{"login":"reviewer"},"state":"CHANGES_REQUESTED ","submitted_at":"2026-08-23T11:00:00Z"}]]' 1
+	assert_ruleset_review_sequence "malformed review timestamp fails closed" \
+		'[[{"id":13,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"not-rfc3339"}]]' 1
+	assert_ruleset_review_sequence "non-positive review id fails closed" \
+		'[[{"id":0,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"}]]' 1
+	assert_ruleset_review_sequence "PR author exclusion is case-insensitive" \
+		'[[{"id":14,"user":{"login":"Author"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"}]]' 1
+
+	teardown_test_env
 	return 0
 }
 
@@ -795,6 +887,7 @@ main() {
 	test_stale_cache_401_retries_admin_merge_once
 	test_terminal_merge_failure_refreshes_state_and_invalidates_cache
 	test_ruleset_fallback_failure_preserves_admin_conversation_context
+	test_ruleset_required_review_decision_sequences
 
 	printf '\n=================================\n'
 	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -315,9 +315,10 @@ assert_ruleset_review_sequence() {
 	local test_name="$1"
 	local reviews_json="$2"
 	local expected_rc="$3"
+	local pr_author="${4-author}"
 	local actual_rc=0
 	RULESET_REVIEWS_JSON="$reviews_json"
-	_check_ruleset_required_reviews_passing "owner/repo" "77" "author" || actual_rc=$?
+	_check_ruleset_required_reviews_passing "owner/repo" "77" "$pr_author" || actual_rc=$?
 	if [[ "$actual_rc" -eq "$expected_rc" ]]; then
 		print_result "$test_name" 0
 		return 0
@@ -353,6 +354,14 @@ test_ruleset_required_review_decision_sequences() {
 		'[[{"id":0,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"}]]' 1
 	assert_ruleset_review_sequence "PR author exclusion is case-insensitive" \
 		'[[{"id":14,"user":{"login":"Author"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"}]]' 1
+	assert_ruleset_review_sequence "lowercase review state fails closed" \
+		'[[{"id":15,"user":{"login":"reviewer"},"state":"approved","submitted_at":"2026-08-23T10:00:00Z"}]]' 1
+	assert_ruleset_review_sequence "COMMENTED without ordering fields remains non-substantive" \
+		'[[{"id":16,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"},{"state":"COMMENTED"}]]' 0
+	assert_ruleset_review_sequence "PENDING without ordering fields remains non-substantive" \
+		'[[{"id":17,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"},{"state":"PENDING"}]]' 0
+	assert_ruleset_review_sequence "missing PR author fails closed" \
+		'[[{"id":18,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-08-23T10:00:00Z"}]]' 1 ""
 
 	teardown_test_env
 	return 0


### PR DESCRIPTION
## Summary

Implementation for issue #30586.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30586


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 11h 11m and 2,660,137 tokens on this with the user in an interactive session.