### PR TITLE
GH#30645: feat: automate exact-tip aggregation successors

### DIFF
--- a/.agents/reference/release-aggregation-recovery.md
+++ b/.agents/reference/release-aggregation-recovery.md
@@ -3,6 +3,29 @@
 
 # Unpublished Release Aggregation Recovery
 
+## Stale reviewed aggregation successor
+
+When `main` advances after a metadata-only aggregation PR has entered review or
+CI, keep that PR immutable and create or adopt one successor at the new exact
+tip:
+
+```bash
+aidevops release refresh-aggregate <stale-aggregation-pr>
+```
+
+The command verifies the stale PR's terminal trailer block, the persisted
+release authorization, and every newly merged `main` commit. Each new commit
+must map uniquely to a merged-main PR at its immutable merge SHA. It then claims
+the repository release lane with compare-and-swap, creates an exact-tip empty
+branch commit, opens one draft PR to allocate its number, and only then appends
+one immutable terminal trailer commit bound to that number and complete source
+set. Retries adopt the same branch, PR, and lane transaction.
+
+The successor remains draft. Review, required checks, ready-for-review, guarded
+merge, signing, tagging, and publication are separate explicit operations. If
+`main` advances again, run the same command against the now-stale successor; the
+ancestry/tree fence is not bypassed.
+
 Use this path only when a protected-main release created a signed local tag but
 publication stopped before the tag reached any remote or package channel. It is
 not a remote-tag rewrite mechanism.

--- a/.agents/reference/release-publication-controls/controls-and-history.md
+++ b/.agents/reference/release-publication-controls/controls-and-history.md
@@ -100,6 +100,14 @@ trailer block so the repository's squash message and
 entry per source. After merge, verify the parsed squash message and run the
 source resolver against the exact `origin/main` tip before publication.
 
+If `main` advances while that PR is in review or CI, do not rewrite its branch
+or reuse its allocated identity. Run `aidevops release refresh-aggregate
+<stale-aggregation-pr>`. The release-lane compare-and-swap transaction converges
+retries on one draft successor at the new exact tip, allocates that PR number
+before writing its sole trailer commit, and leaves review and merge explicit.
+Another `main` advance repeats this successor transition rather than weakening
+the exact-tip fence.
+
 PR #28725 demonstrated the fail-closed duplicate-trailer case: its squash
 message retained an earlier separated trailer block plus the final contiguous
 block. No release was attempted from that ambiguous manifest; a new reviewed
@@ -454,13 +462,10 @@ snapshot_dir="${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}"
   --unattended
 ```
 
-`verify-github` deliberately reports two UI checks rather than claiming
-unsupported API evidence: GitHub's documented environment REST API does not
-expose the admin-bypass toggle, and npm documents Trusted Publisher management
-only through package settings on npmjs.com. Capture those UI values before and
-after mutation. npm also states that saving a publisher does not validate it;
-this issue forbids using a real publication as a test, so exact field review is
-the terminal non-publishing evidence.
+`verify-github` reports two UI checks because GitHub's environment API omits the
+admin-bypass toggle and npm exposes Trusted Publisher management only in package
+settings. Capture both values before and after mutation; exact field review is
+the terminal non-publishing evidence because test publication is forbidden.
 
 ### Mutation order
 
@@ -491,10 +496,3 @@ the terminal non-publishing evidence.
 
 Rollback restores only values captured in the pre-mutation matrix. Code changes
 are reverted normally; live settings are never guessed or broadly reset.
-
-For the unattended transition, capture a fresh snapshot after issue #28737 merges
-and before changing the environment. Add the exact `main` branch deployment
-policy, remove reviewer/wait rules, run `verify-github --unattended`, and compare
-the two UI-only controls above. On any mismatch, restore the fresh snapshot before
-dispatching recovery. The first authorized recovery is the existing newest tag;
-do not create a test tag or version bump solely to validate settings.

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -1108,6 +1108,7 @@ _merge_remove_body_snapshot() {
 # merge transport.
 _merge_validate_release_aggregation_body() {
 	local body_file="$1"
+	local expected_pr="${2:-}"
 	local raw_aggregator=""
 	local raw_aggregates=""
 	local parsed_trailers=""
@@ -1121,8 +1122,19 @@ _merge_validate_release_aggregation_body() {
 	parsed_trailers=$(git interpret-trailers --parse <"$body_file") || return 1
 	parsed_aggregator=$(awk '/^Aidevops-Release-Aggregator-PR: / { print substr($0, 33) }' <<<"$parsed_trailers") || return 1
 	parsed_aggregates=$(awk '/^Aidevops-Release-Aggregates: / { print substr($0, 30) }' <<<"$parsed_trailers") || return 1
+	if ! awk '
+		/^[0-9]+@[0-9a-f]{40}$/ {
+			if (seen[$0]++) exit 2
+			next
+		}
+		{ exit 2 }
+	' <<<"$raw_aggregates"; then
+		print_error "Release-aggregation source trailers must be unique immutable PR@MERGE_SHA entries."
+		return 1
+	fi
 	if [[ "$raw_aggregator" != "$parsed_aggregator" || "$raw_aggregates" != "$parsed_aggregates" ||
-		! "$parsed_aggregator" =~ ^[0-9]+$ || -z "$parsed_aggregates" ]]; then
+		! "$parsed_aggregator" =~ ^[0-9]+$ || -z "$parsed_aggregates" ||
+		(-n "$expected_pr" && "$parsed_aggregator" != "$expected_pr") ]]; then
 		print_error "Release-aggregation trailers must be a terminal parseable block; place any signature footer and --- before the Aidevops-Release trailers."
 		return 1
 	fi
@@ -1964,7 +1976,7 @@ cmd_merge() {
 	if [[ -n "$merge_body_file" ]]; then
 		_merge_body_snapshot=$(_merge_snapshot_body_file "$merge_body_file") || return 1
 		merge_body_file="$_merge_body_snapshot"
-		if ! _merge_validate_release_aggregation_body "$merge_body_file"; then
+		if ! _merge_validate_release_aggregation_body "$merge_body_file" "$pr_number"; then
 			_merge_remove_body_snapshot "$_merge_body_snapshot"
 			return 1
 		fi

--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -25,6 +25,7 @@ _FULL_LOOP_AGGREGATE_RECOVERY_PHASE="aggregation-recovery"
 _FULL_LOOP_AGGREGATE_COMMIT_PHASE="aggregate-publication-committing"
 _FULL_LOOP_FAILED_PREPUBLICATION_PHASE="reconcile-required"
 _FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX="refs/tags/"
+_FULL_LOOP_AGGREGATE_RECOVERY_MAIN_BRANCH="main"
 
 _full_loop_recovery_http_status() {
 	local endpoint="$1"
@@ -1229,6 +1230,223 @@ _full_loop_recovery_finish_version_manager() {
 	printf 'Resume with: aidevops release status %s\n' "$source_pr"
 	printf 'Resume with: aidevops release reconcile %s\n' "$source_pr"
 	return 8
+}
+
+_full_loop_successor_manifest_from_body() {
+	local stale_pr="$1"
+	local body="$2"
+	local raw_identity=""
+	local raw_sources=""
+	local parsed=""
+	local parsed_identity=""
+	local parsed_sources=""
+	local manifest=""
+	raw_identity=$(awk '/^Aidevops-Release-Aggregator-PR: / { print substr($0, 33) }' <<<"$body") || return 1
+	raw_sources=$(awk '/^Aidevops-Release-Aggregates: / { print substr($0, 30) }' <<<"$body") || return 1
+	parsed=$(git -C "$REPO_ROOT" interpret-trailers --parse <<<"$body") || return 1
+	parsed_identity=$(awk '/^Aidevops-Release-Aggregator-PR: / { print substr($0, 33) }' <<<"$parsed") || return 1
+	parsed_sources=$(awk '/^Aidevops-Release-Aggregates: / { print substr($0, 30) }' <<<"$parsed") || return 1
+	[[ "$raw_identity" == "$stale_pr" && "$parsed_identity" == "$stale_pr" &&
+		"$raw_sources" == "$parsed_sources" && -n "$raw_sources" ]] || return 1
+	manifest=$(awk 'BEGIN { first=1 }
+		/^[0-9]+@[0-9a-f]{40}$/ { if (!first) printf ","; printf "%s", $0; first=0; next }
+		{ exit 2 }
+		END { if (first) exit 2 }' <<<"$raw_sources") || return 1
+	release_authorization_manifest_string "$manifest"
+	return $?
+}
+
+_full_loop_successor_source_for_commit() {
+	local repo="$1"
+	local commit_sha="$2"
+	local pulls_json=""
+	local source=""
+	[[ "$commit_sha" =~ $_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX ]] || return 1
+	pulls_json=$(gh api "repos/${repo}/commits/${commit_sha}/pulls" 2>/dev/null) || return 1
+	source=$(jq -er --arg commit "$commit_sha" --arg main "$_FULL_LOOP_AGGREGATE_RECOVERY_MAIN_BRANCH" '
+		[.[] | select(.merged_at != null and .base.ref == $main and .merge_commit_sha == $commit)]
+		| if length == 1 then "\(.[0].number)@\(.[0].merge_commit_sha)" else error("ambiguous merged PR") end
+	' <<<"$pulls_json" 2>/dev/null) || return 1
+	[[ "$source" =~ ^[0-9]+@[0-9a-f]{40}$ ]] || return 1
+	printf '%s\n' "$source"
+	return 0
+}
+
+_full_loop_successor_complete_manifest() {
+	local repo="$1"
+	local stale_head="$2"
+	local stale_manifest="$3"
+	local lane_manifest="$4"
+	local commit_sha=""
+	local source=""
+	local source_lines=""
+	local compare_commits=""
+	local normalized=""
+	[[ "$stale_head" =~ $_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX ]] || return 1
+	source_lines=$(tr ',' '\n' <<<"${stale_manifest},${lane_manifest}") || return 1
+	compare_commits=$(gh api "repos/${repo}/compare/${stale_head}...main" --jq '.commits[].sha' 2>/dev/null) || return 1
+	[[ -n "$compare_commits" ]] || {
+		printf 'Successor aggregation refused: stale aggregate already represents the current main tip\n' >&2
+		return 1
+	}
+	while IFS= read -r commit_sha; do
+		[[ -n "$commit_sha" ]] || continue
+		source=$(_full_loop_successor_source_for_commit "$repo" "$commit_sha") || {
+			printf 'Successor aggregation refused: main commit %s has no unique merged-main PR provenance\n' "$commit_sha" >&2
+			return 1
+		}
+		source_lines+=$'\n'"$source"
+	done <<<"$compare_commits"
+	normalized=$(jq -Rrsc '
+		split("\n") | map(select(length > 0)
+			| if test("^[0-9]+@[0-9a-f]{40}$") then capture("^(?<pr>[0-9]+)@(?<merge>[0-9a-f]{40})$")
+			else error("malformed source") end
+			| {pr:(.pr|tonumber),merge:.merge})
+		| group_by(.pr)
+		| if any(.[]; (map(.merge)|unique|length) != 1) then error("conflicting source") else . end
+		| map(.[0]) | sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")
+	' <<<"$source_lines") || return 1
+	[[ -n "$normalized" ]] || return 1
+	printf '%s\n' "$normalized"
+	return 0
+}
+
+_full_loop_successor_create_commit() {
+	local repo="$1"
+	local parent="$2"
+	local message="$3"
+	local tree_sha=""
+	local payload=""
+	local commit_sha=""
+	tree_sha=$(gh api "repos/${repo}/git/commits/${parent}" --jq '.tree.sha // empty' 2>/dev/null) || return 1
+	[[ "$tree_sha" =~ ^[0-9a-f]{40}$ ]] || return 1
+	payload=$(jq -cn --arg message "$message" --arg tree "$tree_sha" --arg parent "$parent" \
+		'{message:$message,tree:$tree,parents:[$parent]}') || return 1
+	commit_sha=$(gh api "repos/${repo}/git/commits" --method POST --input - --jq '.sha // empty' \
+		<<<"$payload" 2>/dev/null) || return 1
+	[[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]] || return 1
+	printf '%s\n' "$commit_sha"
+	return 0
+}
+
+_full_loop_successor_body() {
+	local stale_pr="$1"
+	local base_sha="$2"
+	local successor_pr="$3"
+	local manifest="$4"
+	local source=""
+	printf "## Summary\n\nMetadata-only successor for stale release aggregation PR #%s at exact main tip \`%s\`.\n\n" \
+		"$stale_pr" "$base_sha"
+	printf 'Review, required checks, and guarded merge remain explicit.\n\n'
+	printf 'Aidevops-Release-Aggregator-PR: %s\n' "$successor_pr"
+	while IFS= read -r source; do
+		[[ -n "$source" ]] || continue
+		printf 'Aidevops-Release-Aggregates: %s\n' "$source"
+	done < <(tr ',' '\n' <<<"$manifest")
+	return 0
+}
+
+_full_loop_successor_final_message() {
+	local successor_pr="$1"
+	local manifest="$2"
+	local source=""
+	printf 'chore(release): bind refreshed exact-tip aggregation\n\n'
+	printf 'Aidevops-Release-Aggregator-PR: %s\n' "$successor_pr"
+	while IFS= read -r source; do
+		[[ -n "$source" ]] || continue
+		printf 'Aidevops-Release-Aggregates: %s\n' "$source"
+	done < <(tr ',' '\n' <<<"$manifest")
+	return 0
+}
+
+# Create or adopt the one draft successor for a stale metadata-only aggregate.
+# PR allocation deliberately precedes the sole terminal trailer commit.
+#aidevops:trust-boundary
+_full_loop_release_refresh_aggregate() {
+	local repo="$1"
+	local stale_pr="$2"
+	local stale_json=""
+	local stale_body=""
+	local stale_head=""
+	local stale_manifest=""
+	local lane_manifest=""
+	local base_sha=""
+	local branch_name=""
+	local owner="${repo%%/*}"
+	local branch_head=""
+	local initial_commit=""
+	local successor_json=""
+	local successor_pr=""
+	local body=""
+	local final_message=""
+	local branch_message=""
+	local final_commit=""
+	local payload=""
+	[[ "$stale_pr" =~ ^[0-9]+$ ]] || return 1
+	git -C "$REPO_ROOT" fetch origin main --quiet || return 1
+	base_sha=$(git -C "$REPO_ROOT" rev-parse origin/main) || return 1
+	stale_json=$(gh api "repos/${repo}/pulls/${stale_pr}" 2>/dev/null) || return 1
+	jq -e --argjson stale "$stale_pr" --arg main "$_FULL_LOOP_AGGREGATE_RECOVERY_MAIN_BRANCH" '
+		.number == $stale and .state == "open" and .base.ref == $main
+		and (.head.sha | test("^[0-9a-f]{40}$"))
+	' <<<"$stale_json" >/dev/null || return 1
+	stale_body=$(jq -er '.body // ""' <<<"$stale_json") || return 1
+	stale_head=$(jq -er '.head.sha' <<<"$stale_json") || return 1
+	[[ "$stale_head" != "$base_sha" ]] || return 1
+	stale_manifest=$(_full_loop_successor_manifest_from_body "$stale_pr" "$stale_body") || return 1
+	release_lane_read "$repo" || return 1
+	lane_manifest=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	lane_manifest=$(release_authorization_manifest_string "$lane_manifest") || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED=$(_full_loop_successor_complete_manifest \
+		"$repo" "$stale_head" "$stale_manifest" "$lane_manifest") || return 1
+	release_authorization_subset "$lane_manifest" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	branch_name="release/aggregate-successor-${stale_pr}-${base_sha:0:12}"
+	release_lane_begin_aggregate_successor "$repo" "$stale_pr" "$base_sha" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$branch_name" || return 1
+	branch_head=$(gh api "repos/${repo}/git/ref/heads/${branch_name}" --jq '.object.sha // empty' 2>/dev/null || true)
+	if [[ -z "$branch_head" ]]; then
+		initial_commit=$(_full_loop_successor_create_commit "$repo" "$base_sha" \
+			"chore(release): open successor aggregation for #${stale_pr}") || return 1
+		payload=$(jq -cn --arg ref "refs/heads/${branch_name}" --arg sha "$initial_commit" '{ref:$ref,sha:$sha}') || return 1
+		gh api "repos/${repo}/git/refs" --method POST --input - <<<"$payload" >/dev/null 2>&1 || return 1
+		branch_head="$initial_commit"
+	fi
+	git -C "$REPO_ROOT" fetch origin "$branch_name" --quiet || return 1
+	git -C "$REPO_ROOT" merge-base --is-ancestor "$base_sha" FETCH_HEAD || return 1
+	[[ "$(git -C "$REPO_ROOT" rev-parse "${base_sha}^{tree}")" == "$(git -C "$REPO_ROOT" rev-parse 'FETCH_HEAD^{tree}')" ]] || return 1
+	successor_json=$(gh api "repos/${repo}/pulls?state=open&head=${owner}:${branch_name}&base=main" 2>/dev/null) || return 1
+	jq -e 'length <= 1' <<<"$successor_json" >/dev/null || return 1
+	successor_pr=$(jq -er 'if length == 1 then .[0].number else empty end' <<<"$successor_json" 2>/dev/null || true)
+	if [[ -z "$successor_pr" ]]; then
+		payload=$(jq -cn --arg title "chore(release): refresh aggregation after #${stale_pr}" \
+			--arg head "$branch_name" --arg main "$_FULL_LOOP_AGGREGATE_RECOVERY_MAIN_BRANCH" \
+			'{title:$title,head:$head,base:$main,draft:true,body:"Successor allocation pending immutable trailer commit."}') || return 1
+		successor_pr=$(gh api "repos/${repo}/pulls" --method POST --input - --jq '.number // empty' \
+			<<<"$payload" 2>/dev/null) || return 1
+	else
+		jq -e --arg main "$_FULL_LOOP_AGGREGATE_RECOVERY_MAIN_BRANCH" \
+			'.[0].draft == true and .[0].base.ref == $main' <<<"$successor_json" >/dev/null || return 1
+	fi
+	[[ "$successor_pr" =~ ^[0-9]+$ ]] || return 1
+	release_lane_bind_aggregate_successor_pr "$repo" "$successor_pr" || return 1
+	body=$(_full_loop_successor_body "$stale_pr" "$base_sha" "$successor_pr" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED") || return 1
+	final_message=$(_full_loop_successor_final_message "$successor_pr" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED") || return 1
+	branch_message=$(gh api "repos/${repo}/git/commits/${branch_head}" --jq '.message // empty' 2>/dev/null) || return 1
+	if [[ "$branch_message" != "$final_message" ]]; then
+		final_commit=$(_full_loop_successor_create_commit "$repo" "$branch_head" "$final_message") || return 1
+		payload=$(jq -cn --arg sha "$final_commit" '{sha:$sha,force:false}') || return 1
+		gh api "repos/${repo}/git/refs/heads/${branch_name}" --method PATCH --input - <<<"$payload" >/dev/null 2>&1 || return 1
+		branch_head="$final_commit"
+	fi
+	payload=$(jq -cn --arg body "$body" '{body:$body}') || return 1
+	gh api "repos/${repo}/pulls/${successor_pr}" --method PATCH --input - <<<"$payload" >/dev/null 2>&1 || return 1
+	release_lane_finish_aggregate_successor "$repo" "$successor_pr" "$branch_head" || return 1
+	printf 'release:aggregate-successor draft_pr=%s stale_pr=%s exact_tip=%s\n' \
+		"$successor_pr" "$stale_pr" "$base_sha"
+	printf 'Review and guarded merge remain explicit; no release or publication was authorized.\n'
+	return 0
 }
 
 _full_loop_release_recover_aggregate() {

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -256,6 +256,7 @@ Usage:
   aidevops release [patch|minor|major] SOURCE_PR [incremental|full] [--expected-sources PR[,PR...]]
   aidevops release status SOURCE_PR
   aidevops release reconcile SOURCE_PR
+  aidevops release refresh-aggregate STALE_AGGREGATION_PR
   aidevops release recover-aggregate SOURCE_PR --tag TAG --expected-sources PR[,PR...]
   aidevops release authorization-gap SOURCE_PR --tag TAG --expected-sources PR@SHA[,PR@SHA...] --reason TEXT
 
@@ -612,6 +613,17 @@ main() {
 		}
 		_full_loop_release_bind_repo_context || return 1
 		_full_loop_release_existing_with_lane "$release_type" "$source_pr"
+		return $?
+		;;
+	refresh-aggregate)
+		[[ "$source_pr" =~ ^[0-9]+$ ]] || {
+			_full_loop_release_usage >&2
+			return 1
+		}
+		_full_loop_release_bind_repo_context || return 1
+		local successor_repo=""
+		successor_repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || return 1
+		_full_loop_release_refresh_aggregate "$successor_repo" "$source_pr"
 		return $?
 		;;
 	recover-aggregate)

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -24,6 +24,7 @@ _AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH="aggregation-recovery-refresh"
 _AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT="aggregate-publication-committing"
 _AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH="reserved-authorization-refresh"
 _AIDEVOPS_RELEASE_LANE_PHASE_RECONCILE_REQUIRED="reconcile-required"
+_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING="aggregation-successor-preparing"
 
 _release_lane_cache_path() {
 	local repo="$1"
@@ -229,6 +230,101 @@ release_lane_acquire() {
 	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
 	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
 	_AIDEVOPS_RELEASE_LANE_RESULT="$_AIDEVOPS_RELEASE_LANE_RESULT_ACQUIRED"
+	return 0
+}
+
+# Claim the single metadata-only successor slot before creating a branch or PR.
+# The exact main tip and immutable source manifest make retries convergent; a
+# different target cannot replace an in-flight transaction.
+#aidevops:trust-boundary
+release_lane_begin_aggregate_successor() {
+	local repo="$1"
+	local stale_pr="$2"
+	local base_sha="$3"
+	local expected_sources="$4"
+	local branch_name="$5"
+	local phase=""
+	local operation_token=""
+	local previous_state=""
+	local state_json=""
+	[[ "$stale_pr" =~ ^[0-9]+$ && "$base_sha" =~ ^[0-9a-f]{40}$ && -n "$expected_sources" && -n "$branch_name" ]] || return 1
+	release_lane_read "$repo" || return 1
+	if jq -e --argjson stale "$stale_pr" --arg base "$base_sha" --arg expected "$expected_sources" \
+		--arg branch "$branch_name" --arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING" '
+		.active == true and .phase == $preparing
+		and .aggregate_successor.stale_pr == $stale
+		and .aggregate_successor.base_sha == $base
+		and .aggregate_successor.expected_sources == $expected
+		and .aggregate_successor.branch == $branch
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null; then
+		_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -er '.operation_token' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		return 0
+	fi
+	phase=$(jq -er '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	jq -e '.active == true' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	[[ "$phase" != "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING" ]] || return 1
+	previous_state=$(jq -c 'del(.aggregate_successor)' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(date +%s)-$$-${RANDOM:-0}"
+	state_json=$(jq -c --argjson stale "$stale_pr" --arg base "$base_sha" \
+		--arg expected "$expected_sources" --arg branch "$branch_name" --arg token "$operation_token" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+		--arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING" --argjson previous "$previous_state" '
+		.phase=$preparing | .operation_token=$token | .updated_at=$now
+		| .aggregate_successor={status:"preparing",stale_pr:$stale,base_sha:$base,
+			expected_sources:$expected,branch:$branch,previous_state:$previous}
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
+	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
+	return 0
+}
+
+# Persist the allocated PR before the immutable trailer commit is written.
+#aidevops:trust-boundary
+release_lane_bind_aggregate_successor_pr() {
+	local repo="$1"
+	local successor_pr="$2"
+	local state_json=""
+	[[ "$successor_pr" =~ ^[0-9]+$ && -n "$_AIDEVOPS_RELEASE_LANE_TOKEN" ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
+		--arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING" \
+		--argjson successor "$successor_pr" '
+		.active == true and .phase == $preparing and .operation_token == $token
+		and ((.aggregate_successor.pr // $successor) == $successor)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	state_json=$(jq -c --argjson successor "$successor_pr" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
+		.aggregate_successor.pr=$successor | .updated_at=$now
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
+	return 0
+}
+
+# Restore the exact prior lane phase while retaining a durable adoption record.
+#aidevops:trust-boundary
+release_lane_finish_aggregate_successor() {
+	local repo="$1"
+	local successor_pr="$2"
+	local head_sha="$3"
+	local state_json=""
+	local previous_state=""
+	[[ "$successor_pr" =~ ^[0-9]+$ && "$head_sha" =~ ^[0-9a-f]{40}$ && -n "$_AIDEVOPS_RELEASE_LANE_TOKEN" ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" --argjson successor "$successor_pr" \
+		--arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING" '
+		.active == true and .phase == $preparing and .operation_token == $token
+		and .aggregate_successor.pr == $successor
+		and .aggregate_successor.previous_state.schema_version == 1
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	previous_state=$(jq -ce '.aggregate_successor.previous_state' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	state_json=$(jq -c --argjson successor "$successor_pr" --arg head "$head_sha" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" --argjson transaction "$_AIDEVOPS_RELEASE_LANE_JSON" '
+		. as $previous
+		| $transaction.aggregate_successor as $successor_state
+		| .operation_token=$transaction.operation_token | .updated_at=$now
+		| .aggregate_successor=($successor_state | del(.previous_state)
+			| .status="ready" | .pr=$successor | .head_sha=$head | .completed_at=$now)
+	' <<<"$previous_state") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
 	return 0
 }
 
@@ -819,7 +915,7 @@ release_lane_merge_guard() {
 		return 0
 	fi
 	case "$phase" in
-	remote-publication | exact-tag-deployment | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" | "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH") ;;
+	remote-publication | exact-tag-deployment | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" | "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" | "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING") ;;
 	*) return 0 ;;
 	esac
 	source_pr=$(jq -r '.source_pr' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
@@ -833,7 +929,8 @@ release_lane_merge_guard() {
 		esac
 	fi
 	if [[ "$phase" != "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" &&
-		"$phase" != "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" ]] &&
+		"$phase" != "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" &&
+		"$phase" != "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING" ]] &&
 		_release_lane_pr_is_metadata_only_aggregate "$repo" "$pr_number"; then
 		return 0
 	fi

--- a/.agents/scripts/tests/test-full-loop-merge-body-file.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-body-file.sh
@@ -198,6 +198,15 @@ write_hidden_aggregation_body() {
 	return 0
 }
 
+write_duplicate_aggregation_body() {
+	local body_file="$1"
+	printf '%s\n' \
+		'Aidevops-Release-Aggregator-PR: 42' \
+		'Aidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f' \
+		'Aidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f' >"$body_file"
+	return 0
+}
+
 assert_transport_preserves_body() {
 	local mode="$1"
 	local label="$2"
@@ -315,6 +324,24 @@ test_hidden_aggregation_trailers_fail_before_merge_write() {
 	return 0
 }
 
+test_duplicate_aggregation_sources_fail_before_merge_write() {
+	local body_file="${TEST_ROOT}/duplicate-aggregation-body"
+	local output=""
+	local rc=0
+	TEST_MODE="normal"
+	cmd_pre_merge_gate() { return 0; }
+	rm -f "${TEST_ROOT}/capture-count" "${TEST_ROOT}/snapshot-paths"
+	write_duplicate_aggregation_body "$body_file"
+	output=$(cmd_merge 42 testorg/testrepo --body-file "$body_file" 2>&1) || rc=$?
+	if [[ "$rc" -ne 0 && ! -e "${TEST_ROOT}/capture-count" &&
+		"$output" == *"unique immutable PR@MERGE_SHA"* ]]; then
+		print_result "duplicate aggregation sources fail before merge write" 0
+	else
+		print_result "duplicate aggregation sources fail before merge write" 1 "rc=${rc}; output=${output}"
+	fi
+	return 0
+}
+
 main() {
 	setup_subject
 	assert_transport_preserves_body normal "normal gh merge" 1
@@ -325,6 +352,7 @@ main() {
 	assert_transport_preserves_body rest "REST fallback" 1
 	test_invalid_body_files_fail_before_gate
 	test_hidden_aggregation_trailers_fail_before_merge_write
+	test_duplicate_aggregation_sources_fail_before_merge_write
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -1331,4 +1331,38 @@ printf 'PASS failed pre-publication preparation admits only reviewed direct or a
 	printf 'PASS equal persisted PR sets still resume stale, fenced, marked, or exact failed pre-publication transactions\n'
 )
 
+(
+	real_git=$(type -P git)
+	source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
+	git() {
+		"$real_git" "$@"
+		return $?
+	}
+	stale_body='Release aggregation
+
+Aidevops-Release-Aggregator-PR: 99
+Aidevops-Release-Aggregates: 42@2222222222222222222222222222222222222222'
+	manifest=$(_full_loop_successor_manifest_from_body 99 "$stale_body")
+	[[ "$manifest" == '42@2222222222222222222222222222222222222222' ]]
+	if _full_loop_successor_manifest_from_body 100 "$stale_body" >/dev/null 2>&1; then
+		exit 1
+	fi
+	gh() {
+		local endpoint="$2"
+		if [[ "$endpoint" == *'/compare/'* ]]; then
+			printf '%s\n' 3333333333333333333333333333333333333333
+			return 0
+		fi
+		if [[ "$endpoint" == *'/commits/3333333333333333333333333333333333333333/pulls' ]]; then
+			printf '%s\n' '[{"number":43,"merged_at":"2026-08-24T00:00:00Z","base":{"ref":"main"},"merge_commit_sha":"3333333333333333333333333333333333333333"}]'
+			return 0
+		fi
+		return 1
+	}
+	complete=$(_full_loop_successor_complete_manifest test/repo \
+		1111111111111111111111111111111111111111 "$manifest" "$manifest")
+	[[ "$complete" == '42@2222222222222222222222222222222222222222,43@3333333333333333333333333333333333333333' ]]
+)
+printf 'PASS successor manifest preserves stale sources and adds uniquely mapped main merges\n'
+
 exit 0

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -120,10 +120,10 @@ run_merge_guard_test() (
 		release_lane_merge_guard test/repo 303 main chore/release-v1.2.3-provenance || return 1
 	AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
 		release_lane_merge_guard test/repo 404 main release/aggregate-recovery || return 1
-	for recovery_phase in aggregation-recovery aggregation-recovery-refresh aggregate-publication-committing reserved-authorization-refresh; do
+	for recovery_phase in aggregation-recovery aggregation-recovery-refresh aggregate-publication-committing reserved-authorization-refresh aggregation-successor-preparing; do
 		state=$(jq -cn --arg phase "$recovery_phase" \
 			'{schema_version:1,repository:"test/repo",active:true,source_pr:101,phase:$phase,
-			  tag:(if $phase == "reserved-authorization-refresh" then null else "v1.2.3" end),
+			  tag:(if ($phase == "reserved-authorization-refresh" or $phase == "aggregation-successor-preparing") then null else "v1.2.3" end),
 			  operation_token:"token-old"}')
 		rc=0
 		output=$(AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
@@ -143,7 +143,8 @@ run_merge_guard_test() (
 			release_lane_merge_guard test/repo 404 main release/aggregate-recovery \
 			>/dev/null 2>&1 || rc=$?
 		if [[ "$recovery_phase" == "aggregate-publication-committing" ||
-			"$recovery_phase" == "reserved-authorization-refresh" ]]; then
+			"$recovery_phase" == "reserved-authorization-refresh" ||
+			"$recovery_phase" == "aggregation-successor-preparing" ]]; then
 			[[ "$rc" -eq 75 ]] || return 1
 		else
 			[[ "$rc" -eq 0 ]] || return 1
@@ -585,6 +586,50 @@ run_failed_prepublication_resume_guard_test() (
 	return 0
 )
 
+run_aggregate_successor_transaction_test() {
+	local state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101@1111111111111111111111111111111111111111","phase":"reserved","tag":null,"operation_token":"lane-old","updated_at":"2026-08-24T00:00:00Z","terminal_receipt":null}'
+	local first_token=""
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$state"
+		_AIDEVOPS_RELEASE_LANE_HEAD=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		return 0
+	}
+	_release_lane_write() {
+		local repo="$1"
+		local state_json="$2"
+		local expected_head="$3"
+		[[ "$repo" == "test/repo" && "$expected_head" == aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ]] || return 1
+		state="$state_json"
+		return 0
+	}
+	release_lane_begin_aggregate_successor test/repo 202 \
+		bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+		'101@1111111111111111111111111111111111111111,203@3333333333333333333333333333333333333333' \
+		release/aggregate-successor-202-bbbbbbbbbbbb || return 1
+	first_token="$_AIDEVOPS_RELEASE_LANE_TOKEN"
+	[[ "$(jq -r '.phase' <<<"$state")" == "aggregation-successor-preparing" ]] || return 1
+	release_lane_begin_aggregate_successor test/repo 202 \
+		bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+		'101@1111111111111111111111111111111111111111,203@3333333333333333333333333333333333333333' \
+		release/aggregate-successor-202-bbbbbbbbbbbb || return 1
+	[[ "$_AIDEVOPS_RELEASE_LANE_TOKEN" == "$first_token" ]] || return 1
+	if release_lane_begin_aggregate_successor test/repo 202 \
+		cccccccccccccccccccccccccccccccccccccccc \
+		'101@1111111111111111111111111111111111111111,203@3333333333333333333333333333333333333333' \
+		release/aggregate-successor-202-cccccccccccc; then
+		return 1
+	fi
+	release_lane_bind_aggregate_successor_pr test/repo 204 || return 1
+	release_lane_finish_aggregate_successor test/repo 204 dddddddddddddddddddddddddddddddddddddddd || return 1
+	jq -e --arg token "$first_token" '
+		.phase == "reserved" and .operation_token == $token
+		and .aggregate_successor.status == "ready" and .aggregate_successor.pr == 204
+		and .aggregate_successor.head_sha == "dddddddddddddddddddddddddddddddddddddddd"
+		and ((.aggregate_successor.previous_state // null) == null)
+	' <<<"$state" >/dev/null
+	return $?
+}
+
 if run_competing_source_test; then assert_result 'competing source receives active lane and reconcile action' true; else assert_result 'competing source receives active lane and reconcile action' false; fi
 if run_same_source_adoption_test; then assert_result 'same source adopts durable lane without another bump' true; else assert_result 'same source adopts durable lane without another bump' false; fi
 if run_terminal_lane_reacquire_test; then assert_result 'terminal lane can be atomically reserved by a later source' true; else assert_result 'terminal lane can be atomically reserved by a later source' false; fi
@@ -600,6 +645,7 @@ if run_aggregate_recovery_rejection_test; then assert_result 'aggregate recovery
 if run_reserved_aggregate_authorization_test; then assert_result 'reserved aggregate authorization rotates through a resumable lane-first transaction' true; else assert_result 'reserved aggregate authorization rotates through a resumable lane-first transaction' false; fi
 if run_failed_prepublication_reopen_test; then assert_result 'verified failed pre-publication lane recovery rotates ownership and rejects unsafe states' true; else assert_result 'verified failed pre-publication lane recovery rotates ownership and rejects unsafe states' false; fi
 if run_failed_prepublication_resume_guard_test; then assert_result 'recovered pre-publication markers revalidate fenced refreshes and clear only at preparing' true; else assert_result 'recovered pre-publication markers revalidate fenced refreshes and clear only at preparing' false; fi
+if run_aggregate_successor_transaction_test; then assert_result 'successor aggregation retries converge through one lane CAS transaction' true; else assert_result 'successor aggregation retries converge through one lane CAS transaction' false; fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary

- add a release-lane CAS transaction for idempotent exact-tip aggregation successors
- allocate the draft PR before writing the sole immutable trailer commit
- preserve explicit review/merge/publication boundaries and harden merge-body trailer validation

## Verification

- `bash .agents/scripts/tests/test-release-provenance-helper.sh`
- `bash .agents/scripts/tests/test-release-lane.sh`
- `bash .agents/scripts/tests/test-version-manager-protected-main-fallback.sh`
- `bash .agents/scripts/tests/test-version-manager-aggregate-recovery.sh`
- `bash .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh`
- `bash .agents/scripts/tests/test-full-loop-release-reconcile.sh`
- `bash .agents/scripts/tests/test-full-loop-merge-body-file.sh`
- ShellCheck on all modified shell scripts and tests

Resolves #30645

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.19 with gpt-5.6-sol
