### PR TITLE
GH#30702: warn on invalid model routing overrides

### DIFF
--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -2,7 +2,7 @@
   "_comment": "Model routing table — SINGLE SOURCE OF TRUTH for tier-to-model mappings. All scripts, docs, and configs should reference this file rather than hardcoding model IDs. When a new model generation releases (e.g., gpt-5.6), update this file and its documented static fallbacks.",
   "_docs": "See .agents/tools/context/model-routing.md for routing rules, .agents/tools/ai-assistants/fallback-chains.md for integration.",
   "_agentic_note": "codex/code-completion models (gpt-5.3-codex, gpt-5.4-codex) are NOT agentic — zero tool calls observed (GH#17669). Never use them for headless worker dispatch. Only general-purpose models support agentic workflows.",
-  "_defaults": "The first model in each tier's array is primary; subsequent entries are same-tier availability fallbacks. Capability failure advances through escalation_order. GLM-5.2 is offered only through the Z.AI coding-plan provider. Use custom/configs/model-routing-table.json or AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST for local overrides.",
+  "_defaults": "The first model in each tier's array is primary; subsequent entries are same-tier availability fallbacks. Capability failure advances through escalation_order. GLM-5.2 is offered only through the Z.AI coding-plan provider. Custom overrides use custom/configs/model-routing-table.json: every configured canonical tier needs a models array of provider/model strings; omitted tiers inherit this table, and reasoning keys should use full provider/model IDs. Use AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST for local provider overrides.",
   "_tier_names": "Canonical workload tiers are simple, standard, and thinking. Provider names, model families, and reasoning variants must not be used as tier names.",
   "tiers": {
     "simple": {

--- a/.agents/scripts/doctor-helper.sh
+++ b/.agents/scripts/doctor-helper.sh
@@ -322,6 +322,38 @@ report_conflict_installs() {
 	return 0
 }
 
+#######################################
+# Report whether a custom model-routing table is usable or partially ignored.
+#######################################
+diagnose_model_routing_table() {
+	local routing_table=""
+	local framework_table=""
+	local findings=""
+
+	if ! declare -F model_routing_table_path >/dev/null 2>&1 || ! declare -F model_routing_framework_table_path >/dev/null 2>&1; then
+		print_warning "Model routing override: validator unavailable"
+		CONFLICTS_FOUND=1
+		return 0
+	fi
+
+	routing_table=$(model_routing_table_path 2>/dev/null) || routing_table=""
+	framework_table=$(model_routing_framework_table_path 2>/dev/null) || framework_table=""
+	if [[ -z "$routing_table" || "$routing_table" == "$framework_table" ]]; then
+		print_info "Model routing override: not found; framework defaults active"
+		return 0
+	fi
+
+	findings=$(model_routing_custom_table_validation_findings "$routing_table" "$framework_table") || findings="document: validation failed"
+	if [[ -n "$findings" ]]; then
+		print_warning "Model routing override: found and parsed, but invalid tiers are ignored: ${findings//$'\n'/; }"
+		CONFLICTS_FOUND=1
+		return 0
+	fi
+
+	print_success "Model routing override: found and parsed; configured tiers are active"
+	return 0
+}
+
 # Diagnose a single binary (aidevops or opencode)
 diagnose_binary() {
 	local binary_name="$1"
@@ -649,6 +681,7 @@ main() {
 
 	diagnose_binary "aidevops"
 	diagnose_binary "opencode"
+	diagnose_model_routing_table
 
 	if [[ "$QUIET_MODE" != "true" ]]; then
 		echo ""

--- a/.agents/scripts/shared-model-tier.sh
+++ b/.agents/scripts/shared-model-tier.sh
@@ -108,6 +108,59 @@ model_routing_framework_table_path() {
 }
 
 #######################################
+# Print per-tier schema findings for a custom routing table.
+#######################################
+model_routing_custom_table_validation_findings() {
+	local custom_table="$1"
+	local framework_table="$2"
+	local findings=""
+
+	[[ -n "$custom_table" && "$custom_table" != "$framework_table" ]] || return 0
+	if ! command -v jq >/dev/null 2>&1; then
+		printf '%s\n' "document: jq is required to validate custom model routing"
+		return 0
+	fi
+
+	if ! findings=$(jq -r '
+		if type != "object" then
+			["document: root must be an object"]
+		elif (.tiers | type) != "object" then
+			["tiers: must be an object"]
+		else
+			[.tiers | to_entries[] | .key as $tier | .value as $definition |
+				if (["simple", "standard", "thinking"] | index($tier) | not) then
+					"\($tier): unsupported tier (use simple, standard, or thinking)"
+				elif ($definition | type) != "object" then
+					"\($tier): must be an object containing models"
+				elif ($definition.models | type) != "array" then
+					"\($tier): models must be an array"
+				else empty end]
+		end | .[]
+	' "$custom_table" 2>/dev/null); then
+		findings="document: could not be parsed"
+	fi
+
+	[[ -z "$findings" ]] || printf '%s\n' "$findings"
+	return 0
+}
+
+#######################################
+# Warn once when a custom routing-table tier cannot supply candidates.
+#######################################
+model_routing_warn_invalid_custom_table() {
+	local custom_table="$1"
+	local framework_table="$2"
+	local findings=""
+
+	[[ "${_MODEL_ROUTING_CUSTOM_TABLE_WARNING_EMITTED:-0}" != "1" ]] || return 0
+	findings=$(model_routing_custom_table_validation_findings "$custom_table" "$framework_table") || return 0
+	[[ -n "$findings" ]] || return 0
+	_MODEL_ROUTING_CUSTOM_TABLE_WARNING_EMITTED=1
+	printf 'WARNING: custom model routing table has invalid tiers; those tiers are ignored: %s\n' "${findings//$'\n'/; }" >&2
+	return 0
+}
+
+#######################################
 # Print the ordered, same-tier model candidates, one per line.
 # A readable routing table is authoritative: a missing tier fails closed.
 #######################################
@@ -126,6 +179,7 @@ model_tier_candidates() {
 	routing_table=$(model_routing_table_path 2>/dev/null) || routing_table=""
 	framework_table=$(model_routing_framework_table_path 2>/dev/null) || framework_table=""
 	if command -v jq >/dev/null 2>&1; then
+		model_routing_warn_invalid_custom_table "$routing_table" "$framework_table"
 		local table=""
 		local previous_table=""
 		for table in "$routing_table" "$framework_table"; do


### PR DESCRIPTION
Summary: warn once for malformed custom model-routing tiers; add aidevops doctor override diagnostics; document the custom schema while preserving valid partial overrides. Verification: shellcheck; jq empty; routing-overlay test; canonical-tier test; doctor diagnostics. Resolves #30702 <!-- aidevops:origin:worker --> <!-- aidevops:sig --> --- [aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 20m and 137,997 tokens on this as a headless worker. Overall, 4h 58m since this issue was created.
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 21m and 147,341 tokens on this as a headless worker.