### PR TITLE
GH#30666: fix: use PR base for merge hygiene checkout

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -199,11 +199,29 @@ fi
 # ============================================================
 PROOF_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Update TODO\.md proof-log' | cut -d: -f1 || true)
 CALLER_CHECKOUT_COUNT=$(printf '%s\n' "${JOB_BODY}" | grep -cE 'name:[[:space:]]+Checkout repo (before closing-hygiene validation|for TODO\.md update)' || true)
+CALLER_CHECKOUT_BODY=$(printf '%s\n' "${JOB_BODY}" | awk '
+	capture && /^      - name:/ { exit }
+	/name:[[:space:]]+Checkout repo before closing-hygiene validation/ { capture=1 }
+	capture { print }
+')
 
 if [[ -z "${CALLER_CHECKOUT_REL_LINE}" ]]; then
 	check 0 "early caller checkout step present" "validated TODO snapshot checkout is missing"
 else
 	check 1 "early caller checkout step present" ""
+fi
+
+# pull_request_target has write permissions, so closing hygiene must resolve
+# TODO.md from the trusted PR base branch rather than a hard-coded default
+# branch or untrusted fork head code.
+# shellcheck disable=SC2016 # Assert the literal GitHub Actions expression.
+if printf '%s\n' "${CALLER_CHECKOUT_BODY}" | grep -qE 'ref:[[:space:]]+\$\{\{[[:space:]]*github\.event\.pull_request\.base\.ref[[:space:]]*\}\}' &&
+	! printf '%s\n' "${CALLER_CHECKOUT_BODY}" | grep -qE 'ref:[[:space:]]+main([[:space:]]|$)' &&
+	! printf '%s\n' "${CALLER_CHECKOUT_BODY}" | grep -qE 'github\.event\.pull_request\.head'; then
+	check 1 "closing-hygiene checkout uses trusted PR base ref" ""
+else
+	check 0 "closing-hygiene checkout uses trusted PR base ref" \
+		"checkout must use github.event.pull_request.base.ref, not main or fork head code"
 fi
 
 if [[ -n "$CALLER_CHECKOUT_REL_LINE" && -n "$RESTORE_REL_LINE" && -n "$RESOLVE_REL_LINE" && -n "$PROOF_REL_LINE" &&

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -782,8 +782,9 @@ jobs:
 
     steps:
       # Security: This job uses pull_request_target to get write permissions for
-      # fork PRs. It only checks out ref:main (base branch), never fork code.
-      # Event metadata (PR title, body, number) is used for issue hygiene only.
+      # fork PRs. It only checks out the trusted PR base ref, never fork head
+      # code. Event metadata (PR title, body, number) is used for issue hygiene
+      # only.
 
       # t2166 / t2696: visibility check mirroring the other three jobs.
       # Ensures the warning/notice emits unconditionally on every merged PR,
@@ -902,7 +903,7 @@ jobs:
         if: steps.extract.outputs.linked_issues != ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: main
+          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Uses the merged pull request trusted base ref for closing-hygiene TODO.md resolution and adds a regression assertion against main or fork-head checkout.

## Files Changed

.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — bash .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh; bash .agents/scripts/tests/test-issue-sync-pr-task-resolver.sh; shellcheck .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh; bash .agents/scripts/lint-workflows-helper.sh .github/workflows/issue-sync-reusable.yml

Resolves #30666


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 5m and 82,853 tokens on this as a headless worker.