### PR TITLE
GH#30638: bind ruleset approvals to current head

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -1197,6 +1197,43 @@ _check_required_pr_checks_passing_fallback() {
 }
 
 #######################################
+# Parse one matching ruleset detail into aggregate approval requirements.
+# #aidevops:trust-boundary — ruleset approval freshness controls whether an
+# admin merge may reuse approvals from an older PR head. Require typed policy
+# fields instead of treating unknown API evidence as policy=false.
+#
+# Args: $1=ruleset detail JSON
+# Stdout: tab-separated required approvals and current-head approvals
+# Returns: 0=valid policy, 1=invalid policy
+#######################################
+_ruleset_pull_request_policy_from_detail() {
+	local detail="$1"
+	# shellcheck disable=SC2016  # jq variables are not shell expansions.
+	printf '%s' "$detail" | aidevops_run_with_log_stderr jq -er '
+		[.rules[]? | select(.type == "pull_request") | .parameters as $parameters |
+			if ($parameters | type) != "object"
+				or ($parameters.required_approving_review_count | type) != "number"
+				or $parameters.required_approving_review_count < 0
+				or ($parameters.required_approving_review_count | floor) != $parameters.required_approving_review_count
+				or ($parameters.dismiss_stale_reviews_on_push | type) != "boolean"
+				or ($parameters.require_last_push_approval | type) != "boolean"
+			then error("invalid pull-request approval policy")
+			else {
+				required: $parameters.required_approving_review_count,
+				current_head_required: (
+					if $parameters.dismiss_stale_reviews_on_push then
+						$parameters.required_approving_review_count
+					elif $parameters.require_last_push_approval and $parameters.required_approving_review_count > 0 then
+						1
+					else 0 end
+				)
+			} end]
+		| "\([.[].required] | max // 0)\t\([.[].current_head_required] | max // 0)"
+	'
+	return $?
+}
+
+#######################################
 # Resolve the maximum approval count and current-head approval count from active
 # rulesets matching the repository default branch. This is separate from
 # required status checks: GitHub stores ruleset approval requirements under
@@ -1275,31 +1312,7 @@ _ruleset_required_review_policy_for_default_branch() {
 		done <<<"$exclude_patterns"
 		[[ "$excluded_default" -eq 0 ]] || continue
 
-		# #aidevops:trust-boundary — ruleset approval freshness controls whether
-		# an admin merge may reuse approvals from an older PR head. Require typed
-		# policy fields instead of treating unknown API evidence as policy=false.
-		# shellcheck disable=SC2016  # jq variables are not shell expansions.
-		policy=$(printf '%s' "$detail" | aidevops_run_with_log_stderr jq -er '
-			[.rules[]? | select(.type == "pull_request") | .parameters as $parameters |
-				if ($parameters | type) != "object"
-					or ($parameters.required_approving_review_count | type) != "number"
-					or $parameters.required_approving_review_count < 0
-					or ($parameters.required_approving_review_count | floor) != $parameters.required_approving_review_count
-					or ($parameters.dismiss_stale_reviews_on_push | type) != "boolean"
-					or ($parameters.require_last_push_approval | type) != "boolean"
-				then error("invalid pull-request approval policy")
-				else {
-					required: $parameters.required_approving_review_count,
-					current_head_required: (
-						if $parameters.dismiss_stale_reviews_on_push then
-							$parameters.required_approving_review_count
-						elif $parameters.require_last_push_approval and $parameters.required_approving_review_count > 0 then
-							1
-						else 0 end
-					)
-				} end]
-			| "\([.[].required] | max // 0)\t\([.[].current_head_required] | max // 0)"
-		') || {
+		policy=$(_ruleset_pull_request_policy_from_detail "$detail") || {
 			aidevops_log_line "[pulse-merge] _ruleset_required_review_policy_for_default_branch: pull-request policy parse failed for ruleset ${id} in ${repo_slug} — caller will fail closed (GH#30638)"
 			return 1
 		}

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -1197,52 +1197,65 @@ _check_required_pr_checks_passing_fallback() {
 }
 
 #######################################
-# Resolve the maximum required approval count from active rulesets matching
-# the repository default branch. This is separate from required status checks:
-# GitHub stores ruleset approval requirements under pull_request rules, not as
-# CI contexts, so an empty status context list is not enough to allow a merge.
+# Resolve the maximum approval count and current-head approval count from active
+# rulesets matching the repository default branch. This is separate from
+# required status checks: GitHub stores ruleset approval requirements under
+# pull_request rules, not as CI contexts, so an empty status context list is not
+# enough to allow a merge.
 #
 # Args: $1=repo_slug, $2=default_branch, $3=optional pre-fetched rulesets JSON
-# Stdout: integer maximum required_approving_review_count (0 when none)
+# Stdout: tab-separated maximum required approvals and current-head approvals
 # Returns: 0=requirement resolved, 1=ruleset API/parse error
 #######################################
-_ruleset_required_review_count_for_default_branch() {
+_ruleset_required_review_policy_for_default_branch() {
 	local repo_slug="$1"
 	local default_branch="$2"
 	local rulesets_json="${3:-}"
 
 	if [[ -z "$rulesets_json" ]]; then
 		rulesets_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/rulesets" 2>/dev/null) || {
-			aidevops_log_line "[pulse-merge] _ruleset_required_review_count_for_default_branch: rulesets list failed for ${repo_slug} — caller will fail closed (GH#24577)"
+			aidevops_log_line "[pulse-merge] _ruleset_required_review_policy_for_default_branch: rulesets list failed for ${repo_slug} — caller will fail closed (GH#24577)"
 			return 1
 		}
 	fi
-	[[ -n "$rulesets_json" && "$rulesets_json" != "[]" && "$rulesets_json" != null ]] || {
-		printf '0'
+	if ! _pmrc_rulesets_list_schema_valid "$rulesets_json"; then
+		aidevops_log_line "[pulse-merge] _ruleset_required_review_policy_for_default_branch: rulesets list parse failed for ${repo_slug} — caller will fail closed (GH#30638)"
+		return 1
+	fi
+	[[ "$rulesets_json" != "[]" ]] || {
+		printf '0\t0'
 		return 0
 	}
 
 	local active_ids=""
-	active_ids=$(printf '%s' "$rulesets_json" | aidevops_run_with_log_stderr jq -r '.[]? | select(.enforcement == "active") | .id // empty') || {
-		aidevops_log_line "[pulse-merge] _ruleset_required_review_count_for_default_branch: rulesets list parse failed for ${repo_slug} — caller will fail closed (GH#24577)"
+	# shellcheck disable=SC2016  # jq variables are not shell expansions.
+	active_ids=$(printf '%s' "$rulesets_json" | aidevops_run_with_log_stderr jq -r \
+		--arg active "$PMRC_RULESET_ACTIVE" --arg branch "$PMRC_RULESET_BRANCH" \
+		'.[] | select(.enforcement == $active and .target == $branch) | .id') || {
+		aidevops_log_line "[pulse-merge] _ruleset_required_review_policy_for_default_branch: rulesets list parse failed for ${repo_slug} — caller will fail closed (GH#24577)"
 		return 1
 	}
 	[[ -n "$active_ids" ]] || {
-		printf '0'
+		printf '0\t0'
 		return 0
 	}
 
 	local max_required=0
+	local max_current_head_required=0
 	local id="" detail="" include_patterns="" exclude_patterns="" pattern=""
-	local matches_default=0 excluded_default=0 approval_count=""
+	local matches_default=0 excluded_default=0 policy="" approval_count="" current_head_required=""
 	while IFS= read -r id; do
 		[[ -n "$id" ]] || continue
 		detail=$(_pmrc_gh_read gh api "repos/${repo_slug}/rulesets/${id}" 2>/dev/null) || {
-			aidevops_log_line "[pulse-merge] _ruleset_required_review_count_for_default_branch: ruleset detail ${id} failed for ${repo_slug} — caller will fail closed (GH#24577)"
+			aidevops_log_line "[pulse-merge] _ruleset_required_review_policy_for_default_branch: ruleset detail ${id} failed for ${repo_slug} — caller will fail closed (GH#24577)"
 			return 1
 		}
-		include_patterns=$(printf '%s' "$detail" | aidevops_run_with_log_stderr jq -r '.conditions?.ref_name?.include? // [] | .[]') || return 1
-		exclude_patterns=$(printf '%s' "$detail" | aidevops_run_with_log_stderr jq -r '.conditions?.ref_name?.exclude? // [] | .[]') || return 1
+		if ! _pmrc_branch_ruleset_detail_schema_valid "$detail" "$id"; then
+			aidevops_log_line "[pulse-merge] _ruleset_required_review_policy_for_default_branch: ruleset detail ${id} parse failed for ${repo_slug} — caller will fail closed (GH#30638)"
+			return 1
+		fi
+		include_patterns=$(printf '%s' "$detail" | aidevops_run_with_log_stderr jq -r '.conditions.ref_name.include | .[]') || return 1
+		exclude_patterns=$(printf '%s' "$detail" | aidevops_run_with_log_stderr jq -r '.conditions.ref_name.exclude // [] | .[]') || return 1
 
 		matches_default=0
 		while IFS= read -r pattern; do
@@ -1262,44 +1275,102 @@ _ruleset_required_review_count_for_default_branch() {
 		done <<<"$exclude_patterns"
 		[[ "$excluded_default" -eq 0 ]] || continue
 
-		approval_count=$(printf '%s' "$detail" | aidevops_run_with_log_stderr jq -r '[.rules[]? | select(.type == "pull_request") | (.parameters?.required_approving_review_count? // 0)] | max // 0') || {
-			aidevops_log_line "[pulse-merge] _ruleset_required_review_count_for_default_branch: pull-request rule parse failed for ruleset ${id} in ${repo_slug} — caller will fail closed (GH#24577)"
+		# #aidevops:trust-boundary — ruleset approval freshness controls whether
+		# an admin merge may reuse approvals from an older PR head. Require typed
+		# policy fields instead of treating unknown API evidence as policy=false.
+		# shellcheck disable=SC2016  # jq variables are not shell expansions.
+		policy=$(printf '%s' "$detail" | aidevops_run_with_log_stderr jq -er '
+			[.rules[]? | select(.type == "pull_request") | .parameters as $parameters |
+				if ($parameters | type) != "object"
+					or ($parameters.required_approving_review_count | type) != "number"
+					or $parameters.required_approving_review_count < 0
+					or ($parameters.required_approving_review_count | floor) != $parameters.required_approving_review_count
+					or ($parameters.dismiss_stale_reviews_on_push | type) != "boolean"
+					or ($parameters.require_last_push_approval | type) != "boolean"
+				then error("invalid pull-request approval policy")
+				else {
+					required: $parameters.required_approving_review_count,
+					current_head_required: (
+						if $parameters.dismiss_stale_reviews_on_push then
+							$parameters.required_approving_review_count
+						elif $parameters.require_last_push_approval and $parameters.required_approving_review_count > 0 then
+							1
+						else 0 end
+					)
+				} end]
+			| "\([.[].required] | max // 0)\t\([.[].current_head_required] | max // 0)"
+		') || {
+			aidevops_log_line "[pulse-merge] _ruleset_required_review_policy_for_default_branch: pull-request policy parse failed for ruleset ${id} in ${repo_slug} — caller will fail closed (GH#30638)"
 			return 1
 		}
-		[[ "$approval_count" =~ ^[0-9]+$ ]] || approval_count=0
+		IFS=$'\t' read -r approval_count current_head_required <<<"$policy"
+		if [[ ! "$approval_count" =~ ^[0-9]+$ || ! "$current_head_required" =~ ^[0-9]+$ ]]; then
+			aidevops_log_line "[pulse-merge] _ruleset_required_review_policy_for_default_branch: invalid policy aggregate for ruleset ${id} in ${repo_slug} — caller will fail closed (GH#30638)"
+			return 1
+		fi
 		[[ "$approval_count" -gt "$max_required" ]] && max_required="$approval_count"
+		[[ "$current_head_required" -gt "$max_current_head_required" ]] && max_current_head_required="$current_head_required"
 	done <<<"$active_ids"
 
-	printf '%s' "$max_required"
+	printf '%s\t%s' "$max_required" "$max_current_head_required"
+	return 0
+}
+
+#######################################
+# Resolve only the maximum approval count for callers that do not evaluate
+# review freshness themselves.
+#
+# Args: $1=repo_slug, $2=default_branch, $3=optional pre-fetched rulesets JSON
+# Stdout: integer maximum required_approving_review_count (0 when none)
+# Returns: 0=requirement resolved, 1=ruleset API/parse error
+#######################################
+_ruleset_required_review_count_for_default_branch() {
+	local repo_slug="$1"
+	local default_branch="$2"
+	local rulesets_json="${3:-}"
+	local policy="" required_count="" current_head_required=""
+	policy=$(_ruleset_required_review_policy_for_default_branch "$repo_slug" "$default_branch" "$rulesets_json") || return 1
+	IFS=$'\t' read -r required_count current_head_required <<<"$policy"
+	[[ "$required_count" =~ ^[0-9]+$ && "$current_head_required" =~ ^[0-9]+$ ]] || return 1
+	printf '%s' "$required_count"
 	return 0
 }
 
 #######################################
 # Verify active ruleset pull_request approval requirements for one PR.
 #
-# Args: $1=repo_slug, $2=pr_number, $3=pr_author
+# Args: $1=repo_slug, $2=pr_number, $3=pr_author, $4=expected_head_sha
 # Returns: 0=passes/no ruleset approval requirement, 1=missing/unverifiable
 #######################################
 _check_ruleset_required_reviews_passing() {
 	local repo_slug="$1"
 	local pr_number="$2"
 	local pr_author="$3"
+	local expected_head_sha="${4:-}"
 
-	local default_branch="" required_count=""
+	local default_branch="" policy="" required_count="" required_current_head_count=""
 	default_branch=$(_pmrc_gh_read gh api "repos/${repo_slug}" --jq '.default_branch' 2>/dev/null) || default_branch=""
 	if [[ -z "$default_branch" ]]; then
 		echo "[pulse-merge] _check_ruleset_required_reviews_passing: failed to resolve default branch for ${repo_slug} — failing closed (GH#24577)" >>"$LOGFILE"
 		return 1
 	fi
-	required_count=$(_ruleset_required_review_count_for_default_branch "$repo_slug" "$default_branch") || return 1
-	[[ "$required_count" =~ ^[0-9]+$ ]] || required_count=0
+	policy=$(_ruleset_required_review_policy_for_default_branch "$repo_slug" "$default_branch") || return 1
+	IFS=$'\t' read -r required_count required_current_head_count <<<"$policy"
+	if [[ ! "$required_count" =~ ^[0-9]+$ || ! "$required_current_head_count" =~ ^[0-9]+$ ]]; then
+		echo "[pulse-merge] _check_ruleset_required_reviews_passing: invalid ruleset approval policy for ${repo_slug} — failing closed (GH#30638)" >>"$LOGFILE"
+		return 1
+	fi
 	[[ "$required_count" -eq 0 ]] && return 0
 	if [[ -z "$pr_author" ]]; then
 		echo "[pulse-merge] _check_ruleset_required_reviews_passing: PR #${pr_number} in ${repo_slug} has no verifiable author — failing closed (GH#30586)" >>"$LOGFILE"
 		return 1
 	fi
+	if [[ "$required_current_head_count" -gt 0 && -z "$expected_head_sha" ]]; then
+		echo "[pulse-merge] _check_ruleset_required_reviews_passing: PR #${pr_number} in ${repo_slug} requires current-head approval but has no expected head — failing closed (GH#30638)" >>"$LOGFILE"
+		return 1
+	fi
 
-	local reviews_pages="" approved_count="" empty_string=""
+	local reviews_pages="" approval_counts="" approved_count="" current_head_approved_count="" empty_string=""
 	reviews_pages=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}/reviews?per_page=100" --paginate --slurp 2>/dev/null) || reviews_pages=""
 	if [[ -z "$reviews_pages" || "$reviews_pages" == null ]]; then
 		echo "[pulse-merge] _check_ruleset_required_reviews_passing: review fetch failed for PR #${pr_number} in ${repo_slug} with ruleset requiring ${required_count} approval(s) — failing closed (GH#24577)" >>"$LOGFILE"
@@ -1308,7 +1379,8 @@ _check_ruleset_required_reviews_passing() {
 	# #aidevops:trust-boundary — count only each reviewer's latest substantive
 	# decision. COMMENTED submissions do not change GitHub's approval state, while
 	# malformed state-changing reviews must keep ruleset admission fail-closed.
-	approved_count=$(jq -er --arg author "$pr_author" --arg empty "$empty_string" \
+	approval_counts=$(jq -er --arg author "$pr_author" --arg empty "$empty_string" \
+		--arg expected_head "$expected_head_sha" --argjson required_current_head "$required_current_head_count" \
 		--arg array_type "$PMRC_JSON_ARRAY" --arg object_type "$PMRC_JSON_OBJECT" \
 		--arg number_type "$PMRC_JSON_NUMBER" --arg string_type "$PMRC_JSON_STRING" '
 		def review_state:
@@ -1332,6 +1404,10 @@ _check_ruleset_required_reviews_passing() {
 				or (.id | type) != $number_type
 				or .id <= 0
 				or (.id | floor) != .id
+				or ($required_current_head > 0 and (
+					(.commit_id | type) != $string_type
+					or (.commit_id | length) == 0
+				))
 			))
 		) then
 			error("malformed state-changing review")
@@ -1340,24 +1416,27 @@ _check_ruleset_required_reviews_passing() {
 				login: ((.user.login // $empty) | ascii_downcase),
 				state: $state,
 				submitted_epoch: ((.submitted_at // $empty) | fromdateiso8601),
-				id: (.id // 0)
+				id: (.id // 0),
+				commit_id: (.commit_id // $empty)
 			} | select(.login != $empty)]
 			| group_by(.login)
 			| map(max_by([.submitted_epoch, .id]))
 			| map(select(.login != $author_login))
 			| map(select(.state == "APPROVED"))
-			| length
+			| [length, map(select(.commit_id == $expected_head)) | length]
+			| @tsv
 		end
-	' <<<"$reviews_pages" 2>/dev/null) || approved_count=""
-	if [[ ! "$approved_count" =~ ^[0-9]+$ ]]; then
+	' <<<"$reviews_pages" 2>/dev/null) || approval_counts=""
+	IFS=$'\t' read -r approved_count current_head_approved_count <<<"$approval_counts"
+	if [[ ! "$approved_count" =~ ^[0-9]+$ || ! "$current_head_approved_count" =~ ^[0-9]+$ ]]; then
 		echo "[pulse-merge] _check_ruleset_required_reviews_passing: review parse failed for PR #${pr_number} in ${repo_slug} — failing closed (GH#24577)" >>"$LOGFILE"
 		return 1
 	fi
-	if [[ "$approved_count" -lt "$required_count" ]]; then
-		echo "[pulse-merge] _check_ruleset_required_reviews_passing: PR #${pr_number} in ${repo_slug} has ${approved_count}/${required_count} ruleset-required approval(s) — deferring merge (GH#24577)" >>"$LOGFILE"
+	if [[ "$approved_count" -lt "$required_count" || "$current_head_approved_count" -lt "$required_current_head_count" ]]; then
+		echo "[pulse-merge] _check_ruleset_required_reviews_passing: PR #${pr_number} in ${repo_slug} has ${approved_count}/${required_count} ruleset-required approval(s), including ${current_head_approved_count}/${required_current_head_count} required on expected head ${expected_head_sha:0:12} — deferring merge (GH#30638)" >>"$LOGFILE"
 		return 1
 	fi
-	echo "[pulse-merge] _check_ruleset_required_reviews_passing: PR #${pr_number} in ${repo_slug} satisfies ${approved_count}/${required_count} ruleset-required approval(s) (GH#24577)" >>"$LOGFILE"
+	echo "[pulse-merge] _check_ruleset_required_reviews_passing: PR #${pr_number} in ${repo_slug} satisfies ${approved_count}/${required_count} ruleset-required approval(s), including ${current_head_approved_count}/${required_current_head_count} required on expected head ${expected_head_sha:0:12} (GH#30638)" >>"$LOGFILE"
 	return 0
 }
 

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1760,7 +1760,7 @@ _process_single_ready_pr() {
 	# Approve (satisfies REVIEW_REQUIRED for collaborator PRs)
 	approve_collaborator_pr "$pr_number" "$repo_slug" "$pr_author" "$pr_head_ref_oid" 2>/dev/null || true
 	[[ -n "$timing_prefix" ]] && _ruleset_start=$(_pmp_now_epoch)
-	if ! _check_ruleset_required_reviews_passing "$repo_slug" "$pr_number" "$pr_author"; then
+	if ! _check_ruleset_required_reviews_passing "$repo_slug" "$pr_number" "$pr_author" "$pr_head_ref_oid"; then
 		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}ruleset_s" "$_ruleset_start"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -79,6 +79,10 @@ print_result() {
 #      status, and the current head's maintainer-gate CheckRun is successful
 #   pr_checks_empty_failure — PR-level required checks exits non-zero with no JSON
 #   ruleset_review_malformed_optional — ruleset detail has unexpected shapes
+#   ruleset_review_stale_head_dismiss — stale approval under dismiss-on-push
+#   ruleset_review_current_head_last_push — current-head approval under last-push policy
+#   ruleset_review_current_head_dismissed — current-head approval is later dismissed
+#   ruleset_review_unknown_freshness — matching ruleset omits freshness policy
 #   ruleset_review_latest_changes_requested — latest review revokes approval
 #   ruleset_review_paginated_approved — later REST page restores approval
 #   ruleset_review_author_only — only the PR author approved
@@ -130,13 +134,22 @@ if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets/"* ]]; then
 	branch_identity='"id":101,"target":"branch","enforcement":"active"'
 	case "${MOCK_GH_MODE:-all_pass}" in
 	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_malformed_element | ruleset_review_fetch_error)
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":1,\"dismiss_stale_reviews_on_push\":false,\"require_last_push_approval\":false}}]}" "$@"
+		;;
+	ruleset_review_stale_head_dismiss | ruleset_review_current_head_dismissed)
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":1,\"dismiss_stale_reviews_on_push\":true,\"require_last_push_approval\":false}}]}" "$@"
+		;;
+	ruleset_review_current_head_last_push)
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":2,\"dismiss_stale_reviews_on_push\":false,\"require_last_push_approval\":true}}]}" "$@"
+		;;
+	ruleset_review_unknown_freshness)
 		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":1}}]}" "$@"
 		;;
 	ruleset_mixed_review_status)
-		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":1}},{\"type\":\"required_status_checks\",\"parameters\":{\"required_status_checks\":[{\"context\":\"required-a\"}]}}]}" "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":1,\"dismiss_stale_reviews_on_push\":false,\"require_last_push_approval\":false}},{\"type\":\"required_status_checks\",\"parameters\":{\"required_status_checks\":[{\"context\":\"required-a\"}]}}]}" "$@"
 		;;
 	ruleset_review_zero)
-		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":0}}]}" "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":0,\"dismiss_stale_reviews_on_push\":false,\"require_last_push_approval\":false}}]}" "$@"
 		;;
 	ruleset_review_malformed_optional)
 		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":\"unexpected\"},\"rules\":[{\"type\":\"pull_request\",\"parameters\":\"unexpected\"}]}" "$@"
@@ -158,7 +171,7 @@ if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets"* ]]; then
 		printf '%s\n' 'gh: HTTP 403: Resource not accessible by integration' >&2
 		exit 1
 		;;
-	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_mixed_review_status | ruleset_review_zero | ruleset_review_malformed_optional | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_malformed_element | ruleset_review_fetch_error)
+	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_mixed_review_status | ruleset_review_zero | ruleset_review_malformed_optional | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_malformed_element | ruleset_review_fetch_error | ruleset_review_stale_head_dismiss | ruleset_review_current_head_last_push | ruleset_review_current_head_dismissed | ruleset_review_unknown_freshness)
 		apply_jq '[{"id":101,"enforcement":"active","target":"branch"}]' "$@"
 		;;
 	*)
@@ -178,6 +191,15 @@ if [[ "$1" == "api" && "$2" == repos/*/pulls/*/reviews* ]]; then
 		;;
 	ruleset_review_paginated_approved)
 		printf '%s\n' '[[{"id":1,"state":"CHANGES_REQUESTED","submitted_at":"2026-06-01T00:00:00Z","user":{"login":"reviewer"}}],[{"id":2,"state":"APPROVED","submitted_at":"2026-06-02T00:00:00Z","user":{"login":"reviewer"}}]]'
+		;;
+	ruleset_review_stale_head_dismiss)
+		printf '%s\n' '[[{"id":3,"state":"APPROVED","commit_id":"old-head","submitted_at":"2026-06-03T00:00:00Z","user":{"login":"reviewer"}}]]'
+		;;
+	ruleset_review_current_head_last_push)
+		printf '%s\n' '[[{"id":4,"state":"APPROVED","commit_id":"old-head","submitted_at":"2026-06-03T00:00:00Z","user":{"login":"reviewer-one"}},{"id":5,"state":"APPROVED","commit_id":"abc123def456789000000000000000000000abcd","submitted_at":"2026-06-04T00:00:00Z","user":{"login":"reviewer-two"}}]]'
+		;;
+	ruleset_review_current_head_dismissed)
+		printf '%s\n' '[[{"id":6,"state":"APPROVED","commit_id":"abc123def456789000000000000000000000abcd","submitted_at":"2026-06-03T00:00:00Z","user":{"login":"reviewer"}},{"id":7,"state":"DISMISSED","commit_id":"abc123def456789000000000000000000000abcd","submitted_at":"2026-06-04T00:00:00Z","user":{"login":"reviewer"}}]]'
 		;;
 	ruleset_review_author_only)
 		printf '%s\n' '[[{"id":1,"state":"APPROVED","submitted_at":"2026-06-01T00:00:00Z","user":{"login":"author"}}]]'
@@ -412,6 +434,7 @@ define_function_under_test() {
 	eval_function_from_file _pr_required_checks_pass "$MERGE_SCRIPT" || return 1
 	eval_function_from_file _pmrc_gh_read "$REQUIRED_CHECKS_SCRIPT" || return 1
 	eval_function_from_file _check_required_pr_checks_passing_fallback "$REQUIRED_CHECKS_SCRIPT" || return 1
+	eval_function_from_file _ruleset_required_review_policy_for_default_branch "$REQUIRED_CHECKS_SCRIPT" || return 1
 	eval_function_from_file _ruleset_required_review_count_for_default_branch "$REQUIRED_CHECKS_SCRIPT" || return 1
 	eval_function_from_file _check_ruleset_required_reviews_passing "$REQUIRED_CHECKS_SCRIPT" || return 1
 	eval_function_from_file _check_required_checks_has_terminal_failure "$REQUIRED_CHECKS_SCRIPT" || return 1
@@ -463,12 +486,26 @@ assert_pr_checks_fallback_returns() {
 assert_ruleset_review_gate_returns() {
 	local expected_rc="$1"
 	local label="$2"
+	local expected_head_sha="${3:-abc123def456789000000000000000000000abcd}"
 	local actual_rc=0
-	_check_ruleset_required_reviews_passing "marcusquinn/aidevops" "19023" "author" || actual_rc=$?
+	_check_ruleset_required_reviews_passing "marcusquinn/aidevops" "19023" "author" "$expected_head_sha" || actual_rc=$?
 	if [[ "$actual_rc" -eq "$expected_rc" ]]; then
 		print_result "$label" 0
 	else
 		print_result "$label" 1 "Expected rc=$expected_rc, got rc=$actual_rc"
+	fi
+	return 0
+}
+
+assert_ruleset_review_policy_output() {
+	local expected_output="$1"
+	local label="$2"
+	local actual_output=""
+	actual_output=$(_ruleset_required_review_policy_for_default_branch "marcusquinn/aidevops" "main") || actual_output="ERR"
+	if [[ "$actual_output" == "$expected_output" ]]; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "Expected output='$expected_output', got output='$actual_output'"
 	fi
 	return 0
 }
@@ -792,6 +829,45 @@ test_ruleset_review_only_approved_allows_merge() {
 	return 0
 }
 
+test_ruleset_stale_head_approval_rejected_when_dismiss_on_push() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_stale_head_dismiss"
+	assert_ruleset_review_policy_output $'1\t1' "dismiss-on-push policy requires all approvals on current head"
+	assert_ruleset_review_gate_returns 1 "old-head approval rejected under dismiss-on-push freshness policy"
+	assert_log_contains "including 0/1 required on expected head" \
+		"stale approval rejection records current-head evidence"
+	return 0
+}
+
+test_ruleset_current_head_approval_accepted_when_last_push_required() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_current_head_last_push"
+	assert_ruleset_review_policy_output $'2\t1' "last-push policy requires one of two approvals on current head"
+	assert_ruleset_review_gate_returns 0 "current-head approval satisfies last-push freshness policy"
+	return 0
+}
+
+test_ruleset_current_head_dismissed_approval_rejected() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_current_head_dismissed"
+	assert_ruleset_review_gate_returns 1 "dismissed current-head approval does not satisfy freshness policy"
+	return 0
+}
+
+test_ruleset_unknown_freshness_policy_fails_closed() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_unknown_freshness"
+	assert_ruleset_review_policy_output "ERR" "missing ruleset freshness fields fail policy parsing"
+	assert_ruleset_review_gate_returns 1 "unknown ruleset freshness evidence fails closed"
+	assert_log_contains "pull-request policy parse failed" \
+		"unknown freshness evidence records fail-closed policy error"
+	return 0
+}
+
 test_ruleset_latest_review_state_controls_approval() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
@@ -867,12 +943,14 @@ test_ruleset_review_zero_does_not_require_approval() {
 	return 0
 }
 
-test_ruleset_review_malformed_optional_does_not_fail_parse() {
+test_ruleset_review_malformed_optional_fails_closed() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
 	export MOCK_GH_MODE="ruleset_review_malformed_optional"
-	assert_ruleset_review_count_output "0" "malformed optional ruleset fields parse as no review gate"
-	assert_ruleset_review_gate_returns 0 "malformed optional ruleset fields do not fail closed"
+	assert_ruleset_review_count_output "ERR" "malformed ruleset detail fails approval policy parsing"
+	assert_ruleset_review_gate_returns 1 "malformed ruleset detail fails closed"
+	assert_log_contains "ruleset detail 101 parse failed" \
+		"malformed ruleset detail records fail-closed schema error"
 	return 0
 }
 
@@ -947,6 +1025,10 @@ main() {
 	test_ruleset_review_only_missing_blocks_merge
 	test_ruleset_review_count_accepts_prefetched_rulesets_json
 	test_ruleset_review_only_approved_allows_merge
+	test_ruleset_stale_head_approval_rejected_when_dismiss_on_push
+	test_ruleset_current_head_approval_accepted_when_last_push_required
+	test_ruleset_current_head_dismissed_approval_rejected
+	test_ruleset_unknown_freshness_policy_fails_closed
 	test_ruleset_latest_review_state_controls_approval
 	test_ruleset_paginated_latest_approval_allows_merge
 	test_ruleset_author_approval_does_not_count
@@ -955,7 +1037,7 @@ main() {
 	test_ruleset_review_fetch_error_fails_closed
 	test_ruleset_mixed_review_status_preserves_both_gates
 	test_ruleset_review_zero_does_not_require_approval
-	test_ruleset_review_malformed_optional_does_not_fail_parse
+	test_ruleset_review_malformed_optional_fails_closed
 	test_rulesets_empty_list_resolves_empty
 	test_rulesets_private_plan_unavailable_resolves_empty
 	test_rulesets_generic_forbidden_fails_closed

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -26,6 +26,7 @@ REMEDIATION_LOG=""
 MERGE_EVENT_LOG=""
 CACHE_INVALIDATION_LOG=""
 _OW_LABEL_PAT=",origin:worker,"
+RULESET_GATE_HEAD=""
 
 print_result() {
 	local test_name="$1"
@@ -233,7 +234,15 @@ _extract_linked_issue() { printf '123'; return 0; }
 _check_pr_merge_gates() { return 0; }
 _pr_required_checks_pass() { return 0; }
 approve_collaborator_pr() { return 0; }
-_check_ruleset_required_reviews_passing() { return 0; }
+_check_ruleset_required_reviews_passing() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local pr_author="$3"
+	local expected_head_sha="$4"
+	: "$repo_slug" "$pr_number" "$pr_author"
+	RULESET_GATE_HEAD="$expected_head_sha"
+	return 0
+}
 _extract_merge_summary() { printf 'summary'; return 0; }
 _retarget_stacked_children() { return 0; }
 _pmp_is_protected_release_pr() { return 1; }
@@ -289,11 +298,11 @@ _pmrc_gh_read() {
 	return 1
 }
 
-_ruleset_required_review_count_for_default_branch() {
+_ruleset_required_review_policy_for_default_branch() {
 	local repo_slug="$1"
 	local default_branch="$2"
 	[[ "$repo_slug" == "owner/repo" && "$default_branch" == "main" ]] || return 1
-	printf '1\n'
+	printf '1\t0\n'
 	return 0
 }
 
@@ -318,7 +327,7 @@ assert_ruleset_review_sequence() {
 	local pr_author="${4-author}"
 	local actual_rc=0
 	RULESET_REVIEWS_JSON="$reviews_json"
-	_check_ruleset_required_reviews_passing "owner/repo" "77" "$pr_author" || actual_rc=$?
+	_check_ruleset_required_reviews_passing "owner/repo" "77" "$pr_author" "head-current" || actual_rc=$?
 	if [[ "$actual_rc" -eq "$expected_rc" ]]; then
 		print_result "$test_name" 0
 		return 0
@@ -433,6 +442,11 @@ test_ruleset_violation_enables_auto_merge_without_admin() {
 	fi
 	if ! grep -qE 'gh pr merge 77 --repo owner/repo --squash --admin' "$GH_LOG"; then
 		print_result "ruleset violation fallback tries admin first" 1 "gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	if [[ "$RULESET_GATE_HEAD" != "head-current" ]]; then
+		print_result "ruleset approval gate receives current PR head" 1 "expected head-current, got ${RULESET_GATE_HEAD:-empty}"
 		teardown_test_env
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Bind Pulse's local ruleset approval gate to the exact PR head whenever active rulesets require stale-review dismissal or last-push approval, while failing closed on unknown policy evidence.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified through focused ruleset fixtures: old-head approvals rejected, current-head last-push approval accepted, dismissed approval rejected, malformed policy/API evidence blocked; ShellCheck and all local linters pass.

Resolves #30638


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol spent 14m and 205,549 tokens on this with the user in an interactive session.