### PR TITLE
t18306: Prevent self-ignore overrides from blocking Pulse launches

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -1490,7 +1490,11 @@ cmd_transition() {
 		fi
 	fi
 	local active_claims="" current_phase="" current_expires_at="" claim_record="" claim_author="" claim_device="" claim_session="" current_login="" current_device=""
-	active_claims=$(_fetch_claims "$issue_number" "$repo_slug") || return 1
+	# Runtime overrides quarantine peer claims only. Resolve and pass this runner
+	# before filtering so a stale self-ignore entry cannot hide the lease that
+	# this same authenticated runner is authorized to transition.
+	current_login=$(_resolve_runner "") || return 1
+	active_claims=$(_fetch_claims "$issue_number" "$repo_slug" "$current_login") || return 1
 	claim_record=$(printf '%s' "$active_claims" | jq -c --arg token "$lease_token" '[.[] | select(.lease_token == $token)] | last // empty' 2>/dev/null) || claim_record=""
 	current_phase=$(printf '%s' "$claim_record" | jq -r '.lease_phase // ""' 2>/dev/null) || current_phase=""
 	[[ -n "$current_phase" ]] || return 1
@@ -1499,7 +1503,6 @@ cmd_transition() {
 	claim_author=$(printf '%s' "$claim_record" | jq -r '.claim_author // ""') || return 1
 	claim_device=$(printf '%s' "$claim_record" | jq -r '.device // ""') || return 1
 	claim_session=$(printf '%s' "$claim_record" | jq -r '.session // ""') || return 1
-	current_login=$(_resolve_runner "") || return 1
 	current_device=$(_resolve_device_id)
 	[[ -n "$claim_author" && "$current_login" == "$claim_author" ]] || return 1
 	[[ "$current_device" == "$claim_device" && "${session_key:-issue-${issue_number}}" == "$claim_session" ]] || return 1

--- a/.agents/scripts/peer-productivity-monitor.sh
+++ b/.agents/scripts/peer-productivity-monitor.sh
@@ -121,7 +121,12 @@ _is_bot() {
 
 # Get our own GitHub login.
 _self_login() {
-	gh api user --jq '.login' 2>/dev/null || echo ""
+	local login=""
+	login=$(gh api user --jq '.login // ""' 2>/dev/null) || return 1
+	if [[ ! "$login" =~ ^[A-Za-z0-9][A-Za-z0-9-]{0,38}$ ]]; then
+		return 1
+	fi
+	printf '%s' "$login"
 	return 0
 }
 
@@ -273,8 +278,15 @@ _attach_repository_observations() {
 # Outputs JSON array: [{"login": ..., "active_claims": N, ...}, ...]
 # Aggregated across repos (sums active_claims, worker_prs, interactive_prs).
 discover_and_observe() {
-	local self_login since_iso
-	self_login="$(_self_login)"
+	local self_login="${1:-}"
+	local since_iso=""
+	if [[ -z "$self_login" ]]; then
+		self_login=$(_self_login) || {
+			log_msg WARN "discover_and_observe: authenticated self login unavailable — skipping peer discovery"
+			printf '[]\n'
+			return 0
+		}
+	fi
 	# Compute since timestamp
 	since_iso=$(date -u -v "-${WINDOW_HOURS}H" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
 		date -u -d "${WINDOW_HOURS} hours ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
@@ -454,6 +466,7 @@ _apply_hysteresis() {
 # between BEGIN and END markers is replaced. Anything after END is preserved.
 _rewrite_override_config() {
 	local state_json="$1"
+	local self_login="${2:-}"
 
 	# Build the managed section content
 	local managed_lines=""
@@ -470,6 +483,7 @@ _rewrite_override_config() {
 	if [[ -n "$peers" ]]; then
 		while IFS= read -r peer; do
 			[[ -z "$peer" ]] && continue
+			[[ -n "$self_login" && "$peer" == "$self_login" ]] && continue
 			local action
 			action=$(printf '%s' "$state_json" | jq -r --arg l "$peer" --arg default "$ACTION_HONOUR" '.[$l].current_action // $default')
 			action=$(_sanitize_action "$action")
@@ -546,24 +560,32 @@ cmd_observe() {
 
 	log_msg INFO "=== observe cycle start ==="
 
+	local self_login=""
+	self_login=$(_self_login) || {
+		log_msg WARN "authenticated self login unavailable — preserving peer state and override config"
+		return 0
+	}
+
 	local observations
-	observations=$(discover_and_observe)
+	observations=$(discover_and_observe "$self_login")
 	local count
 	count=$(printf '%s' "$observations" | jq 'length' 2>/dev/null || echo 0)
 
 	if [[ "$count" -eq 0 ]]; then
 		log_msg INFO "no peers found across pulse-enabled repos"
-		return 0
+	else
+		log_msg INFO "found $count peer(s) to evaluate"
 	fi
-
-	log_msg INFO "found $count peer(s) to evaluate"
 
 	# Load existing state
 	local state_json
 	state_json=$(_load_state)
 
-	# Apply hysteresis per peer, accumulating updated state
-	local updated_state="$state_json"
+	# A peer entry can survive an earlier cycle where GitHub identity lookup was
+	# unavailable. Remove this authenticated runner before applying peer votes so
+	# the managed config can never quarantine its own dispatch claims.
+	local updated_state=""
+	updated_state=$(printf '%s' "$state_json" | jq --arg self "$self_login" 'del(.[$self])') || return 1
 	while IFS= read -r obs; do
 		[[ -z "$obs" ]] && continue
 		local login active_claims worker_prs interactive_prs repositories
@@ -596,7 +618,7 @@ cmd_observe() {
 	chmod 600 "$STATE_FILE" 2>/dev/null || true
 
 	# Rewrite override config
-	_rewrite_override_config "$updated_state"
+	_rewrite_override_config "$updated_state" "$self_login"
 
 	log_msg INFO "=== observe cycle complete ==="
 	return 0

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -412,16 +412,18 @@ test_prelaunch_renewal_covers_slow_startup() {
 	[[ -n "$token" ]] || fail "renewal claim token missing"
 	sleep 2
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		DISPATCH_OVERRIDE_SHARED_LOGIN=ignore \
 		"$CLAIM" transition prelaunch 47 owner/repo "$token" issue-47 3
 	sleep 2
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		DISPATCH_OVERRIDE_SHARED_LOGIN=ignore \
 		"$CLAIM" transition ready 47 owner/repo "$token" issue-47 30 ||
-		fail "renewed prelaunch lease did not survive slow startup"
+		fail "self-preserved prelaunch lease did not survive slow startup"
 	# shellcheck disable=SC2016 # Match the literal runtime variable in the helper source.
 	renewal_call='_hrw_renew_dispatch_prelaunch_lease "$session_key"'
 	grep -Fq "$renewal_call" "${SCRIPTS_DIR}/headless-runtime-run.sh" ||
 		fail "worker does not renew its prelaunch lease before canary"
-	pass "worker prelaunch renewal covers slow startup before ready transition"
+	pass "worker prelaunch renewal preserves self claims across override filtering"
 	return 0
 }
 

--- a/TODO.md
+++ b/TODO.md
@@ -1307,6 +1307,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18305 Fix worktree cleanup false degraded visibility for foreign /proc entries #bug ref:GH#30651
 
+- [ ] t18306 Fix self-ignore overrides blocking Pulse worker launches #auto-dispatch #priority:high ref:GH#30659
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/tests/test-peer-productivity-monitor.sh
+++ b/tests/test-peer-productivity-monitor.sh
@@ -390,6 +390,27 @@ test_hysteresis_keep_preserves_action() {
 test_hysteresis_keep_preserves_action
 
 # ============================================================================
+section "Authenticated self identity validation"
+# ============================================================================
+
+test_self_login_rejects_api_error_payload() {
+	gh() {
+		printf '{"message":"API rate limit exceeded"}\n'
+		return 0
+	}
+	local output="" rc=0
+	output=$(_self_login) || rc=$?
+	unset -f gh
+	if [[ "$rc" -ne 0 && -z "$output" ]]; then
+		pass "self login rejects API error payloads"
+	else
+		fail "self login accepted an API error payload" "rc=$rc output=$output"
+	fi
+	return 0
+}
+test_self_login_rejects_api_error_payload
+
+# ============================================================================
 section "Override config rewrite preserves manual entries"
 # ============================================================================
 
@@ -476,6 +497,60 @@ EOF
 	return 0
 }
 test_rewrite_drops_honour_entries
+
+test_rewrite_drops_authenticated_self_entry() {
+	local conf="$HOME/.config/aidevops/dispatch-override.conf"
+	cat >"$conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+EOF
+	OVERRIDE_CONF="$conf"
+
+	local state='{"self-runner":{"current_action":"ignore","vote_history":["ignore","ignore","ignore"]},"alice":{"current_action":"ignore","vote_history":["ignore","ignore","ignore"]}}'
+	_rewrite_override_config "$state" "self-runner"
+	if ! grep -qF 'DISPATCH_OVERRIDE_SELF_RUNNER' "$conf" &&
+		grep -qF 'DISPATCH_OVERRIDE_ALICE="ignore"' "$conf"; then
+		pass "rewrite omits the authenticated runner while retaining peer overrides"
+	else
+		fail "rewrite emitted a self override or dropped a peer override"
+	fi
+	return 0
+}
+test_rewrite_drops_authenticated_self_entry
+
+# ============================================================================
+section "Observe cycle removes stale self state"
+# ============================================================================
+
+test_observe_removes_stale_self_state() {
+	STATE_FILE="$HOME/.aidevops/state/peer-productivity-state.json"
+	OVERRIDE_CONF="$HOME/.config/aidevops/dispatch-override.conf"
+	DRY_RUN=0
+	cat >"$STATE_FILE" <<'EOF'
+{
+  "self-runner": {"current_action":"ignore","vote_history":["ignore","ignore","ignore"]},
+  "alice": {"current_action":"ignore","vote_history":["ignore","ignore","ignore"]}
+}
+EOF
+	_self_login() {
+		printf 'self-runner'
+		return 0
+	}
+	discover_and_observe() {
+		printf '[]\n'
+		return 0
+	}
+
+	cmd_observe
+	if jq -e 'has("self-runner") | not' "$STATE_FILE" >/dev/null &&
+		! grep -qF 'DISPATCH_OVERRIDE_SELF_RUNNER' "$OVERRIDE_CONF" &&
+		grep -qF 'DISPATCH_OVERRIDE_ALICE="ignore"' "$OVERRIDE_CONF"; then
+		pass "observe removes stale self state even when no peers are discovered"
+	else
+		fail "observe retained stale authenticated self state"
+	fi
+	return 0
+}
+test_observe_removes_stale_self_state
 
 # ============================================================================
 section "Claim regression — broken-peer detection (GH#21135)"


### PR DESCRIPTION
## Summary

- preserve the authenticated runner's own dispatch lease when structured peer overrides ignore the same login
- fail closed when peer-monitor identity lookup is unavailable or invalid, then remove authenticated-self state from managed overrides
- add regressions for lease transitions, identity validation, stale-self cleanup, and managed-config rewriting

## Evidence

Pulse repeatedly won dispatch claims but aborted before runtime with `prelaunch lease renewal failed ... helper_rc=1`. The managed peer override had classified the authenticated runner as ignored, and the transition path filtered that runner's own claim before checking authorization.

## Verification

- `bash .agents/scripts/tests/test-dispatch-atomic-lease.sh` (17 checks passed)
- `bash tests/test-peer-productivity-monitor.sh` (53 checks passed)
- `shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/peer-productivity-monitor.sh .agents/scripts/tests/test-dispatch-atomic-lease.sh tests/test-peer-productivity-monitor.sh`
- `git diff --check origin/main...HEAD`

No release or deployment is included in this PR.

Resolves #30659

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol
