### PR TITLE
GH#30651: fix foreign proc cwd cleanup

### DIFF
--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -164,8 +164,16 @@ _worktree_proc_entry_is_provably_foreign_uid() {
 	local saved_uid=""
 	local filesystem_uid=""
 	local process_uid=""
+	local proc_owner_uid=""
 
-	[[ "$current_uid" =~ ^[0-9]+$ && -r "$proc_dir/status" ]] || return 1
+	[[ "$current_uid" =~ ^[0-9]+$ ]] || return 1
+	if [[ ! -r "$proc_dir/status" ]]; then
+		proc_owner_uid=$(_worktree_proc_entry_owner_uid "$proc_dir" 2>/dev/null || true)
+		if [[ "$proc_owner_uid" =~ ^[0-9]+$ && "$proc_owner_uid" != "$current_uid" ]]; then
+			return 0
+		fi
+		return 1
+	fi
 	while IFS=$' \t' read -r field real_uid effective_uid saved_uid filesystem_uid _; do
 		[[ "$field" == "Uid:" ]] || continue
 		for process_uid in "$real_uid" "$effective_uid" "$saved_uid" "$filesystem_uid"; do
@@ -175,6 +183,21 @@ _worktree_proc_entry_is_provably_foreign_uid() {
 		return 0
 	done <"$proc_dir/status"
 	return 1
+}
+
+_worktree_proc_entry_owner_uid() {
+	local proc_dir="$1"
+
+	python3 - "$proc_dir" <<'PY'
+import os
+import sys
+
+try:
+    print(os.stat(sys.argv[1], follow_symlinks=False).st_uid)
+except OSError:
+    raise SystemExit(1)
+PY
+	return $?
 }
 
 _capture_worktree_proc_cwds() {
@@ -551,16 +574,19 @@ _worktree_log_identity_refusal() {
 
 _worktree_path_identity() {
 	local target_path="$1"
-	local platform=""
 
 	[[ -e "$target_path" && ! -L "$target_path" ]] || return 1
-	platform=$(uname -s 2>/dev/null) || return 1
-	case "$platform" in
-	Darwin) stat -f '%d:%i' "$target_path" 2>/dev/null || return 1 ;;
-	Linux) stat -c '%d:%i' -- "$target_path" 2>/dev/null || return 1 ;;
-	*) return 1 ;;
-	esac
-	return 0
+	python3 - "$target_path" <<'PY'
+import os
+import sys
+
+try:
+    st = os.stat(sys.argv[1], follow_symlinks=False)
+except OSError:
+    raise SystemExit(1)
+print(f"{st.st_dev}:{st.st_ino}")
+PY
+	return $?
 }
 
 # Copy exactly once into a unique destination. In particular, do not retry into

--- a/.agents/scripts/tests/test-worktree-removal-audit-lib.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit-lib.sh
@@ -1632,6 +1632,46 @@ test_proc_snapshot_skips_foreign_uid_unreadable_entry() {
 }
 
 # =============================================================================
+# hidepid-style /proc mounts can deny both cwd and status reads for other users.
+# Directory ownership still proves those entries are foreign, so they must not
+# degrade the whole snapshot and force recoverable archival for every cleanup.
+# =============================================================================
+test_proc_snapshot_skips_foreign_uid_when_status_unreadable() {
+	local proc_root="${TEST_DIR}/fake-proc-foreign-owner"
+	local current_uid=""
+	local foreign_uid=""
+	local output=""
+	local rc=0
+	current_uid=$(id -u)
+	foreign_uid=$((current_uid + 1))
+	mkdir -p "${proc_root}/1" "${proc_root}/2"
+	ln -s /visible-cwd "${proc_root}/1/cwd"
+	ln -s /foreign-cwd "${proc_root}/2/cwd"
+
+	output=$(
+		readlink() {
+			local link_path="$1"
+			[[ "$link_path" == */1/cwd ]] || return 1
+			printf '/visible-cwd\n'
+			return 0
+		}
+		_worktree_proc_entry_owner_uid() {
+			local proc_dir="$1"
+			case "$proc_dir" in
+			*/2) printf '%s\n' "$foreign_uid" ;;
+			*) printf '%s\n' "$current_uid" ;;
+			esac
+			return 0
+		}
+		_capture_worktree_proc_cwds "$proc_root"
+	) || rc=1
+	[[ "$output" == "/visible-cwd" ]] || rc=1
+	print_result "proc_snapshot_skips_foreign_uid_when_status_unreadable" "$rc" \
+		"Expected hidepid-style foreign /proc entries to be skipped without degraded visibility"
+	return 0
+}
+
+# =============================================================================
 # Same-UID unreadability is explicitly degraded while preserving readable cwd
 # evidence for candidate-specific positive matching.
 # =============================================================================
@@ -1917,6 +1957,7 @@ test_snapshot_backend_requires_visible_target
 test_lsof_snapshot_visibility_states
 test_proc_snapshot_preserves_degraded_visibility
 test_proc_snapshot_skips_foreign_uid_unreadable_entry
+test_proc_snapshot_skips_foreign_uid_when_status_unreadable
 test_proc_snapshot_marks_same_uid_unreadable_entry_degraded
 test_degraded_visibility_preserves_positive_candidate_match
 test_proc_snapshot_requires_usable_evidence_after_foreign_skips

--- a/.agents/scripts/tests/test-worktree-removal-audit-lib.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit-lib.sh
@@ -1657,10 +1657,11 @@ test_proc_snapshot_skips_foreign_uid_when_status_unreadable() {
 		}
 		_worktree_proc_entry_owner_uid() {
 			local proc_dir="$1"
-			case "$proc_dir" in
-			*/2) printf '%s\n' "$foreign_uid" ;;
-			*) printf '%s\n' "$current_uid" ;;
-			esac
+			if [[ "${proc_dir##*/}" == "2" ]]; then
+				printf '%s\n' "$foreign_uid"
+			else
+				printf '%s\n' "$current_uid"
+			fi
 			return 0
 		}
 		_capture_worktree_proc_cwds "$proc_root"

--- a/TODO.md
+++ b/TODO.md
@@ -1305,6 +1305,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18304 Improve reliability-adjusted subagent routing observability #auto-dispatch #feat #observability #priority:high #reliability #routing #interactive ~4.75h tier:thinking ref:GH#30521 logged:2026-08-21 -> [todo/tasks/t18304-brief.md] pr:#30524 completed:2026-08-21
 
+- [ ] t18305 Fix worktree cleanup false degraded visibility for foreign /proc entries #bug ref:GH#30651
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- Treat unreadable foreign-owned /proc entries as foreign instead of degrading cleanup visibility
- Keep same-user or unknown process ownership fail-closed
- Add a hidepid-style regression test for worktree removal audit cleanup

## Verification
- bash .agents/scripts/tests/test-worktree-removal-audit-lib.sh
- shellcheck .agents/scripts/audit-worktree-removal-helper.sh .agents/scripts/tests/test-worktree-removal-audit-lib.sh
- git diff --check
- bun run typecheck

Resolves #30651
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.5 spent 2h 14m and 416,548 tokens on this with the user in an interactive session.