### PR TITLE
GH#29938: support push-triggered release evidence

### DIFF
--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -32,6 +32,7 @@ _FULL_LOOP_RELEASE_RECONCILE_PUBLISHED="published-reconcile"
 _FULL_LOOP_RELEASE_RECONCILE_AUTHORIZED="authorized-published-reconcile"
 _FULL_LOOP_RELEASE_EVIDENCE_RECEIPT_CONFLICT="receipt-conflict"
 _FULL_LOOP_RELEASE_ROLE_AGGREGATED="aggregated"
+_FULL_LOOP_WORKFLOW_EVENT_RELEASE="release"
 _FULL_LOOP_SHA40_REGEX='^[0-9a-f]{40}$'
 _FULL_LOOP_VERSION_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
 _FULL_LOOP_JSON_NUMBER_TYPE="number"
@@ -2067,20 +2068,38 @@ _full_loop_verify_published_release() {
 	local repo="$1"
 	local tag_name="$2"
 	local merge_commit="$3"
+	local workflow_file="${4:-}"
+	local workflow_event="${5:-$_FULL_LOOP_WORKFLOW_EVENT_RELEASE}"
 	local tag_commit=""
 	local release_json=""
 	local workflow_runs_json=""
+	local workflow_runs_endpoint=""
 
 	[[ "$repo" == */* && "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX && "$merge_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	if [[ "$workflow_event" != "$_FULL_LOOP_WORKFLOW_EVENT_RELEASE" && \
+		"$workflow_event" != "push" && "$workflow_event" != "workflow_dispatch" ]]; then
+		return 1
+	fi
+	if [[ -n "$workflow_file" ]]; then
+		if [[ ! "$workflow_file" =~ ^[1-9][0-9]*$ && ! "$workflow_file" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml$ ]]; then
+			return 1
+		fi
+		workflow_runs_endpoint="repos/${repo}/actions/workflows/${workflow_file}/runs?event=${workflow_event}&status=success&per_page=100"
+	else
+		[[ "$workflow_event" == "$_FULL_LOOP_WORKFLOW_EVENT_RELEASE" ]] || return 1
+		workflow_runs_endpoint="repos/${repo}/actions/runs?event=release&status=success&per_page=100"
+	fi
 	tag_commit=$(_full_loop_resolve_remote_release_tag_commit "$repo" "$tag_name") || return 1
 	[[ "$tag_commit" == "$merge_commit" ]] || return 1
 	release_json=$(gh api "repos/${repo}/releases/tags/${tag_name}" 2>/dev/null) || return 1
 	jq -e --arg tag_name "$tag_name" '.tag_name == $tag_name and .draft == false' <<<"$release_json" >/dev/null || return 1
-	workflow_runs_json=$(gh api "repos/${repo}/actions/runs?event=release&status=success&per_page=100" 2>/dev/null) || return 1
-	jq -e --arg tag_name "$tag_name" --arg merge_commit "$merge_commit" --arg completed "$_FULL_LOOP_PHASE_COMPLETED" '
+	workflow_runs_json=$(gh api "$workflow_runs_endpoint" 2>/dev/null) || return 1
+	jq -e --arg tag_name "$tag_name" --arg merge_commit "$merge_commit" \
+		--arg completed "$_FULL_LOOP_PHASE_COMPLETED" --arg workflow_event "$workflow_event" '
 		[.workflow_runs[]? | select(
-			.event == "release" and .status == $completed and .conclusion == "success"
-			and .head_branch == $tag_name and .head_sha == $merge_commit
+			.event == $workflow_event and .status == $completed and .conclusion == "success"
+			and .head_sha == $merge_commit
+			and ($workflow_event != "release" or .head_branch == $tag_name)
 		)] | length > 0
 	' <<<"$workflow_runs_json" >/dev/null || return 1
 	return 0
@@ -2134,20 +2153,73 @@ cmd_record_no_release() {
 	return 0
 }
 
+_full_loop_parse_published_release_options() {
+	local -a args=("$@")
+	local arg_count="${#args[@]}"
+	local arg_index=0
+	local option=""
+	local option_value=""
+	_FULL_LOOP_PARSED_REPO_ARG=""
+	_FULL_LOOP_PARSED_WORKFLOW_FILE=""
+	_FULL_LOOP_PARSED_WORKFLOW_EVENT="$_FULL_LOOP_WORKFLOW_EVENT_RELEASE"
+	if [[ "$arg_index" -lt "$arg_count" ]]; then
+		option="${args[$arg_index]}"
+	fi
+	if [[ "$arg_index" -lt "$arg_count" && "$option" != --* ]]; then
+		_FULL_LOOP_PARSED_REPO_ARG="$option"
+		arg_index=$((arg_index + 1))
+	fi
+	while [[ "$arg_index" -lt "$arg_count" ]]; do
+		option="${args[$arg_index]}"
+		case "$option" in
+		--workflow | --event)
+			[[ $((arg_index + 1)) -lt "$arg_count" ]] || {
+				print_error "${option} requires a value"
+				return 1
+			}
+			option_value="${args[$((arg_index + 1))]}"
+			if [[ "$option" == "--workflow" ]]; then
+				_FULL_LOOP_PARSED_WORKFLOW_FILE="$option_value"
+			else
+				_FULL_LOOP_PARSED_WORKFLOW_EVENT="$option_value"
+			fi
+			arg_index=$((arg_index + 2))
+			;;
+		*)
+			print_error "Unknown record-published-release option: $option"
+			return 1
+			;;
+		esac
+	done
+	if [[ -z "$_FULL_LOOP_PARSED_WORKFLOW_FILE" && \
+		"$_FULL_LOOP_PARSED_WORKFLOW_EVENT" != "$_FULL_LOOP_WORKFLOW_EVENT_RELEASE" ]]; then
+		print_error "--event ${_FULL_LOOP_PARSED_WORKFLOW_EVENT} requires --workflow to bind publication evidence to an exact workflow"
+		return 1
+	fi
+	return 0
+}
+
 cmd_record_published_release() {
 	local pr_number="${1:-}"
 	local tag_name="${2:-}"
-	local repo_arg="${3:-}"
+	local repo_arg=""
 	local repo=""
 	local pr_json=""
 	local merge_commit=""
 	local receipt_path=""
 	local release_status=""
+	local workflow_file=""
+	local workflow_event="$_FULL_LOOP_WORKFLOW_EVENT_RELEASE"
 	local status=0
-	if [[ $# -lt 2 || $# -gt 3 ]] || [[ ! "$pr_number" =~ ^[0-9]+$ ]] || [[ ! "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX ]]; then
-		print_error "Usage: full-loop-helper.sh record-published-release <PR> <TAG> [REPO]"
+	if [[ $# -lt 2 ]] || [[ ! "$pr_number" =~ ^[0-9]+$ ]] || [[ ! "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX ]]; then
+		print_error "Usage: full-loop-helper.sh record-published-release <PR> <TAG> [REPO] [--workflow FILE] [--event release|push|workflow_dispatch]"
 		return 1
 	fi
+	shift 2
+	_full_loop_parse_published_release_options "$@" || return 1
+	repo_arg="$_FULL_LOOP_PARSED_REPO_ARG"
+	workflow_file="$_FULL_LOOP_PARSED_WORKFLOW_FILE"
+	workflow_event="$_FULL_LOOP_PARSED_WORKFLOW_EVENT"
 	repo=$(_full_loop_resolve_repo "$repo_arg") || {
 		print_error "Cannot resolve repository for release evidence"
 		return 1
@@ -2161,7 +2233,8 @@ cmd_record_published_release() {
 		print_error "Cannot record release:published: PR #${pr_number} merge commit is invalid"
 		return 1
 	}
-	_full_loop_verify_published_release "$repo" "$tag_name" "$merge_commit" || {
+	_full_loop_verify_published_release "$repo" "$tag_name" "$merge_commit" \
+		"$workflow_file" "$workflow_event" || {
 		print_error "Cannot record release:published: release, tag, and successful release workflow evidence do not match PR #${pr_number}"
 		return 1
 	}

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -293,8 +293,10 @@ Commands:
                                  gh CLI level; if both are given, --admin wins and
                                   --auto is dropped (GH#19310).
   record-no-release <PR> [REPO]  Verify merged evidence and record release:not-requested.
-  record-published-release <PR> <TAG> [REPO]
+  record-published-release <PR> <TAG> [REPO] [--workflow FILE] [--event EVENT]
                                   Verify a GitHub release and record release:published.
+                                  Defaults to release-event evidence; repository-owned
+                                  push/dispatch workflows require an exact workflow identity.
   adopt-merged-receipt <PR> [REPO]
                                  Adopt an externally merged exact-head worktree into cleanup.
   finalize-receipt <PR> [REPO]   Finalize a direct-merge cleanup receipt without local state.

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -46,6 +46,23 @@ if [[ "$*" == *"repos/marcusquinn/aidevops/actions/runs?event=release"* ]]; then
 	esac
 	exit 0
 fi
+if [[ "$*" == *"repos/marcusquinn/aidevops/actions/workflows/release.yml/runs?event=push&status=success&per_page=100"* ]]; then
+	case "$release_mode" in
+	push-failed-workflow)
+		jq -cn --arg sha "$merge_sha" '{workflow_runs:[{event:"push",status:"completed",conclusion:"failure",head_branch:"main",head_sha:$sha}]}'
+		;;
+	push-wrong-event)
+		jq -cn --arg sha "$merge_sha" '{workflow_runs:[{event:"workflow_dispatch",status:"completed",conclusion:"success",head_branch:"main",head_sha:$sha}]}'
+		;;
+	push-wrong-sha)
+		printf '%s\n' '{"workflow_runs":[{"event":"push","status":"completed","conclusion":"success","head_branch":"main","head_sha":"2222222222222222222222222222222222222222"}]}'
+		;;
+	*)
+		jq -cn --arg sha "$merge_sha" '{workflow_runs:[{event:"push",status:"completed",conclusion:"success",head_branch:"main",head_sha:$sha}]}'
+		;;
+	esac
+	exit 0
+fi
 if [[ "$*" == *"state,mergedAt,mergeCommit,headRefName,headRefOid,headRepository,isCrossRepository"* ]]; then
 	jq -cn \
 		--arg head_ref "${COMPLETION_PR_HEAD_REF:-}" \
@@ -224,6 +241,50 @@ AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$c
 	bash "$published_record_runner" 58 v3.0.0 marcusquinn/aidevops >/dev/null
 cmp -s "$published_cleanup_receipt" "${ROOT}/published-release-receipt-before.json"
 printf 'PASS verified manual release records published evidence and reconciles cleanup idempotently\n'
+
+push_published_worktree="${ROOT}/push-published-release-worktree"
+mkdir -p "$push_published_worktree"
+push_published_receipt=$(full_loop_write_cleanup_deferred marcusquinn/aidevops 61 "$push_published_worktree" \
+	feature/push-published-release "$$" push-published-release-session pending FINALIZATION_PENDING)
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$published_record_runner" 61 v3.0.0 marcusquinn/aidevops \
+		--workflow release.yml --event push >/dev/null
+grep -qx 'published' "${receipt_dir}/marcusquinn_aidevops-61.status"
+jq -e '.release_status == "published"' "$push_published_receipt" >/dev/null
+printf 'PASS exact repository-owned push workflow records published evidence\n'
+
+for invalid_push_mode in push-failed-workflow push-wrong-event push-wrong-sha; do
+	invalid_push_worktree="${ROOT}/invalid-${invalid_push_mode}"
+	mkdir -p "$invalid_push_worktree"
+	invalid_push_receipt=$(full_loop_write_cleanup_deferred marcusquinn/aidevops 62 "$invalid_push_worktree" \
+		feature/invalid-push "$$" invalid-push-session pending FINALIZATION_PENDING)
+	cp "$invalid_push_receipt" "${ROOT}/${invalid_push_mode}-before.json"
+	if COMPLETION_RELEASE_MODE="$invalid_push_mode" AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
+		AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+		bash "$published_record_runner" 62 v3.0.0 marcusquinn/aidevops \
+			--workflow release.yml --event push >/dev/null 2>&1; then
+		printf 'FAIL %s evidence recorded a published release\n' "$invalid_push_mode"
+		exit 1
+	fi
+	[[ ! -e "${receipt_dir}/marcusquinn_aidevops-62.status" ]]
+	cmp -s "$invalid_push_receipt" "${ROOT}/${invalid_push_mode}-before.json"
+	rm -f "$invalid_push_receipt" "${ROOT}/${invalid_push_mode}-before.json"
+done
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$published_record_runner" 62 v3.0.0 marcusquinn/aidevops --event push >/dev/null 2>&1; then
+	printf 'FAIL unbound push event recorded a published release\n'
+	exit 1
+fi
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$published_record_runner" 62 v3.0.0 marcusquinn/aidevops \
+		--workflow ../release.yml --event push >/dev/null 2>&1; then
+	printf 'FAIL unsafe workflow identifier recorded a published release\n'
+	exit 1
+fi
+printf 'PASS failed, mismatched, unbound, and unsafe push workflow evidence fails closed\n'
 
 for invalid_release_mode in wrong-tag-commit draft-release failed-workflow wrong-workflow-tag; do
 	invalid_published_worktree="${ROOT}/invalid-published-${invalid_release_mode}"

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -89,6 +89,11 @@ gh() {
 				'{workflow_runs:[{event:"release",status:"completed",conclusion:"success",head_branch:"v1.2.3",head_sha:$sha}]}'
 			return 0
 			;;
+		"repos/example/repo/actions/workflows/release.yml/runs?event=push&status=success&per_page=100")
+			jq -cn --arg sha "$GH_RELEASE_TAG_COMMIT" \
+				'{workflow_runs:[{event:"push",status:"completed",conclusion:"success",head_branch:"main",head_sha:$sha}]}'
+			return 0
+			;;
 		esac
 	fi
 	if [[ "$command" == "pr" && "$subcommand" == "view" ]]; then
@@ -711,6 +716,13 @@ test_release_tag_commit_resolution() {
 	[[ "$resolved_commit" == "$GH_RELEASE_TAG_COMMIT" && ! -s "$stderr_file" ]] || rc=1
 	_full_loop_verify_published_release "example/repo" "v1.2.3" "$GH_RELEASE_TAG_COMMIT" 2>"$stderr_file" || rc=1
 	[[ ! -s "$stderr_file" ]] || rc=1
+	_full_loop_verify_published_release "example/repo" "v1.2.3" "$GH_RELEASE_TAG_COMMIT" \
+		"release.yml" "push" 2>"$stderr_file" || rc=1
+	[[ ! -s "$stderr_file" ]] || rc=1
+	if _full_loop_verify_published_release "example/repo" "v1.2.3" "$GH_RELEASE_TAG_COMMIT" \
+		"../release.yml" "push" 2>"$stderr_file"; then rc=1; fi
+	if _full_loop_verify_published_release "example/repo" "v1.2.3" "$GH_RELEASE_TAG_COMMIT" \
+		"" "push" 2>"$stderr_file"; then rc=1; fi
 
 	GH_RELEASE_TAG_MODE="lightweight"
 	resolved_commit=$(_full_loop_resolve_remote_release_tag_commit "example/repo" "v1.2.3" 2>"$stderr_file") || rc=1
@@ -724,7 +736,7 @@ test_release_tag_commit_resolution() {
 	if _full_loop_resolve_remote_release_tag_commit "example/repo" "v1.2.3" 2>"$stderr_file"; then rc=1; fi
 	[[ ! -s "$stderr_file" ]] || rc=1
 
-	print_result "annotated and lightweight release tags resolve while invalid tag targets fail closed" "$rc"
+	print_result "release evidence accepts exact push workflows while invalid workflow and tag targets fail closed" "$rc"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- extend `record-published-release` with explicit `--workflow` and `--event` evidence selectors
- preserve the existing unscoped `release`-event behavior by default
- require exact workflow identity for `push` and `workflow_dispatch` evidence
- continue requiring a non-draft release, an exact tag-to-merge-SHA match, and a successful completed run at that SHA

## Context

Hit Factor Charts PR #25 published v1.6.3 from a repository-owned `push` workflow. The existing verifier queried only `event=release`, so it rejected otherwise valid publication evidence. This follow-up closes that acceptance gap without broadening unscoped workflow trust.

Fixes #29938

## Files

- `.agents/scripts/full-loop-helper-state.sh`: option parsing and fail-closed workflow verification
- `.agents/scripts/full-loop-helper.sh`: command help
- `.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh`: verifier-level push workflow coverage
- `.agents/scripts/tests/test-full-loop-completion-evidence.sh`: command and receipt integration coverage

## Verification

- `bash .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh` — 16/16 passed
- `bash .agents/scripts/tests/test-full-loop-completion-evidence.sh` — passed
- `shellcheck` on all four changed shell files — passed
- `.agents/scripts/linters-local.sh --changed` — passed
- live verification: `record-published-release 25 v1.6.3 johnwaldo/hitfactorcharts --workflow release.yml --event push` recorded `release:published`

No aidevops release is requested by this PR.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol spent 2h 47m and 976,703 tokens on this with the user in an interactive session.