### PR TITLE
GH#30697: fix: gate inactive launch accounting

### DIFF
--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -239,7 +239,7 @@ end) as $max_workers |
         true
       )
     else empty end,
-    if (($spawned - ([($recent_total), ($current_terminal_events)] | max) - $launch_validation_failed) >= 3 and $active_workers == 0) then
+    if ($dispatch_alive and ($spawned - ([($recent_total), ($current_terminal_events)] | max) - $launch_validation_failed) >= 3 and $active_workers == 0) then
       finding(
         "pulse-launch-accounting-gap";
         "high";
@@ -250,7 +250,8 @@ end) as $max_workers |
           ("worker_terminal_events_in_current_window=" + ($current_terminal_events | tostring)),
           ("worker_launch_validation_failures_in_current_window=" + ($launch_validation_failed | tostring)),
           ("active_workers=" + ($active_workers | tostring)),
-          ("available_slots=" + ($available_slots | tostring))
+          ("available_slots=" + ($available_slots | tostring)),
+          "dispatch_alive=true"
         ];
         "Add or repair launch-validation evidence so every spawned worker becomes an active process, a terminal metric, or a classified launch failure.";
         true

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -392,6 +392,25 @@ IDLE_JSON_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_
 assert_eq "idle dispatch is reported as inactive" "false" "$(printf '%s' "$IDLE_JSON_OUT" | jq -r '.summary.dispatch_alive')"
 assert_not_contains "idle dispatch does not claim a worker-retention underfill" "pulse-underfilled-auto-dispatch-queue" "$IDLE_JSON_OUT"
 
+cat >"${TEST_ROOT}/current-state-idle-after-launch.sh" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "dispatch_alive": false,
+  "dispatch_stage_events": 0,
+  "active_worker_processes": 0,
+  "current_state_guardrails": {"available_slots_last": 6},
+  "pulse_gauges": {"dispatch_capacity_final_max_workers": 6},
+  "worker_outcomes": {"spawned": 4},
+  "worker_terminal_events": 0,
+  "graphql_budget_status": "OK fixture"
+}
+JSON
+SH
+chmod +x "${TEST_ROOT}/current-state-idle-after-launch.sh"
+IDLE_AFTER_LAUNCH_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-idle-after-launch.sh" "$HELPER" json 2>&1)
+assert_not_contains "idle dispatch does not claim a launch-accounting gap" "pulse-launch-accounting-gap" "$IDLE_AFTER_LAUNCH_OUT"
+
 cat >"${TEST_ROOT}/current-state-active-no-gauge.sh" <<'SH'
 #!/usr/bin/env bash
 cat <<'JSON'


### PR DESCRIPTION
## Summary

Gate launch-accounting findings on live dispatch and expose that evidence

## Files Changed

.agents/scripts/pulse-check-report.jq, .agents/scripts/tests/test-pulse-check-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-pulse-check-helper.sh

Resolves #30697


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 27m and 181,307 tokens on this as a headless worker.