### PR TITLE
GH#30588: reconcile worker origin after watchdog recovery

### DIFF
--- a/.agents/scripts/headless-runtime-attempt.sh
+++ b/.agents/scripts/headless-runtime-attempt.sh
@@ -529,7 +529,9 @@ _finish_run_attempt_result() {
 		"${_run_activity_detected:-0}" "${_metric_kill_reason:-}" "${_run_failure_reason:-}")
 	launch_failure_cause="${evidence_fields%%$'\t'*}"
 	next_action="${evidence_fields#*$'\t'}"
-	if [[ "$metric_result_label" == "watchdog_stall_killed" ]] && _worker_post_pr_handoff_confirmed "$session_key" "$work_dir"; then
+	if [[ "$metric_result_label" == "watchdog_stall_killed" &&
+		"${_HRW_RECOVERY_CLASSIFICATION:-}" == "$_HRW_REASON_WORKER_COMPLETE" ]] &&
+		_worker_post_pr_handoff_confirmed "$session_key" "$work_dir"; then
 		launch_failure_cause="post_pr_pending_ci_handoff"
 		next_action="monitor_open_pr"
 	fi

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -1117,16 +1117,12 @@ _hrw_reconcile_worker_handoff_origin() {
 	}
 	# Recheck live issue ownership immediately before mutating trust metadata.
 	_hrw_verify_dispatch_ownership || return 1
-	origin_state=$(_hrw_worker_handoff_origin_state \
-		"$repo_slug" "$pr_number" "$branch_name" "$local_head" "$runner_login") || return 1
-	[[ "$origin_state" == "$_HRW_ORIGIN_STATE_MISSING" ]] || {
-		[[ "$origin_state" == "$_HRW_ORIGIN_STATE_VERIFIED" ]]
-		return $?
-	}
 	gh pr edit "$pr_number" --repo "$repo_slug" --add-label "$_HRW_ORIGIN_WORKER_LABEL" >/dev/null 2>&1 || return 1
 	origin_state=$(_hrw_worker_handoff_origin_state \
 		"$repo_slug" "$pr_number" "$branch_name" "$local_head" "$runner_login") || return 1
 	[[ "$origin_state" == "$_HRW_ORIGIN_STATE_VERIFIED" ]] || return 1
+	# Retain the claim if ownership changed while GitHub applied the label.
+	_hrw_verify_dispatch_ownership || return 1
 	print_info "[pulse-wrapper] Reconciled missing origin:worker label for PR #${pr_number} after worker recovery"
 	return 0
 }

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -48,6 +48,11 @@ _HRW_REASON_READY_MISSING_SUMMARY="worker_ready_missing_summary"
 _HRW_REASON_READY_HANDOFF_FAILED="worker_ready_missing_summary_transition_failed"
 _HRW_REASON_CLOSED_UNMERGED="worker_closed_unmerged_pr"
 _HRW_REASON_UNVERIFIED_HANDOFF="worker_post_pr_handoff_unverified"
+_HRW_REASON_ORIGIN_RECONCILIATION_FAILED="worker_origin_reconciliation_failed"
+_HRW_ORIGIN_WORKER_LABEL="origin:worker"
+_HRW_ORIGIN_STATE_MISSING="missing"
+_HRW_ORIGIN_STATE_VERIFIED="verified"
+_HRW_HANDOFF_READY="ready"
 _HRW_REASON_WORKTREE_CONTINUATION_STATE_REJECTED="worker_worktree_continuation_state_rejected"
 _HRW_REASON_WORKTREE_CONTINUATION_OWNER_ABSENT="worker_worktree_continuation_owner_absent"
 _HRW_REASON_WORKTREE_OWNER_CONCURRENT_MUTATION="worker_worktree_owner_concurrent_mutation"
@@ -1031,6 +1036,102 @@ _handle_worker_dirty_worktree() {
 }
 
 #######################################
+# Classify exact PR metadata for worker-origin reconciliation.
+#
+# Args: repo slug, PR number, branch, head SHA, expected author.
+# Stdout: verified|missing. Returns non-zero for unavailable, mismatched, or
+# conflicting provenance.
+#######################################
+_hrw_worker_handoff_origin_state() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local branch_name="$3"
+	local expected_head="$4"
+	local expected_author="$5"
+	local pr_json=""
+
+	pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json number,state,isDraft,isCrossRepository,headRefName,headRefOid,author,labels 2>/dev/null) || return 1
+	printf '%s' "$pr_json" | jq -e --argjson pr "$pr_number" \
+		--arg branch "$branch_name" --arg head "$expected_head" --arg author "$expected_author" '
+		(.number == $pr) and (.state == "OPEN") and (.isDraft == false) and (.isCrossRepository == false) and
+		(.headRefName == $branch) and (.headRefOid == $head) and
+		((.author.login // "") == $author)
+	' >/dev/null 2>&1 || return 1
+	if ! printf '%s' "$pr_json" | jq -e --arg worker_origin "$_HRW_ORIGIN_WORKER_LABEL" '
+		[.labels[]?.name | select(startswith("origin:") and . != $worker_origin)] | length == 0
+	' >/dev/null 2>&1; then
+		return 1
+	fi
+	if printf '%s' "$pr_json" | jq -e --arg worker_origin "$_HRW_ORIGIN_WORKER_LABEL" \
+		'[.labels[]?.name] | index($worker_origin) != null' >/dev/null 2>&1; then
+		printf '%s' "$_HRW_ORIGIN_STATE_VERIFIED"
+	else
+		printf '%s' "$_HRW_ORIGIN_STATE_MISSING"
+	fi
+	return 0
+}
+
+#######################################
+# Restore missing worker provenance only while this exact issue worker still
+# owns the dispatch and its exact-head, linked, summarized PR. User-controlled
+# body markers are deliberately excluded from the proof chain.
+#
+# Args: session key, worktree path.
+# Returns: 0 when origin:worker was already present or was added and verified.
+#######################################
+_hrw_reconcile_worker_handoff_origin() {
+	local session_key="$1"
+	local work_dir="$2"
+	local repo_slug="${DISPATCH_REPO_SLUG:-}"
+	local runner_login="${WORKER_GITHUB_LOGIN:-${AIDEVOPS_WORKER_GITHUB_LOGIN:-}}"
+	local issue_number="${session_key#issue-}"
+	local branch_name=""
+	local local_head=""
+	local handoff_state=""
+	local pr_number=""
+	local origin_state=""
+
+	[[ "$session_key" == issue-* && "$issue_number" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ "${WORKER_SESSION_KEY:-}" == "$session_key" ]] || return 1
+	[[ "${WORKER_ISSUE_NUMBER:-}" == "$issue_number" ]] || return 1
+	[[ "$repo_slug" == */* && -n "$runner_login" ]] || return 1
+	[[ -n "$work_dir" && -d "$work_dir" ]] || return 1
+	command -v gh >/dev/null 2>&1 || return 1
+
+	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+	local_head=$(git -C "$work_dir" rev-parse HEAD 2>/dev/null || true)
+	[[ -n "$branch_name" && "$branch_name" != "$_HRW_GIT_HEAD" && -n "$local_head" ]] || return 1
+	handoff_state=$(_pr_handoff_state_for_branch_or_issue \
+		"$branch_name" "$issue_number" "$repo_slug" "head-only" "$local_head" "1") || return 1
+	[[ "${handoff_state%%|*}" == "$_HRW_HANDOFF_READY" ]] || return 1
+	pr_number="${handoff_state#*|}"
+	[[ "$pr_number" =~ ^[1-9][0-9]*$ ]] || return 1
+
+	_hrw_verify_dispatch_ownership || return 1
+	origin_state=$(_hrw_worker_handoff_origin_state \
+		"$repo_slug" "$pr_number" "$branch_name" "$local_head" "$runner_login") || return 1
+	[[ "$origin_state" == "$_HRW_ORIGIN_STATE_MISSING" ]] || {
+		[[ "$origin_state" == "$_HRW_ORIGIN_STATE_VERIFIED" ]]
+		return $?
+	}
+	# Recheck live issue ownership immediately before mutating trust metadata.
+	_hrw_verify_dispatch_ownership || return 1
+	origin_state=$(_hrw_worker_handoff_origin_state \
+		"$repo_slug" "$pr_number" "$branch_name" "$local_head" "$runner_login") || return 1
+	[[ "$origin_state" == "$_HRW_ORIGIN_STATE_MISSING" ]] || {
+		[[ "$origin_state" == "$_HRW_ORIGIN_STATE_VERIFIED" ]]
+		return $?
+	}
+	gh pr edit "$pr_number" --repo "$repo_slug" --add-label "$_HRW_ORIGIN_WORKER_LABEL" >/dev/null 2>&1 || return 1
+	origin_state=$(_hrw_worker_handoff_origin_state \
+		"$repo_slug" "$pr_number" "$branch_name" "$local_head" "$runner_login") || return 1
+	[[ "$origin_state" == "$_HRW_ORIGIN_STATE_VERIFIED" ]] || return 1
+	print_info "[pulse-wrapper] Reconciled missing origin:worker label for PR #${pr_number} after worker recovery"
+	return 0
+}
+
+#######################################
 # Recover tangible worker output on failure paths.
 #
 # Watchdog/SIGKILL exits can happen after a worker has already pushed a branch
@@ -1070,7 +1171,12 @@ _recover_worker_output_on_failure() {
 		pr_handoff=$(_pr_handoff_state_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug" \
 			"branch-or-issue" "$local_head" 1)
 		local pr_state="${pr_handoff%%|*}"
-		if [[ "$pr_state" == "ready" || "$pr_state" == "merged" ]]; then
+		if [[ "$pr_state" == "$_HRW_HANDOFF_READY" || "$pr_state" == "merged" ]]; then
+			if [[ "$pr_state" == "$_HRW_HANDOFF_READY" ]] && ! _hrw_reconcile_worker_handoff_origin "$session_key" "$work_dir"; then
+				_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_ORIGIN_RECONCILIATION_FAILED"
+				print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — provenance ambiguous or write unverified; retaining claim"
+				return 0
+			fi
 			print_info "[lifecycle] worker_failure_recovered_existing_pr session=${session_key} branch=${branch_name}"
 			_hrw_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
 			_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_WORKER_COMPLETE"

--- a/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
@@ -618,12 +618,15 @@ test_worker_recovery_reconciles_missing_origin_with_exact_provenance() {
 			export WORKER_SESSION_KEY="issue-99999"
 			export WORKER_ISSUE_NUMBER="99999"
 			export WORKER_GITHUB_LOGIN="worker-login"
-			local label_added=0 edit_count=0 release_reason=""
+			local label_added=0 edit_count=0 ownership_checks=0 release_reason=""
 			_pr_handoff_state_for_branch_or_issue() {
 				printf 'ready|457'
 				return 0
 			}
-			_hrw_verify_dispatch_ownership() { return 0; }
+			_hrw_verify_dispatch_ownership() {
+				ownership_checks=$((ownership_checks + 1))
+				return 0
+			}
 			gh() {
 				local args="$*"
 				if [[ "$args" == "pr view 457"* ]]; then
@@ -646,11 +649,11 @@ test_worker_recovery_reconciles_missing_origin_with_exact_provenance() {
 				return 0
 			}
 			_recover_worker_output_on_failure "issue-99999" "$work_dir"
-			printf 'classification=%s|release=%s|edits=%s\n' \
-				"$_HRW_RECOVERY_CLASSIFICATION" "$release_reason" "$edit_count"
+			printf 'classification=%s|release=%s|edits=%s|ownership=%s\n' \
+				"$_HRW_RECOVERY_CLASSIFICATION" "$release_reason" "$edit_count" "$ownership_checks"
 		)
 	)
-	if [[ "$result" == *"classification=worker_complete|release=worker_complete|edits=1"* ]]; then
+	if [[ "$result" == *"classification=worker_complete|release=worker_complete|edits=1|ownership=3"* ]]; then
 		print_result "worker recovery reconciles missing origin with exact provenance" 0
 	else
 		print_result "worker recovery reconciles missing origin with exact provenance" 1 "$result"

--- a/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
@@ -590,6 +590,7 @@ test_failed_worker_ready_pr_remains_completed_handoff() {
 			}
 			_hrw_resolve_default_branch() { printf 'main'; return 0; }
 			_pr_handoff_state_for_branch_or_issue() { printf 'ready|457'; return 0; }
+			_hrw_reconcile_worker_handoff_origin() { return 0; }
 			_release_dispatch_claim() { printf 'release=%s\n' "$2"; return 0; }
 			_recover_worker_output_on_failure "issue-99999" "${TEST_ROOT}"
 		)
@@ -598,6 +599,111 @@ test_failed_worker_ready_pr_remains_completed_handoff() {
 		print_result "failed worker ready PR remains a completed handoff" 0
 	else
 		print_result "failed worker ready PR remains a completed handoff" 1 "$result"
+	fi
+	return 0
+}
+
+test_worker_recovery_reconciles_missing_origin_with_exact_provenance() {
+	local work_dir="${TEST_ROOT}/repo-reconcile-worker-origin"
+	mkdir -p "$work_dir"
+	init_git_worktree "$work_dir"
+	git -C "$work_dir" checkout -q -b "feature/auto-test-issue-99999"
+	local expected_head=""
+	expected_head=$(git -C "$work_dir" rev-parse HEAD)
+
+	local result=""
+	result=$(
+		(
+			export DISPATCH_REPO_SLUG="test-owner/test-repo"
+			export WORKER_SESSION_KEY="issue-99999"
+			export WORKER_ISSUE_NUMBER="99999"
+			export WORKER_GITHUB_LOGIN="worker-login"
+			local label_added=0 edit_count=0 release_reason=""
+			_pr_handoff_state_for_branch_or_issue() {
+				printf 'ready|457'
+				return 0
+			}
+			_hrw_verify_dispatch_ownership() { return 0; }
+			gh() {
+				local args="$*"
+				if [[ "$args" == "pr view 457"* ]]; then
+					if [[ "$label_added" -eq 1 ]]; then
+						printf '{"number":457,"state":"OPEN","isDraft":false,"isCrossRepository":false,"headRefName":"feature/auto-test-issue-99999","headRefOid":"%s","author":{"login":"worker-login"},"labels":[{"name":"origin:worker"}]}' "$expected_head"
+					else
+						printf '{"number":457,"state":"OPEN","isDraft":false,"isCrossRepository":false,"headRefName":"feature/auto-test-issue-99999","headRefOid":"%s","author":{"login":"worker-login"},"labels":[]}' "$expected_head"
+					fi
+					return 0
+				fi
+				if [[ "$args" == *"pr edit 457"* && "$args" == *"--add-label origin:worker"* ]]; then
+					label_added=1
+					edit_count=$((edit_count + 1))
+					return 0
+				fi
+				return 1
+			}
+			_hrw_release_dispatch_claim() {
+				release_reason="$2"
+				return 0
+			}
+			_recover_worker_output_on_failure "issue-99999" "$work_dir"
+			printf 'classification=%s|release=%s|edits=%s\n' \
+				"$_HRW_RECOVERY_CLASSIFICATION" "$release_reason" "$edit_count"
+		)
+	)
+	if [[ "$result" == *"classification=worker_complete|release=worker_complete|edits=1"* ]]; then
+		print_result "worker recovery reconciles missing origin with exact provenance" 0
+	else
+		print_result "worker recovery reconciles missing origin with exact provenance" 1 "$result"
+	fi
+	return 0
+}
+
+test_worker_recovery_rejects_conflicting_origin_and_retains_claim() {
+	local work_dir="${TEST_ROOT}/repo-conflicting-worker-origin"
+	mkdir -p "$work_dir"
+	init_git_worktree "$work_dir"
+	git -C "$work_dir" checkout -q -b "feature/auto-test-issue-99999"
+	local expected_head=""
+	expected_head=$(git -C "$work_dir" rev-parse HEAD)
+
+	local result=""
+	result=$(
+		(
+			export DISPATCH_REPO_SLUG="test-owner/test-repo"
+			export WORKER_SESSION_KEY="issue-99999"
+			export WORKER_ISSUE_NUMBER="99999"
+			export WORKER_GITHUB_LOGIN="worker-login"
+			local edit_count=0 release_count=0
+			_pr_handoff_state_for_branch_or_issue() {
+				printf 'ready|458'
+				return 0
+			}
+			_hrw_verify_dispatch_ownership() { return 0; }
+			gh() {
+				local args="$*"
+				if [[ "$args" == "pr view 458"* ]]; then
+					printf '{"number":458,"state":"OPEN","isDraft":false,"isCrossRepository":false,"headRefName":"feature/auto-test-issue-99999","headRefOid":"%s","author":{"login":"worker-login"},"labels":[{"name":"origin:interactive"}]}' "$expected_head"
+					return 0
+				fi
+				if [[ "$args" == *"pr edit 458"* ]]; then
+					edit_count=$((edit_count + 1))
+					return 0
+				fi
+				return 1
+			}
+			_hrw_release_dispatch_claim() {
+				release_count=$((release_count + 1))
+				return 0
+			}
+			_recover_worker_output_on_failure "issue-99999" "$work_dir"
+			printf 'classification=%s|releases=%s|edits=%s\n' \
+				"$_HRW_RECOVERY_CLASSIFICATION" "$release_count" "$edit_count"
+		)
+	)
+	if [[ "$result" == *"classification=worker_origin_reconciliation_failed|releases=0|edits=0"* ]]; then
+		print_result "worker recovery rejects conflicting origin and retains claim" 0
+	else
+		print_result "worker recovery rejects conflicting origin and retains claim" 1 "$result"
 	fi
 	return 0
 }
@@ -653,23 +759,35 @@ test_post_pr_handoff_overrides_watchdog_next_action() {
 	}
 
 	local evidence_fields="" launch_failure_cause="" next_action=""
+	local previous_recovery_classification="${_HRW_RECOVERY_CLASSIFICATION:-}"
 	evidence_fields=$(_derive_worker_failure_evidence "watchdog_stall_killed" "79" "1" "hard_kill_stall" "watchdog_stall_killed")
 	launch_failure_cause="${evidence_fields%%$'\t'*}"
 	next_action="${evidence_fields#*$'\t'}"
-	if _worker_post_pr_handoff_confirmed "issue-99999" "$work_dir"; then
+	_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_WORKER_COMPLETE"
+	if [[ "$_HRW_RECOVERY_CLASSIFICATION" == "$_HRW_REASON_WORKER_COMPLETE" ]] && \
+		_worker_post_pr_handoff_confirmed "issue-99999" "$work_dir"; then
 		launch_failure_cause="post_pr_pending_ci_handoff"
 		next_action="monitor_open_pr"
 	fi
+	local failed_cause="unreconciled_origin" failed_next_action="retain_claim"
+	_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_ORIGIN_RECONCILIATION_FAILED"
+	if [[ "$_HRW_RECOVERY_CLASSIFICATION" == "$_HRW_REASON_WORKER_COMPLETE" ]] && \
+		_worker_post_pr_handoff_confirmed "issue-99999" "$work_dir"; then
+		failed_cause="post_pr_pending_ci_handoff"
+		failed_next_action="monitor_open_pr"
+	fi
+	_HRW_RECOVERY_CLASSIFICATION="$previous_recovery_classification"
 
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
 	unset -f gh_pr_list 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 
-	if [[ "$launch_failure_cause" == "post_pr_pending_ci_handoff" && "$next_action" == "monitor_open_pr" ]]; then
+	if [[ "$launch_failure_cause" == "post_pr_pending_ci_handoff" && "$next_action" == "monitor_open_pr" && \
+		"$failed_cause" == "unreconciled_origin" && "$failed_next_action" == "retain_claim" ]]; then
 		print_result "post-PR watchdog handoff suppresses redispatch next_action" 0
 	else
 		print_result "post-PR watchdog handoff suppresses redispatch next_action" 1 \
-			"Expected monitor_open_pr, got cause='${launch_failure_cause}' next='${next_action}'"
+			"recovered=${launch_failure_cause}/${next_action} unreconciled=${failed_cause}/${failed_next_action}"
 	fi
 	return 0
 }
@@ -728,6 +846,8 @@ test_pr_checkpoint_lifecycle_cases() {
 	test_failed_ci_ready_pr_is_durable_handoff
 	test_closed_unmerged_pr_is_failed_not_completed
 	test_failed_worker_ready_pr_remains_completed_handoff
+	test_worker_recovery_reconciles_missing_origin_with_exact_provenance
+	test_worker_recovery_rejects_conflicting_origin_and_retains_claim
 	test_access_denied_has_provider_failure_evidence
 	return 0
 }


### PR DESCRIPTION
## Summary

Reconcile missing origin:worker only after exact session, repository, same-repo PR head, linked issue, merge summary, author, and live ownership checks; retain the claim on ambiguity

## Files Changed

.agents/scripts/headless-runtime-attempt.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified with the headless runtime helper suite; ShellCheck and local quality gates pass

Resolves #30588


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 12h 24m and 3,059,677 tokens on this with the user in an interactive session.