### PR TITLE
GH#30655: fix: recover failed MCP activation once

### DIFF
--- a/.agents/aidevops/mcp-troubleshooting.md
+++ b/.agents/aidevops/mcp-troubleshooting.md
@@ -18,7 +18,14 @@ tools:
 - **Scripts**: `mcp-diagnose.sh check-all`, `tool-version-check.sh`
 - **Primary cause**: version mismatch (outdated tool, changed MCP command)
 - **Config**: `~/.config/opencode/opencode.json`
+- **On-demand activation**: `failed`/`error` status gets one automatic disconnect/reconnect; a second failure is terminal
 - **Dead schemas (t1682)**: MCP tools can remain listed after startup failure; treat that server as unavailable for the session
+
+## Bounded On-Demand Recovery
+
+When the registry-approved `aidevops_mcp` activation tool observes `failed` or `error` status, it makes exactly one automatic reset: disconnect the same MCP, reconnect it, and poll for readiness again. The allowlist remains unchanged and the tool never loops.
+
+If the reset API is unavailable or the second attempt fails, run `mcp-diagnose.sh <mcp-name>` and restart OpenCode after fixing the cause. Timeouts, authentication requirements, direct API errors, and dead tool-schema errors do not trigger this reset.
 
 ## Errored Servers — Dead Tool Schemas (t1682)
 

--- a/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
@@ -20,12 +20,52 @@ async function waitForConnection(name, options) {
     status = payload?.[name]?.status || "unknown";
     if (status === "connected") return;
     if (["error", "failed"].includes(status)) {
-      throw new Error(`MCP entered ${status} status`);
+      const error = new Error(`MCP entered ${status} status`);
+      error.mcpStatus = status;
+      throw error;
     }
     await pause(pollIntervalMs);
   } while (Date.now() < deadline);
 
   throw new Error(`MCP did not become ready (last status: ${status})`);
+}
+
+function lifecycleRequest(name, options) {
+  return {
+    path: { name },
+    ...(options.directory ? { query: { directory: options.directory } } : {}),
+  };
+}
+
+function recoveryFailure(name, detail, resetAttempted) {
+  const state = resetAttempted ? "after one reset attempt" : "because automatic reset is unavailable";
+  return `Error: MCP connect failed for ${name} ${state}: ${detail}. `
+    + `Run mcp-diagnose.sh ${name}; restart OpenCode after fixing the cause.`;
+}
+
+async function recoverFailedConnection(name, options) {
+  const disconnectMethod = options.client?.disconnect;
+  if (typeof disconnectMethod !== "function") {
+    return recoveryFailure(name, "OpenCode does not expose MCP disconnect in this runtime", false);
+  }
+
+  const request = lifecycleRequest(name, options);
+  try {
+    const disconnectResult = await disconnectMethod.call(options.client, request);
+    if (disconnectResult?.error) {
+      throw new Error(disconnectResult.error.message || String(disconnectResult.error));
+    }
+    const reconnectResult = await options.client.connect.call(options.client, request);
+    if (reconnectResult?.error) {
+      throw new Error(reconnectResult.error.message || String(reconnectResult.error));
+    }
+    await waitForConnection(name, options);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return recoveryFailure(name, detail, true);
+  }
+
+  return null;
 }
 
 /**
@@ -60,15 +100,19 @@ export function createMcpActivationTool(tool, z, options) {
       }
 
       try {
-        const result = await method.call(options.client, {
-          path: { name },
-          ...(options.directory ? { query: { directory: options.directory } } : {}),
-        });
+        const result = await method.call(options.client, lifecycleRequest(name, options));
         if (result?.error) {
           return `Error: MCP ${action} failed for ${name}: ${result.error.message || String(result.error)}`;
         }
         if (action === "connect") await waitForConnection(name, options);
       } catch (error) {
+        if (action === "connect" && error?.mcpStatus) {
+          const recoveryError = await recoverFailedConnection(name, options);
+          if (!recoveryError) {
+            return `Connected MCP ${name} after one automatic reset. Continue on the next step with its tools.`;
+          }
+          return recoveryError;
+        }
         return `Error: MCP ${action} failed for ${name}: ${error instanceof Error ? error.message : String(error)}`;
       }
 

--- a/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
@@ -108,10 +108,8 @@ export function createMcpActivationTool(tool, z, options) {
       } catch (error) {
         if (action === "connect" && error?.mcpStatus) {
           const recoveryError = await recoverFailedConnection(name, options);
-          if (!recoveryError) {
-            return `Connected MCP ${name} after one automatic reset. Continue on the next step with its tools.`;
-          }
-          return recoveryError;
+          return recoveryError
+            || `Connected MCP ${name} after one automatic reset. Continue on the next step with its tools.`;
         }
         return `Error: MCP ${action} failed for ${name}: ${error instanceof Error ? error.message : String(error)}`;
       }

--- a/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
@@ -90,13 +90,12 @@ export function createMcpActivationTool(tool, z, options) {
     async execute(args) {
       const action = String(args.action || "");
       const name = String(args.name || "");
-      if (!allowed.has(name) || !["connect", "disconnect"].includes(action)) {
-        return "Error: only registry-approved MCP activation requests are allowed.";
-      }
-
       const method = options.client?.[action];
-      if (typeof method !== "function") {
-        return `Error: OpenCode does not expose MCP ${action} in this runtime.`;
+      const invalidRequest = !allowed.has(name) || !["connect", "disconnect"].includes(action);
+      if (invalidRequest || typeof method !== "function") {
+        return invalidRequest
+          ? "Error: only registry-approved MCP activation requests are allowed."
+          : `Error: OpenCode does not expose MCP ${action} in this runtime.`;
       }
 
       try {

--- a/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
@@ -137,6 +137,76 @@ test("waits until an asynchronously connecting MCP reports ready", async () => {
   ]);
 });
 
+test("resets and reconnects once after an MCP enters failed status", async () => {
+  const statuses = ["failed", "connected"];
+  const calls = [];
+  const client = {
+    async connect(args) { calls.push(["connect", args]); },
+    async disconnect(args) { calls.push(["disconnect", args]); },
+    async status(args) {
+      calls.push(["status", args]);
+      return { data: { playwriter: { status: statuses.shift() } } };
+    },
+  };
+  const activation = createMcpActivationTool(tool, z, {
+    client,
+    directory: "/workspace",
+    allowedNames: ["playwriter"],
+  });
+
+  assert.match(
+    await activation.execute({ action: "connect", name: "playwriter" }),
+    /Connected MCP playwriter after one automatic reset/,
+  );
+  assert.deepEqual(calls, [
+    ["connect", { path: { name: "playwriter" }, query: { directory: "/workspace" } }],
+    ["status", { query: { directory: "/workspace" } }],
+    ["disconnect", { path: { name: "playwriter" }, query: { directory: "/workspace" } }],
+    ["connect", { path: { name: "playwriter" }, query: { directory: "/workspace" } }],
+    ["status", { query: { directory: "/workspace" } }],
+  ]);
+});
+
+test("does not loop when the MCP remains failed after recovery", async () => {
+  const statuses = ["error", "failed"];
+  const calls = [];
+  const client = {
+    async connect() { calls.push("connect"); },
+    async disconnect() { calls.push("disconnect"); },
+    async status() {
+      calls.push("status");
+      return { data: { playwriter: { status: statuses.shift() } } };
+    },
+  };
+  const activation = createMcpActivationTool(tool, z, {
+    client,
+    allowedNames: ["playwriter"],
+  });
+
+  assert.match(
+    await activation.execute({ action: "connect", name: "playwriter" }),
+    /after one reset attempt: MCP entered failed status.*mcp-diagnose\.sh playwriter.*restart OpenCode/,
+  );
+  assert.deepEqual(calls, ["connect", "status", "disconnect", "connect", "status"]);
+});
+
+test("reports actionable recovery when MCP disconnect is unavailable", async () => {
+  let connectCalls = 0;
+  const activation = createMcpActivationTool(tool, z, {
+    client: {
+      async connect() { connectCalls += 1; },
+      async status() { return { data: { playwriter: { status: "failed" } } }; },
+    },
+    allowedNames: ["playwriter"],
+  });
+
+  assert.match(
+    await activation.execute({ action: "connect", name: "playwriter" }),
+    /automatic reset is unavailable.*does not expose MCP disconnect.*mcp-diagnose\.sh playwriter/,
+  );
+  assert.equal(connectCalls, 1);
+});
+
 test("returns OpenCode MCP lifecycle failures to the agent", async () => {
   const activation = createMcpActivationTool(tool, z, {
     client: {


### PR DESCRIPTION
## Summary

- detect terminal `failed` or `error` MCP activation status without weakening the registry allowlist
- make one bounded disconnect/reconnect attempt, with no recursive or repeated retry
- return actionable diagnostics when reset is unavailable or the second attempt fails
- document the distinction between bounded activation recovery and terminal dead-schema failures

Resolves #30655

## Verification

- `node --check .agents/plugins/opencode-aidevops/mcp-activation-tool.mjs`
- `node --test .agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs .agents/plugins/opencode-aidevops/tests/test-quickfile-mcp-registry.mjs` (10 passed)
- `git diff --check`
- pre-commit and pre-push quality hooks passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol
