### PR TITLE
GH#30571: Add Linux model replay sandbox

### DIFF
--- a/.agents/scripts/model-replay-core.mjs
+++ b/.agents/scripts/model-replay-core.mjs
@@ -29,8 +29,10 @@ export {
   loadCorpus,
 } from "./model-replay-corpus.mjs";
 export {
+  assertVerifierSandboxAvailable,
   assertNoSymlinks,
   execute,
+  verifierSandboxBackend,
   workspaceExecutionEnvironment,
 } from "./model-replay-process.mjs";
 export {

--- a/.agents/scripts/model-replay-process.mjs
+++ b/.agents/scripts/model-replay-process.mjs
@@ -285,6 +285,7 @@ function bubblewrapSandboxCommand(argv, workspace, environmentRoot, executable) 
     "--bind", key, key,
     "--bind", canonicalEnvironment, canonicalEnvironment,
     "--bind", isolatedTemporary, "/tmp",
+    "--remount-ro", "/",
     "--chdir", key,
     "--",
     ...argv,

--- a/.agents/scripts/model-replay-process.mjs
+++ b/.agents/scripts/model-replay-process.mjs
@@ -171,15 +171,22 @@ export function verifierSandboxBackend({
 }
 
 function bubblewrapProbe(executable) {
-  const result = spawnSync(executable, [
+  const probeExecutable = ["/usr/bin/true", "/bin/true"].find(executableFile);
+  if (!probeExecutable) unavailableSandbox(process.platform);
+  const probeArguments = [
     "--die-with-parent",
     "--new-session",
     "--unshare-all",
-    "--ro-bind", "/usr", "/usr",
+  ];
+  for (const path of LINUX_RUNTIME_ROOTS.filter(existsSync)) {
+    probeArguments.push("--ro-bind", realpathSync(path), path);
+  }
+  probeArguments.push(
     "--proc", "/proc",
     "--dev", "/dev",
-    "/usr/bin/true",
-  ], {
+    probeExecutable,
+  );
+  const result = spawnSync(executable, probeArguments, {
     encoding: "utf8",
     timeout: 10000,
     stdio: ["ignore", "pipe", "pipe"],

--- a/.agents/scripts/model-replay-process.mjs
+++ b/.agents/scripts/model-replay-process.mjs
@@ -3,7 +3,9 @@
 
 import { spawnSync } from "node:child_process";
 import {
+  accessSync,
   chmodSync,
+  constants,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -11,11 +13,24 @@ import {
   readdirSync,
   realpathSync,
 } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { pathInside } from "./model-replay-common.mjs";
 
 const MAX_CAPTURE_BYTES = 8 * 1024 * 1024;
 const WORKSPACE_ENVIRONMENTS = new Map();
+const LINUX_BWRAP_CANDIDATES = ["/usr/bin/bwrap", "/bin/bwrap"];
+const LINUX_RUNTIME_ROOTS = ["/usr", "/bin", "/sbin", "/lib", "/lib64"];
+const LINUX_RUNTIME_PATHS = [
+  "/etc/group",
+  "/etc/ld.so.cache",
+  "/etc/ld.so.conf",
+  "/etc/ld.so.conf.d",
+  "/etc/localtime",
+  "/etc/nsswitch.conf",
+  "/etc/passwd",
+  "/etc/ssl/certs",
+];
+let verifiedSandboxBackend = null;
 const SAFE_ENVIRONMENT_NAMES = [
   "COMSPEC",
   "LANG",
@@ -41,8 +56,12 @@ export function createCommandEnvironment(environmentRoot) {
   const home = join(environmentRoot, "home");
   const temporary = join(environmentRoot, "tmp");
   const config = join(environmentRoot, "config");
+  const cache = join(environmentRoot, "cache");
+  const data = join(environmentRoot, "data");
+  const runtime = join(environmentRoot, "runtime");
+  const state = join(environmentRoot, "state");
   const gitTemplate = join(environmentRoot, "git-template");
-  for (const directory of [home, temporary, config, gitTemplate]) {
+  for (const directory of [home, temporary, config, cache, data, runtime, state, gitTemplate]) {
     mkdirSync(directory, { recursive: true, mode: 0o700 });
     chmodSync(directory, 0o700);
   }
@@ -57,7 +76,11 @@ export function createCommandEnvironment(environmentRoot) {
     TMPDIR: temporary,
     TMP: temporary,
     TEMP: temporary,
+    XDG_CACHE_HOME: cache,
     XDG_CONFIG_HOME: config,
+    XDG_DATA_HOME: data,
+    XDG_RUNTIME_DIR: runtime,
+    XDG_STATE_HOME: state,
     GIT_CONFIG_GLOBAL: "/dev/null",
     GIT_CONFIG_NOSYSTEM: "1",
     GIT_TERMINAL_PROMPT: "0",
@@ -119,12 +142,153 @@ function seatbeltLiteral(path) {
   return `"${escaped}"`;
 }
 
-export function verifierSandboxCommand(argv, workspace, environmentRoot) {
-  if (process.platform !== "darwin") {
-    throw new Error(`No enforcing verifier filesystem sandbox is available on ${process.platform}`);
+function executableFile(path) {
+  try {
+    accessSync(path, constants.X_OK);
+    const metadata = lstatSync(path);
+    return metadata.isFile() && !metadata.isSymbolicLink();
+  } catch {
+    return false;
   }
-  if (!existsSync("/usr/bin/sandbox-exec")) {
-    throw new Error(`No enforcing verifier filesystem sandbox is available on ${process.platform}`);
+}
+
+function unavailableSandbox(platform) {
+  throw new Error(`No enforcing verifier filesystem sandbox is available on ${platform}`);
+}
+
+export function verifierSandboxBackend({
+  platform = process.platform,
+  linuxCandidates = LINUX_BWRAP_CANDIDATES,
+} = {}) {
+  if (platform === "darwin" && executableFile("/usr/bin/sandbox-exec")) {
+    return { kind: "seatbelt", executable: "/usr/bin/sandbox-exec" };
+  }
+  if (platform === "linux") {
+    const executable = linuxCandidates.find(executableFile);
+    if (executable) return { kind: "bubblewrap", executable };
+  }
+  return unavailableSandbox(platform);
+}
+
+function bubblewrapProbe(executable) {
+  const result = spawnSync(executable, [
+    "--die-with-parent",
+    "--new-session",
+    "--unshare-all",
+    "--ro-bind", "/usr", "/usr",
+    "--proc", "/proc",
+    "--dev", "/dev",
+    "/usr/bin/true",
+  ], {
+    encoding: "utf8",
+    timeout: 10000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    const detail = compactOutput(result.stderr || result.stdout || result.error?.message || "probe failed");
+    throw new Error(`Linux verifier filesystem sandbox is unavailable: ${detail}`);
+  }
+}
+
+export function assertVerifierSandboxAvailable() {
+  if (verifiedSandboxBackend) return { ...verifiedSandboxBackend };
+  const backend = verifierSandboxBackend();
+  if (backend.kind === "bubblewrap") bubblewrapProbe(backend.executable);
+  verifiedSandboxBackend = backend;
+  return { ...backend };
+}
+
+function mountParentDirectories(paths) {
+  const directories = new Set();
+  for (const path of paths) {
+    let parent = dirname(path);
+    while (parent !== "/" && parent !== ".") {
+      directories.add(parent);
+      parent = dirname(parent);
+    }
+  }
+  return [...directories].sort((left, right) => (
+    left.split(sep).length - right.split(sep).length || left.localeCompare(right)
+  ));
+}
+
+function linuxRuntimeExecutable(argv, workspace) {
+  const command = argv[0];
+  if (!isAbsolute(command)) return null;
+  const executable = realpathSync(command);
+  if (LINUX_RUNTIME_ROOTS.some((root) => executable === root || executable.startsWith(`${root}${sep}`))) {
+    return null;
+  }
+  const nodeExecutable = realpathSync(process.execPath);
+  if (executable !== nodeExecutable) {
+    pathInside(workspace, executable);
+    return null;
+  }
+  return { source: executable, destination: command };
+}
+
+function bubblewrapSandboxCommand(argv, workspace, environmentRoot, executable) {
+  const key = realpathSync(workspace);
+  const canonicalEnvironment = realpathSync(environmentRoot);
+  const isolatedTemporary = realpathSync(join(canonicalEnvironment, "tmp"));
+  const runtimeRoots = LINUX_RUNTIME_ROOTS.filter(existsSync).map((path) => ({
+    destination: path,
+    source: realpathSync(path),
+  }));
+  const runtimePaths = LINUX_RUNTIME_PATHS.filter(existsSync).map((path) => ({
+    destination: path,
+    source: realpathSync(path),
+  }));
+  const extraExecutable = linuxRuntimeExecutable(argv, key);
+  const mounts = [
+    ...runtimeRoots,
+    ...runtimePaths,
+    { source: key, destination: key },
+    { source: canonicalEnvironment, destination: canonicalEnvironment },
+    { source: isolatedTemporary, destination: "/tmp" },
+  ];
+  if (extraExecutable) mounts.push(extraExecutable);
+  const command = [
+    executable,
+    "--die-with-parent",
+    "--new-session",
+    "--unshare-all",
+    "--cap-drop", "ALL",
+  ];
+  for (const directory of mountParentDirectories([
+    "/dev",
+    "/proc",
+    "/tmp",
+    ...mounts.map((mount) => mount.destination),
+  ])) {
+    command.push("--dir", directory);
+  }
+  for (const mount of runtimeRoots) {
+    command.push("--ro-bind", mount.source, mount.destination);
+  }
+  for (const mount of runtimePaths) {
+    command.push("--ro-bind", mount.source, mount.destination);
+  }
+  if (extraExecutable) {
+    command.push("--ro-bind", extraExecutable.source, extraExecutable.destination);
+  }
+  command.push(
+    "--proc", "/proc",
+    "--dev", "/dev",
+    "--bind", key, key,
+    "--bind", canonicalEnvironment, canonicalEnvironment,
+    "--bind", isolatedTemporary, "/tmp",
+    "--chdir", key,
+    "--",
+    ...argv,
+  );
+  return command;
+}
+
+export function verifierSandboxCommand(argv, workspace, environmentRoot) {
+  const backend = assertVerifierSandboxAvailable();
+  if (backend.kind === "bubblewrap") {
+    return bubblewrapSandboxCommand(argv, workspace, environmentRoot, backend.executable);
   }
   const key = realpathSync(workspace);
   const canonicalEnvironment = realpathSync(environmentRoot);
@@ -151,7 +315,7 @@ export function verifierSandboxCommand(argv, workspace, environmentRoot) {
     `(allow file-write* ${writeRules})`,
     "(deny network*)",
   ].join("");
-  return ["/usr/bin/sandbox-exec", "-p", profile, ...argv];
+  return [backend.executable, "-p", profile, ...argv];
 }
 
 export function assertNoSymlinks(root) {

--- a/.agents/scripts/model-replay-process.mjs
+++ b/.agents/scripts/model-replay-process.mjs
@@ -248,12 +248,13 @@ function bubblewrapSandboxCommand(argv, workspace, environmentRoot, executable) 
     { source: isolatedTemporary, destination: "/tmp" },
   ];
   if (extraExecutable) mounts.push(extraExecutable);
+  // Bubblewrap drops capabilities before exec; an explicit cap drop also
+  // removes the setup capability needed to initialise the new loopback device.
   const command = [
     executable,
     "--die-with-parent",
     "--new-session",
     "--unshare-all",
-    "--cap-drop", "ALL",
   ];
   for (const directory of mountParentDirectories([
     "/dev",

--- a/.agents/scripts/model-replay-process.mjs
+++ b/.agents/scripts/model-replay-process.mjs
@@ -248,8 +248,7 @@ function bubblewrapSandboxCommand(argv, workspace, environmentRoot, executable) 
     { source: isolatedTemporary, destination: "/tmp" },
   ];
   if (extraExecutable) mounts.push(extraExecutable);
-  // Bubblewrap drops capabilities before exec; an explicit cap drop also
-  // removes the setup capability needed to initialise the new loopback device.
+  // Bubblewrap retains namespace setup capabilities, then drops them before exec.
   const command = [
     executable,
     "--die-with-parent",

--- a/.agents/scripts/model-replay-qualification.mjs
+++ b/.agents/scripts/model-replay-qualification.mjs
@@ -21,6 +21,7 @@ import {
   loadCatalog,
 } from "./model-replay-corpus.mjs";
 import {
+  assertVerifierSandboxAvailable,
   assertNoSymlinks,
   execute,
   workspaceExecutionEnvironment,
@@ -153,6 +154,7 @@ export function qualifyCase({
   allowPromptWarnings = false,
   retainWorkspaces = false,
 }) {
+  assertVerifierSandboxAvailable();
   const loadedCase = loadCase(corpusDir, caseID);
   const loadedCatalog = loadCatalog(catalogPath);
   if (loadedCase.definition.prompt_fidelity !== "exact" && !allowReconstructedPrompt) {

--- a/.agents/scripts/model-replay-workspace.mjs
+++ b/.agents/scripts/model-replay-workspace.mjs
@@ -14,6 +14,7 @@ import { join, relative, resolve, sep } from "node:path";
 import { pathInside } from "./model-replay-common.mjs";
 import { repositoryPathForCase } from "./model-replay-corpus.mjs";
 import {
+  assertVerifierSandboxAvailable,
   assertNoSymlinks,
   createCommandEnvironment,
   deleteWorkspaceEnvironment,
@@ -214,6 +215,7 @@ function runCheck(check, cwd) {
 }
 
 export function runCheckSet(checks, cwd) {
+  assertVerifierSandboxAvailable();
   return checks.map((check) => runCheck(check, cwd));
 }
 

--- a/.agents/scripts/tests/model-replay-benchmark-fixture.mjs
+++ b/.agents/scripts/tests/model-replay-benchmark-fixture.mjs
@@ -200,8 +200,8 @@ function writeCaseInputs(paths) {
   const fixedCheck = "const fs=require('node:fs');process.exit(fs.readFileSync('value.txt','utf8').trim()==='fixed'?0:1)";
   const stableCheck = "const fs=require('node:fs');process.exit(fs.readFileSync('stable.txt','utf8').trim()==='stable'?0:1)";
   const cleanEnvironmentCheck = "process.exit(process.env.AIDEVOPS_TEST_SECRET_SENTINEL?1:0)";
-  const filesystemBoundaryCheck = `const fs=require('node:fs');try{fs.readFileSync(${JSON.stringify(join(paths.inputs, "gold.patch"))});process.exit(1)}catch(error){process.exit(['EACCES','EPERM','ENOENT'].includes(error.code)?0:2)}`;
-  const operatorWriteCheck = `const fs=require('node:fs');try{fs.writeFileSync(${JSON.stringify(paths.operatorOwned)},'changed');process.exit(1)}catch(error){process.exit(['EACCES','EPERM','ENOENT'].includes(error.code)?0:2)}`;
+  const filesystemBoundaryCheck = `const fs=require('node:fs');try{fs.readFileSync(${JSON.stringify(join(paths.inputs, "gold.patch"))});process.exit(1)}catch(error){process.exit(['EACCES','EPERM','ENOENT','EROFS'].includes(error.code)?0:2)}`;
+  const operatorWriteCheck = `const fs=require('node:fs');try{fs.writeFileSync(${JSON.stringify(paths.operatorOwned)},'changed');process.exit(1)}catch(error){process.exit(['EACCES','EPERM','ENOENT','EROFS'].includes(error.code)?0:2)}`;
   const networkBoundaryCheck = "const net=require('node:net');const denied=new Set(['EACCES','EPERM','ENETUNREACH','EHOSTUNREACH','EAFNOSUPPORT']);let settled=false;function finish(ok){if(settled)return;settled=true;process.exit(ok?0:2)}try{const socket=net.connect({host:'192.0.2.1',port:9});socket.once('error',error=>finish(denied.has(error.code)));socket.once('connect',()=>finish(false));setTimeout(()=>{socket.destroy();finish(false)},1000)}catch(error){finish(denied.has(error.code))}";
   const mutationCheck = "require('node:fs').writeFileSync('verifier-marker','isolated');process.exit(0)";
   const noMutationLeakCheck = "process.exit(require('node:fs').existsSync('verifier-marker')?1:0)";

--- a/.agents/scripts/tests/model-replay-benchmark-fixture.mjs
+++ b/.agents/scripts/tests/model-replay-benchmark-fixture.mjs
@@ -165,6 +165,7 @@ function fixturePaths(sandbox) {
     testHome: join(sandbox, "home"),
     fakeOpenCode: join(sandbox, "fake-opencode.sh"),
     fakeEgressBackend: join(sandbox, "fake-egress-backend.sh"),
+    operatorOwned: join(sandbox, "operator-owned.txt"),
   };
 }
 
@@ -199,7 +200,9 @@ function writeCaseInputs(paths) {
   const fixedCheck = "const fs=require('node:fs');process.exit(fs.readFileSync('value.txt','utf8').trim()==='fixed'?0:1)";
   const stableCheck = "const fs=require('node:fs');process.exit(fs.readFileSync('stable.txt','utf8').trim()==='stable'?0:1)";
   const cleanEnvironmentCheck = "process.exit(process.env.AIDEVOPS_TEST_SECRET_SENTINEL?1:0)";
-  const filesystemBoundaryCheck = `const fs=require('node:fs');try{fs.readFileSync(${JSON.stringify(join(paths.inputs, "gold.patch"))});process.exit(1)}catch(error){process.exit(['EACCES','EPERM'].includes(error.code)?0:2)}`;
+  const filesystemBoundaryCheck = `const fs=require('node:fs');try{fs.readFileSync(${JSON.stringify(join(paths.inputs, "gold.patch"))});process.exit(1)}catch(error){process.exit(['EACCES','EPERM','ENOENT'].includes(error.code)?0:2)}`;
+  const operatorWriteCheck = `const fs=require('node:fs');try{fs.writeFileSync(${JSON.stringify(paths.operatorOwned)},'changed');process.exit(1)}catch(error){process.exit(['EACCES','EPERM','ENOENT'].includes(error.code)?0:2)}`;
+  const networkBoundaryCheck = "const net=require('node:net');const denied=new Set(['EACCES','EPERM','ENETUNREACH','EHOSTUNREACH','EAFNOSUPPORT']);let settled=false;function finish(ok){if(settled)return;settled=true;process.exit(ok?0:2)}try{const socket=net.connect({host:'192.0.2.1',port:9});socket.once('error',error=>finish(denied.has(error.code)));socket.once('connect',()=>finish(false));setTimeout(()=>{socket.destroy();finish(false)},1000)}catch(error){finish(denied.has(error.code))}";
   const mutationCheck = "require('node:fs').writeFileSync('verifier-marker','isolated');process.exit(0)";
   const noMutationLeakCheck = "process.exit(require('node:fs').existsSync('verifier-marker')?1:0)";
   writeJson(join(paths.inputs, "checks.json"), {
@@ -214,6 +217,8 @@ function writeCaseInputs(paths) {
       { name: "stable-value", argv: [process.execPath, "--input-type=commonjs", "-e", stableCheck], timeout_seconds: 10 },
       { name: "sanitized-environment", argv: [process.execPath, "--input-type=commonjs", "-e", cleanEnvironmentCheck], timeout_seconds: 10 },
       { name: "filesystem-boundary", argv: [process.execPath, "--input-type=commonjs", "-e", filesystemBoundaryCheck], timeout_seconds: 10 },
+      { name: "operator-write-boundary", argv: [process.execPath, "--input-type=commonjs", "-e", operatorWriteCheck], timeout_seconds: 10 },
+      { name: "network-boundary", argv: [process.execPath, "--input-type=commonjs", "-e", networkBoundaryCheck], timeout_seconds: 10 },
     ],
   });
   return stableCheck;
@@ -251,6 +256,7 @@ function writeRuntimeFixtures(paths) {
   chmodSync(paths.fakeEgressBackend, 0o700);
   writeFileSync(paths.fakeRuntime, FAKE_RUNTIME, { mode: 0o700 });
   chmodSync(paths.fakeRuntime, 0o700);
+  writeFileSync(paths.operatorOwned, "operator-owned\n", { mode: 0o600 });
 }
 
 function fixtureEnvironment(paths) {

--- a/.agents/scripts/tests/test-model-replay-benchmark.mjs
+++ b/.agents/scripts/tests/test-model-replay-benchmark.mjs
@@ -48,10 +48,28 @@ try {
     runtimeState,
     sharedOauthPool,
     sensitiveTemp,
+    operatorOwned,
     baseSHA,
     stableCheck,
     environment,
   } = fixture;
+  const core = await import(pathToFileURL(join(scriptDirectory, "model-replay-core.mjs")).href);
+
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  try {
+    Object.defineProperty(process, "platform", { ...platformDescriptor, value: "unsupported" });
+    assert.throws(
+      () => core.qualifyCase({
+        corpusDir: join(sandbox, "must-not-read-corpus"),
+        caseID: "must-not-run-checks",
+        catalogPath: join(sandbox, "must-not-read-catalog.json"),
+        workRoot: join(sandbox, "must-not-create-workspaces"),
+      }),
+      /No enforcing verifier filesystem sandbox is available on unsupported/u,
+    );
+  } finally {
+    Object.defineProperty(process, "platform", platformDescriptor);
+  }
 
   expectFailure(
     environment,
@@ -103,6 +121,7 @@ try {
   );
   assert.equal(qualification[0].status, "qualified");
   assert.equal(qualification[0].runs.length, 2);
+  assert.equal(readFileSync(operatorOwned, "utf8"), "operator-owned\n");
   assert.match(qualification[0].qualification_sha256, /^[a-f0-9]{64}$/u);
   const qualificationPath = join(corpus, "cases", "case-one", "qualification.json");
   const originalQualification = readFileSync(qualificationPath, "utf8");
@@ -123,7 +142,6 @@ try {
     "qualify", "--corpus", corpus, "--catalog", catalog, "--repetitions", "1",
   );
 
-  const core = await import(pathToFileURL(join(scriptDirectory, "model-replay-core.mjs")).href);
   const framework = await import(
     pathToFileURL(join(scriptDirectory, "model-replay-framework.mjs")).href
   );

--- a/.agents/workflows/optimize-tiers.md
+++ b/.agents/workflows/optimize-tiers.md
@@ -200,9 +200,14 @@ but reports quarantine them from automatic routing or release recommendations.
 It never weakens public triage, worker, or other runtime roles.
 Each deterministic check receives a disposable patch snapshot in a separate
 filesystem-deny sandbox, so check-time writes cannot affect later checks. The
-current enforcing backend is macOS Seatbelt; qualification fails closed on hosts
-without `/usr/bin/sandbox-exec` rather than exposing hidden corpus or operator
-state.
+enforcing backends are macOS Seatbelt and Linux Bubblewrap. Linux requires an
+executable `/usr/bin/bwrap` or `/bin/bwrap`; the sandbox uses a new mount,
+process, user, and network namespace, grants write access only to the disposable
+snapshot and its isolated HOME/TMP/XDG tree, and mounts only required system
+runtime paths read-only. Qualification and grading fail before running checks
+when the platform backend is missing or cannot establish those namespaces,
+rather than exposing hidden corpus, operator state, results, runtime data, or
+sibling workspaces.
 
 Use stages in order:
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -33,7 +33,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # Ubuntu 24.04 hosted runners deny Bubblewrap's network-namespace
+        # setup through host AppArmor policy. Exercise the enforcing backend on
+        # 22.04; unsupported host policy still fails closed in production.
+        os: [ubuntu-22.04, macos-latest]
       fail-fast: false
 
     steps:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -33,10 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Ubuntu 24.04 hosted runners deny Bubblewrap's network-namespace
-        # setup through host AppArmor policy. Exercise the enforcing backend on
-        # 22.04; unsupported host policy still fails closed in production.
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
 
     steps:
@@ -107,13 +104,27 @@ jobs:
         bash .agents/scripts/platform-detect.sh
         echo "Platform detection: OK"
 
-    - name: Install Bubblewrap (Linux)
-      if: runner.os == 'Linux'
+    - name: Model replay verifier boundary (macOS)
+      if: runner.os == 'macOS'
+      run: node .agents/scripts/tests/test-model-replay-benchmark.mjs
+
+  model-replay-linux:
+    # Ubuntu 24.04 hosted runners deny Bubblewrap's network-namespace setup
+    # through host AppArmor policy. Exercise the enforcing backend on 22.04;
+    # unsupported host policy still fails closed in production.
+    name: Model replay verifier boundary (ubuntu-22.04)
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+    - name: Install Bubblewrap
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y bubblewrap
 
-    - name: Model replay verifier boundary (${{ matrix.os }})
+    - name: Run model replay boundary suite
       run: node .agents/scripts/tests/test-model-replay-benchmark.mjs
 
   # Bash 3.2 compatibility: catches "\n"/"\t" in double-quoted strings and other

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -104,8 +104,13 @@ jobs:
         bash .agents/scripts/platform-detect.sh
         echo "Platform detection: OK"
 
-    - name: Model replay verifier boundary (macOS)
-      if: runner.os == 'macOS'
+    - name: Install Bubblewrap (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y bubblewrap
+
+    - name: Model replay verifier boundary (${{ matrix.os }})
       run: node .agents/scripts/tests/test-model-replay-benchmark.mjs
 
   # Bash 3.2 compatibility: catches "\n"/"\t" in double-quoted strings and other


### PR DESCRIPTION
## Summary

Add a fail-closed Bubblewrap verifier backend on Linux with disposable writable
check snapshots, isolated HOME/TMP/XDG state, curated read-only runtime mounts,
and an unshared network namespace. Retain Seatbelt on macOS and document both
enforcing backends.

## Files Changed

.agents/scripts/model-replay-core.mjs, .agents/scripts/model-replay-process.mjs,
.agents/scripts/model-replay-qualification.mjs,
.agents/scripts/model-replay-workspace.mjs,
.agents/scripts/tests/model-replay-benchmark-fixture.mjs,
.agents/scripts/tests/test-model-replay-benchmark.mjs,
.agents/workflows/optimize-tiers.md, .github/workflows/code-quality.yml

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified on exact head `2f265c85070ca86c82d47bcd52ef54f071e60771`
- macOS Seatbelt benchmark suite passed locally and in CI.
- Ubuntu 22.04 Bubblewrap benchmark suite passed in CI, including hidden-input
  denial, operator-write denial, network denial, per-check isolation, and
  unavailable-backend fail-closed behavior.
- Local framework linters, Node syntax checks, and required remote checks passed.

## Decisions

- Accept Bubblewrap only from trusted system paths and fail closed when the
  binary or required namespace support is unavailable.
- Keep the namespace root read-only while preserving writable disposable
  workspace and isolated HOME/TMP/XDG submounts.
- Run Linux integration on Ubuntu 22.04 because the Ubuntu 24.04 hosted-runner
  AppArmor policy blocks unprivileged network-namespace setup; production hosts
  with the same restriction remain safely unavailable rather than unconfined.

Resolves #30571

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.289 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol spent 20m and 123,497 tokens on this with the user in an interactive session.
