### PR TITLE
GH#30728: fix: resolve trusted Secretlint update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -24,6 +24,7 @@ elysia
 @types/react
 @fontsource/dm-sans
 @fontsource/ubuntu
+@secretlint/secretlint-rule-preset-recommend
 typescript
 actions:actions/checkout
 actions:actions/github-script

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -517,6 +517,20 @@ test_repository_allows_fontsource_ubuntu() {
 	return 0
 }
 
+test_repository_allows_secretlint_recommend() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "bun" "@secretlint/secretlint-rule-preset-recommend"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits Secretlint recommend preset Bun updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits Secretlint recommend preset Bun updates" 1
+	return 0
+}
+
 test_repository_allows_trusted_actions() {
 	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
 	local dependency_name=""
@@ -618,6 +632,7 @@ main() {
 	test_repository_allows_vite_react_plugin
 	test_repository_allows_elysia
 	test_repository_allows_fontsource_ubuntu
+	test_repository_allows_secretlint_recommend
 	test_repository_allows_trusted_actions
 	test_trusted_dependabot_can_be_approved
 	test_review_bot_failure_is_ignored_when_other_checks_green

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "vite": "8.2.1",
       },
       "devDependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "11.7.1",
+        "@secretlint/secretlint-rule-preset-recommend": "13.0.4",
         "@types/bun": "1.3.14",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.3",
@@ -178,7 +178,7 @@
 
     "@secretlint/resolver": ["@secretlint/resolver@11.7.1", "", {}, "sha512-TShFKvFDqJalqM4r/NHrpdbd512odIOLZit01r65Szs5vdRq/W38B1QF0hwh0ZJq9wLOOpkTuVWkff0S4LFwZQ=="],
 
-    "@secretlint/secretlint-rule-preset-recommend": ["@secretlint/secretlint-rule-preset-recommend@11.7.1", "", {}, "sha512-LsiEhDWoXi9GNx1Zp5eYRNajeUvBrZ82h3k/vzFqo0WoSdmpyDnkkzBTLXqWqj1VNyPCcTwlxOqnEmlz6lXc7A=="],
+    "@secretlint/secretlint-rule-preset-recommend": ["@secretlint/secretlint-rule-preset-recommend@13.0.4", "", {}, "sha512-Nbcr7tvyKuRF4BKh7RQSCEOaif4gFPH/qjK2ajcoUDGL7HAY/C6PzcsmVR1Y0qQCRqrBuMuXn1onXE+wxNNNsw=="],
 
     "@secretlint/source-creator": ["@secretlint/source-creator@11.7.1", "", { "dependencies": { "@secretlint/types": "11.7.1", "istextorbinary": "^9.5.0" } }, "sha512-y7SS9VXbUJgVn0qT1KvaDsB0asLa+vsg55W6WLX4DStgkB1IrnUdwAtelZizDjeToLtjRhRRroCs8y6FFIpf3g=="],
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "vite": "8.2.1"
   },
   "devDependencies": {
-    "@secretlint/secretlint-rule-preset-recommend": "11.7.1",
+    "@secretlint/secretlint-rule-preset-recommend": "13.0.4",
     "@types/bun": "1.3.14",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.3",


### PR DESCRIPTION
## Summary

Applied the verified Dependabot upgrade for @secretlint/secretlint-rule-preset-recommend 13.0.4, added its exact allowlist entry, and covered the trust-gate allowance.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, bun.lock, package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile --ignore-scripts; bun audit; bunx secretlint --no-color package.json; shellcheck .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh .agents/scripts/trusted-dependabot-lib.sh; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

Resolves #30728


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 8m and 118,118 tokens on this as a headless worker.