### PR TITLE
GH#30637: fix tagless release preflight recovery

### DIFF
--- a/.agents/reference/release-aggregation-recovery.md
+++ b/.agents/reference/release-aggregation-recovery.md
@@ -61,6 +61,35 @@ then return to `reserved`. A retry must inspect this phase even when the request
 and persisted PR sets already match, because the authorization write may have
 completed before the prior process finished the lane transition.
 
+### Tagless preflight retry
+
+A normal `aidevops release` retry may also reopen a same-source
+`reconcile-required` lane after `version-manager.sh` failed before publication.
+This is narrower than signed-tag aggregate recovery: the lane must have no tag or
+terminal receipt, tag discovery must confirm no matching signed tag, and the
+local receipt must remain empty, failed, or `not-requested`. The attempted tag is
+read from new failure evidence or reconstructed from the immutable failed source
+and its recorded bump type. Legacy evidence without a recorded type is accepted
+only for the historical patch path; minor and major retries fail closed. That exact
+version must be absent from every remote, GitHub Releases, npm, and Homebrew. Exact failure
+evidence must bind the requested PR and merge to the prior direct source or
+immutable aggregate merge, whose manifest must equal the persisted and lane
+authorization and remain an ancestor of the reviewed retry. The retry may remain
+direct when main is still at that exact source, or resolve through a newer
+reviewed exact-tip aggregate after intervening merges.
+
+After those checks, a compare-and-swap lane write rotates the fencing token,
+records the failed source merge, and returns the lane to `reserved` with a durable
+`prepublication_recovery` marker. That marker binds the failed and current
+authorization manifests, blocks generic stale reservation reclaim, and forces any
+crash retry—including an interrupted authorization refresh—to repeat the evidence,
+channel-absence, and token-rotation checks. Any required authorization expansion then uses the existing
+`reserved-authorization-refresh` transaction before the ordinary release path
+starts again. The marker is cleared only when the ordinary path enters `preparing`,
+so any later failure records fresh release evidence. Missing or mismatched evidence, an ambiguous remote state, a tag,
+terminal receipt, competing owner, or any other lane phase fails closed. No
+manual lane or receipt edit is a supported recovery path.
+
 ## Failure and interruption
 
 An initial failure before authorization changes may restore the exact prior lane

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -776,24 +776,60 @@ _full_loop_write_release_receipt() {
 	return 0
 }
 
+_full_loop_release_expected_tag_at_commit() {
+	local source_commit="$1"
+	local release_type="$2"
+	local version=""
+	local major=""
+	local minor=""
+	local patch=""
+	[[ "$source_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	case "$release_type" in patch | minor | major) ;; *) return 1 ;; esac
+	version=$(git -C "$REPO_ROOT" show "${source_commit}:VERSION" 2>/dev/null) || return 1
+	[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	IFS='.' read -r major minor patch <<<"$version"
+	case "$release_type" in
+	patch) patch=$((patch + 1)) ;;
+	minor)
+		minor=$((minor + 1))
+		patch=0
+		;;
+	major)
+		major=$((major + 1))
+		minor=0
+		patch=0
+		;;
+	esac
+	printf 'v%s.%s.%s\n' "$major" "$minor" "$patch"
+	return 0
+}
+
 _full_loop_write_release_failure_evidence() {
 	local repo="$1"
 	local requested_pr="$2"
 	local requested_merge="$3"
 	local current_head="$4"
 	local release_source_pr="${5:-}"
+	local attempted_tag="${6:-}"
+	local release_type="${7:-}"
 	local evidence_path=""
 	local now=""
 	[[ "$requested_pr" =~ ^[0-9]+$ ]] || return 1
 	[[ -z "$release_source_pr" || "$release_source_pr" =~ ^[0-9]+$ ]] || return 1
+	[[ -z "$attempted_tag" || "$attempted_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	[[ -z "$release_type" || "$release_type" == "patch" || "$release_type" == "minor" || "$release_type" == "major" ]] || return 1
+	[[ (-z "$attempted_tag" && -z "$release_type") || (-n "$attempted_tag" && -n "$release_type") ]] || return 1
 	[[ "$requested_merge" =~ $_FULL_LOOP_SHA40_REGEX && "$current_head" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
 	evidence_path=$(_full_loop_release_evidence_path "$repo" "$requested_pr" failure) || return 1
 	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 	mkdir -p "${evidence_path%/*}" || return 1
 	jq -cn --arg repo "$repo" --argjson requested_pr "$requested_pr" --arg requested_merge "$requested_merge" \
-		--arg release_source_pr "$release_source_pr" --arg current_head "$current_head" --arg now "$now" \
+		--arg release_source_pr "$release_source_pr" --arg current_head "$current_head" \
+		--arg attempted_tag "$attempted_tag" --arg release_type "$release_type" --arg now "$now" \
 		'{schema_version:1,status:"failed",repository:$repo,requested_pr:$requested_pr,requested_merge:$requested_merge,
-		  release_source_pr:(if $release_source_pr == "" then null else ($release_source_pr | tonumber) end),current_head:$current_head,recorded_at:$now}' \
+		  release_source_pr:(if $release_source_pr == "" then null else ($release_source_pr | tonumber) end),current_head:$current_head,
+		  attempted_tag:(if $attempted_tag == "" then null else $attempted_tag end),
+		  release_type:(if $release_type == "" then null else $release_type end),recorded_at:$now}' \
 		>"${evidence_path}.tmp.$$" || return 1
 	mv "${evidence_path}.tmp.$$" "$evidence_path" || return 1
 	_full_loop_write_release_receipt "$repo" "$requested_pr" "$_FULL_LOOP_PHASE_FAILED"

--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -12,10 +12,18 @@ _FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH=""
 _FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT=""
 _FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON=""
 _FULL_LOOP_AGGREGATE_RECOVERY_EXISTING_CONTEXT="none"
+_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_PR=""
+_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_MERGE=""
+_FULL_LOOP_FAILED_PREPUBLICATION_TAG=""
+_FULL_LOOP_RESERVED_RECOVERY_PHASE=""
+_FULL_LOOP_RESERVED_RECOVERY_LANE_SOURCES=""
+_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION="false"
 _FULL_LOOP_AGGREGATE_RECOVERY_MANIFEST_JQ='sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")'
 _FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX='^[0-9a-f]{40}$'
+_FULL_LOOP_AGGREGATE_RECOVERY_JSON_STRING_TYPE="string"
 _FULL_LOOP_AGGREGATE_RECOVERY_PHASE="aggregation-recovery"
 _FULL_LOOP_AGGREGATE_COMMIT_PHASE="aggregate-publication-committing"
+_FULL_LOOP_FAILED_PREPUBLICATION_PHASE="reconcile-required"
 _FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX="refs/tags/"
 
 _full_loop_recovery_http_status() {
@@ -160,10 +168,11 @@ _full_loop_recovery_validate_interrupted_publication_intent() {
 	release_authorization_subset "$previous_authorization" "$current_authorization" || return 1
 	release_lane_read "$repo" || return 1
 	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
-		--arg sha40 "$_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX" '
+		--arg sha40 "$_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX" \
+		--arg string_type "$_FULL_LOOP_AGGREGATE_RECOVERY_JSON_STRING_TYPE" '
 		.active == true and .source_pr == $source_pr and .tag == $tag
 		and ((.terminal_receipt // null) == null)
-		and ((.phase | type) == "string") and ((.expected_sources | type) == "string")
+		and ((.phase | type) == $string_type) and ((.expected_sources | type) == $string_type)
 		and (.aggregate_recovery.provisional_tag_object | test($sha40))
 		and (.aggregate_recovery.previous_state.schema_version == 1)
 		and (.aggregate_recovery.previous_state.repository == .repository)
@@ -174,7 +183,7 @@ _full_loop_recovery_validate_interrupted_publication_intent() {
 			or (.aggregate_recovery.previous_state.phase == "reconcile-required"))
 		and ((.aggregate_recovery.previous_state.terminal_receipt // null) == null)
 		and ((.aggregate_recovery.previous_state.aggregate_recovery // null) == null)
-		and ((.aggregate_recovery.previous_state.expected_sources | type) == "string")
+		and ((.aggregate_recovery.previous_state.expected_sources | type) == $string_type)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
 	phase=$(jq -er '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	lane_expected=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
@@ -266,6 +275,167 @@ _full_loop_recovery_validate_reserved_receipt() {
 	printf 'Reserved release authorization migration refused: release receipt is terminal (%s)\n' \
 		"$status" >&2
 	return 1
+}
+
+_full_loop_recovery_failed_prepublication_refused() {
+	local reason="$1"
+	printf 'Failed pre-publication release recovery refused: %s\n' "$reason" >&2
+	return 1
+}
+
+_full_loop_recovery_commit_trailer_values() {
+	local commit_sha="$1"
+	local trailer_key="$2"
+	local commit_message=""
+	local parsed_trailers=""
+	commit_message=$(git -C "$REPO_ROOT" log -1 --format='%B' "$commit_sha" 2>/dev/null) || return 1
+	parsed_trailers=$(printf '%s\n' "$commit_message" | git -C "$REPO_ROOT" interpret-trailers --parse) || return 1
+	awk -v prefix="${trailer_key}: " 'index($0, prefix) == 1 { print substr($0, length(prefix) + 1) }' \
+		<<<"$parsed_trailers"
+	return $?
+}
+
+#aidevops:trust-boundary
+_full_loop_recovery_resolve_failed_prepublication_evidence() {
+	local repo="$1"
+	local source_pr="$2"
+	local requested_merge="$3"
+	local release_type="$4"
+	local evidence_path=""
+	local evidence_json=""
+	local failed_source_pr=""
+	local failed_source_merge=""
+	local evidence_attempted_tag=""
+	local evidence_release_type=""
+	local attempted_tag=""
+	[[ "$source_pr" =~ ^[0-9]+$ && "$requested_merge" =~ $_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX ]] || return 1
+	case "$release_type" in patch | minor | major) ;; *) return 1 ;; esac
+	evidence_path=$(_full_loop_release_evidence_path "$repo" "$source_pr" failure) || return 1
+	[[ -f "$evidence_path" ]] || {
+		_full_loop_recovery_failed_prepublication_refused "exact failure evidence is missing"
+		return 1
+	}
+	evidence_json=$(jq -ce --arg repo "$repo" --argjson source_pr "$source_pr" \
+		--arg requested_merge "$requested_merge" --arg sha40 "$_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX" \
+		--arg string_type "$_FULL_LOOP_AGGREGATE_RECOVERY_JSON_STRING_TYPE" '
+		select(.schema_version == 1 and .status == "failed" and .repository == $repo
+			and .requested_pr == $source_pr and .requested_merge == $requested_merge
+			and ((.release_source_pr | type) == "number")
+			and ((.current_head | type) == $string_type) and (.current_head | test($sha40))
+			and (((.attempted_tag // null) == null and (.release_type // null) == null)
+				or (((.attempted_tag | type) == $string_type and (.attempted_tag | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")))
+					and (.release_type == "patch" or .release_type == "minor" or .release_type == "major")))
+			and ((.recorded_at | type) == $string_type) and ((.recorded_at | length) > 0))
+	' "$evidence_path") || {
+		_full_loop_recovery_failed_prepublication_refused "failure evidence does not match the requested release"
+		return 1
+	}
+	failed_source_pr=$(jq -er '.release_source_pr' <<<"$evidence_json") || return 1
+	failed_source_merge=$(jq -er '.current_head' <<<"$evidence_json") || return 1
+	evidence_attempted_tag=$(jq -r '.attempted_tag // ""' <<<"$evidence_json") || return 1
+	evidence_release_type=$(jq -r '.release_type // ""' <<<"$evidence_json") || return 1
+	[[ -n "$evidence_release_type" || "$release_type" == "patch" ]] || {
+		_full_loop_recovery_failed_prepublication_refused "legacy failure evidence permits patch retries only"
+		return 1
+	}
+	[[ -z "$evidence_release_type" || "$evidence_release_type" == "$release_type" ]] || {
+		_full_loop_recovery_failed_prepublication_refused "failure evidence release type differs from the retry"
+		return 1
+	}
+	attempted_tag=$(_full_loop_release_expected_tag_at_commit "$failed_source_merge" "$release_type") || {
+		_full_loop_recovery_failed_prepublication_refused "attempted release tag cannot be reconstructed"
+		return 1
+	}
+	[[ -z "$evidence_attempted_tag" || "$evidence_attempted_tag" == "$attempted_tag" ]] || {
+		_full_loop_recovery_failed_prepublication_refused "failure evidence attempted tag differs from immutable source state"
+		return 1
+	}
+	jq -cn --argjson source_pr "$failed_source_pr" --arg source_merge "$failed_source_merge" \
+		--arg attempted_tag "$attempted_tag" \
+		'{source_pr:$source_pr,source_merge:$source_merge,attempted_tag:$attempted_tag}'
+	return $?
+}
+
+#aidevops:trust-boundary
+_full_loop_recovery_validate_failed_prepublication_intent() {
+	local repo="$1"
+	local source_pr="$2"
+	local current_authorization="$3"
+	local release_type="${4:-}"
+	local normalized_evidence=""
+	local failed_source_pr=""
+	local failed_source_merge=""
+	local attempted_tag=""
+	local failed_pr_json=""
+	local aggregate_identity=""
+	local aggregate_sources=""
+	local aggregate_manifest=""
+	local direct_manifest=""
+	_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_PR=""
+	_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_MERGE=""
+	_FULL_LOOP_FAILED_PREPUBLICATION_TAG=""
+	[[ "$source_pr" =~ ^[0-9]+$ && -n "$current_authorization" ]] || return 1
+	[[ "$_FULL_LOOP_RESOLVED_REQUESTED_MERGE" =~ $_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX &&
+		"$_FULL_LOOP_RESOLVED_SOURCE_MERGE" =~ $_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX ]] || return 1
+	normalized_evidence=$(_full_loop_recovery_resolve_failed_prepublication_evidence \
+		"$repo" "$source_pr" "$_FULL_LOOP_RESOLVED_REQUESTED_MERGE" "$release_type") || return 1
+	failed_source_pr=$(jq -er '.source_pr' <<<"$normalized_evidence") || return 1
+	failed_source_merge=$(jq -er '.source_merge' <<<"$normalized_evidence") || return 1
+	attempted_tag=$(jq -er '.attempted_tag' <<<"$normalized_evidence") || return 1
+	git -C "$REPO_ROOT" cat-file -e "${failed_source_merge}^{commit}" 2>/dev/null || {
+		_full_loop_recovery_failed_prepublication_refused "recorded release source commit is unavailable"
+		return 1
+	}
+	git -C "$REPO_ROOT" merge-base --is-ancestor "$failed_source_merge" \
+		"$_FULL_LOOP_RESOLVED_SOURCE_MERGE" 2>/dev/null || {
+		_full_loop_recovery_failed_prepublication_refused "recorded failed source is not an ancestor of the reviewed retry"
+		return 1
+	}
+	failed_pr_json=$(gh pr view "$failed_source_pr" --repo "$repo" \
+		--json state,mergedAt,mergeCommit,baseRefName 2>/dev/null) || {
+		_full_loop_recovery_failed_prepublication_refused "recorded release-source PR cannot be verified"
+		return 1
+	}
+	jq -e --arg merge "$failed_source_merge" '
+		.state == "MERGED" and ((.mergedAt // "") | length > 0)
+		and .baseRefName == "main" and .mergeCommit.oid == $merge
+	' <<<"$failed_pr_json" >/dev/null || {
+		_full_loop_recovery_failed_prepublication_refused "recorded release-source PR does not match its immutable merge"
+		return 1
+	}
+	direct_manifest="${source_pr}@${_FULL_LOOP_RESOLVED_REQUESTED_MERGE}"
+	if [[ "$failed_source_pr" == "$source_pr" &&
+		"$failed_source_merge" == "$_FULL_LOOP_RESOLVED_REQUESTED_MERGE" ]]; then
+		release_authorization_compare "$current_authorization" "$direct_manifest" || {
+			_full_loop_recovery_failed_prepublication_refused "direct failure evidence conflicts with persisted authorization"
+			return 1
+		}
+	else
+		aggregate_identity=$(_full_loop_recovery_commit_trailer_values "$failed_source_merge" \
+			"Aidevops-Release-Aggregator-PR") || return 1
+		aggregate_sources=$(_full_loop_recovery_commit_trailer_values "$failed_source_merge" \
+			"Aidevops-Release-Aggregates") || return 1
+		[[ "$aggregate_identity" == "$failed_source_pr" && -n "$aggregate_sources" ]] || {
+			_full_loop_recovery_failed_prepublication_refused "recorded release source is not an immutable aggregate"
+			return 1
+		}
+		aggregate_manifest=$(release_authorization_manifest_string "$aggregate_sources") || {
+			_full_loop_recovery_failed_prepublication_refused "recorded aggregate manifest is malformed"
+			return 1
+		}
+		release_authorization_compare "$current_authorization" "$aggregate_manifest" || {
+			_full_loop_recovery_failed_prepublication_refused "recorded aggregate manifest conflicts with persisted authorization"
+			return 1
+		}
+	fi
+	_full_loop_recovery_verify_channels_absent "$repo" "$attempted_tag" || {
+		_full_loop_recovery_failed_prepublication_refused "the attempted tag is not absent from every publication channel"
+		return 1
+	}
+	_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_PR="$failed_source_pr"
+	_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_MERGE="$failed_source_merge"
+	_FULL_LOOP_FAILED_PREPUBLICATION_TAG="$attempted_tag"
+	return 0
 }
 
 _full_loop_recovery_validate_existing_tag() {
@@ -450,6 +620,32 @@ _full_loop_recovery_prepare_aggregate() {
 	return 0
 }
 
+_full_loop_recovery_prepare_prepublication_source() {
+	local repo="$1"
+	local source_pr="$2"
+	local expected_sources="$3"
+	local worktree_base="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"
+	local resolver=""
+	local resolved_mode=""
+	local resolve_rc=0
+	local previous_preserve_evidence="${_FULL_LOOP_PRESERVE_PREPUBLICATION_FAILURE_EVIDENCE:-false}"
+	[[ -d "$worktree_base" ]] || return 1
+	git -C "$REPO_ROOT" fetch origin main >/dev/null || return 1
+	_FULL_LOOP_RELEASE_PATH="${worktree_base}/aidevops-release-prepublication-recovery-${source_pr}-$$"
+	git -C "$REPO_ROOT" worktree add --detach "$_FULL_LOOP_RELEASE_PATH" origin/main >/dev/null || return 1
+	trap 'cleanup_release_worktree' EXIT
+	resolver="$_FULL_LOOP_RELEASE_PATH/.agents/scripts/release-provenance-helper.sh"
+	_FULL_LOOP_PRESERVE_PREPUBLICATION_FAILURE_EVIDENCE=true
+	_full_loop_resolve_requested_release_source "$repo" "$source_pr" "$_FULL_LOOP_RELEASE_PATH" \
+		"$resolver" "$expected_sources" || resolve_rc=$?
+	_FULL_LOOP_PRESERVE_PREPUBLICATION_FAILURE_EVIDENCE="$previous_preserve_evidence"
+	[[ "$resolve_rc" -eq 0 ]] || return "$resolve_rc"
+	resolved_mode=$(jq -er '.mode' <<<"$_FULL_LOOP_RESOLVED_SOURCE_JSON") || return 1
+	case "$resolved_mode" in direct | aggregate) ;; *) return 1 ;; esac
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$_FULL_LOOP_RESOLVED_EXPECTED_SOURCES"
+	return 0
+}
+
 _full_loop_recovery_resolve_lane_authorization() {
 	local lane_sources="$1"
 	local reviewed_sources="$2"
@@ -494,7 +690,21 @@ _full_loop_recovery_reserved_base_authorization() {
 	return 0
 }
 
-_full_loop_recovery_reserved_lane_requires_migration() {
+_full_loop_recovery_lane_has_prepublication_marker() {
+	jq -e '((.prepublication_recovery // null) != null)' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null
+	return $?
+}
+
+_full_loop_recovery_lane_prepublication_sources() {
+	jq -er --arg string_type "$_FULL_LOOP_AGGREGATE_RECOVERY_JSON_STRING_TYPE" '
+		.prepublication_recovery.failed_expected_sources
+		| select(type == $string_type and length > 0)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON"
+	return $?
+}
+
+_full_loop_recovery_lane_requires_prepublication_transaction() {
 	local repo="$1"
 	local source_pr="$2"
 	local persisted_sources="$3"
@@ -502,6 +712,7 @@ _full_loop_recovery_reserved_lane_requires_migration() {
 	local lane_sources=""
 	local lane_prs=""
 	local persisted_prs=""
+	local phase=""
 	release_lane_read "$repo" || read_rc=$?
 	case "$read_rc" in
 	2) return 1 ;;
@@ -511,39 +722,70 @@ _full_loop_recovery_reserved_lane_requires_migration() {
 	jq -e --argjson source_pr "$source_pr" '
 		.active == true and .source_pr == $source_pr and ((.terminal_receipt // null) == null)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
-	if [[ "$(jq -r '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON")" == "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" ]]; then
+	phase=$(jq -er '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 2
+	if [[ "$phase" == "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" ]]; then
 		return 0
 	fi
-	jq -e '.phase == "reserved" and .tag == null and (.expected_sources | type) == "string"' \
+	if [[ "$phase" == "$_FULL_LOOP_FAILED_PREPUBLICATION_PHASE" ]]; then
+		jq -e --arg string_type "$_FULL_LOOP_AGGREGATE_RECOVERY_JSON_STRING_TYPE" \
+			'.tag == null and (.expected_sources | type) == $string_type' \
+			<<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+		lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 2
+		[[ "$lane_sources" == "$persisted_sources" ]]
+		return $?
+	fi
+	jq -e --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \
+		--arg string_type "$_FULL_LOOP_AGGREGATE_RECOVERY_JSON_STRING_TYPE" \
+		'.phase == $reserved and .tag == null and (.expected_sources | type) == $string_type' \
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
 	lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 2
+	if _full_loop_recovery_lane_has_prepublication_marker; then
+		[[ "$lane_sources" == "$persisted_sources" ]]
+		return $?
+	fi
 	lane_prs=$(release_authorization_intent_json "$lane_sources" | jq -c 'map(.pr)') || return 2
 	persisted_prs=$(release_authorization_intent_json "$persisted_sources" | jq -c 'map(.pr)') || return 2
 	[[ "$lane_prs" != "$persisted_prs" ]]
 	return $?
 }
 
-_full_loop_recovery_expand_reserved_authorization() {
+_full_loop_recovery_prepare_reserved_retry_source() {
 	local repo="$1"
 	local source_pr="$2"
 	local expected_sources="$3"
-	local previous_auth=""
-	local lane_sources=""
 	local phase=""
-	local current_auth=""
-	local observed_auth=""
-	local existing_tag_rc=0
-	_full_loop_recovery_validate_reserved_receipt "$repo" "$source_pr" || return 1
-	_full_loop_release_find_tag_for_pr "$repo" "$source_pr" || existing_tag_rc=$?
-	[[ "$existing_tag_rc" -eq 2 ]] || return 1
-	_full_loop_recovery_prepare_aggregate "$repo" "$source_pr" "$expected_sources" || return 1
-	_full_loop_validate_release_candidates "$repo" "$_FULL_LOOP_RESOLVED_SOURCE_JSON" || return 1
-	_full_loop_release_reset_tag_worktree || return 1
-	current_auth=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
 	release_lane_read "$repo" || return 1
-	jq -e --argjson source_pr "$source_pr" '
+	phase=$(jq -er '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	if [[ "$phase" == "$_FULL_LOOP_FAILED_PREPUBLICATION_PHASE" ]] ||
+		_full_loop_recovery_lane_has_prepublication_marker; then
+		_full_loop_recovery_prepare_prepublication_source "$repo" "$source_pr" "$expected_sources" || {
+			_full_loop_recovery_failed_prepublication_refused "reviewed retry source is neither a valid direct source nor aggregate"
+			return 1
+		}
+	else
+		_full_loop_recovery_prepare_aggregate "$repo" "$source_pr" "$expected_sources" || return 1
+	fi
+	return 0
+}
+
+#aidevops:trust-boundary
+_full_loop_recovery_load_reserved_lane_state() {
+	local repo="$1"
+	local source_pr="$2"
+	local current_authorization="$3"
+	local release_type="$4"
+	local phase=""
+	local lane_sources=""
+	local failed_sources=""
+	_FULL_LOOP_RESERVED_RECOVERY_PHASE=""
+	_FULL_LOOP_RESERVED_RECOVERY_LANE_SOURCES=""
+	_FULL_LOOP_RESERVED_RECOVERY_FAILED_SOURCES=""
+	_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION="false"
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" \
+		--arg string_type "$_FULL_LOOP_AGGREGATE_RECOVERY_JSON_STRING_TYPE" '
 		.active == true and .source_pr == $source_pr and .tag == null
-		and (.expected_sources | type) == "string" and (.phase | type) == "string"
+		and (.expected_sources | type) == $string_type and (.phase | type) == $string_type
 		and ((.terminal_receipt // null) == null)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || {
 		printf 'Reserved release lane is not eligible for legacy authorization normalization for PR #%s\n' "$source_pr" >&2
@@ -551,23 +793,89 @@ _full_loop_recovery_expand_reserved_authorization() {
 	}
 	phase=$(jq -er '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	case "$phase" in
-	reserved)
+	"$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED")
 		lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		if _full_loop_recovery_lane_has_prepublication_marker; then
+			[[ "$lane_sources" == "$current_authorization" ]] || {
+				printf 'Failed pre-publication release recovery refused: lane and persisted authorization differ\n' >&2
+				return 1
+			}
+			failed_sources=$(_full_loop_recovery_lane_prepublication_sources) || return 1
+			_full_loop_recovery_validate_failed_prepublication_intent "$repo" "$source_pr" \
+				"$failed_sources" "$release_type" || return 1
+			_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION="true"
+		fi
 		;;
 	"$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH")
 		[[ "$(jq -r '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON")" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
 		lane_sources=$(jq -er '.reserved_authorization_refresh.previous_expected_sources' \
 			<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		if _full_loop_recovery_lane_has_prepublication_marker; then
+			failed_sources=$(_full_loop_recovery_lane_prepublication_sources) || return 1
+			[[ "$lane_sources" == "$failed_sources" ]] || return 1
+			_full_loop_recovery_validate_failed_prepublication_intent "$repo" "$source_pr" \
+				"$failed_sources" "$release_type" || return 1
+			_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION="true"
+		fi
 		;;
-	*) return 1 ;;
+	"$_FULL_LOOP_FAILED_PREPUBLICATION_PHASE")
+		lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		[[ "$lane_sources" == "$current_authorization" ]] || {
+			printf 'Failed pre-publication release recovery refused: lane and persisted authorization differ\n' >&2
+			return 1
+		}
+		failed_sources="$lane_sources"
+		_full_loop_recovery_validate_failed_prepublication_intent "$repo" "$source_pr" \
+			"$failed_sources" "$release_type" || return 1
+		_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION="true"
+		;;
+	*)
+		printf 'Pre-publication release recovery refused: lane phase %s is not eligible\n' "$phase" >&2
+		return 1
+		;;
 	esac
+	_FULL_LOOP_RESERVED_RECOVERY_PHASE="$phase"
+	_FULL_LOOP_RESERVED_RECOVERY_LANE_SOURCES="$lane_sources"
+	_FULL_LOOP_RESERVED_RECOVERY_FAILED_SOURCES="$failed_sources"
+	return 0
+}
+
+_full_loop_recovery_expand_reserved_authorization() {
+	local repo="$1"
+	local source_pr="$2"
+	local expected_sources="$3"
+	local release_type="${4:-patch}"
+	local previous_auth=""
+	local lane_sources=""
+	local phase=""
+	local current_auth=""
+	local observed_auth=""
+	local existing_tag_rc=0
+	local failed_prepublication=false
+	_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_PR=""
+	_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_MERGE=""
+	_FULL_LOOP_FAILED_PREPUBLICATION_TAG=""
+	_FULL_LOOP_RESERVED_RECOVERY_FAILED_SOURCES=""
+	_full_loop_recovery_validate_reserved_receipt "$repo" "$source_pr" || return 1
+	_full_loop_release_find_tag_for_pr "$repo" "$source_pr" || existing_tag_rc=$?
+	[[ "$existing_tag_rc" -eq 2 ]] || return 1
+	_full_loop_recovery_prepare_reserved_retry_source "$repo" "$source_pr" "$expected_sources" || return 1
+	_full_loop_validate_release_candidates "$repo" "$_FULL_LOOP_RESOLVED_SOURCE_JSON" || return 1
+	_full_loop_release_reset_tag_worktree || return 1
+	current_auth=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	_full_loop_recovery_load_reserved_lane_state "$repo" "$source_pr" "$current_auth" \
+		"$release_type" || return 1
+	phase="$_FULL_LOOP_RESERVED_RECOVERY_PHASE"
+	lane_sources="$_FULL_LOOP_RESERVED_RECOVERY_LANE_SOURCES"
+	failed_prepublication="$_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION"
 	previous_auth=$(_full_loop_recovery_reserved_base_authorization "$repo" "$source_pr" \
 		"$current_auth" "$lane_sources" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED") || {
 		printf 'Reserved release lane authorization cannot be normalized against reviewed aggregate PR #%s\n' "$source_pr" >&2
 		return 1
 	}
 	release_authorization_subset "$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
-	if [[ "$phase" == "reserved" && "$lane_sources" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" &&
+	if [[ "$phase" == "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" && "$failed_prepublication" != "true" &&
+		"$lane_sources" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" &&
 		"$current_auth" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
 		_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -er '.operation_token' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 		_AIDEVOPS_RELEASE_LANE_RESULT="adopted"
@@ -576,6 +884,19 @@ _full_loop_recovery_expand_reserved_authorization() {
 	fi
 	release_lane_acquire "$repo" "$source_pr" "$lane_sources" || return $?
 	case "$_AIDEVOPS_RELEASE_LANE_RESULT" in acquired | adopted) ;; *) return 1 ;; esac
+	if [[ "$failed_prepublication" == "true" ]]; then
+		release_lane_reopen_failed_prepublication "$repo" "$source_pr" \
+			"$_FULL_LOOP_RESERVED_RECOVERY_FAILED_SOURCES" \
+			"$_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_PR" \
+			"$_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_MERGE" \
+			"$_FULL_LOOP_FAILED_PREPUBLICATION_TAG" || return 1
+		phase="$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED"
+	fi
+	if [[ "$current_auth" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" &&
+		"$lane_sources" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
+		printf 'Pre-publication release authorization already matches the reviewed retry for PR #%s\n' "$source_pr"
+		return 0
+	fi
 	release_lane_expand_reserved_authorization "$repo" "$source_pr" "$lane_sources" \
 		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
 	if [[ "$current_auth" != "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -140,7 +140,9 @@ _full_loop_resolve_requested_release_source() {
 			<<<"$blocked_pr_json" 2>/dev/null || true)
 		blocked_head=$(git -C "$release_path" rev-parse HEAD 2>/dev/null || true)
 		if [[ "$blocked_merge" =~ $_FULL_LOOP_SHA40_REGEX && "$blocked_head" =~ $_FULL_LOOP_SHA40_REGEX ]] &&
-			git -C "$release_path" merge-base --is-ancestor "$blocked_merge" "$blocked_head" 2>/dev/null; then
+			git -C "$release_path" merge-base --is-ancestor "$blocked_merge" "$blocked_head" 2>/dev/null &&
+			[[ "${_FULL_LOOP_PRESERVE_PREPUBLICATION_FAILURE_EVIDENCE:-false}" != "$_FULL_LOOP_RELEASE_BOOL_TRUE" ]] &&
+			[[ "${_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION:-false}" != "$_FULL_LOOP_RELEASE_BOOL_TRUE" ]]; then
 			_full_loop_write_release_failure_evidence "$repo" "$source_pr" "$blocked_merge" "$blocked_head" || true
 		fi
 		return 1
@@ -327,6 +329,8 @@ _full_loop_release_run_new() {
 	local resolver=""
 	local version_manager=""
 	local release_rc=0
+	local attempted_tag=""
+	local evidence_release_type=""
 	local run_started=""
 	local phase_started=""
 	run_started=$(_full_loop_release_timing_start release-run-new)
@@ -369,8 +373,12 @@ _full_loop_release_run_new() {
 	if [[ "$release_rc" -ne 0 ]]; then
 		_full_loop_release_timing_finish release-run-version-manager "$phase_started" failed
 		release_lane_update "$repo" "$source_pr" "reconcile-required" || true
+		attempted_tag=$(_full_loop_release_expected_tag_at_commit \
+			"$_FULL_LOOP_RESOLVED_SOURCE_MERGE" "$release_type" 2>/dev/null || true)
+		[[ -z "$attempted_tag" ]] || evidence_release_type="$release_type"
 		_full_loop_write_release_failure_evidence "$repo" "$source_pr" "$_FULL_LOOP_RESOLVED_REQUESTED_MERGE" \
-			"$_FULL_LOOP_RESOLVED_SOURCE_MERGE" "$_FULL_LOOP_RESOLVED_SOURCE_PR" || true
+			"$_FULL_LOOP_RESOLVED_SOURCE_MERGE" "$_FULL_LOOP_RESOLVED_SOURCE_PR" \
+			"$attempted_tag" "$evidence_release_type" || true
 		printf 'Publication may still be durable or queued. Reconcile without another version bump:\n' >&2
 		printf '  aidevops release status %s\n' "$source_pr" >&2
 		printf '  aidevops release reconcile %s\n' "$source_pr" >&2
@@ -491,27 +499,30 @@ _full_loop_release_resolve_persisted_intent() {
 	local source_pr="$2"
 	local requested_sources="$3"
 	local persisted_sources="$4"
+	local release_type="${5:-patch}"
 	local persisted_prs=""
 	local requested_prs=""
-	local migration_rc=0
+	local transaction_rc=0
 	_FULL_LOOP_RESERVED_RECOVERY_EXPECTED="$requested_sources"
 	_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=false
+	_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION=false
 	if [[ -z "$requested_sources" ]]; then
+		requested_sources="$persisted_sources"
 		_FULL_LOOP_RESERVED_RECOVERY_EXPECTED="$persisted_sources"
-		return 0
 	fi
 	requested_prs=$(release_authorization_intent_json "$requested_sources" | jq -c 'map(.pr)') || return 1
 	persisted_prs=$(release_authorization_intent_json "$persisted_sources" | jq -c 'map(.pr)') || return 1
 	if [[ "$requested_prs" == "$persisted_prs" ]]; then
-		_full_loop_recovery_reserved_lane_requires_migration "$repo" "$source_pr" \
-			"$persisted_sources" || migration_rc=$?
-		case "$migration_rc" in
+		_full_loop_recovery_lane_requires_prepublication_transaction "$repo" "$source_pr" \
+			"$persisted_sources" || transaction_rc=$?
+		case "$transaction_rc" in
 		0) ;;
 		1) return 0 ;;
 		*) return 1 ;;
 		esac
 	fi
-	_full_loop_recovery_expand_reserved_authorization "$repo" "$source_pr" "$requested_sources" || return $?
+	_full_loop_recovery_expand_reserved_authorization "$repo" "$source_pr" "$requested_sources" \
+		"$release_type" || return $?
 	_FULL_LOOP_RESERVED_RECOVERY_EXPECTED="$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"
 	_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=true
 	return 0
@@ -525,10 +536,12 @@ _full_loop_release_start_new() {
 	local expected_sources="$5"
 	local existing_state_rc=0
 	local persisted_expected=""
+	_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=false
+	_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION=false
 	_full_loop_release_guard_competing_lane "$repo" "$source_pr" || return $?
 	if persisted_expected=$(_full_loop_read_release_authorization "$repo" "$source_pr"); then
 		_full_loop_release_resolve_persisted_intent "$repo" "$source_pr" "$expected_sources" \
-			"$persisted_expected" || return $?
+			"$persisted_expected" "$release_type" || return $?
 		expected_sources="$_FULL_LOOP_RESERVED_RECOVERY_EXPECTED"
 	fi
 	_full_loop_release_guard_existing "$repo" "$source_pr" "${expected_sources:-$source_pr}" || existing_state_rc=$?

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -15,6 +15,7 @@ _AIDEVOPS_RELEASE_LANE_TOKEN=""
 _AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT=""
 _AIDEVOPS_RELEASE_LANE_PHASE_RESERVED="reserved"
 _AIDEVOPS_RELEASE_LANE_JSON_STRING_TYPE="string"
+_AIDEVOPS_RELEASE_LANE_RESULT_ACQUIRED="acquired"
 _AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX="lane-"
 _AIDEVOPS_RELEASE_LANE_OWNER_PREFIX="process-"
 _AIDEVOPS_RELEASE_LANE_STALE_PREPUBLICATION_SECONDS=300
@@ -22,6 +23,7 @@ _AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY="aggregation-recovery"
 _AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH="aggregation-recovery-refresh"
 _AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT="aggregate-publication-committing"
 _AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH="reserved-authorization-refresh"
+_AIDEVOPS_RELEASE_LANE_PHASE_RECONCILE_REQUIRED="reconcile-required"
 
 _release_lane_cache_path() {
 	local repo="$1"
@@ -153,6 +155,7 @@ _release_lane_stale_prepublication() {
 	[[ "$phase" == "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" ]] || return 1
 	[[ -z "$tag_name" ]] || return 1
 	jq -e '(.terminal_receipt // null) == null' <<<"$state_json" >/dev/null || return 1
+	jq -e '(.prepublication_recovery // null) == null' <<<"$state_json" >/dev/null || return 1
 	updated_epoch=$(date -u -d "$updated_at" +%s 2>/dev/null ||
 		date -u -jf '%Y-%m-%dT%H:%M:%SZ' "$updated_at" +%s 2>/dev/null || true)
 	now_epoch=$(date +%s 2>/dev/null || true)
@@ -174,7 +177,7 @@ _release_lane_reclaim_same_source() {
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
 	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
-	_AIDEVOPS_RELEASE_LANE_RESULT="acquired"
+	_AIDEVOPS_RELEASE_LANE_RESULT="$_AIDEVOPS_RELEASE_LANE_RESULT_ACQUIRED"
 	printf 'Recovered stale pre-publication release lane for PR #%s\n' "$source_pr"
 	return 0
 }
@@ -225,7 +228,7 @@ release_lane_acquire() {
 		updated_at:$now,terminal_receipt:null}') || return 1
 	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
 	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
-	_AIDEVOPS_RELEASE_LANE_RESULT="acquired"
+	_AIDEVOPS_RELEASE_LANE_RESULT="$_AIDEVOPS_RELEASE_LANE_RESULT_ACQUIRED"
 	return 0
 }
 
@@ -436,6 +439,95 @@ release_lane_verify_aggregate_publication() {
 	return $?
 }
 
+#aidevops:trust-boundary
+release_lane_reopen_failed_prepublication() {
+	local repo="$1"
+	local source_pr="$2"
+	local failed_expected_sources="$3"
+	local failed_source_pr="$4"
+	local failed_source_merge="$5"
+	local attempted_tag="${6:-}"
+	local operation_token=""
+	local state_json=""
+	local write_rc=0
+	[[ "$source_pr" =~ ^[0-9]+$ && "$failed_source_pr" =~ ^[0-9]+$ ]] || return 1
+	[[ "$failed_source_merge" =~ ^[0-9a-f]{40}$ && "$attempted_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	[[ -n "$failed_expected_sources" ]] || return 1
+	[[ -n "$_AIDEVOPS_RELEASE_LANE_TOKEN" ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
+		--arg failed_expected "$failed_expected_sources" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \
+		--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" \
+		--arg reconcile "$_AIDEVOPS_RELEASE_LANE_PHASE_RECONCILE_REQUIRED" \
+		--arg string_type "$_AIDEVOPS_RELEASE_LANE_JSON_STRING_TYPE" \
+		--argjson failed_source_pr "$failed_source_pr" --arg failed_source_merge "$failed_source_merge" \
+		--arg attempted_tag "$attempted_tag" '
+		(.prepublication_recovery // null) as $recovery
+		| (($recovery != null) and (($recovery | type) == "object")
+			and $recovery.previous_phase == $reconcile
+			and (($recovery.previous_updated_at | type) == $string_type)
+			and (($recovery.recovered_at | type) == $string_type)
+			and $recovery.failed_source_pr == $failed_source_pr
+			and $recovery.failed_source_merge == $failed_source_merge
+			and $recovery.attempted_tag == $attempted_tag
+			and $recovery.failed_expected_sources == $failed_expected
+			and (($recovery.current_expected_sources | type) == $string_type)
+			and .expected_sources == $recovery.current_expected_sources) as $recovery_matches
+		|
+		.active == true and .source_pr == $source_pr and .operation_token == $token
+		and .tag == null
+		and ((.terminal_receipt // null) == null)
+		and ((.phase == $reconcile and .expected_sources == $failed_expected and $recovery == null)
+			or (.phase == $reserved and $recovery_matches)
+			or (.phase == $refresh and $recovery_matches
+				and .reserved_authorization_refresh.previous_expected_sources == $failed_expected
+				and .reserved_authorization_refresh.pending_expected_sources == .expected_sources))
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(date +%s)-$$-${RANDOM:-0}"
+	state_json=$(jq -c --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \
+		--arg reconcile "$_AIDEVOPS_RELEASE_LANE_PHASE_RECONCILE_REQUIRED" \
+		--arg failed_expected "$failed_expected_sources" \
+		--arg token "$operation_token" --arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" --argjson failed_source_pr "$failed_source_pr" \
+		--arg failed_source_merge "$failed_source_merge" --arg attempted_tag "$attempted_tag" '
+		(.prepublication_recovery // null) as $existing_recovery
+		| .updated_at as $previous_updated_at
+		| if $existing_recovery == null then .phase=$reserved else . end
+		| .operation_token=$token | .owner=$owner | .updated_at=$now
+		| .prepublication_recovery=(if $existing_recovery == null then
+			{previous_phase:$reconcile,previous_updated_at:$previous_updated_at,
+			 failed_source_pr:$failed_source_pr,failed_source_merge:$failed_source_merge,
+			 attempted_tag:$attempted_tag,failed_expected_sources:$failed_expected,
+			 current_expected_sources:$failed_expected,recovered_at:$now}
+		  else $existing_recovery + {revalidated_at:$now} end)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || write_rc=$?
+	if [[ "$write_rc" -ne 0 ]]; then
+		release_lane_read "$repo" || return "$write_rc"
+		jq -e --argjson source_pr "$source_pr" --arg token "$operation_token" \
+			--arg failed_expected "$failed_expected_sources" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \
+			--arg refresh "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" \
+			--argjson failed_source_pr "$failed_source_pr" --arg failed_source_merge "$failed_source_merge" \
+			--arg attempted_tag "$attempted_tag" '
+			.active == true and .source_pr == $source_pr and .operation_token == $token
+			and (.phase == $reserved or .phase == $refresh) and .tag == null
+			and ((.terminal_receipt // null) == null)
+			and .prepublication_recovery.failed_source_pr == $failed_source_pr
+			and .prepublication_recovery.failed_source_merge == $failed_source_merge
+			and .prepublication_recovery.attempted_tag == $attempted_tag
+			and .prepublication_recovery.failed_expected_sources == $failed_expected
+			and .prepublication_recovery.current_expected_sources == .expected_sources
+			and (.phase != $refresh
+				or (.reserved_authorization_refresh.previous_expected_sources == $failed_expected
+					and .reserved_authorization_refresh.pending_expected_sources == .expected_sources))
+		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return "$write_rc"
+	fi
+	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
+	_AIDEVOPS_RELEASE_LANE_RESULT="$_AIDEVOPS_RELEASE_LANE_RESULT_ACQUIRED"
+	printf 'Recovered verified failed pre-publication release lane for PR #%s\n' "$source_pr"
+	return 0
+}
+
 release_lane_expand_reserved_authorization() {
 	local repo="$1"
 	local source_pr="$2"
@@ -458,6 +550,8 @@ release_lane_expand_reserved_authorization() {
 		and .reserved_authorization_refresh.previous_expected_sources == $previous
 		and .reserved_authorization_refresh.pending_expected_sources == $expected
 		and (.reserved_authorization_refresh.previous_state.schema_version == 1)
+		and ((.prepublication_recovery // null) == null
+			or .prepublication_recovery.current_expected_sources == $expected)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null; then
 		_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -er '.operation_token' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT=$(jq -ce '.reserved_authorization_refresh.previous_state' \
@@ -469,6 +563,8 @@ release_lane_expand_reserved_authorization() {
 		.active == true and .source_pr == $source_pr and .operation_token == $token
 		and .phase == $reserved and .tag == null and .expected_sources == $previous
 		and ((.terminal_receipt // null) == null)
+		and ((.prepublication_recovery // null) == null
+			or .prepublication_recovery.current_expected_sources == $previous)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
 	_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT="$_AIDEVOPS_RELEASE_LANE_JSON"
 	snapshot_json="$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT"
@@ -479,6 +575,8 @@ release_lane_expand_reserved_authorization() {
 		--argjson snapshot "$snapshot_json" '
 		.expected_sources=$expected | .phase=$refresh | .operation_token=$token
 		| .owner=$owner | .updated_at=$now
+		| if (.prepublication_recovery // null) != null then
+			.prepublication_recovery.current_expected_sources=$expected else . end
 		| .reserved_authorization_refresh={previous_state:$snapshot,
 			previous_expected_sources:$previous,pending_expected_sources:$expected}
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
@@ -493,6 +591,8 @@ release_lane_expand_reserved_authorization() {
 			and ((.terminal_receipt // null) == null)
 			and .reserved_authorization_refresh.previous_expected_sources == $previous
 			and .reserved_authorization_refresh.pending_expected_sources == $expected
+			and ((.prepublication_recovery // null) == null
+				or .prepublication_recovery.current_expected_sources == $expected)
 		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return "$write_rc"
 	fi
 	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
@@ -516,6 +616,8 @@ release_lane_finish_reserved_authorization() {
 		and ((.terminal_receipt // null) == null)
 		and .reserved_authorization_refresh.previous_expected_sources == $previous
 		and .reserved_authorization_refresh.pending_expected_sources == $expected
+		and ((.prepublication_recovery // null) == null
+			or .prepublication_recovery.current_expected_sources == $expected)
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
 	state_json=$(jq -c --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \
 		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
@@ -530,6 +632,8 @@ release_lane_finish_reserved_authorization() {
 			and .phase == $reserved and .tag == null and .expected_sources == $expected
 			and ((.terminal_receipt // null) == null)
 			and ((.reserved_authorization_refresh // null) == null)
+			and ((.prepublication_recovery // null) == null
+				or .prepublication_recovery.current_expected_sources == $expected)
 		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return "$write_rc"
 	fi
 	return 0
@@ -597,8 +701,11 @@ release_lane_update() {
 	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
 		'.active == true and .source_pr == $source_pr and .operation_token == $token' \
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
-	state_json=$(jq -c --arg phase "$phase" --arg tag "$tag_name" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
-		'.phase=$phase | .tag=(if $tag == "" then .tag else $tag end) | .updated_at=$now' \
+	state_json=$(jq -c --arg phase "$phase" --arg tag "$tag_name" --arg preparing "preparing" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
+		.phase=$phase | .tag=(if $tag == "" then .tag else $tag end) | .updated_at=$now
+		| if $phase == $preparing then del(.prepublication_recovery) else . end
+	' \
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD"
 	return $?

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -842,6 +842,188 @@ printf 'PASS persisted replacement-tag recovery recreates its detached tag workt
 	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
 	source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
 	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	failure_fixture_path="${TEST_ROOT}/failed-prepublication.json"
+	requested_merge=2222222222222222222222222222222222222222
+	second_merge=3333333333333333333333333333333333333333
+	failed_merge=4444444444444444444444444444444444444444
+	current_merge=5555555555555555555555555555555555555555
+	old_manifest="42@${requested_merge},43@${second_merge}"
+	trailer_mode=match
+	ancestry_mode=match
+	channel_mode=absent
+	verified_pr_merge="$failed_merge"
+	_FULL_LOOP_RESOLVED_REQUESTED_MERGE="$requested_merge"
+	_FULL_LOOP_RESOLVED_SOURCE_MERGE="$current_merge"
+	_full_loop_release_evidence_path() {
+		printf '%s\n' "$failure_fixture_path"
+		return 0
+	}
+	git() {
+		if [[ " $* " == *" cat-file -e "* ]]; then
+			return 0
+		fi
+		if [[ " $* " == *" merge-base --is-ancestor "* ]]; then
+			[[ "$ancestry_mode" == "match" ]]
+			return $?
+		fi
+		return 1
+	}
+	gh() {
+		jq -cn --arg merge "$verified_pr_merge" \
+			'{state:"MERGED",mergedAt:"2026-08-24T02:00:00Z",baseRefName:"main",mergeCommit:{oid:$merge}}'
+		return 0
+	}
+	_full_loop_release_expected_tag_at_commit() {
+		local source_commit="$1"
+		local release_type="$2"
+		[[ "$source_commit" == "$failed_merge" || "$source_commit" == "$requested_merge" ]] || return 1
+		case "$release_type" in
+		patch) printf 'v1.2.3\n' ;;
+		minor) printf 'v1.3.0\n' ;;
+		major) printf 'v2.0.0\n' ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_recovery_verify_channels_absent() {
+		local repo="$1"
+		local tag_name="$2"
+		[[ "$repo" == "test/repo" && "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ &&
+			"$channel_mode" == "absent" ]]
+		return $?
+	}
+	_full_loop_recovery_commit_trailer_values() {
+		local commit_sha="$1"
+		local trailer_key="$2"
+		[[ "$commit_sha" == "$failed_merge" ]] || return 1
+		case "$trailer_key" in
+		Aidevops-Release-Aggregator-PR) printf '99\n' ;;
+		Aidevops-Release-Aggregates)
+			if [[ "$trailer_mode" == "match" ]]; then
+				printf '42@%s\n43@%s\n' "$requested_merge" "$second_merge"
+			else
+				printf '42@%s\n' "$requested_merge"
+			fi
+			;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	write_failure_evidence() {
+		local merge="$1"
+		local release_source_pr="${2:-99}"
+		local current_head="${3:-$failed_merge}"
+		local attempted_tag="${4:-}"
+		local release_type="${5:-}"
+		jq -cn --arg requested_merge "$merge" --argjson release_source_pr "$release_source_pr" \
+			--arg current_head "$current_head" --arg attempted_tag "$attempted_tag" \
+			--arg release_type "$release_type" '
+			{schema_version:1,status:"failed",repository:"test/repo",requested_pr:42,
+			 requested_merge:$requested_merge,release_source_pr:$release_source_pr,current_head:$current_head,
+			 attempted_tag:(if $attempted_tag == "" then null else $attempted_tag end),
+			 release_type:(if $release_type == "" then null else $release_type end),
+			 recorded_at:"2026-08-24T02:01:47Z"}
+		' >"$failure_fixture_path"
+		return 0
+	}
+	write_failure_evidence "$requested_merge"
+	_full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" patch
+	[[ "$_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_PR" == "99" &&
+		"$_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_MERGE" == "$failed_merge" &&
+		"$_FULL_LOOP_FAILED_PREPUBLICATION_TAG" == "v1.2.3" ]]
+	if _full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" minor \
+		>/dev/null 2>&1; then
+		exit 1
+	fi
+	write_failure_evidence "$requested_merge" 99 "$failed_merge" v1.2.3 patch
+	_full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" patch
+	write_failure_evidence 6666666666666666666666666666666666666666
+	if _full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" patch \
+		>/dev/null 2>&1; then
+		exit 1
+	fi
+	write_failure_evidence "$requested_merge"
+	trailer_mode=mismatch
+	if _full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" patch \
+		>/dev/null 2>&1; then
+		exit 1
+	fi
+	trailer_mode=match
+	ancestry_mode=mismatch
+	if _full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" patch \
+		>/dev/null 2>&1; then
+		exit 1
+	fi
+	ancestry_mode=match
+	write_failure_evidence "$requested_merge" 99 "$failed_merge" v9.9.9 patch
+	if _full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" patch \
+		>/dev/null 2>&1; then
+		exit 1
+	fi
+	write_failure_evidence "$requested_merge" 99 "$failed_merge" v1.2.3 minor
+	if _full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" patch \
+		>/dev/null 2>&1; then
+		exit 1
+	fi
+	write_failure_evidence "$requested_merge" 99 "$failed_merge" v1.2.3 patch
+	channel_mode=published
+	if _full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" patch \
+		>/dev/null 2>&1; then
+		exit 1
+	fi
+	channel_mode=absent
+	verified_pr_merge="$requested_merge"
+	write_failure_evidence "$requested_merge" 42 "$requested_merge" v1.2.3 patch
+	_full_loop_recovery_validate_failed_prepublication_intent test/repo 42 \
+		"42@${requested_merge}" patch
+	[[ "$_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_PR" == "42" &&
+		"$_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_MERGE" == "$requested_merge" &&
+		"$_FULL_LOOP_FAILED_PREPUBLICATION_TAG" == "v1.2.3" ]]
+	rm -f "$failure_fixture_path"
+	if _full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" patch \
+		>/dev/null 2>&1; then
+		exit 1
+	fi
+)
+printf 'PASS failed pre-publication retry binds attempted version, absent channels, and direct or aggregate evidence\n'
+
+(
+	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
+	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	AIDEVOPS_WORKTREE_BASE_DIR="$TEST_ROOT"
+	test_resolved_mode=direct
+	cleanup_release_worktree() { return 0; }
+	git() { return 0; }
+	_full_loop_resolve_requested_release_source() {
+		local repo="$1"
+		local source_pr="$2"
+		local release_path="$3"
+		local resolver="$4"
+		local expected_sources="$5"
+		[[ "$repo" == "test/repo" && "$source_pr" == "42" && -n "$release_path" &&
+			-n "$resolver" && "$expected_sources" == "42" &&
+			"${_FULL_LOOP_PRESERVE_PREPUBLICATION_FAILURE_EVIDENCE:-false}" == "true" ]] || return 1
+		_FULL_LOOP_RESOLVED_SOURCE_JSON=$(jq -cn --arg mode "$test_resolved_mode" '{mode:$mode}') || return 1
+		_FULL_LOOP_RESOLVED_EXPECTED_SOURCES=42@2222222222222222222222222222222222222222
+		return 0
+	}
+	_full_loop_recovery_prepare_prepublication_source test/repo 42 42
+	[[ "$(jq -r '.mode' <<<"$_FULL_LOOP_RESOLVED_SOURCE_JSON")" == "direct" ]]
+	test_resolved_mode=aggregate
+	_full_loop_recovery_prepare_prepublication_source test/repo 42 42
+	[[ "$(jq -r '.mode' <<<"$_FULL_LOOP_RESOLVED_SOURCE_JSON")" == "aggregate" ]]
+	test_resolved_mode=invalid
+	if _full_loop_recovery_prepare_prepublication_source test/repo 42 42 >/dev/null 2>&1; then
+		exit 1
+	fi
+)
+printf 'PASS failed pre-publication preparation admits only reviewed direct or aggregate sources\n'
+
+(
+	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
+	source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
+	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED=reserved
 	_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH=reserved-authorization-refresh
 	RESERVED_LOG="${TEST_ROOT}/reserved.log"
 	: >"$RESERVED_LOG"
@@ -852,6 +1034,12 @@ printf 'PASS persisted replacement-tag recovery recreates its detached tag workt
 	lane_phase=reserved
 	test_lane_sources="$legacy_lane_intent"
 	finish_mode=success
+	failure_mode=match
+	prepublication_mode=aggregate
+	prepublication_expected="$expanded_manifest"
+	prepublication_marker=false
+	prepublication_failed_sources="$old_manifest"
+	refresh_previous_sources="$legacy_lane_intent"
 	root_authorization_record=$(jq -cn --arg merge 2222222222222222222222222222222222222222 \
 		'{schema_version:1,repository:"test/repo",requested_pr:42,
 		  expected_sources:[{pr:42,merge:$merge}],recorded_at:"2026-08-09T00:00:00Z"}')
@@ -860,6 +1048,16 @@ printf 'PASS persisted replacement-tag recovery recreates its detached tag workt
 	_full_loop_recovery_prepare_aggregate() {
 		_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$expanded_manifest"
 		_FULL_LOOP_RESOLVED_SOURCE_JSON='{"mode":"aggregate"}'
+		return 0
+	}
+	_full_loop_recovery_prepare_prepublication_source() {
+		local repo="$1"
+		local source_pr="$2"
+		local expected_sources="$3"
+		[[ "$repo" == "test/repo" && "$source_pr" == "42" && -n "$expected_sources" ]] || return 1
+		_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$prepublication_expected"
+		_FULL_LOOP_RESOLVED_SOURCE_JSON="{\"mode\":\"${prepublication_mode}\"}"
+		printf 'prepare-prepublication\n' >>"$RESERVED_LOG"
 		return 0
 	}
 	_full_loop_validate_release_candidates() {
@@ -877,17 +1075,45 @@ printf 'PASS persisted replacement-tag recovery recreates its detached tag workt
 	}
 	release_lane_read() {
 		if [[ "$lane_phase" == "reserved-authorization-refresh" ]]; then
-			_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$legacy_lane_intent" \
+			_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$refresh_previous_sources" \
 				--arg expected "$expanded_manifest" \
 				'{schema_version:1,active:true,source_pr:42,phase:"reserved-authorization-refresh",
 				  tag:null,expected_sources:$expected,operation_token:"lane-refresh",terminal_receipt:null,
 				  reserved_authorization_refresh:{previous_expected_sources:$previous,
 				    pending_expected_sources:$expected,previous_state:{schema_version:1}}}')
+		elif [[ "$lane_phase" == "reconcile-required" ]]; then
+			_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg expected "$test_lane_sources" \
+				'{schema_version:1,active:true,source_pr:42,phase:"reconcile-required",tag:null,
+				  expected_sources:$expected,operation_token:"lane-failed",terminal_receipt:null}')
 		else
 			_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg expected "$test_lane_sources" \
 				'{schema_version:1,active:true,source_pr:42,phase:"reserved",tag:null,
 				  expected_sources:$expected,operation_token:"lane-old",terminal_receipt:null}')
 		fi
+		if [[ "$prepublication_marker" == "true" ]]; then
+			_AIDEVOPS_RELEASE_LANE_JSON=$(jq -c --arg failed "$prepublication_failed_sources" '
+				.prepublication_recovery={previous_phase:"reconcile-required",
+				 previous_updated_at:"2026-08-24T02:01:43Z",failed_source_pr:99,
+				 failed_source_merge:"4444444444444444444444444444444444444444",
+				 attempted_tag:"v1.2.3",failed_expected_sources:$failed,
+				 current_expected_sources:.expected_sources,recovered_at:"2026-08-24T02:02:00Z"}
+			' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		fi
+		return 0
+	}
+	_full_loop_recovery_validate_failed_prepublication_intent() {
+		local repo="$1"
+		local source_pr="$2"
+		local current_authorization="$3"
+		local release_type="$4"
+		[[ "$repo" == "test/repo" && "$source_pr" == "42" &&
+			"$current_authorization" == "$prepublication_failed_sources" &&
+			"$release_type" == "patch" ]] || return 1
+		printf 'verify-failure\n' >>"$RESERVED_LOG"
+		[[ "$failure_mode" == "match" ]] || return 1
+		_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_PR=99
+		_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_MERGE=4444444444444444444444444444444444444444
+		_FULL_LOOP_FAILED_PREPUBLICATION_TAG=v1.2.3
 		return 0
 	}
 	release_lane_acquire() {
@@ -903,11 +1129,34 @@ printf 'PASS persisted replacement-tag recovery recreates its detached tag workt
 		return 0
 	}
 	release_lane_expand_reserved_authorization() {
-		[[ "$3" == "$legacy_lane_intent" ]] || return 1
+		[[ "$3" == "$legacy_lane_intent" || "$3" == "$old_manifest" ]] || return 1
 		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT='{"schema_version":1,"phase":"reserved"}'
 		printf 'fence\n' >>"$RESERVED_LOG"
+		refresh_previous_sources="$3"
 		lane_phase=reserved-authorization-refresh
 		test_lane_sources="$expanded_manifest"
+		return 0
+	}
+	release_lane_reopen_failed_prepublication() {
+		local repo="$1"
+		local source_pr="$2"
+		local failed_expected="$3"
+		local failed_source_pr="$4"
+		local failed_source_merge="$5"
+		local attempted_tag="$6"
+		[[ "$repo" == "test/repo" && "$source_pr" == "42" &&
+			"$failed_expected" == "$prepublication_failed_sources" ]] || return 1
+		[[ "$failed_source_pr" == "99" && "$failed_source_merge" == "4444444444444444444444444444444444444444" &&
+			"$attempted_tag" == "v1.2.3" ]] || return 1
+		printf 'reopen\n' >>"$RESERVED_LOG"
+		if [[ "$lane_phase" == "reconcile-required" ]]; then
+			lane_phase=reserved
+			test_lane_sources="$failed_expected"
+		fi
+		prepublication_marker=true
+		prepublication_failed_sources="$failed_expected"
+		_AIDEVOPS_RELEASE_LANE_RESULT=acquired
+		_AIDEVOPS_RELEASE_LANE_TOKEN=lane-reopened
 		return 0
 	}
 	release_lane_finish_reserved_authorization() {
@@ -926,7 +1175,8 @@ printf 'PASS persisted replacement-tag recovery recreates its detached tag workt
 	}
 	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43
 	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate acquire fence expand-auth finish " ]]
-	[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved" ]]
+	[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved" &&
+		"$_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION" == "false" ]]
 	printf 'PASS reserved recovery fences the lane before authorization expansion\n'
 
 	: >"$RESERVED_LOG"
@@ -964,16 +1214,121 @@ printf 'PASS persisted replacement-tag recovery recreates its detached tag workt
 	[[ "$lane_phase" == "reserved" ]]
 	printf 'PASS reserved recovery retains and resumes a fenced post-authorization interruption\n'
 
-	lane_phase=reserved
-	test_lane_sources="$legacy_lane_intent"
-	_full_loop_recovery_reserved_lane_requires_migration test/repo 42 "$expanded_manifest"
-	test_lane_sources="$expanded_manifest"
-	if _full_loop_recovery_reserved_lane_requires_migration test/repo 42 "$expanded_manifest"; then
+	: >"$RESERVED_LOG"
+	authorization="$old_manifest"
+	lane_phase=reconcile-required
+	test_lane_sources="$old_manifest"
+	prepublication_marker=false
+	prepublication_failed_sources="$old_manifest"
+	failure_mode=match
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "prepare-prepublication validate verify-failure acquire reopen fence expand-auth finish " ]]
+	[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved" &&
+		"$_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION" == "true" ]]
+	printf 'PASS verified failed pre-publication recovery reopens before authorization expansion\n'
+
+	: >"$RESERVED_LOG"
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "prepare-prepublication validate verify-failure acquire reopen " ]]
+	[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved" && "$prepublication_marker" == "true" ]]
+	printf 'PASS expanded pre-publication marker revalidates the original failed authorization\n'
+
+	: >"$RESERVED_LOG"
+	authorization="$old_manifest"
+	lane_phase=reconcile-required
+	test_lane_sources="$old_manifest"
+	prepublication_marker=false
+	prepublication_failed_sources="$old_manifest"
+	finish_mode=failure
+	if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null 2>&1; then
 		exit 1
 	fi
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "prepare-prepublication validate verify-failure acquire reopen fence expand-auth finish " ]]
+	[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved-authorization-refresh" &&
+		"$prepublication_marker" == "true" ]]
+	finish_mode=success
+	: >"$RESERVED_LOG"
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "prepare-prepublication validate verify-failure acquire reopen fence finish " ]]
+	[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved" ]]
+	printf 'PASS marked authorization-refresh recovery revalidates before resuming expansion\n'
+
+	: >"$RESERVED_LOG"
+	authorization="$expanded_manifest"
+	lane_phase=reconcile-required
+	test_lane_sources="$expanded_manifest"
+	prepublication_marker=false
+	prepublication_failed_sources="$expanded_manifest"
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "prepare-prepublication validate verify-failure acquire reopen " ]]
+	[[ "$authorization" == "$expanded_manifest" && "$lane_phase" == "reserved" ]]
+	printf 'PASS verified same-manifest retry reopens without a redundant authorization write\n'
+
+	: >"$RESERVED_LOG"
+	authorization="$old_manifest"
+	lane_phase=reconcile-required
+	test_lane_sources="$old_manifest"
+	prepublication_marker=false
+	prepublication_failed_sources="$old_manifest"
+	prepublication_mode=direct
+	prepublication_expected="$old_manifest"
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42 patch >/dev/null
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "prepare-prepublication validate verify-failure acquire reopen " ]]
+	[[ "$authorization" == "$old_manifest" && "$lane_phase" == "reserved" ]]
+	prepublication_mode=aggregate
+	prepublication_expected="$expanded_manifest"
+	printf 'PASS verified failed pre-publication recovery reaches the direct-source retry path\n'
+
+	: >"$RESERVED_LOG"
+	authorization="$old_manifest"
+	lane_phase=reserved
+	test_lane_sources="$old_manifest"
+	prepublication_marker=true
+	prepublication_failed_sources="$old_manifest"
+	prepublication_mode=direct
+	prepublication_expected="$old_manifest"
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42 patch >/dev/null
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "prepare-prepublication validate verify-failure acquire reopen " ]]
+	[[ "$authorization" == "$old_manifest" && "$lane_phase" == "reserved" && "$prepublication_marker" == "true" ]]
+	prepublication_mode=aggregate
+	prepublication_expected="$expanded_manifest"
+	printf 'PASS crash retry revalidates a recovered reserved lane before resuming\n'
+
+	: >"$RESERVED_LOG"
+	authorization="$old_manifest"
+	lane_phase=reconcile-required
+	test_lane_sources="$old_manifest"
+	prepublication_marker=false
+	prepublication_failed_sources="$old_manifest"
+	failure_mode=mismatch
+	if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null 2>&1; then
+		exit 1
+	fi
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "prepare-prepublication validate verify-failure " && "$lane_phase" == "reconcile-required" ]]
+	failure_mode=match
+	printf 'PASS failed pre-publication recovery rejects missing or mismatched failure intent before lane mutation\n'
+
+	prepublication_marker=false
+	lane_phase=reserved
+	test_lane_sources="$legacy_lane_intent"
+	_full_loop_recovery_lane_requires_prepublication_transaction test/repo 42 "$expanded_manifest"
+	test_lane_sources="$expanded_manifest"
+	if _full_loop_recovery_lane_requires_prepublication_transaction test/repo 42 "$expanded_manifest"; then
+		exit 1
+	fi
+	prepublication_marker=true
+	_full_loop_recovery_lane_requires_prepublication_transaction test/repo 42 "$expanded_manifest"
+	prepublication_marker=false
 	lane_phase=reserved-authorization-refresh
-	_full_loop_recovery_reserved_lane_requires_migration test/repo 42 "$expanded_manifest"
-	printf 'PASS equal persisted PR sets still resume stale or fenced reserved-lane migration\n'
+	_full_loop_recovery_lane_requires_prepublication_transaction test/repo 42 "$expanded_manifest"
+	lane_phase=reconcile-required
+	test_lane_sources="$expanded_manifest"
+	_full_loop_recovery_lane_requires_prepublication_transaction test/repo 42 "$expanded_manifest"
+	test_lane_sources="$legacy_lane_intent"
+	if _full_loop_recovery_lane_requires_prepublication_transaction test/repo 42 "$expanded_manifest"; then
+		exit 1
+	fi
+	printf 'PASS equal persisted PR sets still resume stale, fenced, marked, or exact failed pre-publication transactions\n'
 )
 
 exit 0

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -20,6 +20,7 @@ cat >"$ROOT/bin/git" <<'STUB'
 printf '%s\n' "$*" >>"${GIT_CALL_LOG:?}"
 case "$*" in
 *rev-parse\ --show-toplevel*) printf '%s\n' "${FAKE_REPO_ROOT:?}" ;;
+*show\ *:VERSION*) printf '2.9.9\n' ;;
 *rev-parse\ refs/tags/v3.0.0*) printf '%040d\n' 0 ;;
 *rev-parse\ HEAD*) printf '%040d\n' 0 ;;
 *worktree\ add*)
@@ -265,7 +266,8 @@ if (
 	exit 1
 fi
 grep -qx 'failed' "$ROOT/receipts/marcusquinn_aidevops-43.status"
-jq -e '.status == "failed" and .requested_pr == 43 and .requested_merge == .current_head' \
+jq -e '.status == "failed" and .requested_pr == 43 and .requested_merge == .current_head
+	and .attempted_tag == "v2.9.10" and .release_type == "patch"' \
 	"$ROOT/receipts/marcusquinn_aidevops-43.failure.json" >/dev/null
 printf 'PASS failed release persists actionable provenance without publication evidence\n'
 rm -f "$LANE_HEAD_FILE" "$LANE_STATE_FILE"
@@ -360,5 +362,109 @@ fi
 jq -e '.repository == "wrong/repo" and .release_status == "not-requested"' \
 	"$ROOT/cleanup/marcusquinn_aidevops-45.json" >/dev/null
 printf 'PASS reviewed aggregate source publishes once and truthfully supersedes included receipts\n'
+
+(
+	cd "$ROOT/repo/linked-branch"
+	export PATH="$ROOT/bin:/usr/bin:/bin"
+	export GIT_CALL_LOG="$ROOT/git.log"
+	export FAKE_REPO_ROOT="$ROOT/repo"
+	export AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees"
+	export AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$ROOT/receipts"
+	export AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops
+	source "$SCRIPT_DIR/full-loop-release-helper.sh" help >/dev/null
+	persisted_sources=48@0000000000000000000000000000000000000000
+	lane_checks=0
+	expansion_calls=0
+	_full_loop_recovery_lane_requires_prepublication_transaction() {
+		local repo="$1"
+		local source_pr="$2"
+		local observed_sources="$3"
+		[[ "$repo" == "marcusquinn/aidevops" && "$source_pr" == "48" &&
+			"$observed_sources" == "$persisted_sources" ]] || return 1
+		lane_checks=$((lane_checks + 1))
+		return 0
+	}
+	_full_loop_recovery_expand_reserved_authorization() {
+		local repo="$1"
+		local source_pr="$2"
+		local requested_sources="$3"
+		local release_type="$4"
+		[[ "$repo" == "marcusquinn/aidevops" && "$source_pr" == "48" &&
+			"$requested_sources" == "$persisted_sources" && "$release_type" == "patch" ]] || return 1
+		expansion_calls=$((expansion_calls + 1))
+		_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$requested_sources"
+		return 0
+	}
+	_full_loop_release_resolve_persisted_intent marcusquinn/aidevops 48 "" "$persisted_sources" patch
+	[[ "$lane_checks" -eq 1 && "$expansion_calls" -eq 1 &&
+		"$_FULL_LOOP_RESERVED_RECOVERY_EXPECTED" == "$persisted_sources" &&
+		"$_FULL_LOOP_RESERVED_RECOVERY_COMPLETED" == "true" &&
+		"$_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION" == "false" ]]
+)
+printf 'PASS omitted expected sources still resume a persisted failed pre-publication transaction\n'
+
+(
+	cd "$ROOT/repo/linked-branch"
+	export PATH="$ROOT/bin:/usr/bin:/bin"
+	export GIT_CALL_LOG="$ROOT/git.log"
+	export FAKE_REPO_ROOT="$ROOT/repo"
+	export AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees"
+	export AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops
+	export RESOLVER_MODE=blocked
+	source "$SCRIPT_DIR/full-loop-release-helper.sh" help >/dev/null
+	evidence_writes=0
+	persisted_sources=48@0000000000000000000000000000000000000000
+	fixture_blocked_merge=0000000000000000000000000000000000000001
+	fixture_blocked_head=0000000000000000000000000000000000000000
+	_full_loop_write_release_failure_evidence() {
+		local repo="$1"
+		local source_pr="$2"
+		local requested_merge="$3"
+		local current_head="$4"
+		[[ "$repo" == "marcusquinn/aidevops" && "$source_pr" == "48" &&
+			"$requested_merge" == "$fixture_blocked_merge" && "$current_head" == "$fixture_blocked_head" ]] || return 1
+		evidence_writes=$((evidence_writes + 1))
+		return 0
+	}
+	gh() {
+		local command_name="$1"
+		local object_name="$2"
+		[[ "$command_name" == "pr" && "$object_name" == "view" ]] || return 1
+		jq -cn --arg merge "$fixture_blocked_merge" \
+			'{state:"MERGED",mergedAt:"2026-08-24T02:00:00Z",baseRefName:"main",mergeCommit:{oid:$merge}}'
+		return 0
+	}
+	git() {
+		local option="$1"
+		local repo_path="$2"
+		local operation="$3"
+		[[ "$option" == "-C" && "$repo_path" == "$ROOT/repo/linked-branch" ]] || return 1
+		case "$operation" in
+		rev-parse) printf '%s\n' "$fixture_blocked_head" ;;
+		merge-base) return 0 ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=true
+	_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION=true
+	_FULL_LOOP_PRESERVE_PREPUBLICATION_FAILURE_EVIDENCE=false
+	resolve_rc=0
+	_full_loop_resolve_requested_release_source marcusquinn/aidevops 48 \
+		"$ROOT/repo/linked-branch" "$ROOT/source-resolver.sh" "$persisted_sources" || resolve_rc=$?
+	[[ "$resolve_rc" -ne 0 && "$evidence_writes" -eq 0 ]]
+	_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION=false
+	_FULL_LOOP_PRESERVE_PREPUBLICATION_FAILURE_EVIDENCE=true
+	resolve_rc=0
+	_full_loop_resolve_requested_release_source marcusquinn/aidevops 48 \
+		"$ROOT/repo/linked-branch" "$ROOT/source-resolver.sh" "$persisted_sources" || resolve_rc=$?
+	[[ "$resolve_rc" -ne 0 && "$evidence_writes" -eq 0 ]]
+	_FULL_LOOP_PRESERVE_PREPUBLICATION_FAILURE_EVIDENCE=false
+	resolve_rc=0
+	_full_loop_resolve_requested_release_source marcusquinn/aidevops 48 \
+		"$ROOT/repo/linked-branch" "$ROOT/source-resolver.sh" "$persisted_sources" || resolve_rc=$?
+	[[ "$resolve_rc" -ne 0 && "$evidence_writes" -eq 1 ]]
+)
+printf 'PASS recovered retries preserve their original failure evidence until preparing\n'
 
 exit 0

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -433,6 +433,158 @@ run_reserved_aggregate_authorization_test() (
 	return 0
 )
 
+run_failed_prepublication_reopen_test() (
+	local previous='101@1111111111111111111111111111111111111111'
+	local failed_merge=2222222222222222222222222222222222222222
+	local attempted_tag=v1.2.3
+	local original_state=""
+	local state=""
+	local write_mode="ambiguous"
+	local recovered_token=""
+	original_state=$(jq -cn --arg expected "$previous" '
+		{schema_version:1,repository:"test/repo",active:true,source_pr:101,
+		 expected_sources:$expected,phase:"reconcile-required",tag:null,
+		 updated_at:"2026-08-24T02:01:43Z",owner:"process-old",
+		 operation_token:"token-owned",terminal_receipt:null}
+	') || return 1
+	state="$original_state"
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$state"
+		_AIDEVOPS_RELEASE_LANE_HEAD="1111111111111111111111111111111111111111"
+		return 0
+	}
+	_release_lane_write() {
+		local repo="$1"
+		local state_json="$2"
+		local expected_head="$3"
+		[[ "$repo" == "test/repo" && "$expected_head" == "1111111111111111111111111111111111111111" ]] || return 1
+		if [[ "$write_mode" == "conflict" ]]; then
+			return 2
+		fi
+		state="$state_json"
+		[[ "$write_mode" == "success" ]] && return 0
+		return 2
+	}
+	_AIDEVOPS_RELEASE_LANE_TOKEN=token-owned
+	release_lane_reopen_failed_prepublication test/repo 101 "$previous" 99 "$failed_merge" "$attempted_tag" \
+		>/dev/null || return 1
+	recovered_token=$(jq -er '.operation_token' <<<"$state") || return 1
+	[[ "$(jq -r '.phase' <<<"$state")" == "reserved" && "$recovered_token" != "token-owned" &&
+	"$_AIDEVOPS_RELEASE_LANE_TOKEN" == "$recovered_token" &&
+	"$(jq -r '.prepublication_recovery.previous_phase' <<<"$state")" == "reconcile-required" &&
+	"$(jq -r '.prepublication_recovery.previous_updated_at' <<<"$state")" == "2026-08-24T02:01:43Z" &&
+	"$(jq -r '.prepublication_recovery.failed_source_pr' <<<"$state")" == "99" &&
+	"$(jq -r '.prepublication_recovery.failed_source_merge' <<<"$state")" == "$failed_merge" &&
+	"$(jq -r '.prepublication_recovery.attempted_tag' <<<"$state")" == "$attempted_tag" ]] || return 1
+	state="$original_state"
+	write_mode=conflict
+	_AIDEVOPS_RELEASE_LANE_TOKEN=token-owned
+	if release_lane_reopen_failed_prepublication test/repo 101 "$previous" 99 "$failed_merge" "$attempted_tag" \
+		>/dev/null 2>&1; then
+		return 1
+	fi
+	[[ "$state" == "$original_state" ]] || return 1
+	write_mode=success
+	_AIDEVOPS_RELEASE_LANE_TOKEN=stale-token
+	if release_lane_reopen_failed_prepublication test/repo 101 "$previous" 99 "$failed_merge" "$attempted_tag" \
+		>/dev/null 2>&1; then
+		return 1
+	fi
+	_AIDEVOPS_RELEASE_LANE_TOKEN=token-owned
+	state=$(jq -c '.tag="v1.2.3"' <<<"$original_state") || return 1
+	if release_lane_reopen_failed_prepublication test/repo 101 "$previous" 99 "$failed_merge" "$attempted_tag" \
+		>/dev/null 2>&1; then
+		return 1
+	fi
+	state=$(jq -c '.tag=null | .terminal_receipt="published"' <<<"$original_state") || return 1
+	if release_lane_reopen_failed_prepublication test/repo 101 "$previous" 99 "$failed_merge" "$attempted_tag" \
+		>/dev/null 2>&1; then
+		return 1
+	fi
+	state=$(jq -c '.terminal_receipt=null | .phase="preparing"' <<<"$original_state") || return 1
+	if release_lane_reopen_failed_prepublication test/repo 101 "$previous" 99 "$failed_merge" "$attempted_tag" \
+		>/dev/null 2>&1; then
+		return 1
+	fi
+	state="$original_state"
+	_AIDEVOPS_RELEASE_LANE_TOKEN=token-owned
+	if release_lane_reopen_failed_prepublication test/repo 101 "$previous" 99 "$failed_merge" "" \
+		>/dev/null 2>&1; then
+		return 1
+	fi
+	if release_lane_reopen_failed_prepublication test/repo 101 "$previous" 99 "$failed_merge" v1.2 \
+		>/dev/null 2>&1; then
+		return 1
+	fi
+	return 0
+)
+
+run_failed_prepublication_resume_guard_test() (
+	local previous='101@1111111111111111111111111111111111111111'
+	local failed_merge=2222222222222222222222222222222222222222
+	local attempted_tag=v1.2.3
+	local recovered_at=2026-08-24T02:02:00Z
+	local expanded='101@1111111111111111111111111111111111111111,102@2222222222222222222222222222222222222222'
+	local state=""
+	local resumed_token=""
+	local stale_state=""
+	local write_mode=ambiguous
+	state=$(jq -cn --arg expected "$previous" --arg failed_merge "$failed_merge" \
+		--arg attempted_tag "$attempted_tag" --arg recovered_at "$recovered_at" '
+		{schema_version:1,repository:"test/repo",active:true,source_pr:101,
+		 expected_sources:$expected,phase:"reserved",tag:null,
+		 updated_at:"2026-08-24T02:02:00Z",owner:"process-recovered",
+		 operation_token:"token-recovered",terminal_receipt:null,
+			 prepublication_recovery:{previous_phase:"reconcile-required",
+		  previous_updated_at:"2026-08-24T02:01:43Z",failed_source_pr:99,
+		  failed_source_merge:$failed_merge,attempted_tag:$attempted_tag,recovered_at:$recovered_at}}
+	') || return 1
+	state=$(jq -c --arg expected "$previous" '
+		.prepublication_recovery.failed_expected_sources=$expected
+		| .prepublication_recovery.current_expected_sources=$expected
+	' <<<"$state") || return 1
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$state"
+		_AIDEVOPS_RELEASE_LANE_HEAD="1111111111111111111111111111111111111111"
+		return 0
+	}
+	_release_lane_write() {
+		local repo="$1"
+		local state_json="$2"
+		local expected_head="$3"
+		[[ "$repo" == "test/repo" && "$expected_head" == "1111111111111111111111111111111111111111" ]] || return 1
+		state="$state_json"
+		[[ "$write_mode" == "success" ]] && return 0
+		return 2
+	}
+	_AIDEVOPS_RELEASE_LANE_TOKEN=token-recovered
+	release_lane_reopen_failed_prepublication test/repo 101 "$previous" 99 "$failed_merge" "$attempted_tag" \
+		>/dev/null || return 1
+	resumed_token=$(jq -er '.operation_token' <<<"$state") || return 1
+	[[ "$resumed_token" != "token-recovered" && "$_AIDEVOPS_RELEASE_LANE_TOKEN" == "$resumed_token" &&
+		"$(jq -r '.prepublication_recovery.recovered_at' <<<"$state")" == "$recovered_at" &&
+		-n "$(jq -r '.prepublication_recovery.revalidated_at // ""' <<<"$state")" ]] || return 1
+	stale_state=$(jq -c '.updated_at="2020-01-01T00:00:00Z"' <<<"$state") || return 1
+	export AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1
+	if _release_lane_stale_prepublication "$stale_state"; then
+		return 1
+	fi
+	release_lane_expand_reserved_authorization test/repo 101 "$previous" "$expanded" || return 1
+	[[ "$(jq -r '.phase' <<<"$state")" == "reserved-authorization-refresh" &&
+	"$(jq -r '.prepublication_recovery.current_expected_sources' <<<"$state")" == "$expanded" ]] || return 1
+	resumed_token="$_AIDEVOPS_RELEASE_LANE_TOKEN"
+	release_lane_reopen_failed_prepublication test/repo 101 "$previous" 99 "$failed_merge" "$attempted_tag" \
+		>/dev/null || return 1
+	[[ "$(jq -r '.phase' <<<"$state")" == "reserved-authorization-refresh" &&
+	"$_AIDEVOPS_RELEASE_LANE_TOKEN" != "$resumed_token" ]] || return 1
+	release_lane_finish_reserved_authorization test/repo 101 "$previous" "$expanded" || return 1
+	write_mode=success
+	release_lane_update test/repo 101 preparing || return 1
+	jq -e '.phase == "preparing" and ((.prepublication_recovery // null) == null)' \
+		<<<"$state" >/dev/null || return 1
+	return 0
+)
+
 if run_competing_source_test; then assert_result 'competing source receives active lane and reconcile action' true; else assert_result 'competing source receives active lane and reconcile action' false; fi
 if run_same_source_adoption_test; then assert_result 'same source adopts durable lane without another bump' true; else assert_result 'same source adopts durable lane without another bump' false; fi
 if run_terminal_lane_reacquire_test; then assert_result 'terminal lane can be atomically reserved by a later source' true; else assert_result 'terminal lane can be atomically reserved by a later source' false; fi
@@ -446,6 +598,8 @@ if run_stale_reclamation_guard_test; then assert_result 'preparing, tagged, and 
 if run_aggregate_recovery_rotation_test; then assert_result 'reviewed aggregate recovery rotates and can restore its lane transaction' true; else assert_result 'reviewed aggregate recovery rotates and can restore its lane transaction' false; fi
 if run_aggregate_recovery_rejection_test; then assert_result 'aggregate recovery rejects competing owners and terminal lanes' true; else assert_result 'aggregate recovery rejects competing owners and terminal lanes' false; fi
 if run_reserved_aggregate_authorization_test; then assert_result 'reserved aggregate authorization rotates through a resumable lane-first transaction' true; else assert_result 'reserved aggregate authorization rotates through a resumable lane-first transaction' false; fi
+if run_failed_prepublication_reopen_test; then assert_result 'verified failed pre-publication lane recovery rotates ownership and rejects unsafe states' true; else assert_result 'verified failed pre-publication lane recovery rotates ownership and rejects unsafe states' false; fi
+if run_failed_prepublication_resume_guard_test; then assert_result 'recovered pre-publication markers revalidate fenced refreshes and clear only at preparing' true; else assert_result 'recovered pre-publication markers revalidate fenced refreshes and clear only at preparing' false; fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary

Recover a release lane that failed before tag creation without weakening authorization, source-manifest, or channel-absence checks.

## Files Changed

.agents/reference/release-aggregation-recovery.md, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/full-loop-release-aggregate-recovery.sh, .agents/scripts/full-loop-release-helper.sh, .agents/scripts/release-lane-helper.sh, .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh, .agents/scripts/tests/test-full-loop-release-helper.sh, .agents/scripts/tests/test-release-lane.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Passed test-release-lane.sh (15/15), test-full-loop-release-aggregate-recovery.sh, test-full-loop-release-helper.sh, test-full-loop-release-reconcile.sh, ShellCheck, shfmt, git diff --check, function-complexity validation, and linters-local.sh --changed --no-cache. Independent trust-boundary review returned no findings.

Resolves #30637


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1d 6h and 8,657,571 tokens on this with the user in an interactive session.