### PR TITLE
GH#30646: fix: make qlty scan uncertainty explicit

### DIFF
--- a/.agents/scripts/linters-local-analysis.sh
+++ b/.agents/scripts/linters-local-analysis.sh
@@ -106,6 +106,41 @@ check_sonarcloud_status() {
 	return 0
 }
 
+check_qlty_cloud_grade() {
+	local repo_slug=""
+	local badge_svg=""
+	local grade=""
+	repo_slug=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||') || repo_slug=""
+	if [[ -z "$repo_slug" ]]; then
+		return 0
+	fi
+	badge_svg=$(curl -sS --fail --connect-timeout 5 --max-time 10 \
+		"https://qlty.sh/gh/${repo_slug}/maintainability.svg" 2>/dev/null) || badge_svg=""
+	if [[ -z "$badge_svg" ]]; then
+		return 0
+	fi
+	grade=$(python3 -c "
+import sys, re
+svg = sys.stdin.read()
+colors = {'#22C55E':'A','#84CC16':'B','#EAB308':'C','#F97316':'D','#EF4444':'F'}
+for c in re.findall(r'fill=\"(#[A-F0-9]+)\"', svg):
+    if c in colors:
+        print(colors[c])
+        sys.exit(0)
+print('UNKNOWN')
+" <<<"$badge_svg" 2>/dev/null) || grade="UNKNOWN"
+	if [[ "$grade" == "A" || "$grade" == "B" ]]; then
+		print_success "Qlty Cloud grade: ${grade}"
+	elif [[ "$grade" == "C" ]]; then
+		print_warning "Qlty Cloud grade: ${grade} (target: A)"
+	elif [[ "$grade" == "D" || "$grade" == "F" ]]; then
+		print_error "Qlty Cloud grade: ${grade} (needs significant improvement)"
+	else
+		echo "Qlty Cloud grade: ${grade}"
+	fi
+	return 0
+}
+
 check_qlty_maintainability() {
 	echo -e "${BLUE}Checking Qlty Maintainability...${NC}"
 
@@ -120,14 +155,57 @@ check_qlty_maintainability() {
 		return 0
 	fi
 
-	# Get smell count via SARIF for accuracy
-	local sarif_output
-	sarif_output=$("$qlty_bin" smells --all --sarif --no-snippets --quiet 2>/dev/null) || sarif_output=""
+	# Use a disposable cache and bounded normalized-identity consensus. Scanner
+	# uncertainty is diagnostic and must never be rendered as a clean zero.
+	local sarif_output=""
+	local first_sarif=""
+	local second_sarif=""
+	local third_sarif=""
+	local cache_dir=""
+	local first_ids=""
+	local second_ids=""
+	local third_ids=""
+	cache_dir=$(mktemp -d "${TMPDIR:-/tmp}/qlty-local-cache.XXXXXX") || {
+		print_warning "Qlty status: inconclusive (failed to create isolated cache)"
+		return 0
+	}
+	first_sarif=$(XDG_CACHE_HOME="$cache_dir" "$qlty_bin" smells --all --sarif --no-snippets --quiet 2>/dev/null) || true
+	second_sarif=$(XDG_CACHE_HOME="$cache_dir" "$qlty_bin" smells --all --sarif --no-snippets --quiet 2>/dev/null) || true
+	if ! printf '%s\n' "$first_sarif" | jq -e '.runs[0].results | type == "array"' >/dev/null 2>&1 ||
+		! printf '%s\n' "$second_sarif" | jq -e '.runs[0].results | type == "array"' >/dev/null 2>&1; then
+		rm -rf "$cache_dir"
+		print_warning "Qlty status: inconclusive (empty or invalid SARIF); no numeric result recorded"
+		return 0
+	fi
+	first_ids=$(printf '%s\n' "$first_sarif" | jq -r '.runs[0].results[] | [(.ruleId // "unknown"), ([.locations[]?.physicalLocation?.artifactLocation?.uri? | select(. != null)] | sort | join("|"))] | @tsv' | LC_ALL=C sort)
+	second_ids=$(printf '%s\n' "$second_sarif" | jq -r '.runs[0].results[] | [(.ruleId // "unknown"), ([.locations[]?.physicalLocation?.artifactLocation?.uri? | select(. != null)] | sort | join("|"))] | @tsv' | LC_ALL=C sort)
+	if [[ "$first_ids" == "$second_ids" ]]; then
+		sarif_output="$second_sarif"
+	else
+		third_sarif=$(XDG_CACHE_HOME="$cache_dir" "$qlty_bin" smells --all --sarif --no-snippets --quiet 2>/dev/null) || true
+		if ! printf '%s\n' "$third_sarif" | jq -e '.runs[0].results | type == "array"' >/dev/null 2>&1; then
+			rm -rf "$cache_dir"
+			print_warning "Qlty status: inconclusive (invalid third SARIF); no numeric result recorded"
+			return 0
+		fi
+		third_ids=$(printf '%s\n' "$third_sarif" | jq -r '.runs[0].results[] | [(.ruleId // "unknown"), ([.locations[]?.physicalLocation?.artifactLocation?.uri? | select(. != null)] | sort | join("|"))] | @tsv' | LC_ALL=C sort)
+		if [[ "$first_ids" == "$third_ids" || "$second_ids" == "$third_ids" ]]; then
+			sarif_output="$third_sarif"
+		else
+			rm -rf "$cache_dir"
+			print_warning "Qlty status: inconclusive (unstable normalized identities); no numeric result recorded"
+			return 0
+		fi
+	fi
+	rm -rf "$cache_dir"
 
 	if [[ -n "$sarif_output" ]]; then
 		local smell_count
-		smell_count=$(echo "$sarif_output" | jq '.runs[0].results | length' 2>/dev/null) || smell_count=0
-		[[ "$smell_count" =~ ^[0-9]+$ ]] || smell_count=0
+		smell_count=$(echo "$sarif_output" | jq '.runs[0].results | length' 2>/dev/null) || smell_count="inconclusive"
+		if [[ ! "$smell_count" =~ ^[0-9]+$ ]]; then
+			print_warning "Qlty status: inconclusive (unparseable count); no numeric result recorded"
+			return 0
+		fi
 
 		if [[ "$smell_count" -eq 0 ]]; then
 			print_success "Qlty: 0 smells (clean)"
@@ -159,36 +237,7 @@ check_qlty_maintainability() {
 		print_warning "Qlty analysis returned empty"
 	fi
 
-	# Check badge grade from Qlty Cloud
-	local repo_slug
-	repo_slug=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||') || repo_slug=""
-	if [[ -n "$repo_slug" ]]; then
-		local badge_svg
-		badge_svg=$(curl -sS --fail --connect-timeout 5 --max-time 10 \
-			"https://qlty.sh/gh/${repo_slug}/maintainability.svg" 2>/dev/null) || badge_svg=""
-		if [[ -n "$badge_svg" ]]; then
-			local grade
-			grade=$(python3 -c "
-import sys, re
-svg = sys.stdin.read()
-colors = {'#22C55E':'A','#84CC16':'B','#EAB308':'C','#F97316':'D','#EF4444':'F'}
-for c in re.findall(r'fill=\"(#[A-F0-9]+)\"', svg):
-    if c in colors:
-        print(colors[c])
-        sys.exit(0)
-print('UNKNOWN')
-" <<<"$badge_svg" 2>/dev/null) || grade="UNKNOWN"
-			if [[ "$grade" == "A" || "$grade" == "B" ]]; then
-				print_success "Qlty Cloud grade: ${grade}"
-			elif [[ "$grade" == "C" ]]; then
-				print_warning "Qlty Cloud grade: ${grade} (target: A)"
-			elif [[ "$grade" == "D" || "$grade" == "F" ]]; then
-				print_error "Qlty Cloud grade: ${grade} (needs significant improvement)"
-			else
-				echo "Qlty Cloud grade: ${grade}"
-			fi
-		fi
-	fi
+	check_qlty_cloud_grade
 
 	return 0
 }

--- a/.agents/scripts/qlty-regression-helper.sh
+++ b/.agents/scripts/qlty-regression-helper.sh
@@ -106,6 +106,9 @@ run_qlty_sarif() {
 	local _first=""
 	local _second=""
 	local _third=""
+	local _first_rc=0
+	local _second_rc=0
+	local _third_rc=0
 	_cache_key=$(basename "$_out" .sarif)
 	_cache_dir="$TMP_DIR/cache-${_cache_key}"
 	_first="$TMP_DIR/${_cache_key}.first.sarif"
@@ -119,15 +122,17 @@ run_qlty_sarif() {
 	# warming an empty cache. Accept the first matching identity set from up to
 	# three scans so one transient pass cannot create or hide a regression.
 	(cd "$_dir" && XDG_CACHE_HOME="$_cache_dir" "$QLTY_BIN" smells --all --sarif --no-snippets --quiet) \
-		>"$_first" 2>/dev/null || true
+		>"$_first" 2>/dev/null || _first_rc=$?
 	(cd "$_dir" && XDG_CACHE_HOME="$_cache_dir" "$QLTY_BIN" smells --all --sarif --no-snippets --quiet) \
-		>"$_second" 2>/dev/null || true
+		>"$_second" 2>/dev/null || _second_rc=$?
 	if [ ! -s "$_first" ] || [ ! -s "$_second" ]; then
-		log "ERROR: qlty produced no output for $_dir"
+		emit_scan_inconclusive "empty SARIF" "$_dir" "$_cache_key" \
+			"1:rc=$_first_rc,count=$(scan_result_count "$_first");2:rc=$_second_rc,count=$(scan_result_count "$_second")"
 		return 1
 	fi
-	if ! jq -e '.runs[0].results' "$_first" "$_second" >/dev/null 2>&1; then
-		log "ERROR: qlty output is not valid SARIF for $_dir"
+	if ! jq -e '.runs[0].results | type == "array"' "$_first" "$_second" >/dev/null 2>&1; then
+		emit_scan_inconclusive "invalid SARIF" "$_dir" "$_cache_key" \
+			"1:rc=$_first_rc,count=$(scan_result_count "$_first");2:rc=$_second_rc,count=$(scan_result_count "$_second")"
 		return 1
 	fi
 	if cmp -s <(normalized_identities "$_first") <(normalized_identities "$_second"); then
@@ -136,9 +141,10 @@ run_qlty_sarif() {
 		return 0
 	fi
 	(cd "$_dir" && XDG_CACHE_HOME="$_cache_dir" "$QLTY_BIN" smells --all --sarif --no-snippets --quiet) \
-		>"$_third" 2>/dev/null || true
-	if [ ! -s "$_third" ] || ! jq -e '.runs[0].results' "$_third" >/dev/null 2>&1; then
-		log "ERROR: qlty third scan did not produce valid SARIF for $_dir"
+		>"$_third" 2>/dev/null || _third_rc=$?
+	if [ ! -s "$_third" ] || ! jq -e '.runs[0].results | type == "array"' "$_third" >/dev/null 2>&1; then
+		emit_scan_inconclusive "invalid third SARIF" "$_dir" "$_cache_key" \
+			"1:rc=$_first_rc,count=$(scan_result_count "$_first");2:rc=$_second_rc,count=$(scan_result_count "$_second");3:rc=$_third_rc,count=$(scan_result_count "$_third")"
 		return 1
 	fi
 	if cmp -s <(normalized_identities "$_first") <(normalized_identities "$_third") ||
@@ -147,8 +153,53 @@ run_qlty_sarif() {
 		log "qlty identities stabilized after 3 scans for $_dir"
 		return 0
 	fi
-	log "ERROR: qlty identities did not stabilize after 3 scans for $_dir"
+	emit_scan_inconclusive "unstable normalized identities" "$_dir" "$_cache_key" \
+		"1:rc=$_first_rc,count=$(scan_result_count "$_first");2:rc=$_second_rc,count=$(scan_result_count "$_second");3:rc=$_third_rc,count=$(scan_result_count "$_third")"
+	log "identity differences (attempt 1 -> 2):"
+	diff -u <(normalized_identities "$_first") <(normalized_identities "$_second") >&2 || true
+	log "identity differences (attempt 2 -> 3):"
+	diff -u <(normalized_identities "$_second") <(normalized_identities "$_third") >&2 || true
 	return 1
+}
+
+scan_result_count() {
+	local _sarif="$1"
+	if [ ! -s "$_sarif" ]; then
+		printf '%s' "$UNKNOWN_VALUE"
+		return 0
+	fi
+	jq -r 'if (.runs[0].results | type) == "array" then (.runs[0].results | length) else "unknown" end' \
+		"$_sarif" 2>/dev/null || printf '%s' "$UNKNOWN_VALUE"
+	return 0
+}
+
+scan_input_hash() {
+	local _dir="$1"
+	local _path="$2"
+	if [ ! -f "$_dir/$_path" ]; then
+		printf '%s' "none"
+		return 0
+	fi
+	"$GIT_BIN" -C "$_dir" hash-object "$_path" 2>/dev/null || printf '%s' "$UNKNOWN_VALUE"
+	return 0
+}
+
+emit_scan_inconclusive() {
+	local _reason="$1"
+	local _dir="$2"
+	local _cache_key="$3"
+	local _attempts="$4"
+	local _commit="$UNKNOWN_VALUE"
+	local _tree="$UNKNOWN_VALUE"
+	_commit=$("$GIT_BIN" -C "$_dir" rev-parse HEAD 2>/dev/null) || _commit="$UNKNOWN_VALUE"
+	_tree=$("$GIT_BIN" -C "$_dir" rev-parse 'HEAD^{tree}' 2>/dev/null) || _tree="$UNKNOWN_VALUE"
+	log "INCONCLUSIVE: $_reason"
+	log "scan identity: version=$QLTY_VERSION commit=$_commit tree=$_tree mode=isolated-clone cwd=repository-root"
+	log "command: qlty smells --all --sarif --no-snippets --quiet"
+	log "cache namespace: isolated-${_cache_key}"
+	log "input hashes: config=$(scan_input_hash "$_dir" '.qlty/qlty.toml') ignore=$(scan_input_hash "$_dir" '.qltyignore')"
+	log "attempts: $_attempts"
+	return 0
 }
 
 create_scan_clone() {
@@ -438,9 +489,10 @@ if [ "$DRY_RUN" -eq 1 ]; then
 	TMP_DIR=$(mktemp -d)
 	QLTY_BIN=$(find_qlty) || die "qlty CLI not found"
 	QLTY_VERSION=$("$QLTY_BIN" --version 2>/dev/null) || QLTY_VERSION="$UNKNOWN_VALUE"
+	GIT_BIN=$(resolve_git) || die "native git executable not found"
 	_head_sarif="$TMP_DIR/head.sarif"
 	log "dry-run: scanning current tree"
-	run_qlty_sarif "." "$_head_sarif"
+	run_qlty_sarif "." "$_head_sarif" || die "inconclusive qlty dry-run scan"
 	emit_scan_metadata "head" "." "$_head_sarif" "current-tree"
 	_count=$(count_smells "$_head_sarif")
 	printf 'Total smells: %s\n' "$_count"
@@ -486,9 +538,7 @@ fi
 
 log "scanning base ($BASE_SHA)"
 if ! run_qlty_sarif "$BASE_WORKTREE" "$_base_sarif"; then
-	log "WARN: base scan failed; treating base count as equal to head (no regression)"
-	# Fall back: copy head result once we have it so delta is zero.
-	BASE_SCAN_FAILED=1
+	die "inconclusive base scan for $BASE_SHA; refusing a synthetic clean delta"
 else
 	BASE_SCAN_FAILED=0
 	emit_scan_metadata "base" "$BASE_WORKTREE" "$_base_sarif" "isolated-clone"
@@ -510,10 +560,6 @@ if ! run_qlty_sarif "$HEAD_SCAN_DIR" "$_head_sarif" "$HEAD_SCAN_MODE"; then
 	die "failed to scan head ($HEAD_SHA)"
 fi
 emit_scan_metadata "head" "$HEAD_SCAN_DIR" "$_head_sarif" "$HEAD_SCAN_MODE"
-
-if [ "$BASE_SCAN_FAILED" -eq 1 ]; then
-	cp "$_head_sarif" "$_base_sarif"
-fi
 
 IDENTITY_MISMATCH=0
 if [ "$BASE_SCAN_FAILED" -eq 0 ] && ! verify_same_tree_results "$BASE_TREE" "$HEAD_TREE" "$_base_sarif" "$_head_sarif"; then

--- a/.agents/scripts/qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/qlty-smell-threshold-helper.sh
@@ -11,6 +11,13 @@ UNKNOWN_VALUE="unknown"
 SCAN_GIT_BIN=""
 SCAN_TMP=""
 SCAN_DIR=""
+THRESHOLD_VALUE=""
+THRESHOLD_QLTY_BIN=""
+THRESHOLD_QLTY_VERSION=""
+THRESHOLD_DIAG_FILE=""
+THRESHOLD_WARMUP_FILE=""
+THRESHOLD_THIRD_FILE=""
+THRESHOLD_CACHE_DIR=""
 
 log() {
 	local _msg="$1"
@@ -191,6 +198,60 @@ is_valid_sarif_results() {
 	return $?
 }
 
+normalized_identities() {
+	local _sarif_file="$1"
+	jq -r --arg unknown "$UNKNOWN_VALUE" '.runs[0].results[] |
+		[(.ruleId // $unknown),
+		 ([.locations[]?.physicalLocation?.artifactLocation?.uri? | select(. != null)] | sort | join("|"))]
+		| @tsv' "$_sarif_file" 2>/dev/null | LC_ALL=C sort
+	return 0
+}
+
+scan_result_count() {
+	local _sarif_file="$1"
+	if [ ! -s "$_sarif_file" ]; then
+		printf '%s' "$UNKNOWN_VALUE"
+		return 0
+	fi
+	jq -r 'if (.runs[0].results | type) == "array" then (.runs[0].results | length) else "unknown" end' \
+		"$_sarif_file" 2>/dev/null || printf '%s' "$UNKNOWN_VALUE"
+	return 0
+}
+
+scan_input_hash() {
+	local _scan_dir="$1"
+	local _path="$2"
+	local _git_bin="$3"
+	if [ ! -f "$_scan_dir/$_path" ]; then
+		printf '%s' "none"
+		return 0
+	fi
+	"$_git_bin" -C "$_scan_dir" hash-object "$_path" 2>/dev/null || printf '%s' "$UNKNOWN_VALUE"
+	return 0
+}
+
+emit_inconclusive_metadata() {
+	local _reason="$1"
+	local _qlty_version="$2"
+	local _scan_dir="$3"
+	local _git_bin="$4"
+	local _attempts="$5"
+	local _commit="$UNKNOWN_VALUE"
+	local _tree="$UNKNOWN_VALUE"
+	_commit=$("$_git_bin" -C "$_scan_dir" rev-parse HEAD 2>/dev/null) || _commit="$UNKNOWN_VALUE"
+	_tree=$("$_git_bin" -C "$_scan_dir" rev-parse 'HEAD^{tree}' 2>/dev/null) || _tree="$UNKNOWN_VALUE"
+	printf 'Absolute threshold status: inconclusive (%s); diagnostic-only for this run.\n' "$_reason"
+	printf 'Scan identity: version=%s commit=%s tree=%s mode=isolated-clone cwd=repository-root\n' \
+		"$_qlty_version" "$_commit" "$_tree"
+	printf 'Command: qlty smells --all --sarif --no-snippets --quiet\n'
+	printf 'Cache namespace: isolated-per-run\n'
+	printf 'Input hashes: config=%s ignore=%s\n' \
+		"$(scan_input_hash "$_scan_dir" '.qlty/qlty.toml' "$_git_bin")" \
+		"$(scan_input_hash "$_scan_dir" '.qltyignore' "$_git_bin")"
+	printf 'Attempts: %s\n' "$_attempts"
+	return 0
+}
+
 emit_remediation_evidence() {
 	local _count="$1"
 	local _threshold="$2"
@@ -219,89 +280,13 @@ emit_remediation_evidence() {
 	return 0
 }
 
-run_threshold_check() {
-	local _conf="${1:-.agents/configs/complexity-thresholds.conf}"
-	local _threshold=""
-	local _qlty_bin=""
-	local _git_bin=""
-	local _cache_dir=""
-	local _diag_file=""
-	local _warmup_file=""
-	local _scan_tmp=""
-	local _scan_dir=""
-	local _sarif=""
-	local _count=""
+evaluate_threshold_sarif() {
+	local _count="$1"
+	local _threshold="$2"
+	local _sarif="$3"
 	local _headroom=""
-	local _qlty_rc="0"
-	local _qlty_version=""
-	_threshold=$(read_threshold "$_conf")
-	if [ "$_threshold" -eq 0 ]; then
-		printf '::warning::QLTY_SMELL_THRESHOLD not set in %s — skipping check\n' "$_conf"
-		return 0
-	fi
-
-	_qlty_bin=$(find_qlty) || {
-		printf '::error::qlty CLI not found\n'
-		return 1
-	}
-	_qlty_version=$(qlty_version "$_qlty_bin")
-	verify_qlty_version "$_qlty_version" || return 1
-
-	printf 'Creating standalone clone for authoritative qlty scan...\n'
-	prepare_scan_clone || return 1
-	_git_bin="$SCAN_GIT_BIN"
-	_scan_tmp="$SCAN_TMP"
-	_scan_dir="$SCAN_DIR"
-	printf 'Warming isolated qlty cache before authoritative scan...\n'
-	_diag_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-threshold.XXXXXX") || {
-		rm -rf "$_scan_tmp"
-		return 1
-	}
-	_warmup_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-warmup.XXXXXX") || {
-		rm -f "$_diag_file"
-		rm -rf "$_scan_tmp"
-		return 1
-	}
-	_cache_dir=$(mktemp -d "${TMPDIR:-/tmp}/qlty-smell-cache.XXXXXX") || {
-		rm -f "$_diag_file" "$_warmup_file"
-		rm -rf "$_scan_tmp"
-		return 1
-	}
-	(cd "$_scan_dir" && XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet) \
-		>"$_warmup_file" 2>/dev/null || true
-	printf 'Counting total qlty smells across all files...\n'
-	_sarif=$(cd "$_scan_dir" && XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet 2>"$_diag_file")
-	_qlty_rc=$?
-	rm -f "$_warmup_file"
-	rm -rf "$_cache_dir"
-	if is_blank_output "$_sarif"; then
-		emit_sarif_warning "empty" "$_diag_file" "$_qlty_bin" "" "$_qlty_rc"
-		rm -f "$_diag_file"
-		rm -rf "$_scan_tmp"
-		return 0
-	fi
-	if ! is_valid_sarif_results "$_sarif"; then
-		emit_sarif_warning "invalid" "$_diag_file" "$_qlty_bin" "$_sarif" "$_qlty_rc"
-		rm -f "$_diag_file"
-		rm -rf "$_scan_tmp"
-		return 0
-	fi
-	rm -f "$_diag_file"
-
-	_count=$(printf '%s\n' "$_sarif" | jq '.runs[0].results | length' 2>/dev/null || true)
-	if ! is_non_negative_integer "$_count"; then
-		rm -rf "$_scan_tmp"
-		printf '::error::Failed to parse smell count from SARIF output\n'
-		return 1
-	fi
-	emit_valid_scan_metadata "$_qlty_version" "$_sarif" "$_scan_dir" "$_git_bin"
-	rm -rf "$_scan_tmp"
-
-	printf '\n'
-	printf 'Total qlty smells: %s\n' "$_count"
-	printf 'Threshold:         %s\n' "$_threshold"
-	printf '\n'
-
+	printf '\nTotal qlty smells: %s\n' "$_count"
+	printf 'Threshold:         %s\n\n' "$_threshold"
 	if [ "$_count" -gt "$_threshold" ]; then
 		printf '::error::Qlty smell regression: %s smells exceeds threshold %s\n' "$_count" "$_threshold"
 		emit_remediation_evidence "$_count" "$_threshold" "$_sarif"
@@ -315,10 +300,167 @@ run_threshold_check() {
 		printf '  3. Do not raise QLTY_SMELL_THRESHOLD to absorb recurring debt\n'
 		return 1
 	fi
-
 	_headroom=$((_threshold - _count))
 	printf 'Within threshold (%s headroom)\n' "$_headroom"
 	return 0
+}
+
+prepare_threshold_context() {
+	local _conf="$1"
+	THRESHOLD_VALUE=$(read_threshold "$_conf")
+	if [ "$THRESHOLD_VALUE" -eq 0 ]; then
+		printf '::warning::QLTY_SMELL_THRESHOLD not set in %s — skipping check\n' "$_conf"
+		return 2
+	fi
+	THRESHOLD_QLTY_BIN=$(find_qlty) || {
+		printf '::error::qlty CLI not found\n'
+		return 1
+	}
+	THRESHOLD_QLTY_VERSION=$(qlty_version "$THRESHOLD_QLTY_BIN")
+	verify_qlty_version "$THRESHOLD_QLTY_VERSION" || return 1
+	printf 'Creating standalone clone for authoritative qlty scan...\n'
+	prepare_scan_clone || return 1
+	return 0
+}
+
+prepare_threshold_resources() {
+	local _scan_tmp="$1"
+	THRESHOLD_DIAG_FILE=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-threshold.XXXXXX") || return 1
+	THRESHOLD_WARMUP_FILE=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-warmup.XXXXXX") || {
+		rm -f "$THRESHOLD_DIAG_FILE"
+		return 1
+	}
+	THRESHOLD_THIRD_FILE=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-third.XXXXXX") || {
+		rm -f "$THRESHOLD_DIAG_FILE" "$THRESHOLD_WARMUP_FILE"
+		return 1
+	}
+	THRESHOLD_CACHE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/qlty-smell-cache.XXXXXX") || {
+		rm -f "$THRESHOLD_DIAG_FILE" "$THRESHOLD_WARMUP_FILE" "$THRESHOLD_THIRD_FILE"
+		return 1
+	}
+	return 0
+}
+
+finish_threshold_result() {
+	local _sarif="$1"
+	local _threshold="$2"
+	local _qlty_version="$3"
+	local _scan_dir="$4"
+	local _git_bin="$5"
+	local _scan_tmp="$6"
+	local _count=""
+	_count=$(printf '%s\n' "$_sarif" | jq '.runs[0].results | length' 2>/dev/null || true)
+	if ! is_non_negative_integer "$_count"; then
+		rm -rf "$_scan_tmp"
+		printf '::error::Failed to parse smell count from SARIF output\n'
+		return 1
+	fi
+	emit_valid_scan_metadata "$_qlty_version" "$_sarif" "$_scan_dir" "$_git_bin"
+	rm -rf "$_scan_tmp"
+	evaluate_threshold_sarif "$_count" "$_threshold" "$_sarif"
+	return $?
+}
+
+run_threshold_check() {
+	local _conf="${1:-.agents/configs/complexity-thresholds.conf}"
+	local _threshold=""
+	local _qlty_bin=""
+	local _git_bin=""
+	local _cache_dir=""
+	local _diag_file=""
+	local _warmup_file=""
+	local _third_file=""
+	local _scan_tmp=""
+	local _scan_dir=""
+	local _sarif=""
+	local _qlty_rc="0"
+	local _warmup_rc="0"
+	local _third_rc="0"
+	local _qlty_version=""
+	prepare_threshold_context "$_conf"
+	case $? in
+	2) return 0 ;;
+	1) return 1 ;;
+	esac
+	_threshold="$THRESHOLD_VALUE"
+	_qlty_bin="$THRESHOLD_QLTY_BIN"
+	_qlty_version="$THRESHOLD_QLTY_VERSION"
+	_git_bin="$SCAN_GIT_BIN"
+	_scan_tmp="$SCAN_TMP"
+	_scan_dir="$SCAN_DIR"
+	printf 'Warming isolated qlty cache before authoritative scan...\n'
+	prepare_threshold_resources "$_scan_tmp" || {
+		rm -rf "$_scan_tmp"
+		return 1
+	}
+	_diag_file="$THRESHOLD_DIAG_FILE"
+	_warmup_file="$THRESHOLD_WARMUP_FILE"
+	_third_file="$THRESHOLD_THIRD_FILE"
+	_cache_dir="$THRESHOLD_CACHE_DIR"
+	(cd "$_scan_dir" && XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet) \
+		>"$_warmup_file" 2>>"$_diag_file" || _warmup_rc=$?
+	printf 'Counting total qlty smells across all files...\n'
+	_sarif=$(cd "$_scan_dir" && XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet 2>>"$_diag_file")
+	_qlty_rc=$?
+	if is_blank_output "$_sarif"; then
+		emit_sarif_warning "empty" "$_diag_file" "$_qlty_bin" "" "$_qlty_rc"
+		emit_inconclusive_metadata "empty SARIF" "$_qlty_version" "$_scan_dir" "$_git_bin" \
+			"1:rc=$_warmup_rc,count=$(scan_result_count "$_warmup_file");2:rc=$_qlty_rc,count=$UNKNOWN_VALUE"
+		rm -f "$_diag_file" "$_warmup_file" "$_third_file"
+		rm -rf "$_cache_dir" "$_scan_tmp"
+		return 0
+	fi
+	if ! is_valid_sarif_results "$_sarif"; then
+		emit_sarif_warning "invalid" "$_diag_file" "$_qlty_bin" "$_sarif" "$_qlty_rc"
+		emit_inconclusive_metadata "invalid SARIF" "$_qlty_version" "$_scan_dir" "$_git_bin" \
+			"1:rc=$_warmup_rc,count=$(scan_result_count "$_warmup_file");2:rc=$_qlty_rc,count=$UNKNOWN_VALUE"
+		rm -f "$_diag_file"
+		rm -f "$_warmup_file" "$_third_file"
+		rm -rf "$_cache_dir"
+		rm -rf "$_scan_tmp"
+		return 0
+	fi
+	if [ ! -s "$_warmup_file" ] || ! jq -e '.runs[0].results | type == "array"' "$_warmup_file" >/dev/null 2>&1; then
+		emit_inconclusive_metadata "empty or invalid warm-up SARIF" "$_qlty_version" "$_scan_dir" "$_git_bin" \
+			"1:rc=$_warmup_rc,count=$(scan_result_count "$_warmup_file");2:rc=$_qlty_rc,count=$(printf '%s\n' "$_sarif" | jq -r '.runs[0].results | length')"
+		rm -f "$_diag_file" "$_warmup_file" "$_third_file"
+		rm -rf "$_cache_dir" "$_scan_tmp"
+		return 0
+	fi
+	printf '%s\n' "$_sarif" >"${_third_file}.second"
+	if ! cmp -s <(normalized_identities "$_warmup_file") <(normalized_identities "${_third_file}.second"); then
+		printf 'Qlty identities differ after two scans; collecting a third consensus attempt...\n'
+		(cd "$_scan_dir" && XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet) \
+			>"$_third_file" 2>>"$_diag_file" || _third_rc=$?
+		if [ ! -s "$_third_file" ] || ! jq -e '.runs[0].results | type == "array"' "$_third_file" >/dev/null 2>&1; then
+			emit_inconclusive_metadata "invalid third SARIF" "$_qlty_version" "$_scan_dir" "$_git_bin" \
+				"1:rc=$_warmup_rc,count=$(scan_result_count "$_warmup_file");2:rc=$_qlty_rc,count=$(scan_result_count "${_third_file}.second");3:rc=$_third_rc,count=$(scan_result_count "$_third_file")"
+			rm -f "$_diag_file" "$_warmup_file" "$_third_file" "${_third_file}.second"
+			rm -rf "$_cache_dir" "$_scan_tmp"
+			return 0
+		fi
+		if cmp -s <(normalized_identities "$_warmup_file") <(normalized_identities "$_third_file"); then
+			_sarif=$(<"$_third_file")
+		elif cmp -s <(normalized_identities "${_third_file}.second") <(normalized_identities "$_third_file"); then
+			_sarif=$(<"$_third_file")
+		else
+			emit_inconclusive_metadata "unstable normalized identities" "$_qlty_version" "$_scan_dir" "$_git_bin" \
+				"1:rc=$_warmup_rc,count=$(scan_result_count "$_warmup_file");2:rc=$_qlty_rc,count=$(scan_result_count "${_third_file}.second");3:rc=$_third_rc,count=$(scan_result_count "$_third_file")"
+			printf 'Identity differences (attempt 1 -> 2):\n'
+			diff -u <(normalized_identities "$_warmup_file") <(normalized_identities "${_third_file}.second") || true
+			printf 'Identity differences (attempt 2 -> 3):\n'
+			diff -u <(normalized_identities "${_third_file}.second") <(normalized_identities "$_third_file") || true
+			rm -f "$_diag_file" "$_warmup_file" "$_third_file" "${_third_file}.second"
+			rm -rf "$_cache_dir" "$_scan_tmp"
+			return 0
+		fi
+	fi
+	rm -f "$_warmup_file" "$_third_file" "${_third_file}.second"
+	rm -rf "$_cache_dir"
+	rm -f "$_diag_file"
+
+	finish_threshold_result "$_sarif" "$_threshold" "$_qlty_version" "$_scan_dir" "$_git_bin" "$_scan_tmp"
+	return $?
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -255,9 +255,10 @@ _sweep_qlty() {
 		return 0
 	fi
 
-	# Use SARIF output for machine-parseable smell data (structured by rule, file, location)
+	# Use a bounded identity consensus so telemetry and remediation cannot consume
+	# a transient cache result as an authoritative count.
 	local qlty_sarif
-	qlty_sarif=$(CDPATH='' cd -- "$repo_path" && "$qlty_bin" smells --all --sarif --no-snippets --quiet) || qlty_sarif=""
+	qlty_sarif=$(_qlty_consensus_sarif "$qlty_bin" "$repo_path") || qlty_sarif=""
 
 	local qlty_result
 	qlty_result=$(_build_qlty_section_from_sarif "$qlty_sarif")
@@ -272,7 +273,7 @@ _sweep_qlty() {
 	# When repository-wide debt exceeds the configured absolute threshold, create
 	# bounded, per-file remediation issues from this same SARIF scan. The pulse
 	# handles dispatch deduplication, worker capacity, and active-PR collisions.
-	if [[ -n "$qlty_sarif" && "$qlty_smell_count" -gt 0 ]] &&
+	if [[ -n "$qlty_sarif" && "$qlty_smell_count" =~ ^[0-9]+$ && "$qlty_smell_count" -gt 0 ]] &&
 		_qlty_scan_matches_remote_default "$repo_slug" "$repo_path"; then
 		local qlty_smell_threshold
 		qlty_smell_threshold=$(_repo_qlty_smell_threshold "$repo_path")
@@ -289,6 +290,102 @@ _Scheduled ${issues_created} autonomous Qlty remediation issue(s) (tier:thinking
 	return 0
 }
 
+_qlty_normalized_identities() {
+	local qlty_sarif="$1"
+	printf '%s\n' "$qlty_sarif" | jq -r '
+		.runs[0].results[] |
+		[(.ruleId // "unknown"),
+		 ([.locations[]?.physicalLocation?.artifactLocation?.uri? | select(. != null)] | sort | join("|"))]
+		| @tsv' 2>/dev/null | LC_ALL=C sort
+	return 0
+}
+
+_qlty_valid_sarif() {
+	local qlty_sarif="$1"
+	[[ -n "${qlty_sarif//[[:space:]]/}" ]] || return 1
+	printf '%s\n' "$qlty_sarif" | jq -e '.runs[0].results | type == "array"' >/dev/null 2>&1
+	return $?
+}
+
+_qlty_consensus_diagnostic() {
+	local reason="$1"
+	local repo_path="$2"
+	local qlty_bin="$3"
+	local attempts="$4"
+	local version="unknown"
+	local commit="unknown"
+	local tree="unknown"
+	local config_hash="none"
+	local ignore_hash="none"
+	version=$("$qlty_bin" --version 2>/dev/null) || version="unknown"
+	commit=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null) || commit="unknown"
+	tree=$(git -C "$repo_path" rev-parse 'HEAD^{tree}' 2>/dev/null) || tree="unknown"
+	if [[ -f "${repo_path}/.qlty/qlty.toml" ]]; then
+		config_hash=$(git -C "$repo_path" hash-object '.qlty/qlty.toml' 2>/dev/null) || config_hash="unknown"
+	fi
+	if [[ -f "${repo_path}/.qltyignore" ]]; then
+		ignore_hash=$(git -C "$repo_path" hash-object '.qltyignore' 2>/dev/null) || ignore_hash="unknown"
+	fi
+	printf '[stats] Qlty telemetry INCONCLUSIVE: %s; version=%s commit=%s tree=%s mode=repository-root cwd=repository-root command="qlty smells --all --sarif --no-snippets --quiet" cache=isolated-per-run config=%s ignore=%s attempts=%s\n' \
+		"$reason" "$version" "$commit" "$tree" "$config_hash" "$ignore_hash" "$attempts" >>"${LOGFILE:-/dev/null}"
+	return 0
+}
+
+_qlty_consensus_sarif() {
+	local qlty_bin="$1"
+	local repo_path="$2"
+	local cache_dir=""
+	local first=""
+	local second=""
+	local third=""
+	local first_rc=0
+	local second_rc=0
+	local third_rc=0
+	local first_count="unknown"
+	local second_count="unknown"
+	local third_count="unknown"
+	cache_dir=$(mktemp -d "${TMPDIR:-/tmp}/qlty-sweep-cache.XXXXXX") || return 1
+	first=$(CDPATH='' cd -- "$repo_path" && XDG_CACHE_HOME="$cache_dir" "$qlty_bin" smells --all --sarif --no-snippets --quiet 2>/dev/null) || first_rc=$?
+	second=$(CDPATH='' cd -- "$repo_path" && XDG_CACHE_HOME="$cache_dir" "$qlty_bin" smells --all --sarif --no-snippets --quiet 2>/dev/null) || second_rc=$?
+	if _qlty_valid_sarif "$first"; then
+		first_count=$(printf '%s\n' "$first" | jq -r '.runs[0].results | length')
+	fi
+	if _qlty_valid_sarif "$second"; then
+		second_count=$(printf '%s\n' "$second" | jq -r '.runs[0].results | length')
+	fi
+	if ! _qlty_valid_sarif "$first" || ! _qlty_valid_sarif "$second"; then
+		_qlty_consensus_diagnostic "empty or invalid SARIF" "$repo_path" "$qlty_bin" \
+			"1:rc=${first_rc},count=${first_count};2:rc=${second_rc},count=${second_count}"
+		rm -rf "$cache_dir"
+		return 1
+	fi
+	if [[ "$(_qlty_normalized_identities "$first")" == "$(_qlty_normalized_identities "$second")" ]]; then
+		printf '%s' "$second"
+		rm -rf "$cache_dir"
+		return 0
+	fi
+	third=$(CDPATH='' cd -- "$repo_path" && XDG_CACHE_HOME="$cache_dir" "$qlty_bin" smells --all --sarif --no-snippets --quiet 2>/dev/null) || third_rc=$?
+	if _qlty_valid_sarif "$third"; then
+		third_count=$(printf '%s\n' "$third" | jq -r '.runs[0].results | length')
+	fi
+	if ! _qlty_valid_sarif "$third"; then
+		_qlty_consensus_diagnostic "invalid third SARIF" "$repo_path" "$qlty_bin" \
+			"1:rc=${first_rc},count=${first_count};2:rc=${second_rc},count=${second_count};3:rc=${third_rc},count=${third_count}"
+		rm -rf "$cache_dir"
+		return 1
+	fi
+	if [[ "$(_qlty_normalized_identities "$first")" == "$(_qlty_normalized_identities "$third")" ||
+		"$(_qlty_normalized_identities "$second")" == "$(_qlty_normalized_identities "$third")" ]]; then
+		printf '%s' "$third"
+		rm -rf "$cache_dir"
+		return 0
+	fi
+	_qlty_consensus_diagnostic "unstable normalized identities" "$repo_path" "$qlty_bin" \
+		"1:rc=${first_rc},count=${first_count};2:rc=${second_rc},count=${second_count};3:rc=${third_rc},count=${third_count}"
+	rm -rf "$cache_dir"
+	return 1
+}
+
 _build_qlty_section_from_sarif() {
 	local qlty_sarif="$1"
 
@@ -296,7 +393,7 @@ _build_qlty_section_from_sarif() {
 		printf '%s|%s|%s' "### Qlty Maintainability
 
 _Qlty analysis returned empty or failed to parse._
-" "0" "UNKNOWN"
+" "inconclusive" "UNKNOWN"
 		return 0
 	fi
 
@@ -306,7 +403,13 @@ _Qlty analysis returned empty or failed to parse._
 	local qlty_remainder="${qlty_data#*|}"
 	local qlty_rules_breakdown="${qlty_remainder%%|*}"
 	local qlty_files_breakdown="${qlty_remainder#*|}"
-	[[ "$qlty_smell_count" =~ ^[0-9]+$ ]] || qlty_smell_count=0
+	if [[ ! "$qlty_smell_count" =~ ^[0-9]+$ ]]; then
+		printf '%s|%s|%s' "### Qlty Maintainability
+
+_Qlty analysis was inconclusive; no numeric telemetry or remediation evidence was recorded._
+" "inconclusive" "UNKNOWN"
+		return 0
+	fi
 	qlty_rules_breakdown=$(_sanitize_markdown "$qlty_rules_breakdown")
 	qlty_files_breakdown=$(_sanitize_markdown "$qlty_files_breakdown")
 
@@ -329,7 +432,7 @@ _extract_qlty_sarif_summary() {
 			group_by(.) | map({file: .[0], count: length}) | sort_by(-.count)[:10] |
 			map("  - `\(.file)`: \(.count) smells") | join("\n")) as $files |
 		"\($total)|\($rules)|\($files)"
-	' || printf '%s' "0||"
+	' || printf '%s' "inconclusive||"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-qlty-regression-helper.sh
+++ b/.agents/scripts/tests/test-qlty-regression-helper.sh
@@ -107,6 +107,16 @@ if [ "${QLTY_STUB_MODE:-parity}" = "second-pass-unstable" ]; then
 	fi
 	exit 0
 fi
+if [ "${QLTY_STUB_MODE:-parity}" = "never-stable" ]; then
+	run_count=0
+	if [ -f "$XDG_CACHE_HOME/run-count" ]; then
+		run_count=$(cat "$XDG_CACHE_HOME/run-count")
+	fi
+	run_count=$((run_count + 1))
+	printf '%s\n' "$run_count" >"$XDG_CACHE_HOME/run-count"
+	printf '{"runs":[{"results":[{"ruleId":"qlty:unstable","locations":[{"physicalLocation":{"artifactLocation":{"uri":"attempt-%s.sh"}}}]}]}]}\n' "$run_count"
+	exit 0
+fi
 if [ "${QLTY_STUB_MODE:-parity}" = "topology-sensitive" ]; then
 	if [ "$(basename "$PWD")" = "repo" ]; then
 		printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"direct-only.sh"}}}]}]}]}'
@@ -222,8 +232,16 @@ QLTY_STUB_MODE=base-fail
 export QLTY_STUB_MODE
 fallback_output=$(cd "$REPO" && "$HELPER" --base HEAD --head HEAD 2>&1)
 fallback_rc=$?
-assert_rc "base scan failure retains diagnostic fallback" "0" "$fallback_rc"
-assert_contains "base failure fallback is logged" "base scan failed; treating base count as equal to head" "$fallback_output"
+assert_rc "base scan failure is non-passing" "2" "$fallback_rc"
+assert_contains "base failure refuses a synthetic clean delta" "refusing a synthetic clean delta" "$fallback_output"
+
+QLTY_STUB_MODE=never-stable
+export QLTY_STUB_MODE
+never_stable_output=$(cd "$REPO" && "$HELPER" --base HEAD --head HEAD 2>&1)
+never_stable_rc=$?
+assert_rc "unstable scanner identities are non-passing" "2" "$never_stable_rc"
+assert_contains "unstable scanner reports explicit inconclusive state" "INCONCLUSIVE: unstable normalized identities" "$never_stable_output"
+assert_contains "unstable scanner reports attempt diagnostics" "attempts: 1:rc=0,count=1;2:rc=0,count=1;3:rc=0,count=1" "$never_stable_output"
 
 if [ "$TESTS_FAILED" -eq 0 ]; then
 	printf 'All %s tests passed\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
@@ -107,6 +107,19 @@ case "${QLTY_STUB_MODE:-empty}" in
 		fi
 		exit 0
 		;;
+	never-stable)
+		if [ -z "${XDG_CACHE_HOME:-}" ]; then
+			exit 2
+		fi
+		run_count=0
+		if [ -f "$XDG_CACHE_HOME/run-count" ]; then
+			run_count=$(cat "$XDG_CACHE_HOME/run-count")
+		fi
+		run_count=$((run_count + 1))
+		printf '%s\n' "$run_count" >"$XDG_CACHE_HOME/run-count"
+		printf '{"runs":[{"results":[{"ruleId":"qlty:unstable","locations":[{"physicalLocation":{"artifactLocation":{"uri":"attempt-%s.py"}}}]}]}]}' "$run_count"
+		exit 0
+		;;
 	topology-sensitive)
 		if [ -d .git ]; then
 			printf '{"runs":[{"results":[{"ruleId":"file-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"stable.py"}}}]}]}]}'
@@ -208,6 +221,14 @@ repeated_cache_output=$($HELPER "$CONF" 2>&1)
 repeated_cache_rc=$?
 assert_rc "repeated isolated-cache scan remains stable" "0" "$repeated_cache_rc"
 assert_contains "repeated scan retains stable count" "Normalized result count: 1" "$repeated_cache_output"
+
+write_stub_qlty never-stable "$BIN_DIR"
+never_stable_output=$($HELPER "$CONF" 2>&1)
+never_stable_rc=$?
+assert_rc "unstable identities are diagnostic-only" "0" "$never_stable_rc"
+assert_contains "unstable identities return explicit inconclusive state" "Absolute threshold status: inconclusive (unstable normalized identities)" "$never_stable_output"
+assert_contains "unstable identities include attempt diagnostics" "Attempts: 1:rc=0,count=1;2:rc=0,count=1;3:rc=0,count=1" "$never_stable_output"
+assert_not_contains "unstable identities cannot emit threshold remediation" "QLTY_REMEDIATION_EVIDENCE=" "$never_stable_output"
 
 write_stub_qlty topology-sensitive "$BIN_DIR"
 topology_sensitive_output=$($HELPER "$CONF" 2>&1)

--- a/.agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh
@@ -22,13 +22,14 @@ TMP_CDPATH_PARENT=$(mktemp -d)
 FAKE_BIN=$(mktemp -d)
 QLTY_PWD_FILE="${TMP_HOME}/qlty-pwd.txt"
 QLTY_CREATE_CALLS="${TMP_HOME}/qlty-create-calls.txt"
+QLTY_MODE="stable"
 LOCAL_HEAD="1111111111111111111111111111111111111111"
 REMOTE_HEAD="$LOCAL_HEAD"
 WORKTREE_STATE=""
 export HOME="$TMP_HOME"
 export LOGFILE="${TMP_HOME}/test.log"
 export QUALITY_SWEEP_STATE_DIR="${TMP_HOME}/state"
-export QLTY_PWD_FILE QLTY_CREATE_CALLS LOCAL_HEAD REMOTE_HEAD WORKTREE_STATE
+export QLTY_PWD_FILE QLTY_CREATE_CALLS QLTY_MODE LOCAL_HEAD REMOTE_HEAD WORKTREE_STATE
 PATH="${FAKE_BIN}:${PATH}"
 export PATH
 
@@ -45,6 +46,20 @@ cat >"${HOME}/.qlty/bin/qlty" <<'QLTY'
 #!/usr/bin/env bash
 set -euo pipefail
 pwd >"${QLTY_PWD_FILE:?}"
+if [[ "${1:-}" == "--version" ]]; then
+	printf '%s\n' "qlty test-stub"
+	exit 0
+fi
+if [[ "${QLTY_MODE:-stable}" == "unstable" ]]; then
+	run_count=0
+	if [[ -f "${XDG_CACHE_HOME:?}/run-count" ]]; then
+		run_count=$(<"${XDG_CACHE_HOME}/run-count")
+	fi
+	run_count=$((run_count + 1))
+	printf '%s\n' "$run_count" >"${XDG_CACHE_HOME}/run-count"
+	printf '{"runs":[{"results":[{"ruleId":"function-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"scripts/attempt-%s.sh"}}}]}]}]}\n' "$run_count"
+	exit 0
+fi
 printf '%s\n' '{"runs":[{"results":[{"ruleId":"function-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"scripts/example.sh"}}}]}]}]}'
 QLTY
 chmod +x "${HOME}/.qlty/bin/qlty"
@@ -144,6 +159,26 @@ if ! grep -q 'skipping uncommitted scan' "$LOGFILE"; then
 fi
 WORKTREE_STATE=""
 export WORKTREE_STATE
+
+QLTY_MODE="unstable"
+export QLTY_MODE
+unstable_result=$(_sweep_qlty "owner/repo" "$TMP_REPO")
+unstable_remainder="${unstable_result#*|}"
+unstable_count="${unstable_remainder%%|*}"
+if [[ "$unstable_count" != "inconclusive" ]]; then
+	printf '%s\n' "FAIL unstable qlty scan became numeric telemetry: ${unstable_count}"
+	exit 1
+fi
+if [[ "$(<"$QLTY_CREATE_CALLS")" != "called" ]]; then
+	printf '%s\n' "FAIL unstable qlty scan created remediation evidence"
+	exit 1
+fi
+if ! grep -q 'Qlty telemetry INCONCLUSIVE: unstable normalized identities' "$LOGFILE"; then
+	printf '%s\n' "FAIL unstable qlty scan omitted inconclusive diagnostics"
+	exit 1
+fi
+QLTY_MODE="stable"
+export QLTY_MODE
 
 mkdir -p "${TMP_REL_PARENT}/target-repo/.qlty" "${TMP_CDPATH_PARENT}/target-repo/.qlty"
 printf '%s\n' '[plugins]' >"${TMP_REL_PARENT}/target-repo/.qlty/qlty.toml"


### PR DESCRIPTION
## Summary

Require bounded normalized-identity consensus before absolute, delta, local, or telemetry consumers accept Qlty SARIF; expose detailed inconclusive diagnostics and refuse synthetic clean base deltas.

## Files Changed

.agents/scripts/linters-local-analysis.sh, .agents/scripts/qlty-regression-helper.sh, .agents/scripts/qlty-smell-threshold-helper.sh, .agents/scripts/stats-quality-sweep.sh, .agents/scripts/tests/test-qlty-regression-helper.sh, .agents/scripts/tests/test-qlty-smell-threshold-helper.sh, .agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-qlty-regression-helper.sh; bash .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; bash .agents/scripts/tests/test-qlty-workflow-version-pin.sh; bash .agents/scripts/tests/test-linters-local-cache.sh; bash .agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh; bash -n and shellcheck on modified helpers

Resolves #30646


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 23m and 147,760 tokens on this as a headless worker.