### PR TITLE
GH#30591: fix: detect env-prefixed gh writes

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
@@ -53,9 +53,23 @@ function isCommentLine(trimmedLine) {
   return trimmedLine.startsWith("#");
 }
 
+function hasExplicitShimBypassWrite(trimmedLine) {
+  const bypassPrefix =
+    /(^|[;&|(`!]|\$\()\s*AIDEVOPS_GH_SHIM_DISABLE=.*\bgh\s+/;
+  if (!bypassPrefix.test(trimmedLine)) return false;
+  return (
+    /\bgh\s+(?:pr\s+(?:create|comment)|issue\s+(?:create|comment))\b/.test(
+      trimmedLine,
+    ) ||
+    (/\bgh\s+issue\s+close\b/.test(trimmedLine) &&
+      /(?:^|\s)(?:--comment(?:=|\s)|-c(?:=|\s))/.test(trimmedLine))
+  );
+}
+
 function lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern) {
   const trimmed = line.trim();
   if (isCommentLine(trimmed)) return false;
+  if (hasExplicitShimBypassWrite(trimmed)) return true;
   const command = stripQuotedStrings(trimmed);
   if (ghWritePattern.test(command)) return true;
   // A close without a comment is a state-only mutation and must retain native
@@ -75,7 +89,7 @@ function lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern) {
 export function isGhWriteCommand(cmd) {
   if (typeof cmd !== "string") return false;
   const assignment = String.raw`[A-Za-z_][A-Za-z0-9_]*=(?:\$\((?:[^()]|\([^()]*\))*\)|\S*)`;
-  const prefix = String.raw`(?:(?:${assignment}|sudo|command|time(?:\s+-\S+)*|env(?:\s+(?:-\S+|${assignment}))*)\s+)*`;
+  const prefix = String.raw`(?:(?:${assignment}|sudo|command(?:\s+-\S+)*|time(?:\s+-\S+)*|env(?:\s+(?:(?:-\S+)(?:\s+\S+)?|${assignment}))*)\s+)*`;
   const boundary = String.raw`(^|[;&|(` + "!" + String.raw`]|\$\()`;
   const ghWritePattern = new RegExp(
     String.raw`${boundary}\s*${prefix}gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b`,

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
@@ -42,7 +42,10 @@ function stripHeredocBodies(cmd) {
  * @returns {string}
  */
 function stripQuotedStrings(line) {
-  const withoutDouble = line.replace(/"(?:[^"\\]|\\.)*"/g, '""');
+  const withoutDouble = line.replace(/"(?:[^"\\]|\\.)*"/g, (quoted) => {
+    const substitutions = quoted.match(/\$\((?:[^()]|\([^()]*\))*\)/g) ?? [];
+    return `""${substitutions.join(" ")}`;
+  });
   return withoutDouble.replace(/'[^']*'/g, "''");
 }
 
@@ -71,10 +74,15 @@ function lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern) {
  */
 export function isGhWriteCommand(cmd) {
   if (typeof cmd !== "string") return false;
-  const ghWritePattern =
-    /(^|[;&|(`!]|\$\()\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=(?:\$\([^)]*\)|\S*)|sudo|time|command|env(?:\s+[A-Za-z_][A-Za-z0-9_]*=(?:\$\([^)]*\)|\S*))*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
-  const ghIssueClosePattern =
-    /(^|[;&|(`!]|\$\()\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=(?:\$\([^)]*\)|\S*)|sudo|time|command|env(?:\s+[A-Za-z_][A-Za-z0-9_]*=(?:\$\([^)]*\)|\S*))*)\s+)*gh\s+issue\s+close\b/;
+  const assignment = String.raw`[A-Za-z_][A-Za-z0-9_]*=(?:\$\((?:[^()]|\([^()]*\))*\)|\S*)`;
+  const prefix = String.raw`(?:(?:${assignment}|sudo|command|time(?:\s+-\S+)*|env(?:\s+(?:-\S+|${assignment}))*)\s+)*`;
+  const boundary = String.raw`(^|[;&|(` + "!" + String.raw`]|\$\()`;
+  const ghWritePattern = new RegExp(
+    String.raw`${boundary}\s*${prefix}gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b`,
+  );
+  const ghIssueClosePattern = new RegExp(
+    String.raw`${boundary}\s*${prefix}gh\s+issue\s+close\b`,
+  );
   return stripHeredocBodies(cmd)
     .split("\n")
     .some((line) => lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern));

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
@@ -46,13 +46,13 @@ function stripQuotedStrings(line) {
   return withoutDouble.replace(/'[^']*'/g, "''");
 }
 
-function isCommentOrGitCommit(trimmedLine) {
-  return trimmedLine.startsWith("#") || /\bgit\s+commit\b/.test(trimmedLine);
+function isCommentLine(trimmedLine) {
+  return trimmedLine.startsWith("#");
 }
 
 function lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern) {
   const trimmed = line.trim();
-  if (isCommentOrGitCommit(trimmed)) return false;
+  if (isCommentLine(trimmed)) return false;
   const command = stripQuotedStrings(trimmed);
   if (ghWritePattern.test(command)) return true;
   // A close without a comment is a state-only mutation and must retain native
@@ -72,9 +72,9 @@ function lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern) {
 export function isGhWriteCommand(cmd) {
   if (typeof cmd !== "string") return false;
   const ghWritePattern =
-    /(^|[;&|(`!]|\$\()\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=\S*|sudo|time|env(?:\s+[A-Za-z_][A-Za-z0-9_]*=\S*)*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
+    /(^|[;&|(`!]|\$\()\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=(?:\$\([^)]*\)|\S*)|sudo|time|command|env(?:\s+[A-Za-z_][A-Za-z0-9_]*=(?:\$\([^)]*\)|\S*))*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
   const ghIssueClosePattern =
-    /(^|[;&|(`!]|\$\()\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=\S*|sudo|time|env(?:\s+[A-Za-z_][A-Za-z0-9_]*=\S*)*)\s+)*gh\s+issue\s+close\b/;
+    /(^|[;&|(`!]|\$\()\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=(?:\$\([^)]*\)|\S*)|sudo|time|command|env(?:\s+[A-Za-z_][A-Za-z0-9_]*=(?:\$\([^)]*\)|\S*))*)\s+)*gh\s+issue\s+close\b/;
   return stripHeredocBodies(cmd)
     .split("\n")
     .some((line) => lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern));

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
@@ -72,9 +72,9 @@ function lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern) {
 export function isGhWriteCommand(cmd) {
   if (typeof cmd !== "string") return false;
   const ghWritePattern =
-    /(^|[;&|(`!]|\$\()\s*(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
+    /(^|[;&|(`!]|\$\()\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=\S*|sudo|time|env(?:\s+[A-Za-z_][A-Za-z0-9_]*=\S*)*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
   const ghIssueClosePattern =
-    /(^|[;&|(`!]|\$\()\s*(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*gh\s+issue\s+close\b/;
+    /(^|[;&|(`!]|\$\()\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=\S*|sudo|time|env(?:\s+[A-Za-z_][A-Za-z0-9_]*=\S*)*)\s+)*gh\s+issue\s+close\b/;
   return stripHeredocBodies(cmd)
     .split("\n")
     .some((line) => lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern));

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -109,7 +109,27 @@ describe("isGhWriteCommand", () => {
       true,
     );
     assert.equal(
+      isGhWriteCommand('TOKEN=$(( 1 )) gh issue comment 1 --body "x"'),
+      true,
+    );
+    assert.equal(
+      isGhWriteCommand('TOKEN=$(printf $(printf 1)) gh issue comment 1 --body "x"'),
+      true,
+    );
+    assert.equal(
       isGhWriteCommand('TOKEN=1 command gh issue comment 1 --body "x"'),
+      true,
+    );
+    assert.equal(
+      isGhWriteCommand('TOKEN=1 time -p gh issue comment 1 --body "x"'),
+      true,
+    );
+    assert.equal(
+      isGhWriteCommand('env -i TOKEN=1 PATH="$PATH" gh issue comment 1 --body "x"'),
+      true,
+    );
+    assert.equal(
+      isGhWriteCommand('BODY="$(TOKEN=1 gh issue comment 1 --body x)"'),
       true,
     );
   });

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -117,7 +117,17 @@ describe("isGhWriteCommand", () => {
       true,
     );
     assert.equal(
+      isGhWriteCommand(
+        'AIDEVOPS_GH_SHIM_DISABLE=$(printf $(printf $(printf 1))) gh issue comment 1 --body "x"',
+      ),
+      true,
+    );
+    assert.equal(
       isGhWriteCommand('TOKEN=1 command gh issue comment 1 --body "x"'),
+      true,
+    );
+    assert.equal(
+      isGhWriteCommand('TOKEN=1 command -- gh issue comment 1 --body "x"'),
       true,
     );
     assert.equal(
@@ -126,6 +136,12 @@ describe("isGhWriteCommand", () => {
     );
     assert.equal(
       isGhWriteCommand('env -i TOKEN=1 PATH="$PATH" gh issue comment 1 --body "x"'),
+      true,
+    );
+    assert.equal(
+      isGhWriteCommand(
+        'env -u UNUSED AIDEVOPS_GH_SHIM_DISABLE=1 gh issue comment 1 --body "x"',
+      ),
       true,
     );
     assert.equal(

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -104,6 +104,14 @@ describe("isGhWriteCommand", () => {
       isGhWriteCommand('TOKEN= gh issue close 1 --comment "x"'),
       true,
     );
+    assert.equal(
+      isGhWriteCommand('TOKEN=$(printf 1) gh issue comment 1 --body "x"'),
+      true,
+    );
+    assert.equal(
+      isGhWriteCommand('TOKEN=1 command gh issue comment 1 --body "x"'),
+      true,
+    );
   });
 
   test("leaves env-prefixed gh reads outside signature enforcement", () => {
@@ -201,6 +209,15 @@ echo done`;
   test("semicolon chain: setup; gh pr create → BLOCK", () => {
     assert.equal(
       isGhWriteCommand('git add .; gh pr create --title t --body b'),
+      true,
+    );
+  });
+
+  test("git commit followed by env-prefixed gh write → BLOCK", () => {
+    assert.equal(
+      isGhWriteCommand(
+        'git commit -m "checkpoint" && TOKEN=1 gh issue comment 1 --body "x"',
+      ),
       true,
     );
   });

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -89,6 +89,30 @@ describe("isGhWriteCommand", () => {
     assert.equal(isGhWriteCommand('gh pr comment 1 --body "x"'), true);
   });
 
+  test("detects gh writes after bare environment assignments", () => {
+    assert.equal(
+      isGhWriteCommand(
+        'AIDEVOPS_GH_SHIM_DISABLE=1 gh pr create --title "t" --body "x"',
+      ),
+      true,
+    );
+    assert.equal(
+      isGhWriteCommand('ONE=1 TWO="two words" gh issue comment 1 --body "x"'),
+      true,
+    );
+    assert.equal(
+      isGhWriteCommand('TOKEN= gh issue close 1 --comment "x"'),
+      true,
+    );
+  });
+
+  test("leaves env-prefixed gh reads outside signature enforcement", () => {
+    assert.equal(
+      isGhWriteCommand("AIDEVOPS_GH_SHIM_DISABLE=1 gh issue view 1"),
+      false,
+    );
+  });
+
   test("ignores non-string input", () => {
     assert.equal(isGhWriteCommand(undefined), false);
     assert.equal(isGhWriteCommand({ command: 'gh issue comment 1 --body "x"' }), false);


### PR DESCRIPTION
## Summary

Extend OpenCode signature-gate command detection to recognize one or more POSIX-style bare environment assignments before gh while preserving read-only and quoted-prose exclusions.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs, .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused signature footer gate suite passed 81/81; local linters and security gates passed. Full plugin suite passed 662/663, with only the unrelated adapter test blocked because the worktree lacks the @opencode-ai/plugin peer dependency.

Resolves #30591


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.288 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 13h 34m and 3,375,246 tokens on this with the user in an interactive session.