### PR TITLE
GH#30701: fix: skip cooling providers in configured models

### DIFF
--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -104,6 +104,9 @@ get_configured_models() {
 			if ! provider_auth_available "$provider"; then
 				continue
 			fi
+			if ! provider_oauth_pool_available "$provider"; then
+				continue
+			fi
 
 			models+=("$model")
 	done < <(model_tier_candidates "$tier_name" 2>/dev/null || true)


### PR DESCRIPTION
## Summary

Filter configured model candidates through provider_oauth_pool_available so canary and small-model selection avoid providers whose OAuth pools are cooling down.

## Files Changed

.agents/scripts/headless-runtime-model.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash -n and shellcheck on headless-runtime-model.sh; test-headless-runtime-oauth-pool-gate.sh; focused get_configured_models cooldown and recovery verification

Resolves #30701


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 6m and 62,673 tokens on this as a headless worker.