### PR TITLE
GH#30648: preserve auth failures as infrastructure retries

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -998,7 +998,7 @@ _hrff_retry_class_for_reason() {
 	local session_count="$2"
 	case "$reason" in
 	opencode_version_pin_failed | canary_failed | worker_prepare_failed | duplicate_session | \
-		worker_noop_zero_output | crash_during_startup | access_denied | rate_limit* | provider_error | \
+		worker_noop_zero_output | crash_during_startup | access_denied | auth_error | rate_limit* | provider_error | \
 		startup_no_model_activity | service_interruption_exhausted | worker_runtime_not_invoked | \
 		worker_sensitive_temp_preflight_failed | worker_ownership_lost | worker_ledger_ready_failed | \
 		worker_claim_ready_transition_failed | signal_terminated_continue | watchdog_stall_killed)

--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -1415,7 +1415,8 @@ _prrts_classify_previous_dispatch() {
 	if [[ "$repeated" == "$PRRTS_BOOL_TRUE" && "$same_head" == "$PRRTS_BOOL_TRUE" ]] &&
 		_prrts_outcome_matches_dispatch "$expected_outcome_id" "$observed_outcome_id" \
 			"$outcome_reason" "$outcome_session_count" "$outcome_finished_at" "$dispatched_at" "$now_epoch"; then
-		if [[ "$outcome_retry_class" == "$PRRTS_RETRY_CLASS_INFRASTRUCTURE" ]]; then
+		if [[ "$outcome_retry_class" == "$PRRTS_RETRY_CLASS_INFRASTRUCTURE" ||
+			("$outcome_reason" == "auth_error" && "$outcome_retry_class" == "$PRRTS_RETRY_CLASS_REMEDIATION") ]]; then
 			infrastructure="$PRRTS_BOOL_TRUE"
 		elif [[ "$outcome_retry_class" == "$PRRTS_RETRY_CLASS_MAINTAINER_GATE" ]]; then
 			maintainer="$PRRTS_BOOL_TRUE"

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -196,6 +196,10 @@ assert_eq "access denied is retryable infrastructure without provider rotation" 
 	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "access_denied" "0")"
 assert_eq "access denied remains infrastructure after session creation" \
 	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "access_denied" "1")"
+assert_eq "authentication failure is retryable infrastructure without a session" \
+	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "auth_error" "0")"
+assert_eq "authentication failure remains infrastructure after session creation" \
+	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "auth_error" "1")"
 assert_eq "terminated worker remains retryable infrastructure after session creation" \
 	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "signal_terminated_continue" "1")"
 assert_eq "watchdog hard kill remains retryable infrastructure after session creation" \

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -1647,6 +1647,33 @@ test_dispatch_retries_session_bearing_typed_infrastructure_outcome() {
 	return 0
 }
 
+test_dispatch_retries_legacy_auth_error_remediation_outcome() {
+	setup_test_env
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	local outcome_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.outcome"
+	local old_epoch="" outcome_id=""
+	outcome_id="$(read_state_value "$state_file" outcome_id)"
+	old_epoch="$(($(date +%s) - 120))"
+	expire_state_dispatch_time "$state_file" "$old_epoch"
+	write_worker_outcome "$outcome_file" "auth_error" "1" "$((old_epoch + 1))" "$outcome_id" "meaningful_remediation"
+	: >"$HEADLESS_LOG"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	if [[ -s "$HEADLESS_LOG" ]] &&
+		grep -q '^attempt_count=1$' "$state_file" 2>/dev/null &&
+		grep -q '^infrastructure_failure_count=1$' "$state_file" 2>/dev/null &&
+		grep -q 'outcome=auth_error retry_class=retryable_infrastructure' "$LOGFILE" 2>/dev/null; then
+		print_result "legacy session-bearing auth error does not consume remediation attempt" 0
+	else
+		print_result "legacy session-bearing auth error does not consume remediation attempt" 1 \
+			"headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf ''), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_dispatch_stops_on_typed_maintainer_gate_outcome() {
 	setup_test_env
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
@@ -2570,6 +2597,7 @@ main() {
 	test_dispatch_retries_zero_session_infrastructure_failure_after_short_cooldown
 	test_dispatch_defers_zero_session_infrastructure_failure_during_short_cooldown
 	test_dispatch_retries_session_bearing_typed_infrastructure_outcome
+	test_dispatch_retries_legacy_auth_error_remediation_outcome
 	test_dispatch_stops_on_typed_maintainer_gate_outcome
 	test_dispatch_applies_bounded_infrastructure_circuit_breaker
 	test_dispatch_preserves_full_cooldown_after_model_session


### PR DESCRIPTION
## Summary

Classify auth_error outcomes as retryable infrastructure regardless of model-session creation and route already-persisted auth_error/meaningful_remediation outcomes through the bounded infrastructure retry path.

## Files Changed

.agents/scripts/headless-runtime-failure.sh, .agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-headless-runtime-failure-classification.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified with test-headless-runtime-failure-classification.sh (115/115), test-pr-review-thread-response-scanner.sh (91/91), ShellCheck, bash -n, and linters-local.sh --changed.

Resolves #30648


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1h 1m and 233,464 tokens on this with the user in an interactive session.