### PR TITLE
GH#30656: fix: preflight authenticated Playwriter tabs

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-agent-profiles.mjs
+++ b/.agents/plugins/opencode-aidevops/config-agent-profiles.mjs
@@ -103,6 +103,13 @@ function onDemandMcpPrompt(mcp, agentsDir) {
 
 function createOnDemandMcpProfile(mcp, agentsDir) {
   const { parsed, prompt } = onDemandMcpPrompt(mcp, agentsDir);
+  const playwriterSafetyPrompt = mcp.name === "playwriter"
+    ? [
+      "Before requesting authentication, enumerate the accessible pages and confirm the intended tab by URL or title; if it is unavailable, relay the consent diagnostic and stop.",
+      "Do not silently substitute isolated Playwright for Playwriter; explain the profile and storage difference and obtain explicit user consent before falling back.",
+      "Treat attached browser windows as user-owned: disconnect the MCP after work, but never close the browser or its contexts, including during cancellation cleanup.",
+    ]
+    : [];
   return {
     description: parsed?.profile.description || mcp.description,
     mode: "subagent",
@@ -111,6 +118,7 @@ function createOnDemandMcpProfile(mcp, agentsDir) {
       `After it succeeds, continue on the next step with ${mcp.toolPattern} tools.`,
       `When browser work is complete, call ${MCP_ACTIVATION_TOOL} with action \"disconnect\".`,
       "If no browser tab is approved, relay the MCP consent diagnostic instead of claiming the tools are missing.",
+      ...playwriterSafetyPrompt,
       "",
       prompt,
     ].join("\n"),

--- a/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
@@ -29,6 +29,9 @@ test("registers only the explicit browser MCP activation profiles", () => {
   assert.equal(config.agent.playwriter.permission["playwriter_*"], "allow");
   assert.match(config.agent.playwriter.prompt, /connect.*playwriter/);
   assert.match(config.agent.playwriter.prompt, /no browser tab is approved/i);
+  assert.match(config.agent.playwriter.prompt, /before requesting authentication.*enumerate.*pages/i);
+  assert.match(config.agent.playwriter.prompt, /do not silently substitute isolated Playwright/i);
+  assert.match(config.agent.playwriter.prompt, /never close the browser or its contexts/i);
   assert.match(config.agent.playwriter.prompt, /# Playwriter - Browser Extension MCP/);
   assert.equal(config.agent.playwright.mode, "subagent");
   assert.equal(config.agent.playwright.tools.aidevops_mcp, true);
@@ -36,6 +39,7 @@ test("registers only the explicit browser MCP activation profiles", () => {
   assert.equal(config.agent.playwright.permission.aidevops_mcp, "allow");
   assert.equal(config.agent.playwright.permission["playwright_*"], "allow");
   assert.match(config.agent.playwright.prompt, /connect.*playwright/);
+  assert.doesNotMatch(config.agent.playwright.prompt, /do not silently substitute isolated Playwright/i);
   assert.match(config.agent.playwright.prompt, /# Playwright MCP/);
 });
 

--- a/.agents/tools/browser/extension-dev/testing.md
+++ b/.agents/tools/browser/extension-dev/testing.md
@@ -67,6 +67,17 @@ test('extension popup works', async () => {
 });
 ```
 
+## Persistent Manual-Test Installation
+
+Use a project-configured stable unpacked-extension directory when testing in the user's normal browser profile. Transient build output paths can change or disappear, forcing Chrome to load a new installation and losing extension-local state.
+
+1. Build the extension using the repository's existing command.
+2. Deploy the complete build to `<stable-unpacked-directory>`; do not expose a partially written build to Chrome.
+3. Select that directory once with `chrome://extensions` → **Load unpacked**.
+4. After each deployment, use the extension card's **Reload** action and reload affected application tabs.
+
+If browser automation cannot control Chrome's native directory picker, ask the user to select the stable directory once. Subsequent test cycles should reuse the same path and require only reload, not another native picker interaction.
+
 ## Debugging
 
 | Target | How |

--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -32,6 +32,8 @@ mcp:
 
 **Why Playwriter**: 1 tool (vs 10-17), minimal context bloat, uses your existing browser with extensions/sessions/cookies, bypasses detection (disconnect → manual action → reconnect).
 
+**Authenticated preflight**: Before requesting login, enumerate accessible pages and confirm the intended tab by URL or title. If it is absent, stop and ask the user to approve that tab. Never silently fall back to isolated Playwright, whose profile, cookies, storage, and extensions differ.
+
 **When to use alternatives**: **Stagehand** for natural language / self-healing selectors. **Playwright MCP** for isolated automation. **Crawl4AI** for scraping. **playwright-cli** for headless.
 
 **Parallel tabs**: Click extension on each tab. Shared session — not isolated. For isolated parallel work, use Playwright direct.
@@ -91,6 +93,22 @@ Use `@playwriter` for browser tasks. The agent connects Playwriter before its fi
 
 ## Usage
 
+### Authenticated Session Preflight
+
+Before asking the user to log in or relying on existing session state, inspect the pages Playwriter can actually access:
+
+```javascript
+const pages = context.pages()
+return await Promise.all(pages.map(async (candidate) => ({
+  title: await candidate.title(),
+  url: candidate.url(),
+})))
+```
+
+Confirm the intended tab by URL or title before continuing. If it is missing, relay the tab-consent diagnostic and stop; do not claim the user is logged out. If isolated Playwright is a useful alternative, explain that it has a separate profile, cookies, storage, and extensions, then obtain explicit consent before switching.
+
+The attached browser and its contexts are user-owned. On completion or cancellation, disconnect the MCP but do not call browser/context close methods or terminate the user's browser window.
+
 ### The `execute` Tool
 
 Runs Playwright code against connected tabs:
@@ -123,7 +141,7 @@ const browser = await chromium.connectOverCDP(getCdpUrl())
 const page = browser.contexts()[0].pages()[0]
 await page.goto('https://example.com')
 await page.screenshot({ path: 'screenshot.png' })
-await browser.close()
+// Do not call browser.close() on the user's attached browser.
 server.close()
 ```
 
@@ -148,6 +166,7 @@ await page.pdf({ path: 'page.pdf', format: 'A4' })
 - **User-controlled** — only tabs where you clicked the extension are accessible
 - **Explicit consent** — Chrome shows automation banner on controlled tabs
 - New tabs from automation are controlled; unconnected tabs and remote access are not possible
+- **User-owned lifecycle** — disconnect automation without closing attached browser windows or contexts
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- require the generated Playwriter profile to verify the intended approved tab before requesting authentication
- prohibit silent fallback to isolated Playwright and protect user-owned browser windows from cleanup
- document stable unpacked-extension deployment and reload for repeatable manual testing
- assert that Playwriter receives the safeguards without changing the isolated Playwright profile

Resolves #30656

## Verification

- `node --check .agents/plugins/opencode-aidevops/config-agent-profiles.mjs`
- `node --test .agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs` (6 passed)
- `git diff --check`
- pre-commit and pre-push quality hooks passed

The broader plugin suite reached 663/664 tests; its unrelated `test-opencode-v2-adapter.mjs` test could not import the locally absent `@opencode-ai/plugin` package. `markdownlint-cli2` was also unavailable locally without installing a new package.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol
