### PR TITLE
GH#30649: type Anthropic fallback credentials

### DIFF
--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -118,23 +118,33 @@ resolve_oauth_pool_token() {
 	return 0
 }
 
-resolve_provider_credential() {
+_AI_RESEARCH_CREDENTIAL_KIND=""
+_AI_RESEARCH_CREDENTIAL_VALUE=""
+_AI_RESEARCH_CREDENTIAL_KIND_API_KEY="api-key"
+
+resolve_provider_credential_typed() {
 	local provider="${1:-anthropic}"
-	local key_var
+	local key_var=""
+	local secret_path=""
+	local credential=""
+	local oauth_token=""
+	_AI_RESEARCH_CREDENTIAL_KIND=""
+	_AI_RESEARCH_CREDENTIAL_VALUE=""
 	key_var=$(provider_key_var "$provider") || return 1
 
 	if [[ -n "${!key_var:-}" ]]; then
-		printf '%s\n' "${!key_var}"
+		_AI_RESEARCH_CREDENTIAL_KIND="$_AI_RESEARCH_CREDENTIAL_KIND_API_KEY"
+		_AI_RESEARCH_CREDENTIAL_VALUE="${!key_var}"
 		return 0
 	fi
 
 	if command -v gopass &>/dev/null; then
-		local secret_path key
 		secret_path=$(provider_gopass_secret "$provider") || secret_path=""
 		if [[ -n "$secret_path" ]]; then
-			key=$(gopass show -o "$secret_path" 2>/dev/null) || true
-			if [[ -n "$key" ]]; then
-				printf '%s\n' "$key"
+			credential=$(gopass show -o "$secret_path" 2>/dev/null) || true
+			if [[ -n "$credential" ]]; then
+				_AI_RESEARCH_CREDENTIAL_KIND="$_AI_RESEARCH_CREDENTIAL_KIND_API_KEY"
+				_AI_RESEARCH_CREDENTIAL_VALUE="$credential"
 				return 0
 			fi
 		fi
@@ -142,21 +152,32 @@ resolve_provider_credential() {
 
 	local creds_file="${HOME}/.config/aidevops/credentials.sh"
 	if [[ -f "$creds_file" ]]; then
-		local key
-		key=$(grep -E "^${key_var}=" "$creds_file" 2>/dev/null | cut -d= -f2- | tr -d "'\"" || true)
-		if [[ -n "$key" ]]; then
-			printf '%s\n' "$key"
+		credential=$(grep -E "^${key_var}=" "$creds_file" 2>/dev/null | cut -d= -f2- | tr -d "'\"" || true)
+		if [[ -n "$credential" ]]; then
+			_AI_RESEARCH_CREDENTIAL_KIND="$_AI_RESEARCH_CREDENTIAL_KIND_API_KEY"
+			_AI_RESEARCH_CREDENTIAL_VALUE="$credential"
 			return 0
 		fi
 	fi
 
-	local oauth_token
 	if oauth_token=$(resolve_oauth_pool_token "$provider"); then
-		printf '%s\n' "$oauth_token"
+		_AI_RESEARCH_CREDENTIAL_KIND="oauth-pool"
+		_AI_RESEARCH_CREDENTIAL_VALUE="$oauth_token"
 		return 0
 	fi
 
 	return 1
+}
+
+resolve_provider_credential() {
+	local provider="${1:-anthropic}"
+	local credential_value=""
+	resolve_provider_credential_typed "$provider" || return 1
+	credential_value="$_AI_RESEARCH_CREDENTIAL_VALUE"
+	_AI_RESEARCH_CREDENTIAL_KIND=""
+	_AI_RESEARCH_CREDENTIAL_VALUE=""
+	printf '%s\n' "$credential_value"
+	return 0
 }
 
 # Backwards-compatible Anthropic resolver used by existing sourced tests/callers.
@@ -251,17 +272,33 @@ call_anthropic() {
 	local model_name="${2:-simple}"
 	local max_tokens="${3:-150}"
 
-	local api_key
-	api_key=$(resolve_provider_credential anthropic) || {
+	local credential_kind=""
+	local credential_value=""
+	local -a auth_headers=()
+	if ! resolve_provider_credential_typed anthropic; then
 		log_error "No Anthropic API key found (env, gopass, credentials.sh, or OAuth pool)"
 		return 2
-	}
+	fi
+	credential_kind="$_AI_RESEARCH_CREDENTIAL_KIND"
+	credential_value="$_AI_RESEARCH_CREDENTIAL_VALUE"
+	_AI_RESEARCH_CREDENTIAL_KIND=""
+	_AI_RESEARCH_CREDENTIAL_VALUE=""
+	case "$credential_kind" in
+	"$_AI_RESEARCH_CREDENTIAL_KIND_API_KEY") auth_headers=(-H "x-api-key: ${credential_value}") ;;
+	oauth-pool)
+		auth_headers=(-H "Authorization: Bearer ${credential_value}" -H "anthropic-beta: oauth-2025-04-20")
+		;;
+	*)
+		log_error "Unsupported Anthropic credential kind"
+		return 2
+		;;
+	esac
 
 	local model_id payload response text
 	model_id=$(resolve_model_id "$model_name")
 	payload=$(json_payload anthropic "$prompt" "$model_id" "$max_tokens") || return 1
 	response=$(curl -sS --max-time 30 \
-		-H "x-api-key: ${api_key}" \
+		"${auth_headers[@]}" \
 		-H "anthropic-version: 2023-06-01" \
 		-H "${CONTENT_TYPE_JSON}" \
 		-d "$payload" \

--- a/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
+++ b/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
@@ -31,12 +31,27 @@ record_result() {
 
 setup_sandbox() {
 	TEST_ROOT=$(mktemp -d)
+	export TEST_ROOT
 	export HOME="${TEST_ROOT}/home"
 	mkdir -p "${HOME}/.aidevops/cache" "${TEST_ROOT}/bin"
 	unset ANTHROPIC_API_KEY || true
 	printf '#!/usr/bin/env bash\nexit 1\n' >"${TEST_ROOT}/bin/gopass"
 	chmod +x "${TEST_ROOT}/bin/gopass"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
+	return 0
+}
+
+write_curl_capture_stub() {
+	cat >"${TEST_ROOT}/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+: >"${TEST_ROOT}/curl.args"
+for arg in "$@"; do
+	printf '%s\n' "$arg" >>"${TEST_ROOT}/curl.args"
+done
+printf '{"content":[{"text":"OK"}]}\n'
+exit 0
+STUB
+	chmod +x "${TEST_ROOT}/bin/curl"
 	return 0
 }
 
@@ -123,6 +138,71 @@ test_oauth_pool_fallbacks() {
 	probe_resolver "$env_token"
 	assert_probe "env var wins over OAuth pool" 0 "$env_token"
 
+	return 0
+}
+
+probe_anthropic_request() {
+	local kind="$1"
+	local credential="$2"
+	local future_ms=$((($(date +%s) + 3600) * 1000))
+	local rc=0
+	write_curl_capture_stub
+	if [[ "$kind" == "oauth-pool" ]]; then
+		unset ANTHROPIC_API_KEY || true
+		write_pool "$credential" "$future_ms"
+	else
+		export ANTHROPIC_API_KEY="$credential"
+		rm -f "${HOME}/.aidevops/oauth-pool.json"
+	fi
+	set +e
+	(
+		# shellcheck source=/dev/null
+		source "${REPO_ROOT}/.agents/scripts/ai-research-helper.sh"
+		call_anthropic "ping" simple 5
+	) >"${TEST_ROOT}/anthropic-call.out" 2>"${TEST_ROOT}/anthropic-call.err"
+	rc=$?
+	set -e
+	unset ANTHROPIC_API_KEY || true
+	printf '%s\n' "$rc" >"${TEST_ROOT}/anthropic-call.rc"
+	return 0
+}
+
+test_anthropic_credential_header_shapes() {
+	local pool_token="[redacted-pool-token]"
+	local api_key="[redacted-api-key]"
+	local rc=""
+
+	probe_anthropic_request oauth-pool "$pool_token"
+	rc=$(<"${TEST_ROOT}/anthropic-call.rc")
+	if [[ "$rc" == "0" ]] &&
+		grep -Fxq "Authorization: Bearer ${pool_token}" "${TEST_ROOT}/curl.args" &&
+		grep -Fxq 'anthropic-beta: oauth-2025-04-20' "${TEST_ROOT}/curl.args" &&
+		! grep -Fq 'x-api-key:' "${TEST_ROOT}/curl.args"; then
+		record_result "OAuth pool credential uses Bearer and OAuth beta headers only" 0
+	else
+		record_result "OAuth pool credential uses Bearer and OAuth beta headers only" 1 "rc=${rc}"
+	fi
+	if ! grep -Fq "$pool_token" "${TEST_ROOT}/anthropic-call.out" "${TEST_ROOT}/anthropic-call.err"; then
+		record_result "OAuth pool credential is absent from helper output and diagnostics" 0
+	else
+		record_result "OAuth pool credential is absent from helper output and diagnostics" 1
+	fi
+
+	probe_anthropic_request api-key "$api_key"
+	rc=$(<"${TEST_ROOT}/anthropic-call.rc")
+	if [[ "$rc" == "0" ]] &&
+		grep -Fxq "x-api-key: ${api_key}" "${TEST_ROOT}/curl.args" &&
+		! grep -Fq 'Authorization: Bearer' "${TEST_ROOT}/curl.args" &&
+		! grep -Fq 'anthropic-beta: oauth-2025-04-20' "${TEST_ROOT}/curl.args"; then
+		record_result "static API key keeps x-api-key authentication only" 0
+	else
+		record_result "static API key keeps x-api-key authentication only" 1 "rc=${rc}"
+	fi
+	if ! grep -Fq "$api_key" "${TEST_ROOT}/anthropic-call.out" "${TEST_ROOT}/anthropic-call.err"; then
+		record_result "static API key is absent from helper output and diagnostics" 0
+	else
+		record_result "static API key is absent from helper output and diagnostics" 1
+	fi
 	return 0
 }
 
@@ -240,6 +320,7 @@ main() {
 	setup_sandbox
 	trap teardown_sandbox EXIT
 	test_oauth_pool_fallbacks
+	test_anthropic_credential_header_shapes
 	test_auto_provider_prefers_opencode
 	test_opencode_tier_models
 	test_detector_rc2_records_cooldown


### PR DESCRIPTION
## Summary

Preserve credential-source metadata through the direct Anthropic fallback so static API keys use x-api-key while OAuth-pool tokens use Bearer authentication and the required OAuth beta header.

## Files Changed

.agents/scripts/ai-research-helper.sh, .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified through the production call_anthropic path with a secret-safe curl stub: 11/11 focused tests pass for OAuth and API-key headers, output redaction, resolver compatibility, and OpenCode-first behavior; ShellCheck, bash -n, secretlint, and linters-local.sh --changed pass.

Resolves #30649


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol spent 1h 21m and 284,914 tokens on this with the user in an interactive session.