### PR TITLE
GH#30724: fix: allow trusted Poppins dependency update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -23,6 +23,7 @@ elysia
 @types/bun
 @types/react
 @fontsource/dm-sans
+@fontsource/poppins
 @fontsource/ubuntu
 typescript
 actions:actions/checkout

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
         "@fontsource/inter": "5.2.8",
         "@fontsource/mohave": "5.2.10",
         "@fontsource/playpen-sans": "5.3.0",
-        "@fontsource/poppins": "5.2.7",
+        "@fontsource/poppins": "5.3.0",
         "@fontsource/source-sans-3": "5.3.0",
         "@fontsource/source-serif-4": "5.2.9",
         "@fontsource/tilt-neon": "5.2.10",
@@ -112,7 +112,7 @@
 
     "@fontsource/playpen-sans": ["@fontsource/playpen-sans@5.3.0", "", {}, "sha512-94O9WdgAmvFpAjsPOgg5JZII4clcNeeMqQdNZh7Jz40rmcNv05jzwxyuw25IRjTb4o2aMV7eXjXC8GTFo/+s8Q=="],
 
-    "@fontsource/poppins": ["@fontsource/poppins@5.2.7", "", {}, "sha512-6uQyPmseo4FgI97WIhA4yWRlNaoLk4vSDK/PyRwdqqZb5zAEuc+Kunt8JTMcsHYUEGYBtN15SNkMajMdqUSUmg=="],
+    "@fontsource/poppins": ["@fontsource/poppins@5.3.0", "", {}, "sha512-cms1nM7U6SN8epIV1WMVOV8VsA645aSm3wHfzIQnkk188U341ThbJGSl2Sv54V29gnDbT2arMPfLzvVIIVCceQ=="],
 
     "@fontsource/source-sans-3": ["@fontsource/source-sans-3@5.3.0", "", {}, "sha512-VrWixSgF93kOVSEkwjs9ImnAbxrBew4PgcnaJYEitG9TyJSwxjFUNJIgzB1XFP/acyAWcTDg7+sWe7JI8LTB9w=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -15,7 +15,7 @@
     "@fontsource/inter": "5.2.8",
     "@fontsource/mohave": "5.2.10",
     "@fontsource/playpen-sans": "5.3.0",
-    "@fontsource/poppins": "5.2.7",
+    "@fontsource/poppins": "5.3.0",
     "@fontsource/source-sans-3": "5.3.0",
     "@fontsource/source-serif-4": "5.2.9",
     "@fontsource/tilt-neon": "5.2.10",


### PR DESCRIPTION
## Summary

Implementation for issue #30724.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30724


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 4m and 81,884 tokens on this as a headless worker.