### PR TITLE
GH#30693: Gate pulse queue underfill on live dispatch

### DIFF
--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -33,6 +33,7 @@ end) as $max_workers |
 ($queue.aggregate.gh_errors // 0 | number_or_zero) as $gh_errors |
 ($queue.error // "") as $queue_error |
 ($queue_error == "" and $gh_errors == 0) as $queue_scan_complete |
+($current.dispatch_alive // false) as $dispatch_alive |
 ($current.worker_outcomes.spawned // 0 | number_or_zero) as $spawned |
 ($current.worker_outcomes.launch_validation_failed // $current.pulse_counter_hits.dispatch_worker_launch_failed // 0 | number_or_zero) as $launch_validation_failed |
 ($current.worker_terminal_events // 0 | number_or_zero) as $current_terminal_events |
@@ -63,7 +64,7 @@ end) as $max_workers |
     active_workers_source: (if $active_worker_processes == null then "capacity_gauge" else "process_scan" end),
     inferred_active_workers: $inferred_active_workers,
     available_slots: $effective_available_slots,
-    dispatch_alive: ($current.dispatch_alive // false),
+    dispatch_alive: $dispatch_alive,
     dispatch_stage_events: ($current.dispatch_stage_events // 0),
     worker_launches_in_window: $spawned,
     worker_terminal_events_in_window: $current_terminal_events,
@@ -186,7 +187,7 @@ end) as $max_workers |
         true
       )
     else empty end,
-    if ($queue_scan_complete and $eligible_issues >= $threshold and $active_workers == 0) then
+    if ($queue_scan_complete and $dispatch_alive and $eligible_issues >= $threshold and $active_workers == 0) then
       finding(
         "pulse-underfilled-auto-dispatch-queue";
         "high";
@@ -195,6 +196,7 @@ end) as $max_workers |
           ("active_workers=" + ($active_workers | tostring) + "/" + ($max_workers | tostring)),
           ("eligible_available_unassigned_auto_dispatch=" + ($eligible_issues | tostring)),
           ("available_older_than_threshold=" + ($old_available | tostring)),
+          "dispatch_alive=true",
           ("dispatch_stage_events=" + (($current.dispatch_stage_events // 0) | tostring))
         ];
         "Inspect why the pulse did not retain active workers for visible status:available auto-dispatch issues; start with pulse-current-state-helper, worker-activity-helper, and pulse-diagnose-helper cycle-health.";

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -372,6 +372,26 @@ assert_eq "json reports process-scan active workers" "2" "$ACTIVE_COUNT"
 assert_eq "json recomputes available slots from process count" "4" "$ACTIVE_AVAILABLE"
 assert_eq "process-scan active workers suppress underfill finding" "auto-dispatch-missing-tier-labels" "$ACTIVE_IDS"
 
+cat >"${TEST_ROOT}/current-state-idle.sh" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "dispatch_alive": false,
+  "dispatch_stage_events": 0,
+  "active_worker_processes": 0,
+  "current_state_guardrails": {"available_slots_last": 6},
+  "pulse_gauges": {"dispatch_capacity_final_max_workers": 6},
+  "worker_outcomes": {"spawned": 0},
+  "worker_terminal_events": 0,
+  "graphql_budget_status": "OK fixture"
+}
+JSON
+SH
+chmod +x "${TEST_ROOT}/current-state-idle.sh"
+IDLE_JSON_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-idle.sh" "$HELPER" json 2>&1)
+assert_eq "idle dispatch is reported as inactive" "false" "$(printf '%s' "$IDLE_JSON_OUT" | jq -r '.summary.dispatch_alive')"
+assert_not_contains "idle dispatch does not claim a worker-retention underfill" "pulse-underfilled-auto-dispatch-queue" "$IDLE_JSON_OUT"
+
 cat >"${TEST_ROOT}/current-state-active-no-gauge.sh" <<'SH'
 #!/usr/bin/env bash
 cat <<'JSON'


### PR DESCRIPTION
Resolves #30693

## Summary

- require current dispatch activity before reporting a worker-retention underfill
- retain the aggregate dispatch-state evidence and cover an idle-dispatch fixture

## Verification

- `.agents/scripts/tests/test-pulse-check-helper.sh`
- `shellcheck .agents/scripts/tests/test-pulse-check-helper.sh`

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra
