### PR TITLE
t18309: Fix same-user daemon proc cwd cleanup degradation

### DIFF
--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -200,6 +200,28 @@ PY
 	return $?
 }
 
+_worktree_proc_entry_is_known_non_worktree_daemon() {
+	local proc_dir="$1"
+	local proc_name=""
+	local proc_cmdline=""
+
+	if [[ -r "$proc_dir/comm" ]]; then
+		IFS= read -r proc_name <"$proc_dir/comm" || proc_name=""
+	fi
+	case "$proc_name" in
+	"(sd-pam)" | gpg-agent)
+		return 0
+		;;
+	sshd)
+		proc_cmdline=$(tr '\0' ' ' <"$proc_dir/cmdline" 2>/dev/null || true)
+		case "$proc_cmdline" in
+		sshd:*@pts/* | sshd:*@notty*) return 0 ;;
+		esac
+		;;
+	esac
+	return 1
+}
+
 _capture_worktree_proc_cwds() {
 	local proc_root="$1"
 	local cwd_link=""
@@ -215,12 +237,15 @@ _capture_worktree_proc_cwds() {
 		[[ -L "$cwd_link" || -e "$cwd_link" ]] || continue
 		if ! cwd_target=$(readlink "$cwd_link" 2>/dev/null); then
 			# Vanished processes are harmless. Linux commonly denies cwd reads for
-			# other users, so skip only entries whose four status UIDs prove they
-			# are foreign. Persistent same-user or unknown-ownership denials make
-			# visibility degraded without discarding readable cwd evidence.
+			# other users, so skip entries whose ownership proves they are foreign.
+			# Some same-UID session daemons intentionally hide cwd via dumpability
+			# hardening even though they are not worktree-scoped jobs; ignoring those
+			# prevents one login daemon from globally blocking autonomous cleanup.
+			# Unknown same-user processes still degrade visibility fail-closed.
 			[[ -L "$cwd_link" || -e "$cwd_link" ]] || continue
 			proc_dir="${cwd_link%/cwd}"
 			_worktree_proc_entry_is_provably_foreign_uid "$proc_dir" "$current_uid" && continue
+			_worktree_proc_entry_is_known_non_worktree_daemon "$proc_dir" && continue
 			visibility_degraded=1
 			continue
 		fi

--- a/.agents/scripts/tests/test-worktree-removal-audit-lib.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit-lib.sh
@@ -1710,6 +1710,38 @@ test_proc_snapshot_marks_same_uid_unreadable_entry_degraded() {
 }
 
 # =============================================================================
+# Same-UID hardened login daemons can deny cwd reads indefinitely. They are not
+# worktree-scoped jobs, so they must not globally degrade every cleanup scan.
+# =============================================================================
+test_proc_snapshot_skips_known_same_uid_daemon_denial() {
+	local proc_root="${TEST_DIR}/fake-proc-same-uid-daemon"
+	local current_uid=""
+	local output=""
+	local rc=0
+	current_uid=$(id -u)
+	mkdir -p "${proc_root}/1" "${proc_root}/2"
+	ln -s /visible-cwd "${proc_root}/1/cwd"
+	ln -s /daemon-hidden-cwd "${proc_root}/2/cwd"
+	printf 'Uid:\t%s\t%s\t%s\t%s\n' \
+		"$current_uid" "$current_uid" "$current_uid" "$current_uid" >"${proc_root}/2/status"
+	printf 'gpg-agent\n' >"${proc_root}/2/comm"
+
+	output=$(
+		readlink() {
+			local link_path="$1"
+			[[ "$link_path" == */1/cwd ]] || return 1
+			printf '/visible-cwd\n'
+			return 0
+		}
+		_capture_worktree_proc_cwds "$proc_root"
+	) || rc=1
+	[[ "$output" == "/visible-cwd" ]] || rc=1
+	print_result "proc_snapshot_skips_known_same_uid_daemon_denial" "$rc" \
+		"Expected hardened same-UID session daemon cwd denial to be skipped"
+	return 0
+}
+
+# =============================================================================
 # Degraded visibility is candidate-specific: unrelated readable CWDs require a
 # recoverable path, while any readable target inside the candidate hard-blocks.
 # =============================================================================
@@ -1960,6 +1992,7 @@ test_proc_snapshot_preserves_degraded_visibility
 test_proc_snapshot_skips_foreign_uid_unreadable_entry
 test_proc_snapshot_skips_foreign_uid_when_status_unreadable
 test_proc_snapshot_marks_same_uid_unreadable_entry_degraded
+test_proc_snapshot_skips_known_same_uid_daemon_denial
 test_degraded_visibility_preserves_positive_candidate_match
 test_proc_snapshot_requires_usable_evidence_after_foreign_skips
 test_proc_snapshot_ignores_vanished_entry

--- a/TODO.md
+++ b/TODO.md
@@ -520,6 +520,8 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 
 ## Backlog
 
+- [ ] t18309 Fix same-user daemon proc cwd cleanup degradation #bug #framework #cleanup #worktree #interactive ~1h tier:standard ref:GH#30740 logged:2026-08-25 -> [todo/tasks/t18309-brief.md]
+
 - [x] t18294 Stop approval batches after systemic GitHub transport failure #bug #framework #reliability #interactive #auto-dispatch ~3h tier:standard blocked-by:t18293 ref:GH#30339 logged:2026-08-17 -> [todo/tasks/t18294-brief.md] pr:#30352 completed:2026-08-17
 
 - [x] t18071 Establish privacy-safe linter forensics and bounded resource baselines across mission targets #mission:m-20260710-11431d #investigate #performance #security #interactive ~30m tier:thinking ref:GH#26914 assignee:marcusquinn started:2026-07-10T03:55:55Z logged:2026-07-10 -> [todo/tasks/t18071-brief.md] pr:#26918 completed:2026-07-10

--- a/todo/tasks/t18309-brief.md
+++ b/todo/tasks/t18309-brief.md
@@ -1,0 +1,58 @@
+# t18309: Fix same-user daemon proc cwd cleanup degradation
+
+## Origin
+
+- **Created:** 2026-08-25
+- **Session:** OpenCode interactive follow-up after GH#30651 / PR #30653
+- **Created by:** ai-interactive
+- **Task ref:** pending issue sync
+
+## What
+
+Make autonomous worktree cleanup tolerate same-UID hardened login/session daemons whose `/proc/<pid>/cwd` is unreadable, without weakening active worktree cwd protection for unknown same-user processes.
+
+## Why
+
+After PR #30653 fixed foreign-UID `/proc` denial handling, live cleanup still logged fresh `cwd-visibility-degraded — mode=recoverable-required` entries. A local `/proc` probe found the remaining denials were same-UID non-worktree daemons: `(sd-pam)`, `gpg-agent`, and `sshd`. One hardened login daemon should not globally force degraded visibility and prevent autonomous stale worktree cleanup.
+
+## How
+
+### Files to Modify
+
+- EDIT: `.agents/scripts/audit-worktree-removal-helper.sh`
+- EDIT: `.agents/scripts/tests/test-worktree-removal-audit-lib.sh`
+- EDIT: `TODO.md`
+
+### Implementation Steps
+
+1. Add a narrow helper that recognizes known non-worktree same-UID daemons from `/proc/<pid>/comm` and, for `sshd`, session-style cmdline.
+2. In the `/proc` cwd capture path, skip those known daemon cwd denials after foreign-UID checks and before marking visibility degraded.
+3. Preserve fail-closed behaviour for unknown same-UID or unknown-owner cwd denials.
+4. Add regression coverage proving `gpg-agent`-style same-UID daemon denial no longer degrades a usable snapshot while the unknown same-UID denial test still degrades.
+
+### Verification
+
+```bash
+bash .agents/scripts/tests/test-worktree-removal-audit-lib.sh
+shellcheck .agents/scripts/audit-worktree-removal-helper.sh .agents/scripts/tests/test-worktree-removal-audit-lib.sh
+git diff --check
+python3 -c "import subprocess; r=subprocess.run(['bash','-c','source .agents/scripts/audit-worktree-removal-helper.sh; capture_worktree_process_cwds >/dev/null']); print('capture_rc=%s' % r.returncode)"
+```
+
+## Acceptance
+
+- Regression tests pass with a case for known same-UID daemon denials.
+- Unknown same-UID cwd denial remains fail-closed/degraded.
+- Live `capture_worktree_process_cwds` returns `0` on a host with same-UID `(sd-pam)`, `gpg-agent`, and `sshd` cwd denials.
+- Cleanup logs stop producing fresh global `cwd-visibility-degraded` lines solely from those daemons after deployment.
+
+## Context
+
+- PR #30653 fixed foreign `/proc` ownership denials but did not address same-UID non-dumpable session daemons.
+- Live evidence before this fix: `/proc` scan reported `foreign_skip=1499`, `same_or_unknown_degraded=3`; degraded PIDs were `(sd-pam)`, `gpg-agent`, and `sshd`.
+- This is intentionally a narrow allowlist, not a blanket same-UID skip.
+
+## Complexity Impact
+
+- `_capture_worktree_proc_cwds` gains only one helper call and comment adjustment.
+- New helper is small and isolated; no existing function should exceed complexity thresholds.


### PR DESCRIPTION
## Summary

- Skip known same-UID hardened session daemons when Linux denies `/proc/<pid>/cwd` reads.
- Preserve degraded/fail-closed behaviour for unknown same-UID cwd denials.
- Add regression coverage for `gpg-agent`-style daemon denial.

Resolves #30740

## Verification

- `bash .agents/scripts/tests/test-worktree-removal-audit-lib.sh` → `50/50 passed`
- `shellcheck .agents/scripts/audit-worktree-removal-helper.sh .agents/scripts/tests/test-worktree-removal-audit-lib.sh`
- `git diff --check`
- `python3 -c "import subprocess; r=subprocess.run(['bash','-c','source .agents/scripts/audit-worktree-removal-helper.sh; capture_worktree_process_cwds >/dev/null']); print('capture_rc=%s' % r.returncode)"` → `capture_rc=0`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.5
