### PR TITLE
GH#30695: promote verified OpenCode 1.18.23 pin

### DIFF
--- a/.agents/plugins/opencode-aidevops/package-lock.json
+++ b/.agents/plugins/opencode-aidevops/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
-        "@opencode-ai/plugin": "^1.18.21"
+        "@opencode-ai/plugin": "^1.18.23"
       },
       "peerDependencies": {
         "opencode-ai": ">=1.3.0"
@@ -113,13 +113,13 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.21",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.21.tgz",
-      "integrity": "sha512-wQXMbSvg3pG75F8fYAiJxYuyr6Cl9Hd74lSCY2yznZnejpwa+ksd2kMphmgSo+/UgLhb2AId9KAI6dsRhprzTg==",
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.23.tgz",
+      "integrity": "sha512-a+LbJe+wyyiwOQ7DeYOY4MkI/6VL45wkgYunVNZGC93UQgaj6sMGemS45CsLXrjyF4bvJMtqGd66GJvgjzbXAg==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.21",
+        "@opencode-ai/sdk": "1.18.23",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.21",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.21.tgz",
-      "integrity": "sha512-k6iHQ5C8wOPglk+LgFyYnst168cGMQYumgpbVoeXJ+iC1AtvwD5zmjuF8CxMze/y9G1K2bOeO6p9yRvA7eHZLA==",
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.23.tgz",
+      "integrity": "sha512-VouYbL8O2ynLq0atr5fjzCv8YLtFi/zKLQ/uYkCvTJ4CmUdA01XwPn8om+u3TvxnGEfQsBfmThGU141vt3sg5w==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/.agents/plugins/opencode-aidevops/package.json
+++ b/.agents/plugins/opencode-aidevops/package.json
@@ -17,7 +17,7 @@
   "author": "Marcus Quinn",
   "license": "MIT",
   "opencode": {
-    "tracked_version": "1.18.21",
+    "tracked_version": "1.18.23",
     "repo": "anomalyco/opencode"
   },
   "peerDependencies": {
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0",
-    "@opencode-ai/plugin": "^1.18.21"
+    "@opencode-ai/plugin": "^1.18.23"
   }
 }

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -183,18 +183,19 @@ aidevops_ensure_symlink_target() {
 # location services with an isolated XDG_DATA_HOME. GH#28892 advanced the pin
 # after 1.18.9 passed the isolated Linux-headless canary; GH#29964 promoted
 # 1.18.16 after a credential-free same-revision baseline comparison; GH#30393
-# promoted 1.18.18 after making that comparison self-contained. Keep the complete
-# compatibility decision visible and machine-readable; general installs track
-# latest because the observed failure scope is Linux headless.
-readonly OPENCODE_PINNED_VERSION="1.18.18"
+# promoted 1.18.18 after making that comparison self-contained; GH#30695
+# promoted 1.18.23 after the isolated baseline and candidate probes passed. Keep
+# the complete compatibility decision visible and machine-readable; general
+# installs track latest because the observed failure scope is Linux headless.
+readonly OPENCODE_PINNED_VERSION="1.18.23"
 readonly OPENCODE_PIN_REASON="GH#28766 Linux headless bootstrap stalled with isolated XDG_DATA_HOME"
 readonly OPENCODE_PIN_PLATFORM="Linux"
 readonly OPENCODE_PIN_RUNTIME_MODE="headless"
 readonly OPENCODE_PIN_INTRODUCED_DATE="2026-07-30"
-readonly OPENCODE_PIN_LAST_CANARY_DATE="2026-08-19"
-readonly OPENCODE_PIN_LAST_CANARY_RESULT="pass:1.18.18"
-readonly OPENCODE_PIN_REVIEW_DEADLINE="2026-08-26"
-readonly OPENCODE_PLUGIN_TESTED_VERSION="1.18.18"
+readonly OPENCODE_PIN_LAST_CANARY_DATE="2026-08-25"
+readonly OPENCODE_PIN_LAST_CANARY_RESULT="pass:1.18.23"
+readonly OPENCODE_PIN_REVIEW_DEADLINE="2026-09-01"
+readonly OPENCODE_PLUGIN_TESTED_VERSION="1.18.23"
 
 aidevops_opencode_pin_applies() {
 	local platform="${1:-$(uname -s 2>/dev/null || printf 'unknown')}"

--- a/.agents/scripts/tests/test-opencode-pin-policy.sh
+++ b/.agents/scripts/tests/test-opencode-pin-policy.sh
@@ -19,13 +19,13 @@ assert_eq() {
 	fi
 }
 
-assert_eq "pin version is explicit" "1.18.18" "$OPENCODE_PINNED_VERSION"
+assert_eq "pin version is explicit" "1.18.23" "$OPENCODE_PINNED_VERSION"
 assert_eq "pin platform is scoped" "Linux" "$OPENCODE_PIN_PLATFORM"
 assert_eq "pin runtime is scoped" "headless" "$OPENCODE_PIN_RUNTIME_MODE"
 assert_eq "introduction date is recorded" "2026-07-30" "$OPENCODE_PIN_INTRODUCED_DATE"
-assert_eq "last canary is recorded" "2026-08-19" "$OPENCODE_PIN_LAST_CANARY_DATE"
-assert_eq "review deadline is recorded" "2026-08-26" "$OPENCODE_PIN_REVIEW_DEADLINE"
-assert_eq "plugin compatibility signal is explicit" "1.18.18" "$OPENCODE_PLUGIN_TESTED_VERSION"
+assert_eq "last canary is recorded" "2026-08-25" "$OPENCODE_PIN_LAST_CANARY_DATE"
+assert_eq "review deadline is recorded" "2026-09-01" "$OPENCODE_PIN_REVIEW_DEADLINE"
+assert_eq "plugin compatibility signal is explicit" "1.18.23" "$OPENCODE_PLUGIN_TESTED_VERSION"
 
 scope_rc=0
 aidevops_opencode_pin_applies Linux headless || scope_rc=$?
@@ -40,7 +40,7 @@ assert_eq "interactive setup is outside observed scope" "1" "$scope_rc"
 status=$(
 	PATH="/usr/bin:/bin" "$REPO_ROOT/.agents/scripts/opencode-pin-canary.sh" status
 )
-[[ "$status" == *"pinned=1.18.18"* && "$status" == *"registry-latest="* && "$status" == *"plugin-tested=1.18.18"* && "$status" == *"last-canary=2026-08-19"* ]] || {
+[[ "$status" == *"pinned=1.18.23"* && "$status" == *"registry-latest="* && "$status" == *"plugin-tested=1.18.23"* && "$status" == *"last-canary=2026-08-25"* ]] || {
 	printf 'FAIL: status omits compatibility evidence: %s\n' "$status" >&2
 	fail=$((fail + 1))
 }

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -91,7 +91,7 @@ extract_function
 printf 'Test 0: OpenCode remains pinned to the last verified headless release\n'
 # shellcheck source=../shared-constants.sh
 source "$SHARED_CONSTANTS"
-assert_eq "OpenCode headless regression pin" "1.18.18" "$OPENCODE_PINNED_VERSION"
+assert_eq "OpenCode headless regression pin" "1.18.23" "$OPENCODE_PINNED_VERSION"
 
 printf 'Test 0a: routine freshness tracks registry outside Linux headless dispatch\n'
 mkdir -p "$SANDBOX/routine-freshness/bin"
@@ -212,7 +212,7 @@ assert_eq "npm OpenCode upgrade command" "npm install -g opencode-ai@1.15.10" "$
 printf 'Test 4: headless guard provisions an isolated pin without changing newer general install\n'
 mkdir -p "$SANDBOX/version-guard/runtime" "$SANDBOX/version-guard/bin" "$SANDBOX/version-guard/state"
 write_executable "$SANDBOX/version-guard/runtime/opencode" '#!/usr/bin/env bash
-printf "1.18.19\n"'
+printf "1.18.24\n"'
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
 write_executable "$SANDBOX/version-guard/bin/npm" '#!/usr/bin/env bash
 printf "%s\n" "$*" >>"'"$SANDBOX"'/version-guard/calls"
@@ -224,7 +224,7 @@ done
 mkdir -p "$prefix/node_modules/opencode-linux-x64/bin"
 cat >"$prefix/node_modules/opencode-linux-x64/bin/opencode" <<"BIN"
 #!/usr/bin/env bash
-printf "1.18.18\n"
+printf "1.18.23\n"
 BIN
 chmod +x "$prefix/node_modules/opencode-linux-x64/bin/opencode"'
 guard_rc=0
@@ -244,10 +244,10 @@ headless_bin=""
 ) || guard_rc=$?
 assert_eq "headless pin repair status" "0" "$guard_rc"
 headless_bin=$(<"$SANDBOX/version-guard/headless-bin")
-assert_eq "general install remains newer" "1.18.19" "$("$SANDBOX/version-guard/runtime/opencode")"
-assert_eq "isolated headless runtime is pinned" "1.18.18" "$("$headless_bin")"
+assert_eq "general install remains newer" "1.18.24" "$("$SANDBOX/version-guard/runtime/opencode")"
+assert_eq "isolated headless runtime is pinned" "1.18.23" "$("$headless_bin")"
 install_call=$(<"$SANDBOX/version-guard/calls")
-[[ "$install_call" == "install --ignore-scripts --no-audit --no-fund --prefix "*"/opencode-runtimes/.1.18.18.install."*"/prefix opencode-ai@1.18.18" ]] && install_shape="valid" || install_shape="invalid"
+[[ "$install_call" == "install --ignore-scripts --no-audit --no-fund --prefix "*"/opencode-runtimes/.1.18.23.install."*"/prefix opencode-ai@1.18.23" ]] && install_shape="valid" || install_shape="invalid"
 assert_eq "isolated install requests exact pin" "valid" "$install_shape"
 
 printf 'Test 4b: existing isolated pin is reused without package-manager mutation\n'
@@ -270,7 +270,7 @@ assert_eq "existing isolated runtime avoids second install" "1" "$(wc -l <"$SAND
 printf 'Test 4c: stale pin repair locks are cleared after the bounded wait\n'
 mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes" "$SANDBOX/version-stale-lock/bin"
 write_executable "$SANDBOX/version-stale-lock/runtime-opencode" '#!/usr/bin/env bash
-printf "1.18.19\n"'
+printf "1.18.24\n"'
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
 write_executable "$SANDBOX/version-stale-lock/bin/npm" '#!/usr/bin/env bash
 prefix=""
@@ -281,14 +281,14 @@ done
 mkdir -p "$prefix/node_modules/opencode-linux-x64/bin"
 cat >"$prefix/node_modules/opencode-linux-x64/bin/opencode" <<"BIN"
 #!/usr/bin/env bash
-printf "1.18.18\n"
+printf "1.18.23\n"
 BIN
 chmod +x "$prefix/node_modules/opencode-linux-x64/bin/opencode"'
 (:) &
 dead_installer_pid=$!
 wait "$dead_installer_pid" || true
 mkdir -p "$SANDBOX/version-stale-lock/state/opencode-pin-repair.lock"
-mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.18.install.$dead_installer_pid"
+mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.23.install.$dead_installer_pid"
 stale_lock_rc=0
 (
 	source_extracted
@@ -306,14 +306,14 @@ stale_lock_rc=0
 ) || stale_lock_rc=$?
 assert_eq "stale lock repair status" "0" "$stale_lock_rc"
 assert_eq "stale lock is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-pin-repair.lock" ]] && printf '1\n' || printf '0\n')"
-assert_eq "dead install temp is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.18.install.$dead_installer_pid" ]] && printf '1\n' || printf '0\n')"
+assert_eq "dead install temp is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.23.install.$dead_installer_pid" ]] && printf '1\n' || printf '0\n')"
 stale_headless_bin=$(<"$SANDBOX/version-stale-lock/headless-bin")
-assert_eq "stale lock path provisions pinned runtime" "1.18.18" "$("$stale_headless_bin")"
+assert_eq "stale lock path provisions pinned runtime" "1.18.23" "$("$stale_headless_bin")"
 
 printf 'Test 5: headless version guard fails closed when isolated provisioning fails\n'
 mkdir -p "$SANDBOX/version-install-failure/state"
 write_executable "$SANDBOX/version-install-failure/opencode" '#!/usr/bin/env bash
-printf "1.18.19\n"'
+printf "1.18.24\n"'
 write_executable "$SANDBOX/version-install-failure/npm" '#!/usr/bin/env bash
 exit 42'
 guard_rc=0

--- a/.github/workflows/opencode-pin-canary.yml
+++ b/.github/workflows/opencode-pin-canary.yml
@@ -78,6 +78,6 @@ jobs:
           body=$(printf '%s\n\n%s\n\n%s\n\n%s\n' \
             "$summary" \
             "Status: ${status}" "Result: ${result}" \
-            'Files: `.agents/scripts/shared-constants.sh`, `.opencode/package.json`, and `.opencode/package-lock.json`. Retain the current fail-closed pin after failed or inconclusive results; after a passing rerun, advance the tested version, dates, result, and plugin lock together. Verify with `.agents/scripts/tests/test-opencode-pin-policy.sh` and the workflow canary.')
+            'Files: `.agents/scripts/shared-constants.sh`, `.agents/plugins/opencode-aidevops/package.json`, and `.agents/plugins/opencode-aidevops/package-lock.json`. Retain the current fail-closed pin after failed or inconclusive results; after a passing rerun, advance the tested version, dates, result, and plugin lock together. Verify with `.agents/scripts/tests/test-opencode-pin-policy.sh` and the workflow canary.')
           gh api --method POST "repos/${REPO}/issues" -f title="$title" -f body="$body" \
             -f 'labels[]=origin:worker' -f 'labels[]=status:in-review' >/dev/null


### PR DESCRIPTION
## Summary

Promote the passing Linux-headless OpenCode candidate to 1.18.23, align the plugin lock, and correct future promotion guidance paths.

## Files Changed

.agents/plugins/opencode-aidevops/package-lock.json, .agents/plugins/opencode-aidevops/package.json, .agents/scripts/shared-constants.sh, .agents/scripts/tests/test-opencode-pin-policy.sh, .agents/scripts/tests/test-tool-version-check-opencode.sh, .github/workflows/opencode-pin-canary.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Scheduled Linux-headless canary run 32820241302 passed; pin policy tests, tool-version regression tests, 671 plugin tests, ShellCheck, Actionlint, JSON validation, and local linters pass.

Resolves #30695


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 10m and 138,881 tokens on this with the user in an interactive session.