### PR TITLE
GH#30726: fix: trust Source Serif Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -23,6 +23,7 @@ elysia
 @types/bun
 @types/react
 @fontsource/dm-sans
+@fontsource/source-serif-4
 @fontsource/ubuntu
 typescript
 actions:actions/checkout

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -517,6 +517,20 @@ test_repository_allows_fontsource_ubuntu() {
 	return 0
 }
 
+test_repository_allows_fontsource_source_serif() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "bun" "@fontsource/source-serif-4"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits @fontsource/source-serif-4 Bun updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits @fontsource/source-serif-4 Bun updates" 1
+	return 0
+}
+
 test_repository_allows_trusted_actions() {
 	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
 	local dependency_name=""
@@ -618,6 +632,7 @@ main() {
 	test_repository_allows_vite_react_plugin
 	test_repository_allows_elysia
 	test_repository_allows_fontsource_ubuntu
+	test_repository_allows_fontsource_source_serif
 	test_repository_allows_trusted_actions
 	test_trusted_dependabot_can_be_approved
 	test_review_bot_failure_is_ignored_when_other_checks_green

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
         "@fontsource/playpen-sans": "5.3.0",
         "@fontsource/poppins": "5.2.7",
         "@fontsource/source-sans-3": "5.3.0",
-        "@fontsource/source-serif-4": "5.2.9",
+        "@fontsource/source-serif-4": "5.3.0",
         "@fontsource/tilt-neon": "5.2.10",
         "@fontsource/ubuntu": "5.3.0",
         "@fontsource/ubuntu-mono": "5.2.8",
@@ -116,7 +116,7 @@
 
     "@fontsource/source-sans-3": ["@fontsource/source-sans-3@5.3.0", "", {}, "sha512-VrWixSgF93kOVSEkwjs9ImnAbxrBew4PgcnaJYEitG9TyJSwxjFUNJIgzB1XFP/acyAWcTDg7+sWe7JI8LTB9w=="],
 
-    "@fontsource/source-serif-4": ["@fontsource/source-serif-4@5.2.9", "", {}, "sha512-er/Pym9emsEVJNf947umJ4kXarXfsiN6CN7kTYinefKRaHLwiquiiHOZvKvxWgkV8JMCf3pV3g0NcsPFpVCH9w=="],
+    "@fontsource/source-serif-4": ["@fontsource/source-serif-4@5.3.0", "", {}, "sha512-yQz8xmIgMzks8zQbpuca3UYtjxK798XCyQAGdDXmzBgvV7sdoK6d0YvE9F9kiYxORCEMRBgGZDZsSYcXj5KvwA=="],
 
     "@fontsource/tilt-neon": ["@fontsource/tilt-neon@5.2.10", "", {}, "sha512-qBointHhyP7K/avRTmfYkHUrGoCOLt3EG0dpXKJdHua/2OjU74YrCUeVIFO9agSX6A0dM2dUUsrE2ZuxYwC1Eg=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -17,7 +17,7 @@
     "@fontsource/playpen-sans": "5.3.0",
     "@fontsource/poppins": "5.2.7",
     "@fontsource/source-sans-3": "5.3.0",
-    "@fontsource/source-serif-4": "5.2.9",
+    "@fontsource/source-serif-4": "5.3.0",
     "@fontsource/tilt-neon": "5.2.10",
     "@fontsource/ubuntu": "5.3.0",
     "@fontsource/ubuntu-mono": "5.2.8",


### PR DESCRIPTION
## Summary

Allowlists @fontsource/source-serif-4 after validating the exact Dependabot update, then applies the locked 5.3.0 package update.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, bun.lock, packages/gui-web/package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; bun --cwd packages/gui-web test; shellcheck .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

Resolves #30726


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 6m and 125,081 tokens on this as a headless worker.