### PR TITLE
GH#30727: fix: allow trusted source-serif Dependabot updates

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -24,6 +24,7 @@ elysia
 @types/react
 @fontsource/dm-sans
 @fontsource/ibm-plex-serif
+@fontsource/source-serif-4
 @fontsource/ubuntu
 typescript
 actions:actions/checkout

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -531,6 +531,20 @@ test_repository_allows_fontsource_ibm_plex_serif() {
 	return 0
 }
 
+test_repository_allows_fontsource_source_serif_4() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "bun" "@fontsource/source-serif-4"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits @fontsource/source-serif-4 Bun updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits @fontsource/source-serif-4 Bun updates" 1
+	return 0
+}
+
 test_repository_allows_trusted_actions() {
 	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
 	local dependency_name=""
@@ -633,6 +647,7 @@ main() {
 	test_repository_allows_elysia
 	test_repository_allows_fontsource_ubuntu
 	test_repository_allows_fontsource_ibm_plex_serif
+	test_repository_allows_fontsource_source_serif_4
 	test_repository_allows_trusted_actions
 	test_trusted_dependabot_can_be_approved
 	test_review_bot_failure_is_ignored_when_other_checks_green


### PR DESCRIPTION
## Summary

Reapply the verified source-serif Dependabot allowlist on current main, preserving the concurrent IBM Plex Serif allowlist and regression coverage.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; shellcheck .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

Resolves #30727


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 41m and 234,415 tokens on this as a headless worker.