### PR TITLE
GH#30726: fix: apply Source Serif Dependabot update

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
         "@fontsource/playpen-sans": "5.3.0",
         "@fontsource/poppins": "5.2.7",
         "@fontsource/source-sans-3": "5.3.0",
-        "@fontsource/source-serif-4": "5.2.9",
+        "@fontsource/source-serif-4": "5.3.0",
         "@fontsource/tilt-neon": "5.2.10",
         "@fontsource/ubuntu": "5.3.0",
         "@fontsource/ubuntu-mono": "5.2.8",
@@ -116,7 +116,7 @@
 
     "@fontsource/source-sans-3": ["@fontsource/source-sans-3@5.3.0", "", {}, "sha512-VrWixSgF93kOVSEkwjs9ImnAbxrBew4PgcnaJYEitG9TyJSwxjFUNJIgzB1XFP/acyAWcTDg7+sWe7JI8LTB9w=="],
 
-    "@fontsource/source-serif-4": ["@fontsource/source-serif-4@5.2.9", "", {}, "sha512-er/Pym9emsEVJNf947umJ4kXarXfsiN6CN7kTYinefKRaHLwiquiiHOZvKvxWgkV8JMCf3pV3g0NcsPFpVCH9w=="],
+    "@fontsource/source-serif-4": ["@fontsource/source-serif-4@5.3.0", "", {}, "sha512-yQz8xmIgMzks8zQbpuca3UYtjxK798XCyQAGdDXmzBgvV7sdoK6d0YvE9F9kiYxORCEMRBgGZDZsSYcXj5KvwA=="],
 
     "@fontsource/tilt-neon": ["@fontsource/tilt-neon@5.2.10", "", {}, "sha512-qBointHhyP7K/avRTmfYkHUrGoCOLt3EG0dpXKJdHua/2OjU74YrCUeVIFO9agSX6A0dM2dUUsrE2ZuxYwC1Eg=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -17,7 +17,7 @@
     "@fontsource/playpen-sans": "5.3.0",
     "@fontsource/poppins": "5.2.7",
     "@fontsource/source-sans-3": "5.3.0",
-    "@fontsource/source-serif-4": "5.2.9",
+    "@fontsource/source-serif-4": "5.3.0",
     "@fontsource/tilt-neon": "5.2.10",
     "@fontsource/ubuntu": "5.3.0",
     "@fontsource/ubuntu-mono": "5.2.8",


### PR DESCRIPTION
## Summary

Applies the verified @fontsource/source-serif-4 5.3.0 lockfile and manifest update now that the narrow trusted Dependabot allowlist is present on main.

## Files Changed

bun.lock, packages/gui-web/package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile --ignore-scripts; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; bun --cwd packages/gui-web test; bun audit --audit-level=high; shellcheck .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

Resolves #30726


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 1h 3m and 405,670 tokens on this as a headless worker.