### PR TITLE
fix: preserve managed OpenCode web sessions

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -56,6 +56,7 @@ import {
 import { loadModelRouting } from "./model-routing.mjs";
 import { createSessionContinuationGuard } from "./session-continuation-guard.mjs";
 import { createSessionRecoveryMarkerHandler } from "./session-recovery-marker.mjs";
+import { createSessionStallRecovery } from "./session-stall-recovery.mjs";
 import { createPermissionBroker } from "./permission-broker.mjs";
 import { createSubagentCancellationReceipt } from "./subagent-cancellation-receipt.mjs";
 import { createRoutingFeedbackHandler } from "./routing-feedback-handler.mjs";
@@ -528,6 +529,12 @@ export async function AidevopsPlugin({ directory, client }) {
     dataDir: process.env.XDG_DATA_HOME || "",
     workDir: process.env.AIDEVOPS_WORK_DIR || join(WORKSPACE_DIR, "work"),
   });
+  const sessionStallRecovery = createSessionStallRecovery({
+    client,
+    directory,
+    workDir: process.env.AIDEVOPS_WORK_DIR || join(WORKSPACE_DIR, "work"),
+    log: qualityLog,
+  });
 
   const debugEventError = (label, err) => {
     if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
@@ -579,12 +586,14 @@ export async function AidevopsPlugin({ directory, client }) {
     // Quality hooks
     "tool.execute.before": async (input, output) => {
       enforceManagedMcpArtifactPath(input, output, mcpRuntime.workspaces);
+      sessionStallRecovery.beforeTool(input, output);
       permissionBroker.recordToolCall(input, output);
       cancellationReceipt.beforeTool(input, output);
       subagentEffortHooks.beforeTool(input, output);
       return toolExecuteBefore(input, output);
     },
     "tool.execute.after": async (input, output) => {
+      sessionStallRecovery.afterTool(input, output);
       await cancellationReceipt.afterTool(input, output);
       await subagentEffortHooks.afterTool(input, output);
       return toolExecuteAfter(input, output);
@@ -614,6 +623,7 @@ export async function AidevopsPlugin({ directory, client }) {
         sessionTitleSuffixHandler(input).catch((err) => debugEventError("title suffix handler", err)),
         sessionTitleFallbackHandler(input).catch((err) => debugEventError("title fallback handler", err)),
         sessionRecoveryMarkerHandler(input).catch((err) => debugEventError("session recovery marker", err)),
+        Promise.resolve(sessionStallRecovery.handleEvent(input)),
         greetingHandler(input).catch((err) => debugEventError("greeting handler", err)),
       ]);
     },

--- a/.agents/plugins/opencode-aidevops/session-stall-recovery-events.mjs
+++ b/.agents/plugins/opencode-aidevops/session-stall-recovery-events.mjs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const ACTIVE_TOOL_STATES = new Set(["pending", "running"]);
+const FINISHED_TOOL_STATES = new Set([
+  "completed",
+  "error",
+  "failed",
+  "aborted",
+  "cancelled",
+  "canceled",
+]);
+
+function sessionIDFromEvent(event) {
+  const candidates = [
+    event?.properties?.sessionID,
+    event?.properties?.info?.id,
+    event?.properties?.info?.sessionID,
+    event?.properties?.part?.sessionID,
+  ];
+  return String(candidates.find(Boolean) || "");
+}
+
+function markIntervention(state) {
+  if (state.recoveryPending) state.recoveryIntervened = true;
+}
+
+class SessionStallEventHandler {
+  constructor(store, clock) {
+    this.store = store;
+    this.clock = clock;
+    this.handlers = new Map([
+      ["session.created", this.updateSession.bind(this)],
+      ["session.updated", this.updateSession.bind(this)],
+      ["session.deleted", this.deleteSession.bind(this)],
+      ["permission.asked", this.askPermission.bind(this)],
+      ["permission.updated", this.askPermission.bind(this)],
+      ["permission.replied", this.replyPermission.bind(this)],
+      ["session.status", this.updateStatus.bind(this)],
+      ["session.idle", this.markIdle.bind(this)],
+      ["message.part.updated", this.updatePart.bind(this)],
+      ["message.part.delta", this.updatePart.bind(this)],
+      ["message.updated", this.updateMessage.bind(this)],
+      ["session.error", this.recordError.bind(this)],
+    ]);
+  }
+
+  handle({ event } = {}) {
+    const sessionID = sessionIDFromEvent(event);
+    const handler = this.handlers.get(event?.type);
+    if (sessionID && handler) {
+      handler(event, this.store.stateFor(sessionID), sessionID);
+    }
+  }
+
+  updateSession(event, state) {
+    const info = event.properties?.info || {};
+    if (!state.parentKnown || Object.hasOwn(info, "parentID")) {
+      state.parentKnown = true;
+      state.parentID = String(info.parentID || "");
+    }
+    state.lastActivityAt = this.clock();
+  }
+
+  deleteSession(_event, _state, sessionID) {
+    this.store.sessions.delete(sessionID);
+  }
+
+  askPermission(event, state) {
+    const requestID = String(event.properties?.id || "");
+    if (requestID) state.pendingPermissionIDs.add(requestID);
+    markIntervention(state);
+    state.lastActivityAt = this.clock();
+  }
+
+  replyPermission(event, state) {
+    const requestID = String(event.properties?.requestID || event.properties?.permissionID || "");
+    if (requestID) state.pendingPermissionIDs.delete(requestID);
+    state.lastActivityAt = this.clock();
+  }
+
+  updateStatus(event, state) {
+    const status = String(event.properties?.status?.type || "").toLowerCase();
+    if (status) {
+      const startingTurn = ["busy", "retry"].includes(status)
+        && !["busy", "retry"].includes(state.status);
+      if (startingTurn) {
+        markIntervention(state);
+        state.busySince = this.clock();
+        state.lastActivityAt = this.clock();
+        state.turnUnsafe = false;
+      }
+      state.status = status;
+      if (status === "idle") state.activeTool = null;
+    }
+  }
+
+  markIdle(_event, state) {
+    state.status = "idle";
+    state.activeTool = null;
+  }
+
+  updatePart(event, state, sessionID) {
+    const part = event.properties?.part;
+    state.lastActivityAt = this.clock();
+    if (part?.type !== "tool") {
+      markIntervention(state);
+    } else {
+      this.updateToolPart(part, state, sessionID);
+    }
+  }
+
+  updateToolPart(part, state, sessionID) {
+    const status = String(part?.state?.status || "").toLowerCase();
+    if (ACTIVE_TOOL_STATES.has(status)) {
+      markIntervention(state);
+      this.store.recordTool({ sessionID, callID: part.callID, tool: part.tool }, part.state?.input || {});
+    } else if (FINISHED_TOOL_STATES.has(status)) {
+      const callID = String(part.callID || "");
+      if (!state.activeTool?.callID || state.activeTool.callID === callID) {
+        state.activeTool = null;
+      }
+    }
+  }
+
+  updateMessage(event, state) {
+    state.lastActivityAt = this.clock();
+    if (event.properties?.info?.role === "user") markIntervention(state);
+  }
+
+  recordError(_event, state) {
+    state.lastActivityAt = this.clock();
+  }
+}
+
+export { SessionStallEventHandler };

--- a/.agents/plugins/opencode-aidevops/session-stall-recovery-ledger.mjs
+++ b/.agents/plugins/opencode-aidevops/session-stall-recovery-ledger.mjs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { createHash } from "node:crypto";
+import { chmod, lstat, mkdir, open, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const DEFAULT_LOCK_STALE_MS = 60_000;
+
+function processIsLive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+async function createLock(lockPath) {
+  const lock = await open(lockPath, "wx", 0o600);
+  try {
+    await lock.writeFile(`${process.pid}\n`);
+    return lock;
+  } catch (error) {
+    await lock.close();
+    await rm(lockPath, { force: true });
+    throw error;
+  }
+}
+
+async function staleLockCanBeReclaimed(lockPath, clock, lockStaleMs) {
+  try {
+    const existing = await lstat(lockPath);
+    const owned = existing.isFile()
+      && !existing.isSymbolicLink()
+      && existing.uid === process.getuid()
+      && (existing.mode & 0o077) === 0;
+    if (!owned || clock() - existing.mtimeMs < lockStaleMs) return false;
+    const ownerPid = Number.parseInt(await readFile(lockPath, "utf8"), 10);
+    return !processIsLive(ownerPid);
+  } catch {
+    return false;
+  }
+}
+
+async function acquireLock(lockPath, clock, lockStaleMs) {
+  try {
+    return await createLock(lockPath);
+  } catch (error) {
+    if (error?.code !== "EEXIST") return null;
+  }
+
+  if (!await staleLockCanBeReclaimed(lockPath, clock, lockStaleMs)) return null;
+  try {
+    await rm(lockPath);
+    return await createLock(lockPath);
+  } catch {
+    return null;
+  }
+}
+
+async function readAttemptedAt(markerPath) {
+  try {
+    const previous = JSON.parse(await readFile(markerPath, "utf8"));
+    return Number(previous?.attempted_at || 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function writeMarker(markerPath, fingerprint, clock) {
+  const attemptedAt = clock();
+  const temporaryPath = `${markerPath}.${process.pid}.${attemptedAt}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify({ fingerprint, attempted_at: attemptedAt })}\n`, {
+    mode: 0o600,
+    flag: "wx",
+  });
+  await rename(temporaryPath, markerPath);
+  await chmod(markerPath, 0o600);
+}
+
+function recoveryFingerprint(sessionID, state) {
+  return createHash("sha256")
+    .update(`${sessionID}:${state.busySince}:${state.lastActivityAt}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+class PersistentRecoveryLedger {
+  constructor(root, clock, lockStaleMs = DEFAULT_LOCK_STALE_MS) {
+    this.root = root;
+    this.clock = clock;
+    this.lockStaleMs = lockStaleMs;
+  }
+
+  pathFor(sessionID) {
+    const name = createHash("sha256").update(sessionID).digest("hex").slice(0, 24);
+    return join(this.root, `${name}.json`);
+  }
+
+  async claim(sessionID, fingerprint, cooldownMs) {
+    await mkdir(this.root, { recursive: true, mode: 0o700 });
+    await chmod(this.root, 0o700);
+    const markerPath = this.pathFor(sessionID);
+    const lockPath = `${markerPath}.lock`;
+    const lock = await acquireLock(lockPath, this.clock, this.lockStaleMs);
+    if (!lock) return false;
+
+    try {
+      const attemptedAt = await readAttemptedAt(markerPath);
+      if (attemptedAt > 0 && this.clock() - attemptedAt < cooldownMs) return false;
+      await writeMarker(markerPath, fingerprint, this.clock);
+      return true;
+    } finally {
+      await lock.close();
+      await rm(lockPath, { force: true });
+    }
+  }
+}
+
+export { PersistentRecoveryLedger, recoveryFingerprint };

--- a/.agents/plugins/opencode-aidevops/session-stall-recovery-runner.mjs
+++ b/.agents/plugins/opencode-aidevops/session-stall-recovery-runner.mjs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { recoveryFingerprint } from "./session-stall-recovery-ledger.mjs";
+
+const ACTIVE_SESSION_STATES = new Set(["busy", "retry"]);
+
+function unwrap(response) {
+  return response?.data ?? response;
+}
+
+function responseError(response) {
+  return response?.error || response?.data?.error || null;
+}
+
+class SessionRecoveryRunner {
+  constructor({
+    client,
+    directory,
+    store,
+    ledger,
+    clock,
+    staleMs,
+    cooldownMs,
+    idleWaitMs,
+    sleep,
+    isEnabled,
+    log,
+  }) {
+    this.client = client;
+    this.directory = directory;
+    this.store = store;
+    this.ledger = ledger;
+    this.clock = clock;
+    this.staleMs = staleMs;
+    this.cooldownMs = cooldownMs;
+    this.idleWaitMs = idleWaitMs;
+    this.sleep = sleep;
+    this.isEnabled = isEnabled;
+    this.log = log;
+    this.checks = new Set();
+  }
+
+  async liveStatus(sessionID) {
+    if (typeof this.client?.session?.status !== "function") return "";
+    for (const args of [{ query: { directory: this.directory } }, {}]) {
+      try {
+        const response = await this.client.session.status(args);
+        const statuses = unwrap(response);
+        const status = statuses?.[sessionID];
+        if (typeof status?.type === "string") return status.type.toLowerCase();
+      } catch {
+        // Try the next SDK argument shape.
+      }
+    }
+    return "";
+  }
+
+  recoveryAllowed(sessionID, state) {
+    if (!state.parentKnown || state.parentID) return false;
+    if (!ACTIVE_SESSION_STATES.has(state.status)) return false;
+    if (state.pendingPermissionIDs.size > 0) return false;
+    if (state.turnUnsafe || state.activeTool?.safe === false) return false;
+    return this.clock() - state.lastActivityAt >= this.staleMs && !this.checks.has(sessionID);
+  }
+
+  stateStillSafe(state, checkActiveTool = true) {
+    if (state.recoveryIntervened || state.pendingPermissionIDs.size > 0) return false;
+    if (state.turnUnsafe) return false;
+    if (checkActiveTool && state.activeTool?.safe === false) return false;
+    return true;
+  }
+
+  async waitForIdle(sessionID) {
+    const deadline = this.clock() + this.idleWaitMs;
+    while (this.clock() < deadline) {
+      const status = await this.liveStatus(sessionID);
+      if (status === "idle") return true;
+      await this.sleep(Math.min(250, Math.max(1, deadline - this.clock())));
+    }
+    return false;
+  }
+
+  async abortAndWait(sessionID) {
+    if (typeof this.client?.session?.abort !== "function") return false;
+    const aborted = await this.client.session.abort({ path: { id: sessionID }, body: {} });
+    if (responseError(aborted) || unwrap(aborted) !== true) return false;
+    return this.waitForIdle(sessionID);
+  }
+
+  async promptResume(sessionID, state, fingerprint) {
+    if (!this.stateStillSafe(state, false)) return false;
+    if (typeof this.client?.session?.prompt !== "function") return false;
+    const text = [
+      "AIDEVOPS SAFE STALL RECOVERY.",
+      "The previous assistant turn stopped producing activity and was aborted.",
+      "Re-read the recent conversation and inspect current state before continuing the unfinished safe step.",
+      "Do not repeat any write, deployment, external request, or other side effect. If safe continuation is uncertain, stop and ask the user.",
+      `Recovery marker: ${fingerprint}`,
+    ].join("\n");
+    const prompted = await this.client.session.prompt({
+      path: { id: sessionID },
+      body: { parts: [{ type: "text", text, synthetic: true }] },
+    });
+    if (responseError(prompted)) return false;
+    this.log("INFO", `[session-stall-recovery] resumed session marker=${fingerprint}`);
+    return true;
+  }
+
+  async claimRecovery(sessionID, state) {
+    const status = await this.liveStatus(sessionID);
+    if (!ACTIVE_SESSION_STATES.has(status)) return "";
+    if (!this.stateStillSafe(state)) return "";
+    const fingerprint = recoveryFingerprint(sessionID, state);
+    if (!await this.ledger.claim(sessionID, fingerprint, this.cooldownMs)) return "";
+    if (!this.stateStillSafe(state)) return "";
+    return fingerprint;
+  }
+
+  async performRecovery(sessionID, state) {
+    const fingerprint = await this.claimRecovery(sessionID, state);
+    if (!fingerprint) return false;
+    if (!await this.abortAndWait(sessionID)) return false;
+    return this.promptResume(sessionID, state, fingerprint);
+  }
+
+  async recover(sessionID, state) {
+    if (!this.recoveryAllowed(sessionID, state)) return false;
+    this.checks.add(sessionID);
+    state.recoveryIntervened = false;
+    state.recoveryPending = true;
+    let recovered = false;
+    try {
+      recovered = await this.performRecovery(sessionID, state);
+    } catch (error) {
+      this.log("WARN", `[session-stall-recovery] recovery failed: ${error?.name || "Error"}`);
+    } finally {
+      state.recoveryPending = false;
+      this.checks.delete(sessionID);
+    }
+    return recovered;
+  }
+
+  async checkNow() {
+    if (!this.isEnabled()) return [];
+    const recovered = [];
+    for (const [sessionID, state] of this.store.sessions) {
+      if (await this.recover(sessionID, state)) recovered.push(sessionID);
+    }
+    return recovered;
+  }
+}
+
+export { SessionRecoveryRunner };

--- a/.agents/plugins/opencode-aidevops/session-stall-recovery-scheduler.mjs
+++ b/.agents/plugins/opencode-aidevops/session-stall-recovery-scheduler.mjs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const RECOVERY_REGISTRY = Symbol.for("aidevops.session-stall-recovery.registry");
+
+class SessionRecoveryScheduler {
+  constructor({ client, directory, fallbackOwner, checkNow, isEnabled, checkMs, log }) {
+    const registry = globalThis[RECOVERY_REGISTRY] || new WeakMap();
+    globalThis[RECOVERY_REGISTRY] = registry;
+    const registryOwner = client && typeof client === "object" ? client : fallbackOwner;
+    this.clientRegistry = registry.get(registryOwner) || new Map();
+    registry.set(registryOwner, this.clientRegistry);
+    this.registryKey = String(directory || "unknown-directory");
+    this.checkNow = checkNow;
+    this.isEnabled = isEnabled;
+    this.checkMs = checkMs;
+    this.log = log;
+    this.timer = null;
+    this.stop = this.stop.bind(this);
+  }
+
+  start() {
+    const previousStop = this.clientRegistry.get(this.registryKey);
+    if (previousStop) previousStop();
+    if (this.isEnabled()) {
+      this.timer = setInterval(() => {
+        this.checkNow().catch((error) => {
+          this.log("WARN", `[session-stall-recovery] check failed: ${error?.name || "Error"}`);
+        });
+      }, this.checkMs);
+      this.timer.unref?.();
+      this.clientRegistry.set(this.registryKey, this.stop);
+    }
+  }
+
+  stop() {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+    if (this.clientRegistry.get(this.registryKey) === this.stop) {
+      this.clientRegistry.delete(this.registryKey);
+    }
+  }
+}
+
+export { SessionRecoveryScheduler };

--- a/.agents/plugins/opencode-aidevops/session-stall-recovery-state.mjs
+++ b/.agents/plugins/opencode-aidevops/session-stall-recovery-state.mjs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const MAX_SESSION_STATES = 64;
+const SAFE_TOOLS = new Set([
+  "glob",
+  "grep",
+  "read",
+  "skill",
+  "todowrite",
+  "webfetch",
+  "functions.glob",
+  "functions.grep",
+  "functions.read",
+  "functions.skill",
+  "functions.todowrite",
+  "functions.webfetch",
+]);
+
+function safeToolCall(tool, args = {}) {
+  const name = String(tool || "").toLowerCase();
+  if (SAFE_TOOLS.has(name)) return true;
+  if (name === "aidevops_memory" || name === "functions.aidevops_memory") {
+    return String(args?.action || "recall").toLowerCase() === "recall";
+  }
+  return false;
+}
+
+function initialState(clock) {
+  return {
+    activeTool: null,
+    busySince: 0,
+    lastActivityAt: clock(),
+    parentKnown: false,
+    parentID: "",
+    pendingPermissionIDs: new Set(),
+    recoveryIntervened: false,
+    recoveryPending: false,
+    status: "",
+    turnUnsafe: false,
+  };
+}
+
+class SessionStallStateStore {
+  constructor(clock) {
+    this.clock = clock;
+    this.sessions = new Map();
+  }
+
+  stateFor(sessionID) {
+    if (!this.sessions.has(sessionID)) {
+      this.sessions.set(sessionID, initialState(this.clock));
+      while (this.sessions.size > MAX_SESSION_STATES) {
+        this.sessions.delete(this.sessions.keys().next().value);
+      }
+    }
+    return this.sessions.get(sessionID);
+  }
+
+  recordTool(input, args) {
+    const sessionID = String(input?.sessionID || "");
+    if (sessionID) {
+      const state = this.stateFor(sessionID);
+      if (state.recoveryPending) state.recoveryIntervened = true;
+      const safe = safeToolCall(input?.tool, args);
+      state.activeTool = { callID: String(input?.callID || ""), safe };
+      state.lastActivityAt = this.clock();
+      if (!safe) state.turnUnsafe = true;
+    }
+  }
+
+  beforeTool(input, output) {
+    this.recordTool(input, output?.args || input?.args || {});
+  }
+
+  afterTool(input) {
+    const sessionID = String(input?.sessionID || "");
+    if (sessionID) {
+      const state = this.stateFor(sessionID);
+      const callID = String(input?.callID || "");
+      if (!state.activeTool?.callID || state.activeTool.callID === callID) {
+        state.activeTool = null;
+      }
+      state.lastActivityAt = this.clock();
+    }
+  }
+}
+
+export { safeToolCall, SessionStallStateStore };

--- a/.agents/plugins/opencode-aidevops/session-stall-recovery.mjs
+++ b/.agents/plugins/opencode-aidevops/session-stall-recovery.mjs
@@ -1,172 +1,18 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
-import { createHash } from "node:crypto";
-import { chmod, lstat, mkdir, open, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+
+import { SessionStallEventHandler } from "./session-stall-recovery-events.mjs";
+import { PersistentRecoveryLedger } from "./session-stall-recovery-ledger.mjs";
+import { SessionRecoveryRunner } from "./session-stall-recovery-runner.mjs";
+import { SessionRecoveryScheduler } from "./session-stall-recovery-scheduler.mjs";
+import { safeToolCall, SessionStallStateStore } from "./session-stall-recovery-state.mjs";
 
 const DEFAULT_CHECK_MS = 60_000;
 const DEFAULT_STALE_MS = 10 * 60_000;
 const DEFAULT_COOLDOWN_MS = 30 * 60_000;
 const DEFAULT_IDLE_WAIT_MS = 5_000;
-const DEFAULT_LOCK_STALE_MS = 60_000;
-const MAX_SESSION_STATES = 64;
-const RECOVERY_REGISTRY = Symbol.for("aidevops.session-stall-recovery.registry");
-const SAFE_TOOLS = new Set([
-  "glob",
-  "grep",
-  "read",
-  "skill",
-  "todowrite",
-  "webfetch",
-  "functions.glob",
-  "functions.grep",
-  "functions.read",
-  "functions.skill",
-  "functions.todowrite",
-  "functions.webfetch",
-]);
-
-function unwrap(response) {
-  return response?.data ?? response;
-}
-
-function responseError(response) {
-  return response?.error || response?.data?.error || null;
-}
-
-function sessionIDFromEvent(event) {
-  return String(
-    event?.properties?.sessionID
-      || event?.properties?.info?.id
-      || event?.properties?.info?.sessionID
-      || event?.properties?.part?.sessionID
-      || "",
-  );
-}
-
-function safeToolCall(tool, args = {}) {
-  const name = String(tool || "").toLowerCase();
-  if (SAFE_TOOLS.has(name)) return true;
-  if (name === "aidevops_memory" || name === "functions.aidevops_memory") {
-    return String(args?.action || "recall").toLowerCase() === "recall";
-  }
-  return false;
-}
-
-function toolPartState(part) {
-  return String(part?.state?.status || "").toLowerCase();
-}
-
-function capMap(map) {
-  while (map.size > MAX_SESSION_STATES) map.delete(map.keys().next().value);
-}
-
-function processIsLive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error?.code === "EPERM";
-  }
-}
-
-async function createLock(lockPath) {
-  const lock = await open(lockPath, "wx", 0o600);
-  try {
-    await lock.writeFile(`${process.pid}\n`);
-    return lock;
-  } catch (error) {
-    await lock.close();
-    await rm(lockPath, { force: true });
-    throw error;
-  }
-}
-
-function recoveryFingerprint(sessionID, state) {
-  return createHash("sha256")
-    .update(`${sessionID}:${state.busySince}:${state.lastActivityAt}`)
-    .digest("hex")
-    .slice(0, 16);
-}
-
-class PersistentRecoveryLedger {
-  constructor(root, clock, lockStaleMs = DEFAULT_LOCK_STALE_MS) {
-    this.root = root;
-    this.clock = clock;
-    this.lockStaleMs = lockStaleMs;
-  }
-
-  pathFor(sessionID) {
-    const name = createHash("sha256").update(sessionID).digest("hex").slice(0, 24);
-    return join(this.root, `${name}.json`);
-  }
-
-  async claim(sessionID, fingerprint, cooldownMs) {
-    await mkdir(this.root, { recursive: true, mode: 0o700 });
-    await chmod(this.root, 0o700);
-    const markerPath = this.pathFor(sessionID);
-    const lockPath = `${markerPath}.lock`;
-    let lock;
-    try {
-      lock = await createLock(lockPath);
-    } catch (error) {
-      if (error?.code !== "EEXIST") return false;
-      try {
-        const existing = await lstat(lockPath);
-        const owned = existing.isFile()
-          && !existing.isSymbolicLink()
-          && existing.uid === process.getuid()
-          && (existing.mode & 0o077) === 0;
-        if (!owned || this.clock() - existing.mtimeMs < this.lockStaleMs) return false;
-        const ownerPid = Number.parseInt(await readFile(lockPath, "utf8"), 10);
-        if (processIsLive(ownerPid)) return false;
-        await rm(lockPath);
-        lock = await createLock(lockPath);
-      } catch {
-        return false;
-      }
-    }
-
-    try {
-      let previous = null;
-      try {
-        previous = JSON.parse(await readFile(markerPath, "utf8"));
-      } catch {
-        previous = null;
-      }
-      const attemptedAt = Number(previous?.attempted_at || 0);
-      if (attemptedAt > 0 && this.clock() - attemptedAt < cooldownMs) return false;
-
-      const temporaryPath = `${markerPath}.${process.pid}.${this.clock()}.tmp`;
-      await writeFile(temporaryPath, `${JSON.stringify({ fingerprint, attempted_at: this.clock() })}\n`, {
-        mode: 0o600,
-        flag: "wx",
-      });
-      await rename(temporaryPath, markerPath);
-      await chmod(markerPath, 0o600);
-      return true;
-    } finally {
-      await lock.close();
-      await rm(lockPath, { force: true });
-    }
-  }
-}
-
-async function liveStatus(client, sessionID, directory) {
-  if (typeof client?.session?.status !== "function") return "";
-  for (const args of [{ query: { directory } }, {}]) {
-    try {
-      const statuses = unwrap(await client.session.status(args));
-      const status = statuses?.[sessionID];
-      if (typeof status?.type === "string") return status.type.toLowerCase();
-    } catch {
-      // Try the next SDK argument shape.
-    }
-  }
-  return "";
-}
 
 export function createSessionStallRecovery({
   client,
@@ -182,222 +28,38 @@ export function createSessionStallRecovery({
   ledger = new PersistentRecoveryLedger(join(workDir, "opencode-stall-recovery"), clock),
   log = () => {},
 } = {}) {
-  const sessions = new Map();
-  const checks = new Set();
-
-  function stateFor(sessionID) {
-    if (!sessions.has(sessionID)) {
-      sessions.set(sessionID, {
-        activeTool: null,
-        busySince: 0,
-        lastActivityAt: clock(),
-        parentKnown: false,
-        parentID: "",
-        pendingPermissionIDs: new Set(),
-        recoveryIntervened: false,
-        recoveryPending: false,
-        status: "",
-        turnUnsafe: false,
-      });
-      capMap(sessions);
-    }
-    return sessions.get(sessionID);
-  }
-
-  function recordTool(input, args) {
-    const sessionID = String(input?.sessionID || "");
-    if (!sessionID) return;
-    const state = stateFor(sessionID);
-    if (state.recoveryPending) state.recoveryIntervened = true;
-    const safe = safeToolCall(input?.tool, args);
-    state.activeTool = { callID: String(input?.callID || ""), safe };
-    state.lastActivityAt = clock();
-    if (!safe) state.turnUnsafe = true;
-  }
-
-  function beforeTool(input, output) {
-    recordTool(input, output?.args || input?.args || {});
-  }
-
-  function afterTool(input) {
-    const sessionID = String(input?.sessionID || "");
-    if (!sessionID) return;
-    const state = stateFor(sessionID);
-    if (!state.activeTool?.callID || state.activeTool.callID === String(input?.callID || "")) {
-      state.activeTool = null;
-    }
-    state.lastActivityAt = clock();
-  }
-
-  function handleEvent({ event } = {}) {
-    if (!event) return;
-    const sessionID = sessionIDFromEvent(event);
-    if (!sessionID) return;
-    const state = stateFor(sessionID);
-
-    if (["session.created", "session.updated"].includes(event.type)) {
-      const info = event.properties?.info || {};
-      if (!state.parentKnown || Object.hasOwn(info, "parentID")) {
-        state.parentKnown = true;
-        state.parentID = String(info.parentID || "");
-      }
-      state.lastActivityAt = clock();
-      return;
-    }
-    if (event.type === "session.deleted") {
-      sessions.delete(sessionID);
-      return;
-    }
-    if (["permission.asked", "permission.updated"].includes(event.type)) {
-      const requestID = String(event.properties?.id || "");
-      if (requestID) state.pendingPermissionIDs.add(requestID);
-      if (state.recoveryPending) state.recoveryIntervened = true;
-      state.lastActivityAt = clock();
-      return;
-    }
-    if (event.type === "permission.replied") {
-      const requestID = String(event.properties?.requestID || event.properties?.permissionID || "");
-      if (requestID) state.pendingPermissionIDs.delete(requestID);
-      state.lastActivityAt = clock();
-      return;
-    }
-    if (event.type === "session.status") {
-      const status = String(event.properties?.status?.type || "").toLowerCase();
-      if (!status) return;
-      if (["busy", "retry"].includes(status) && !["busy", "retry"].includes(state.status)) {
-        if (state.recoveryPending) state.recoveryIntervened = true;
-        state.busySince = clock();
-        state.lastActivityAt = clock();
-        state.turnUnsafe = false;
-      }
-      state.status = status;
-      if (status === "idle") state.activeTool = null;
-      return;
-    }
-    if (event.type === "session.idle") {
-      state.status = "idle";
-      state.activeTool = null;
-      return;
-    }
-    if (["message.part.updated", "message.part.delta"].includes(event.type)) {
-      const part = event.properties?.part;
-      state.lastActivityAt = clock();
-      if (part?.type !== "tool") {
-        if (state.recoveryPending) state.recoveryIntervened = true;
-        return;
-      }
-      const status = toolPartState(part);
-      if (["pending", "running"].includes(status)) {
-        if (state.recoveryPending) state.recoveryIntervened = true;
-        recordTool({ sessionID, callID: part.callID, tool: part.tool }, part.state?.input || {});
-      } else if (["completed", "error", "failed", "aborted", "cancelled", "canceled"].includes(status)) {
-        if (!state.activeTool?.callID || state.activeTool.callID === String(part.callID || "")) {
-          state.activeTool = null;
-        }
-      }
-      return;
-    }
-    if (event.type === "message.updated") {
-      state.lastActivityAt = clock();
-      if (state.recoveryPending && event.properties?.info?.role === "user") {
-        state.recoveryIntervened = true;
-      }
-    } else if (event.type === "session.error") {
-      state.lastActivityAt = clock();
-    }
-  }
-
-  async function waitForIdle(sessionID) {
-    const deadline = clock() + idleWaitMs;
-    while (clock() < deadline) {
-      const status = await liveStatus(client, sessionID, directory);
-      if (status === "idle") return true;
-      await sleep(Math.min(250, Math.max(1, deadline - clock())));
-    }
-    return false;
-  }
-
-  async function recover(sessionID, state) {
-    if (!state.parentKnown || state.parentID || !["busy", "retry"].includes(state.status)) return false;
-    if (state.pendingPermissionIDs.size > 0) return false;
-    if (state.turnUnsafe || state.activeTool?.safe === false) return false;
-    if (clock() - state.lastActivityAt < staleMs || checks.has(sessionID)) return false;
-    checks.add(sessionID);
-    state.recoveryIntervened = false;
-    state.recoveryPending = true;
-    try {
-      const status = await liveStatus(client, sessionID, directory);
-      if (!["busy", "retry"].includes(status)) return false;
-      if (state.recoveryIntervened || state.pendingPermissionIDs.size > 0 || state.turnUnsafe || state.activeTool?.safe === false) return false;
-      const fingerprint = recoveryFingerprint(sessionID, state);
-      if (!await ledger.claim(sessionID, fingerprint, cooldownMs)) return false;
-      if (state.recoveryIntervened || state.pendingPermissionIDs.size > 0 || state.turnUnsafe || state.activeTool?.safe === false) return false;
-
-      if (typeof client?.session?.abort !== "function") return false;
-      const aborted = await client.session.abort({ path: { id: sessionID }, body: {} });
-      if (responseError(aborted) || unwrap(aborted) !== true || !await waitForIdle(sessionID)) return false;
-      if (state.recoveryIntervened || state.pendingPermissionIDs.size > 0 || state.turnUnsafe) return false;
-
-      const text = [
-        "AIDEVOPS SAFE STALL RECOVERY.",
-        "The previous assistant turn stopped producing activity and was aborted.",
-        "Re-read the recent conversation and inspect current state before continuing the unfinished safe step.",
-        "Do not repeat any write, deployment, external request, or other side effect. If safe continuation is uncertain, stop and ask the user.",
-        `Recovery marker: ${fingerprint}`,
-      ].join("\n");
-      if (typeof client?.session?.prompt !== "function") return false;
-      const prompted = await client.session.prompt({
-        path: { id: sessionID },
-        body: { parts: [{ type: "text", text, synthetic: true }] },
-      });
-      if (responseError(prompted)) return false;
-      log("INFO", `[session-stall-recovery] resumed session marker=${fingerprint}`);
-      return true;
-    } catch (error) {
-      log("WARN", `[session-stall-recovery] recovery failed: ${error?.name || "Error"}`);
-      return false;
-    } finally {
-      state.recoveryPending = false;
-      checks.delete(sessionID);
-    }
-  }
-
-  async function checkNow() {
-    if (!isEnabled()) return [];
-    const recovered = [];
-    for (const [sessionID, state] of sessions) {
-      if (await recover(sessionID, state)) recovered.push(sessionID);
-    }
-    return recovered;
-  }
-
-  const registry = globalThis[RECOVERY_REGISTRY] || new WeakMap();
-  globalThis[RECOVERY_REGISTRY] = registry;
-  const registryOwner = client && typeof client === "object" ? client : sessions;
-  const clientRegistry = registry.get(registryOwner) || new Map();
-  registry.set(registryOwner, clientRegistry);
-  const registryKey = String(directory || "unknown-directory");
-  clientRegistry.get(registryKey)?.();
-  let timer = null;
-  const stop = () => {
-    if (timer) clearInterval(timer);
-    timer = null;
-    if (clientRegistry.get(registryKey) === stop) clientRegistry.delete(registryKey);
-  };
-  if (isEnabled()) {
-    timer = setInterval(() => {
-      checkNow().catch((error) => log("WARN", `[session-stall-recovery] check failed: ${error?.name || "Error"}`));
-    }, checkMs);
-    timer.unref?.();
-    clientRegistry.set(registryKey, stop);
-  }
+  const store = new SessionStallStateStore(clock);
+  const eventHandler = new SessionStallEventHandler(store, clock);
+  const runner = new SessionRecoveryRunner({
+    client,
+    directory,
+    store,
+    ledger,
+    clock,
+    staleMs,
+    cooldownMs,
+    idleWaitMs,
+    sleep,
+    isEnabled,
+    log,
+  });
+  const scheduler = new SessionRecoveryScheduler({
+    client,
+    directory,
+    fallbackOwner: store.sessions,
+    checkNow: runner.checkNow.bind(runner),
+    isEnabled,
+    checkMs,
+    log,
+  });
+  scheduler.start();
 
   return {
-    afterTool,
-    beforeTool,
-    checkNow,
-    handleEvent,
-    stop,
+    afterTool: store.afterTool.bind(store),
+    beforeTool: store.beforeTool.bind(store),
+    checkNow: runner.checkNow.bind(runner),
+    handleEvent: eventHandler.handle.bind(eventHandler),
+    stop: scheduler.stop,
   };
 }
 

--- a/.agents/plugins/opencode-aidevops/session-stall-recovery.mjs
+++ b/.agents/plugins/opencode-aidevops/session-stall-recovery.mjs
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { createHash } from "node:crypto";
+import { chmod, lstat, mkdir, open, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const DEFAULT_CHECK_MS = 60_000;
+const DEFAULT_STALE_MS = 10 * 60_000;
+const DEFAULT_COOLDOWN_MS = 30 * 60_000;
+const DEFAULT_IDLE_WAIT_MS = 5_000;
+const DEFAULT_LOCK_STALE_MS = 60_000;
+const MAX_SESSION_STATES = 64;
+const RECOVERY_REGISTRY = Symbol.for("aidevops.session-stall-recovery.registry");
+const SAFE_TOOLS = new Set([
+  "glob",
+  "grep",
+  "read",
+  "skill",
+  "todowrite",
+  "webfetch",
+  "functions.glob",
+  "functions.grep",
+  "functions.read",
+  "functions.skill",
+  "functions.todowrite",
+  "functions.webfetch",
+]);
+
+function unwrap(response) {
+  return response?.data ?? response;
+}
+
+function responseError(response) {
+  return response?.error || response?.data?.error || null;
+}
+
+function sessionIDFromEvent(event) {
+  return String(
+    event?.properties?.sessionID
+      || event?.properties?.info?.id
+      || event?.properties?.info?.sessionID
+      || event?.properties?.part?.sessionID
+      || "",
+  );
+}
+
+function safeToolCall(tool, args = {}) {
+  const name = String(tool || "").toLowerCase();
+  if (SAFE_TOOLS.has(name)) return true;
+  if (name === "aidevops_memory" || name === "functions.aidevops_memory") {
+    return String(args?.action || "recall").toLowerCase() === "recall";
+  }
+  return false;
+}
+
+function toolPartState(part) {
+  return String(part?.state?.status || "").toLowerCase();
+}
+
+function capMap(map) {
+  while (map.size > MAX_SESSION_STATES) map.delete(map.keys().next().value);
+}
+
+function processIsLive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+async function createLock(lockPath) {
+  const lock = await open(lockPath, "wx", 0o600);
+  try {
+    await lock.writeFile(`${process.pid}\n`);
+    return lock;
+  } catch (error) {
+    await lock.close();
+    await rm(lockPath, { force: true });
+    throw error;
+  }
+}
+
+function recoveryFingerprint(sessionID, state) {
+  return createHash("sha256")
+    .update(`${sessionID}:${state.busySince}:${state.lastActivityAt}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+class PersistentRecoveryLedger {
+  constructor(root, clock, lockStaleMs = DEFAULT_LOCK_STALE_MS) {
+    this.root = root;
+    this.clock = clock;
+    this.lockStaleMs = lockStaleMs;
+  }
+
+  pathFor(sessionID) {
+    const name = createHash("sha256").update(sessionID).digest("hex").slice(0, 24);
+    return join(this.root, `${name}.json`);
+  }
+
+  async claim(sessionID, fingerprint, cooldownMs) {
+    await mkdir(this.root, { recursive: true, mode: 0o700 });
+    await chmod(this.root, 0o700);
+    const markerPath = this.pathFor(sessionID);
+    const lockPath = `${markerPath}.lock`;
+    let lock;
+    try {
+      lock = await createLock(lockPath);
+    } catch (error) {
+      if (error?.code !== "EEXIST") return false;
+      try {
+        const existing = await lstat(lockPath);
+        const owned = existing.isFile()
+          && !existing.isSymbolicLink()
+          && existing.uid === process.getuid()
+          && (existing.mode & 0o077) === 0;
+        if (!owned || this.clock() - existing.mtimeMs < this.lockStaleMs) return false;
+        const ownerPid = Number.parseInt(await readFile(lockPath, "utf8"), 10);
+        if (processIsLive(ownerPid)) return false;
+        await rm(lockPath);
+        lock = await createLock(lockPath);
+      } catch {
+        return false;
+      }
+    }
+
+    try {
+      let previous = null;
+      try {
+        previous = JSON.parse(await readFile(markerPath, "utf8"));
+      } catch {
+        previous = null;
+      }
+      const attemptedAt = Number(previous?.attempted_at || 0);
+      if (attemptedAt > 0 && this.clock() - attemptedAt < cooldownMs) return false;
+
+      const temporaryPath = `${markerPath}.${process.pid}.${this.clock()}.tmp`;
+      await writeFile(temporaryPath, `${JSON.stringify({ fingerprint, attempted_at: this.clock() })}\n`, {
+        mode: 0o600,
+        flag: "wx",
+      });
+      await rename(temporaryPath, markerPath);
+      await chmod(markerPath, 0o600);
+      return true;
+    } finally {
+      await lock.close();
+      await rm(lockPath, { force: true });
+    }
+  }
+}
+
+async function liveStatus(client, sessionID, directory) {
+  if (typeof client?.session?.status !== "function") return "";
+  for (const args of [{ query: { directory } }, {}]) {
+    try {
+      const statuses = unwrap(await client.session.status(args));
+      const status = statuses?.[sessionID];
+      if (typeof status?.type === "string") return status.type.toLowerCase();
+    } catch {
+      // Try the next SDK argument shape.
+    }
+  }
+  return "";
+}
+
+export function createSessionStallRecovery({
+  client,
+  directory,
+  workDir,
+  isEnabled = () => process.env.AIDEVOPS_STALLED_SESSION_RECOVERY === "1",
+  clock = () => Date.now(),
+  checkMs = DEFAULT_CHECK_MS,
+  staleMs = DEFAULT_STALE_MS,
+  cooldownMs = DEFAULT_COOLDOWN_MS,
+  idleWaitMs = DEFAULT_IDLE_WAIT_MS,
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  ledger = new PersistentRecoveryLedger(join(workDir, "opencode-stall-recovery"), clock),
+  log = () => {},
+} = {}) {
+  const sessions = new Map();
+  const checks = new Set();
+
+  function stateFor(sessionID) {
+    if (!sessions.has(sessionID)) {
+      sessions.set(sessionID, {
+        activeTool: null,
+        busySince: 0,
+        lastActivityAt: clock(),
+        parentKnown: false,
+        parentID: "",
+        pendingPermissionIDs: new Set(),
+        recoveryIntervened: false,
+        recoveryPending: false,
+        status: "",
+        turnUnsafe: false,
+      });
+      capMap(sessions);
+    }
+    return sessions.get(sessionID);
+  }
+
+  function recordTool(input, args) {
+    const sessionID = String(input?.sessionID || "");
+    if (!sessionID) return;
+    const state = stateFor(sessionID);
+    if (state.recoveryPending) state.recoveryIntervened = true;
+    const safe = safeToolCall(input?.tool, args);
+    state.activeTool = { callID: String(input?.callID || ""), safe };
+    state.lastActivityAt = clock();
+    if (!safe) state.turnUnsafe = true;
+  }
+
+  function beforeTool(input, output) {
+    recordTool(input, output?.args || input?.args || {});
+  }
+
+  function afterTool(input) {
+    const sessionID = String(input?.sessionID || "");
+    if (!sessionID) return;
+    const state = stateFor(sessionID);
+    if (!state.activeTool?.callID || state.activeTool.callID === String(input?.callID || "")) {
+      state.activeTool = null;
+    }
+    state.lastActivityAt = clock();
+  }
+
+  function handleEvent({ event } = {}) {
+    if (!event) return;
+    const sessionID = sessionIDFromEvent(event);
+    if (!sessionID) return;
+    const state = stateFor(sessionID);
+
+    if (["session.created", "session.updated"].includes(event.type)) {
+      const info = event.properties?.info || {};
+      if (!state.parentKnown || Object.hasOwn(info, "parentID")) {
+        state.parentKnown = true;
+        state.parentID = String(info.parentID || "");
+      }
+      state.lastActivityAt = clock();
+      return;
+    }
+    if (event.type === "session.deleted") {
+      sessions.delete(sessionID);
+      return;
+    }
+    if (["permission.asked", "permission.updated"].includes(event.type)) {
+      const requestID = String(event.properties?.id || "");
+      if (requestID) state.pendingPermissionIDs.add(requestID);
+      if (state.recoveryPending) state.recoveryIntervened = true;
+      state.lastActivityAt = clock();
+      return;
+    }
+    if (event.type === "permission.replied") {
+      const requestID = String(event.properties?.requestID || event.properties?.permissionID || "");
+      if (requestID) state.pendingPermissionIDs.delete(requestID);
+      state.lastActivityAt = clock();
+      return;
+    }
+    if (event.type === "session.status") {
+      const status = String(event.properties?.status?.type || "").toLowerCase();
+      if (!status) return;
+      if (["busy", "retry"].includes(status) && !["busy", "retry"].includes(state.status)) {
+        if (state.recoveryPending) state.recoveryIntervened = true;
+        state.busySince = clock();
+        state.lastActivityAt = clock();
+        state.turnUnsafe = false;
+      }
+      state.status = status;
+      if (status === "idle") state.activeTool = null;
+      return;
+    }
+    if (event.type === "session.idle") {
+      state.status = "idle";
+      state.activeTool = null;
+      return;
+    }
+    if (["message.part.updated", "message.part.delta"].includes(event.type)) {
+      const part = event.properties?.part;
+      state.lastActivityAt = clock();
+      if (part?.type !== "tool") {
+        if (state.recoveryPending) state.recoveryIntervened = true;
+        return;
+      }
+      const status = toolPartState(part);
+      if (["pending", "running"].includes(status)) {
+        if (state.recoveryPending) state.recoveryIntervened = true;
+        recordTool({ sessionID, callID: part.callID, tool: part.tool }, part.state?.input || {});
+      } else if (["completed", "error", "failed", "aborted", "cancelled", "canceled"].includes(status)) {
+        if (!state.activeTool?.callID || state.activeTool.callID === String(part.callID || "")) {
+          state.activeTool = null;
+        }
+      }
+      return;
+    }
+    if (event.type === "message.updated") {
+      state.lastActivityAt = clock();
+      if (state.recoveryPending && event.properties?.info?.role === "user") {
+        state.recoveryIntervened = true;
+      }
+    } else if (event.type === "session.error") {
+      state.lastActivityAt = clock();
+    }
+  }
+
+  async function waitForIdle(sessionID) {
+    const deadline = clock() + idleWaitMs;
+    while (clock() < deadline) {
+      const status = await liveStatus(client, sessionID, directory);
+      if (status === "idle") return true;
+      await sleep(Math.min(250, Math.max(1, deadline - clock())));
+    }
+    return false;
+  }
+
+  async function recover(sessionID, state) {
+    if (!state.parentKnown || state.parentID || !["busy", "retry"].includes(state.status)) return false;
+    if (state.pendingPermissionIDs.size > 0) return false;
+    if (state.turnUnsafe || state.activeTool?.safe === false) return false;
+    if (clock() - state.lastActivityAt < staleMs || checks.has(sessionID)) return false;
+    checks.add(sessionID);
+    state.recoveryIntervened = false;
+    state.recoveryPending = true;
+    try {
+      const status = await liveStatus(client, sessionID, directory);
+      if (!["busy", "retry"].includes(status)) return false;
+      if (state.recoveryIntervened || state.pendingPermissionIDs.size > 0 || state.turnUnsafe || state.activeTool?.safe === false) return false;
+      const fingerprint = recoveryFingerprint(sessionID, state);
+      if (!await ledger.claim(sessionID, fingerprint, cooldownMs)) return false;
+      if (state.recoveryIntervened || state.pendingPermissionIDs.size > 0 || state.turnUnsafe || state.activeTool?.safe === false) return false;
+
+      if (typeof client?.session?.abort !== "function") return false;
+      const aborted = await client.session.abort({ path: { id: sessionID }, body: {} });
+      if (responseError(aborted) || unwrap(aborted) !== true || !await waitForIdle(sessionID)) return false;
+      if (state.recoveryIntervened || state.pendingPermissionIDs.size > 0 || state.turnUnsafe) return false;
+
+      const text = [
+        "AIDEVOPS SAFE STALL RECOVERY.",
+        "The previous assistant turn stopped producing activity and was aborted.",
+        "Re-read the recent conversation and inspect current state before continuing the unfinished safe step.",
+        "Do not repeat any write, deployment, external request, or other side effect. If safe continuation is uncertain, stop and ask the user.",
+        `Recovery marker: ${fingerprint}`,
+      ].join("\n");
+      if (typeof client?.session?.prompt !== "function") return false;
+      const prompted = await client.session.prompt({
+        path: { id: sessionID },
+        body: { parts: [{ type: "text", text, synthetic: true }] },
+      });
+      if (responseError(prompted)) return false;
+      log("INFO", `[session-stall-recovery] resumed session marker=${fingerprint}`);
+      return true;
+    } catch (error) {
+      log("WARN", `[session-stall-recovery] recovery failed: ${error?.name || "Error"}`);
+      return false;
+    } finally {
+      state.recoveryPending = false;
+      checks.delete(sessionID);
+    }
+  }
+
+  async function checkNow() {
+    if (!isEnabled()) return [];
+    const recovered = [];
+    for (const [sessionID, state] of sessions) {
+      if (await recover(sessionID, state)) recovered.push(sessionID);
+    }
+    return recovered;
+  }
+
+  const registry = globalThis[RECOVERY_REGISTRY] || new WeakMap();
+  globalThis[RECOVERY_REGISTRY] = registry;
+  const registryOwner = client && typeof client === "object" ? client : sessions;
+  const clientRegistry = registry.get(registryOwner) || new Map();
+  registry.set(registryOwner, clientRegistry);
+  const registryKey = String(directory || "unknown-directory");
+  clientRegistry.get(registryKey)?.();
+  let timer = null;
+  const stop = () => {
+    if (timer) clearInterval(timer);
+    timer = null;
+    if (clientRegistry.get(registryKey) === stop) clientRegistry.delete(registryKey);
+  };
+  if (isEnabled()) {
+    timer = setInterval(() => {
+      checkNow().catch((error) => log("WARN", `[session-stall-recovery] check failed: ${error?.name || "Error"}`));
+    }, checkMs);
+    timer.unref?.();
+    clientRegistry.set(registryKey, stop);
+  }
+
+  return {
+    afterTool,
+    beforeTool,
+    checkNow,
+    handleEvent,
+    stop,
+  };
+}
+
+export { PersistentRecoveryLedger, safeToolCall };

--- a/.agents/plugins/opencode-aidevops/tests/test-session-stall-recovery.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-stall-recovery.mjs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  createSessionStallRecovery,
+  PersistentRecoveryLedger,
+  safeToolCall,
+} from "../session-stall-recovery.mjs";
+
+function event(type, properties) {
+  return { event: { type, properties } };
+}
+
+function memoryLedger() {
+  const claims = new Set();
+  return {
+    async claim(sessionID, fingerprint) {
+      const key = `${sessionID}:${fingerprint}`;
+      if (claims.has(key)) return false;
+      claims.add(key);
+      return true;
+    },
+  };
+}
+
+function fixture() {
+  let current = 1_000;
+  let status = "busy";
+  let statusAvailable = true;
+  let statusHook = async () => {};
+  let abortHook = async () => {};
+  const calls = { abort: 0, prompt: 0 };
+  const client = {
+    session: {
+      abort: async () => {
+        calls.abort += 1;
+        status = "idle";
+        await abortHook();
+        return { data: true };
+      },
+      prompt: async () => {
+        calls.prompt += 1;
+        return { data: true };
+      },
+      status: async () => {
+        await statusHook();
+        statusHook = async () => {};
+        return statusAvailable ? { data: { ses_primary: { type: status } } } : { data: {} };
+      },
+    },
+  };
+  const recovery = createSessionStallRecovery({
+    client,
+    directory: "/workspace",
+    workDir: "/unused",
+    isEnabled: () => true,
+    clock: () => current,
+    staleMs: 100,
+    idleWaitMs: 10,
+    sleep: async (milliseconds) => { current += milliseconds; },
+    ledger: memoryLedger(),
+  });
+  recovery.handleEvent(event("session.created", { info: { id: "ses_primary" } }));
+  recovery.handleEvent(event("session.status", { sessionID: "ses_primary", status: { type: "busy" } }));
+  return {
+    calls,
+    recovery,
+    advance: (milliseconds) => { current += milliseconds; },
+    onAbort: (hook) => { abortHook = hook; },
+    onStatus: (hook) => { statusHook = hook; },
+    setStatus: (value) => { status = value; },
+    setStatusAvailable: (value) => { statusAvailable = value; },
+  };
+}
+
+assert.equal(safeToolCall("read"), true);
+assert.equal(safeToolCall("aidevops_memory", { action: "recall" }), true);
+assert.equal(safeToolCall("aidevops_memory", { action: "store" }), false);
+assert.equal(safeToolCall("bash", { command: "npm test" }), false);
+assert.equal(safeToolCall("apply_patch"), false);
+
+{
+  const test = fixture();
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), ["ses_primary"]);
+  assert.deepEqual(test.calls, { abort: 1, prompt: 1 });
+  assert.deepEqual(await test.recovery.checkNow(), []);
+  assert.deepEqual(test.calls, { abort: 1, prompt: 1 });
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.onStatus(async () => {
+    test.recovery.handleEvent(event("permission.asked", {
+      sessionID: "ses_primary",
+      id: "permission-during-check",
+    }));
+  });
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), []);
+  assert.deepEqual(test.calls, { abort: 0, prompt: 0 });
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.recovery.handleEvent(event("permission.asked", {
+    sessionID: "ses_primary",
+    id: "permission-1",
+  }));
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), []);
+  assert.deepEqual(test.calls, { abort: 0, prompt: 0 });
+  test.recovery.handleEvent(event("permission.replied", {
+    sessionID: "ses_primary",
+    requestID: "permission-1",
+  }));
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), ["ses_primary"]);
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.recovery.beforeTool(
+    { sessionID: "ses_primary", callID: "call-write", tool: "apply_patch" },
+    { args: { patchText: "redacted" } },
+  );
+  test.recovery.afterTool({ sessionID: "ses_primary", callID: "call-write", tool: "apply_patch" });
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), []);
+  assert.deepEqual(test.calls, { abort: 0, prompt: 0 });
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.recovery.beforeTool(
+    { sessionID: "ses_primary", callID: "call-read", tool: "read" },
+    { args: { filePath: "/workspace/file" } },
+  );
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), ["ses_primary"]);
+  assert.deepEqual(test.calls, { abort: 1, prompt: 1 });
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.setStatus("idle");
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), []);
+  assert.deepEqual(test.calls, { abort: 0, prompt: 0 });
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.recovery.handleEvent(event("session.updated", {
+    info: { id: "ses_primary", parentID: "ses_parent" },
+  }));
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), []);
+  assert.deepEqual(test.calls, { abort: 0, prompt: 0 });
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.onAbort(async () => {
+    test.recovery.handleEvent(event("message.part.updated", {
+      part: {
+        sessionID: "ses_primary",
+        callID: "call-read",
+        type: "tool",
+        tool: "read",
+        state: { status: "aborted" },
+      },
+    }));
+  });
+  test.recovery.beforeTool(
+    { sessionID: "ses_primary", callID: "call-read", tool: "read" },
+    { args: { filePath: "/workspace/file" } },
+  );
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), ["ses_primary"]);
+  assert.deepEqual(test.calls, { abort: 1, prompt: 1 });
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.onAbort(async () => {
+    test.recovery.handleEvent(event("message.updated", {
+      info: { sessionID: "ses_primary", role: "user" },
+    }));
+  });
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), []);
+  assert.deepEqual(test.calls, { abort: 1, prompt: 0 });
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.onStatus(async () => {
+    test.recovery.handleEvent(event("message.updated", {
+      info: { sessionID: "ses_primary", role: "user" },
+    }));
+  });
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), []);
+  assert.deepEqual(test.calls, { abort: 0, prompt: 0 });
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.onAbort(async () => { test.setStatusAvailable(false); });
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), []);
+  assert.deepEqual(test.calls, { abort: 1, prompt: 0 });
+  test.recovery.stop();
+}
+
+{
+  const test = fixture();
+  test.recovery.handleEvent(event("session.updated", {
+    info: { id: "ses_primary", parentID: "ses_parent" },
+  }));
+  test.recovery.handleEvent(event("session.updated", { info: { id: "ses_primary" } }));
+  test.advance(101);
+  assert.deepEqual(await test.recovery.checkNow(), []);
+  assert.deepEqual(test.calls, { abort: 0, prompt: 0 });
+  test.recovery.stop();
+}
+
+{
+  const tempRoot = process.env.AIDEVOPS_TEMP_DIR
+    || join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+  await mkdir(tempRoot, { recursive: true, mode: 0o700 });
+  const root = await mkdtemp(join(tempRoot, "stall-recovery-ledger-"));
+  let current = 100_000;
+  try {
+    const ledger = new PersistentRecoveryLedger(root, () => current, 1_000);
+    const lockPath = `${ledger.pathFor("ses_primary")}.lock`;
+    await writeFile(lockPath, "", { mode: 0o600 });
+    await utimes(lockPath, new Date(0), new Date(0));
+    assert.equal(await ledger.claim("ses_primary", "fingerprint", 5_000), true);
+    assert.equal(await ledger.claim("ses_primary", "fingerprint", 5_000), false);
+    current += 5_001;
+    assert.equal(await ledger.claim("ses_primary", "fingerprint", 5_000), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+console.log("session stall recovery tests passed");

--- a/.agents/scripts/auto-update-helper-check.sh
+++ b/.agents/scripts/auto-update-helper-check.sh
@@ -305,6 +305,20 @@ _cmd_check_stale_agent_redeploy() {
 		deployed_sha=$(tr -d '[:space:]' <"$stamp_file" 2>/dev/null) || deployed_sha=""
 		head_sha=$(git -C "$INSTALL_DIR" rev-parse HEAD 2>/dev/null) || head_sha=""
 		if [[ -n "$deployed_sha" && -n "$head_sha" && "$deployed_sha" != "$head_sha" ]]; then
+			# An interactive linked-worktree deployment can intentionally be ahead
+			# of canonical main. Re-deploying main in that state rolls back the
+			# active hotfix and can restart live runtimes every polling interval.
+			if git -C "$INSTALL_DIR" merge-base --is-ancestor "$head_sha" "$deployed_sha" 2>/dev/null; then
+				log_info "Preserving deployed runtime ${deployed_sha:0:7}; it includes canonical HEAD ${head_sha:0:7}"
+				return 0
+			fi
+			# Diverged history is also not safe for unattended replacement. Normal
+			# stale deployments remain eligible when deployed_sha is an ancestor of
+			# head_sha, preserving the t2706 same-version repair path.
+			if ! git -C "$INSTALL_DIR" merge-base --is-ancestor "$deployed_sha" "$head_sha" 2>/dev/null; then
+				log_warn "Skipping script-drift redeploy: deployed runtime ${deployed_sha:0:7} diverges from canonical HEAD ${head_sha:0:7}"
+				return 0
+			fi
 			local has_code_drift=0
 			# Per Gemini code-review on PR #20342: use git's path filter +
 			# `grep -q .` to detect drift across the full set of deploy-affecting

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -617,6 +617,20 @@ _cmd_check_stale_agent_redeploy() {
 		deployed_sha=$(tr -d '[:space:]' <"$stamp_file" 2>/dev/null) || deployed_sha=""
 		head_sha=$(git -C "$INSTALL_DIR" rev-parse HEAD 2>/dev/null) || head_sha=""
 		if [[ -n "$deployed_sha" && -n "$head_sha" && "$deployed_sha" != "$head_sha" ]]; then
+			# An interactive linked-worktree deployment can intentionally be ahead
+			# of canonical main. Re-deploying main in that state rolls back the
+			# active hotfix and can restart live runtimes every polling interval.
+			if git -C "$INSTALL_DIR" merge-base --is-ancestor "$head_sha" "$deployed_sha" 2>/dev/null; then
+				log_info "Preserving deployed runtime ${deployed_sha:0:7}; it includes canonical HEAD ${head_sha:0:7}"
+				return 0
+			fi
+			# Diverged history is also not safe for unattended replacement. Normal
+			# stale deployments remain eligible when deployed_sha is an ancestor of
+			# head_sha, preserving the t2706 same-version repair path.
+			if ! git -C "$INSTALL_DIR" merge-base --is-ancestor "$deployed_sha" "$head_sha" 2>/dev/null; then
+				log_warn "Skipping script-drift redeploy: deployed runtime ${deployed_sha:0:7} diverges from canonical HEAD ${head_sha:0:7}"
+				return 0
+			fi
 			local has_code_drift=0
 			# Per Gemini code-review on PR #20342: use git's path filter +
 			# `grep -q .` to detect drift across the full set of deploy-affecting

--- a/.agents/scripts/process-guard-helper.sh
+++ b/.agents/scripts/process-guard-helper.sh
@@ -189,10 +189,9 @@ _is_managed_worker_process() {
 }
 
 #######################################
-# Return whether a process is the OpenCode web server (or one of its
-# descendants) owned by a long-running systemd service. The service manager
-# and its health watchdog own that lifecycle; applying the generic two-hour
-# process limit restarts every web session in the middle of active work.
+# Return whether a process belongs to the OpenCode web server or its watchdog
+# service. The service manager owns both long-running lifecycles; applying the
+# generic two-hour process limit to either unit disrupts active web sessions.
 # Arguments:
 #   $1 - PID
 # Returns: 0 for managed OpenCode web-service lineage, 1 otherwise
@@ -200,7 +199,7 @@ _is_managed_worker_process() {
 _is_managed_opencode_web_process() {
 	local pid="$1"
 	local cgroup_path=""
-	local service_regex='/opencode-web(@[^/]+)?\.service(/|$)'
+	local service_regex='/opencode-web(-watchdog|@[^/]+)?\.service(/|$)'
 
 	[[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
 	cgroup_path=$(_get_process_cgroup_path "$pid")

--- a/.agents/scripts/process-guard-helper.sh
+++ b/.agents/scripts/process-guard-helper.sh
@@ -122,7 +122,7 @@ _get_process_cwd() {
 }
 
 #######################################
-# Return the process's first systemd cgroup path when available.
+# Return the process's systemd or unified cgroup path when available.
 # Arguments:
 #   $1 - PID
 # Output: cgroup path or "unknown"
@@ -132,12 +132,26 @@ _get_process_cgroup_path() {
 	local proc_root="${AIDEVOPS_PROCESS_GUARD_PROC_ROOT:-/proc}"
 	local cgroup_file="${proc_root%/}/${pid}/cgroup"
 	local cgroup_line=""
+	local cgroup_path=""
+	local fallback_path=""
 
 	if [[ -r "$cgroup_file" ]]; then
 		while IFS= read -r cgroup_line || [[ -n "$cgroup_line" ]]; do
-			printf '%s' "${cgroup_line#*:*:}"
-			return 0
+			cgroup_path="${cgroup_line#*:*:}"
+			if [[ -z "$fallback_path" && -n "$cgroup_path" ]]; then
+				fallback_path="$cgroup_path"
+			fi
+			case "$cgroup_line" in
+			0::* | *:name=systemd:*)
+				printf '%s' "$cgroup_path"
+				return 0
+				;;
+			esac
 		done <"$cgroup_file"
+	fi
+	if [[ -n "$fallback_path" ]]; then
+		printf '%s' "$fallback_path"
+		return 0
 	fi
 
 	printf '%s' "$PROCESS_CGROUP_UNKNOWN"

--- a/.agents/scripts/process-guard-helper.sh
+++ b/.agents/scripts/process-guard-helper.sh
@@ -70,6 +70,7 @@ SESSION_COUNT_WARN="${SESSION_COUNT_WARN:-5}"
 readonly PROCESS_RUNTIME_OK="OK"
 readonly PROCESS_RUNTIME_MANAGED="MANAGED"
 readonly PROCESS_RUNTIME_OVER="OVER"
+readonly PROCESS_CGROUP_UNKNOWN='unknown'
 
 # Validate all numeric config to prevent command injection via arithmetic expansion
 CHILD_RSS_LIMIT_KB=$(_validate_int CHILD_RSS_LIMIT_KB "$CHILD_RSS_LIMIT_KB" 2097152 1)
@@ -121,6 +122,29 @@ _get_process_cwd() {
 }
 
 #######################################
+# Return the process's first systemd cgroup path when available.
+# Arguments:
+#   $1 - PID
+# Output: cgroup path or "unknown"
+#######################################
+_get_process_cgroup_path() {
+	local pid="$1"
+	local proc_root="${AIDEVOPS_PROCESS_GUARD_PROC_ROOT:-/proc}"
+	local cgroup_file="${proc_root%/}/${pid}/cgroup"
+	local cgroup_line=""
+
+	if [[ -r "$cgroup_file" ]]; then
+		while IFS= read -r cgroup_line || [[ -n "$cgroup_line" ]]; do
+			printf '%s' "${cgroup_line#*:*:}"
+			return 0
+		done <"$cgroup_file"
+	fi
+
+	printf '%s' "$PROCESS_CGROUP_UNKNOWN"
+	return 0
+}
+
+#######################################
 # Return whether a process belongs to a systemd-managed aidevops worker.
 # All descendants of a transient worker service share its cgroup, so this
 # verifies lifecycle ownership without relying on mutable command strings.
@@ -151,9 +175,51 @@ _is_managed_worker_process() {
 }
 
 #######################################
+# Return whether a process is the OpenCode web server (or one of its
+# descendants) owned by a long-running systemd service. The service manager
+# and its health watchdog own that lifecycle; applying the generic two-hour
+# process limit restarts every web session in the middle of active work.
+# Arguments:
+#   $1 - PID
+# Returns: 0 for managed OpenCode web-service lineage, 1 otherwise
+#######################################
+_is_managed_opencode_web_process() {
+	local pid="$1"
+	local cgroup_path=""
+	local service_regex='/opencode-web(@[^/]+)?\.service(/|$)'
+
+	[[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+	cgroup_path=$(_get_process_cgroup_path "$pid")
+	[[ "$cgroup_path" != "$PROCESS_CGROUP_UNKNOWN" ]] || return 1
+	if [[ "$cgroup_path" =~ $service_regex ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Describe the lifecycle owner that supersedes the generic runtime limit.
+# Arguments:
+#   $1 - PID
+# Output: owner label, or empty when unmanaged
+#######################################
+_runtime_management_owner() {
+	local pid="$1"
+	if _is_managed_worker_process "$pid"; then
+		printf '%s' "worker-service"
+		return 0
+	fi
+	if _is_managed_opencode_web_process "$pid"; then
+		printf '%s' "opencode-web-service"
+		return 0
+	fi
+	return 0
+}
+
+#######################################
 # Classify a process against the generic runtime limit.
-# Managed worker services delegate runtime decisions to their lifecycle-aware
-# watchdog/sandbox controls. RSS limits remain independently enforced.
+# Managed services delegate runtime decisions to their lifecycle-aware service,
+# watchdog, or sandbox controls. RSS limits remain independently enforced.
 # Arguments:
 #   $1 - PID
 #   $2 - process age in seconds
@@ -164,6 +230,7 @@ _classify_runtime_limit() {
 	local pid="$1"
 	local age_seconds="$2"
 	local runtime_limit="$3"
+	local management_owner=""
 
 	if [[ ! "$age_seconds" =~ ^[0-9]+$ || ! "$runtime_limit" =~ ^[0-9]+$ ]]; then
 		printf '%s' "$PROCESS_RUNTIME_OK"
@@ -173,7 +240,8 @@ _classify_runtime_limit() {
 		printf '%s' "$PROCESS_RUNTIME_OK"
 		return 0
 	fi
-	if _is_managed_worker_process "$pid"; then
+	management_owner=$(_runtime_management_owner "$pid")
+	if [[ -n "$management_owner" ]]; then
 		printf '%s' "$PROCESS_RUNTIME_MANAGED"
 		return 0
 	fi
@@ -372,7 +440,7 @@ cmd_scan() {
 			violations=$((violations + 1))
 		elif [[ "$runtime_status" == "$PROCESS_RUNTIME_MANAGED" ]]; then
 			status="MANAGED"
-			detail="runtime delegated to worker lifecycle controls"
+			detail="runtime delegated to $(_runtime_management_owner "$pid") lifecycle controls"
 		elif [[ "$cmd_base" == "shellcheck" ]]; then
 			[[ "$ppid" =~ ^[0-9]+$ ]] || ppid=0
 			if [[ "$ppid" -eq 1 ]] && [[ "$age_seconds" -gt 120 ]]; then
@@ -459,8 +527,8 @@ cmd_kill_runaways() {
 			violation="runtime ${age_seconds}s > ${runtime_limit}s"
 		fi
 
-		# Managed worker trees have dedicated activity, sandbox, service, and
-		# lease controls. Do not apply any generic age-based cleanup to them.
+		# Managed service trees have dedicated activity, health, sandbox, service,
+		# or lease controls. Do not apply generic age-based cleanup to them.
 		if [[ -z "$violation" && "$runtime_status" == "$PROCESS_RUNTIME_MANAGED" ]]; then
 			continue
 		fi
@@ -481,7 +549,7 @@ cmd_kill_runaways() {
 
 		if [[ -n "$violation" ]]; then
 			local rss_mb=$((rss / 1024))
-			local process_class killed_at
+			local process_class killed_at cgroup_path
 			process_class='other'
 			case "$cmd_base" in
 			shellcheck) process_class='lint' ;;
@@ -495,9 +563,10 @@ cmd_kill_runaways() {
 			opencode | opencode-ai | claude | claude-ai) process_class='ai-runtime' ;;
 			esac
 			killed_at=$(_process_guard_timestamp)
+			cgroup_path=$(_get_process_cgroup_path "$pid")
 			echo "Killing PID $pid ($cmd_base) — $violation"
-			printf '[process-guard] %s Killing PID %s class=%s cmd=%s rss_mb=%s age_seconds=%s — %s\n' \
-				"$killed_at" "$pid" "$process_class" "$cmd_base" "$rss_mb" "$age_seconds" "$violation" >>"$LOGFILE"
+			printf '[process-guard] %s action=kill pid=%s ppid=%s class=%s cmd=%s rss_mb=%s age_seconds=%s runtime_limit_seconds=%s cgroup=%s reason=%s\n' \
+				"$killed_at" "$pid" "$ppid" "$process_class" "$cmd_base" "$rss_mb" "$age_seconds" "$runtime_limit" "$cgroup_path" "$violation" >>"$LOGFILE"
 			kill "$pid" 2>/dev/null || true
 			sleep 1
 			if kill -0 "$pid" 2>/dev/null; then

--- a/.agents/scripts/tests/test-cmd-update-sha-drift.sh
+++ b/.agents/scripts/tests/test-cmd-update-sha-drift.sh
@@ -59,6 +59,7 @@ print_result() {
 
 AIDEVOPS_SH="$WORKTREE_ROOT/aidevops.sh"
 AUTO_UPDATE_SH="$WORKTREE_ROOT/.agents/scripts/auto-update-helper.sh"
+AUTO_UPDATE_CHECK_SH="$WORKTREE_ROOT/.agents/scripts/auto-update-helper-check.sh"
 UPDATE_CHECK_SH="$WORKTREE_ROOT/.agents/scripts/aidevops-update-check.sh"
 UPDATE_LIB="$WORKTREE_ROOT/.agents/scripts/aidevops-cli/aidevops-update-lib.sh"
 
@@ -114,6 +115,14 @@ if grep -q '\.deployed-sha' "$AUTO_UPDATE_SH" &&
 else
 	print_result "auto-update-helper.sh has stamp-drift check (t2706 marker)" 1 \
 		"(expected .deployed-sha reference and t2706 marker)"
+fi
+
+if grep -q 'merge-base --is-ancestor.*head_sha.*deployed_sha' "$AUTO_UPDATE_SH" &&
+	grep -q 'merge-base --is-ancestor.*head_sha.*deployed_sha' "$AUTO_UPDATE_CHECK_SH"; then
+	print_result "auto-update preserves deployed runtimes ahead of canonical HEAD" 0
+else
+	print_result "auto-update preserves deployed runtimes ahead of canonical HEAD" 1 \
+		"(expected ancestry guard in orchestrator and check sub-library)"
 fi
 
 # Test 5: auto-update-helper.sh filters for framework code paths
@@ -198,8 +207,17 @@ printf '#!/usr/bin/env bash\necho aidevops v2\n' >"$SANDBOX_REPO/aidevops.sh"
 /usr/bin/git -C "$SANDBOX_REPO" commit -qm "update aidevops.sh" 2>/dev/null
 HEAD_WITH_AIDEVOPS_DRIFT_SHA=$(/usr/bin/git -C "$SANDBOX_REPO" rev-parse HEAD)
 
+# Add an intentional linked-worktree-style hotfix deployment ahead of the
+# canonical HEAD, then return the sandbox checkout to the canonical commit.
+printf '#!/usr/bin/env bash\necho hotfix\n' >"$SANDBOX_REPO/.agents/scripts/foo.sh"
+/usr/bin/git -C "$SANDBOX_REPO" add -A
+/usr/bin/git -C "$SANDBOX_REPO" commit -qm "active hotfix" 2>/dev/null
+DEPLOYED_AHEAD_SHA=$(/usr/bin/git -C "$SANDBOX_REPO" rev-parse HEAD)
+/usr/bin/git -C "$SANDBOX_REPO" checkout -q --detach "$HEAD_WITH_AIDEVOPS_DRIFT_SHA"
+
 if [[ -z "$DEPLOYED_SHA" || -z "$HEAD_SHA" || -z "$HEAD_WITH_DOCS_SHA" ||
-	-z "$HEAD_WITH_SETUP_DRIFT_SHA" || -z "$HEAD_WITH_AIDEVOPS_DRIFT_SHA" ]]; then
+	-z "$HEAD_WITH_SETUP_DRIFT_SHA" || -z "$HEAD_WITH_AIDEVOPS_DRIFT_SHA" ||
+	-z "$DEPLOYED_AHEAD_SHA" ]]; then
 	printf '%sSETUP FAILED%s sandbox repo SHAs empty\n' "$TEST_RED" "$TEST_RESET"
 	exit 1
 fi
@@ -263,6 +281,27 @@ count_setup_calls() {
 	return 0
 }
 
+run_auto_update_stale_check() {
+	local stamp_content="$1"
+	printf '%s\n' "$stamp_content" >"$SANDBOX_AIDEVOPS/.deployed-sha"
+	HOME="$SANDBOX_HOME" bash -c '
+		INSTALL_DIR="$1"
+		LOG_FILE="$2"
+		SCRIPT_DIR="${3%/*}"
+		setup_calls_log="$4"
+		source "$3"
+		log_info() { return 0; }
+		log_warn() { return 0; }
+		log_error() { return 0; }
+		_run_setup_ai_session_with_fallback() {
+			printf "called\n" >>"$setup_calls_log"
+			return 0
+		}
+		_cmd_check_stale_agent_redeploy v1
+	' _ "$SANDBOX_REPO" "${TEST_ROOT}/auto-update-test.log" "$AUTO_UPDATE_CHECK_SH" "$SETUP_CALLS_LOG"
+	return 0
+}
+
 # Test 6: no stamp file → no-op
 rm -f "$SETUP_CALLS_LOG"
 run_cmd_update_stamp_branch ""
@@ -320,6 +359,27 @@ if [[ "$(count_setup_calls)" -eq 1 ]]; then
 	print_result "setup.sh fires when aidevops.sh drifts" 0
 else
 	print_result "setup.sh fires when aidevops.sh drifts" 1 \
+		"(expected 1 call, got $(count_setup_calls))"
+fi
+
+# Test 12: an intentionally deployed hotfix ahead of canonical HEAD must not be
+# replaced by the unattended same-version drift reconciler.
+rm -f "$SETUP_CALLS_LOG"
+run_auto_update_stale_check "$DEPLOYED_AHEAD_SHA"
+if [[ "$(count_setup_calls)" -eq 0 ]]; then
+	print_result "auto-update preserves an ahead deployed runtime" 0
+else
+	print_result "auto-update preserves an ahead deployed runtime" 1 \
+		"(setup.sh was called for an intentional hotfix deployment)"
+fi
+
+# Test 13: the ancestry guard must retain the original stale-runtime repair.
+rm -f "$SETUP_CALLS_LOG"
+run_auto_update_stale_check "$DEPLOYED_SHA"
+if [[ "$(count_setup_calls)" -eq 1 ]]; then
+	print_result "auto-update still repairs a deployed runtime behind HEAD" 0
+else
+	print_result "auto-update still repairs a deployed runtime behind HEAD" 1 \
 		"(expected 1 call, got $(count_setup_calls))"
 fi
 

--- a/.agents/scripts/tests/test-process-guard-managed-workers.sh
+++ b/.agents/scripts/tests/test-process-guard-managed-workers.sh
@@ -103,6 +103,30 @@ test_managed_observer_runtime_is_delegated() {
 	return 0
 }
 
+test_opencode_web_service_runtime_is_delegated() {
+	write_cgroup 4104 '/user.slice/user-1000.slice/user@1000.service/app.slice/opencode-web.service'
+	local actual
+	actual=$(_classify_runtime_limit 4104 7210 7200)
+	assert_eq "OpenCode web server older than generic limit is delegated" "MANAGED" "$actual"
+	return 0
+}
+
+test_opencode_web_service_descendant_is_delegated() {
+	write_cgroup 4105 '/user.slice/user-1000.slice/user@1000.service/app.slice/opencode-web.service/browser.scope'
+	local actual
+	actual=$(_classify_runtime_limit 4105 9000 7200)
+	assert_eq "OpenCode web-service descendant inherits protection" "MANAGED" "$actual"
+	return 0
+}
+
+test_opencode_web_template_service_is_delegated() {
+	write_cgroup 4106 '/user.slice/user-1000.slice/user@1000.service/app.slice/opencode-web@4096.service'
+	local actual
+	actual=$(_classify_runtime_limit 4106 9000 7200)
+	assert_eq "OpenCode web template service inherits protection" "MANAGED" "$actual"
+	return 0
+}
+
 test_unmanaged_lookalike_remains_over_limit() {
 	write_cgroup 4201 '/user.slice/user-1000.slice/session-2.scope'
 	local actual
@@ -116,6 +140,14 @@ test_command_string_is_not_lineage_evidence() {
 	local actual
 	actual=$(_classify_runtime_limit 4202 966 600)
 	assert_eq "worker-like cgroup text without valid service identity is rejected" "OVER" "$actual"
+	return 0
+}
+
+test_opencode_web_scope_lookalike_remains_over_limit() {
+	write_cgroup 4203 '/user.slice/user-1000.slice/opencode-web.scope'
+	local actual
+	actual=$(_classify_runtime_limit 4203 7210 7200)
+	assert_eq "OpenCode-like scope without service identity is rejected" "OVER" "$actual"
 	return 0
 }
 
@@ -144,6 +176,20 @@ test_kill_runaways_skips_managed_worker() {
 	output=$(cmd_kill_runaways)
 	assert_eq "kill path skips old managed worker" "No runaway processes found" "$output"
 	assert_eq "managed worker receives no signal" "" "$(<"$MOCK_KILL_LOG")"
+	return 0
+}
+
+test_kill_runaways_skips_opencode_web_service() {
+	write_cgroup 4504 '/user.slice/user-1000.slice/user@1000.service/app.slice/opencode-web.service'
+	MOCK_PROCESS_LINE='4504 1 ? 2860032 2:00:10 /home/test/.opencode/bin/opencode serve --port 4096'
+	MOCK_PROCESS_AGE=7210
+	CHILD_RUNTIME_LIMIT=7200
+	CHILD_RSS_LIMIT_KB=4194304
+	: >"$MOCK_KILL_LOG"
+	local output
+	output=$(cmd_kill_runaways)
+	assert_eq "kill path skips long-running OpenCode web service" "No runaway processes found" "$output"
+	assert_eq "OpenCode web service receives no signal" "" "$(<"$MOCK_KILL_LOG")"
 	return 0
 }
 
@@ -182,11 +228,16 @@ main() {
 	test_managed_worker_runtime_is_delegated
 	test_managed_worker_descendant_is_delegated
 	test_managed_observer_runtime_is_delegated
+	test_opencode_web_service_runtime_is_delegated
+	test_opencode_web_service_descendant_is_delegated
+	test_opencode_web_template_service_is_delegated
 	test_unmanaged_lookalike_remains_over_limit
 	test_command_string_is_not_lineage_evidence
+	test_opencode_web_scope_lookalike_remains_over_limit
 	test_unavailable_cgroup_keeps_existing_behavior
 	test_fresh_managed_worker_is_not_misreported
 	test_kill_runaways_skips_managed_worker
+	test_kill_runaways_skips_opencode_web_service
 	test_kill_runaways_keeps_unmanaged_cleanup
 	test_status_matches_kill_exemption
 

--- a/.agents/scripts/tests/test-process-guard-managed-workers.sh
+++ b/.agents/scripts/tests/test-process-guard-managed-workers.sh
@@ -136,6 +136,14 @@ test_opencode_web_template_service_is_delegated() {
 	return 0
 }
 
+test_opencode_web_watchdog_service_is_delegated() {
+	write_hybrid_cgroup 4107 '/user.slice/user-1000.slice/user@1000.service/app.slice/opencode-web-watchdog.service'
+	local actual
+	actual=$(_classify_runtime_limit 4107 7210 7200)
+	assert_eq "OpenCode web watchdog older than generic limit is delegated" "MANAGED" "$actual"
+	return 0
+}
+
 test_unmanaged_lookalike_remains_over_limit() {
 	write_cgroup 4201 '/user.slice/user-1000.slice/session-2.scope'
 	local actual
@@ -202,6 +210,20 @@ test_kill_runaways_skips_opencode_web_service() {
 	return 0
 }
 
+test_kill_runaways_skips_opencode_web_watchdog() {
+	write_hybrid_cgroup 4505 '/user.slice/user-1000.slice/user@1000.service/app.slice/opencode-web-watchdog.service'
+	MOCK_PROCESS_LINE='4505 1 ? 3072 2:00:10 bash /home/test/.local/bin/opencode-web-watchdog.sh'
+	MOCK_PROCESS_AGE=7210
+	CHILD_RUNTIME_LIMIT=7200
+	CHILD_RSS_LIMIT_KB=4194304
+	: >"$MOCK_KILL_LOG"
+	local output
+	output=$(cmd_kill_runaways)
+	assert_eq "kill path skips long-running OpenCode web watchdog" "No runaway processes found" "$output"
+	assert_eq "OpenCode web watchdog receives no signal" "" "$(<"$MOCK_KILL_LOG")"
+	return 0
+}
+
 test_kill_runaways_keeps_unmanaged_cleanup() {
 	write_cgroup 4502 '/user.slice/user-1000.slice/session-2.scope'
 	MOCK_PROCESS_LINE='4502 1 ? 1024 16:06 bash /usr/bin/bash stale-wrapper opencode run'
@@ -240,6 +262,7 @@ main() {
 	test_opencode_web_service_runtime_is_delegated
 	test_opencode_web_service_descendant_is_delegated
 	test_opencode_web_template_service_is_delegated
+	test_opencode_web_watchdog_service_is_delegated
 	test_unmanaged_lookalike_remains_over_limit
 	test_command_string_is_not_lineage_evidence
 	test_opencode_web_scope_lookalike_remains_over_limit
@@ -247,6 +270,7 @@ main() {
 	test_fresh_managed_worker_is_not_misreported
 	test_kill_runaways_skips_managed_worker
 	test_kill_runaways_skips_opencode_web_service
+	test_kill_runaways_skips_opencode_web_watchdog
 	test_kill_runaways_keeps_unmanaged_cleanup
 	test_status_matches_kill_exemption
 

--- a/.agents/scripts/tests/test-process-guard-managed-workers.sh
+++ b/.agents/scripts/tests/test-process-guard-managed-workers.sh
@@ -79,6 +79,15 @@ write_cgroup() {
 	return 0
 }
 
+write_hybrid_cgroup() {
+	local pid="$1"
+	local cgroup_path="$2"
+	mkdir -p "${AIDEVOPS_PROCESS_GUARD_PROC_ROOT}/${pid}"
+	printf '13:pids:/user.slice/user-1000.slice/user@1000.service\n1:name=systemd:%s\n0::%s\n' \
+		"$cgroup_path" "$cgroup_path" >"${AIDEVOPS_PROCESS_GUARD_PROC_ROOT}/${pid}/cgroup"
+	return 0
+}
+
 test_managed_worker_runtime_is_delegated() {
 	write_cgroup 4101 '/user.slice/user-1000.slice/user@1000.service/app.slice/aidevops-worker-27693-4001-17.service'
 	local actual
@@ -104,7 +113,7 @@ test_managed_observer_runtime_is_delegated() {
 }
 
 test_opencode_web_service_runtime_is_delegated() {
-	write_cgroup 4104 '/user.slice/user-1000.slice/user@1000.service/app.slice/opencode-web.service'
+	write_hybrid_cgroup 4104 '/user.slice/user-1000.slice/user@1000.service/app.slice/opencode-web.service'
 	local actual
 	actual=$(_classify_runtime_limit 4104 7210 7200)
 	assert_eq "OpenCode web server older than generic limit is delegated" "MANAGED" "$actual"
@@ -180,7 +189,7 @@ test_kill_runaways_skips_managed_worker() {
 }
 
 test_kill_runaways_skips_opencode_web_service() {
-	write_cgroup 4504 '/user.slice/user-1000.slice/user@1000.service/app.slice/opencode-web.service'
+	write_hybrid_cgroup 4504 '/user.slice/user-1000.slice/user@1000.service/app.slice/opencode-web.service'
 	MOCK_PROCESS_LINE='4504 1 ? 2860032 2:00:10 /home/test/.opencode/bin/opencode serve --port 4096'
 	MOCK_PROCESS_AGE=7210
 	CHILD_RUNTIME_LIMIT=7200

--- a/.agents/scripts/tests/test-process-guard-playwright-list.sh
+++ b/.agents/scripts/tests/test-process-guard-playwright-list.sh
@@ -124,14 +124,14 @@ test_rejects_substring_grep_option() {
 test_kill_log_format_carries_timestamp_and_process_class() {
 	local helper_text
 	helper_text=$(<"$HELPER")
-	if [[ "$helper_text" == *"class=%s cmd=%s rss_mb=%s age_seconds=%s"* && \
+	if [[ "$helper_text" == *"action=kill pid=%s ppid=%s class=%s cmd=%s rss_mb=%s age_seconds=%s runtime_limit_seconds=%s cgroup=%s reason=%s"* && \
 		"$helper_text" == *"_process_guard_timestamp"* && \
 		"$helper_text" == *"process_class='playwright-list'"* ]]; then
-		print_result "kill log format carries timestamp and process class" 0
+		print_result "kill log format carries timestamp, process class, and cgroup" 0
 		return 0
 	fi
 
-	print_result "kill log format carries timestamp and process class" 1
+	print_result "kill log format carries timestamp, process class, and cgroup" 1
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Delegate generic process-age enforcement for processes in `opencode-web.service`, `opencode-web@*.service`, and `opencode-web-watchdog.service` cgroups.
- Keep RSS limits active and retain generic age enforcement when cgroup evidence is missing or only resembles the service name.
- Add structured kill attribution containing the PID, parent PID, process class, resource values, cgroup, and reason.
- Preserve intentionally newer linked-worktree runtime bundles instead of treating them as stale canonical deployments every ten minutes.

## Root cause

The generic process guard applied `CHILD_RUNTIME_LIMIT=7200` to the long-running OpenCode web service. Once the service process exceeded two hours, the guard killed it even during active sessions. The systemd service then restarted, interrupting the model stream.

The same exact-name matcher initially omitted `opencode-web-watchdog.service`, so the guard continued killing the service-owned health watchdog at two-hour intervals. The matcher now delegates both long-running OpenCode service lifecycles while preserving independent RSS enforcement.

After that fix was deployed, the unattended auto-update drift check compared the active PR bundle to canonical `main` in the wrong direction. It repeatedly classified the newer deployed bundle as stale, launched a redeploy, timed out, and—because the locally generated unit still used `KillMode=process`—left updater children alive. One such run was immediately followed by the web-service SIGTERM. The ancestry guard now redeploys only when the active bundle is actually behind canonical HEAD; newer or diverged deployments are preserved.

The first exemption revision selected only the first entry from `/proc/<pid>/cgroup`. On hybrid cgroup hosts that entry can be a generic controller path; the authoritative `name=systemd` or unified `0::` entry appears later. The revised parser explicitly prefers those authoritative entries and retains the first path only as a diagnostic fallback.

## Implementation

- `.agents/scripts/process-guard-helper.sh`: detect the exact systemd service lineage, delegate its runtime lifecycle, and improve kill logs.
- `.agents/scripts/tests/test-process-guard-managed-workers.sh`: cover direct, descendant, template-service, lookalike, unavailable-cgroup, and kill-path behavior.
- `.agents/scripts/tests/test-process-guard-playwright-list.sh`: verify the expanded structured log contract.
- `.agents/scripts/auto-update-helper-check.sh` and `.agents/scripts/auto-update-helper.sh`: add ancestry-aware same-version drift reconciliation.
- `.agents/scripts/tests/test-cmd-update-sha-drift.sh`: prove ahead deployments are preserved while genuinely stale deployments still reconcile.

The existing managed-worker cgroup classification is the reference pattern. The new OpenCode classification follows the same fail-closed behavior while leaving memory enforcement independent.

## Verification

- `shellcheck .agents/scripts/process-guard-helper.sh .agents/scripts/tests/test-process-guard-managed-workers.sh .agents/scripts/tests/test-process-guard-playwright-list.sh`
- `bash .agents/scripts/tests/test-process-guard-managed-workers.sh` — 20/20 passed
- `bash .agents/scripts/tests/test-process-guard-playwright-list.sh` — 7/7 passed
- `bash .agents/scripts/tests/test-cmd-update-sha-drift.sh` — 18/18 passed
- `bash .agents/scripts/tests/test-systemd-unit-generation.sh` — 13/13 passed
- `./.agents/scripts/linters-local.sh`
- Pre-commit and pre-push repository hooks passed.
- Live hybrid-cgroup verification classifies both the over-age web service and the running watchdog as `MANAGED` while using an independently high RSS threshold.
- Live drift verification preserves deployed bundle `2ab5691` because it contains current canonical HEAD `f7286aa`; persistent configuration now disables auto-update, and the regenerated service uses `KillMode=control-group` when explicitly enabled.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 1d 12h and 2,237,538 tokens on this with the user in an interactive session.
