### PR TITLE
GH#30700: classify worker exits by model activity

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -62,9 +62,10 @@ readonly _HRFF_RETRY_CLASS_UNKNOWN="unknown"
 readonly _HRFF_SESSION_COUNT_QUERY_PREFIX="SELECT count(*) FROM session WHERE time_created >= "
 
 #######################################
-# Count attempt-local OpenCode activity. Fresh runs are evidenced by a new
-# session; continuations are evidenced by a completed assistant message or part
-# on the exact persisted session, whose session.time_created remains old.
+# Count attempt-local OpenCode model activity. Fresh runs are scoped to sessions
+# created during the attempt, while continuations use the exact persisted
+# session whose session.time_created remains old. A boot-only session row is not
+# activity; require a completed assistant message or assistant-owned part.
 # Args: $1 = DB path, $2 = attempt start epoch ms, $3 = persisted session ID.
 # Outputs a non-negative integer, or returns 1 when evidence is unavailable.
 #######################################
@@ -73,6 +74,7 @@ _hrff_attempt_activity_count() {
 	local start_epoch_ms="$2"
 	local persisted_session_id="${3:-}"
 	local persisted_session_sql=""
+	local session_scope=""
 	local query=""
 	local count=""
 
@@ -80,10 +82,11 @@ _hrff_attempt_activity_count() {
 	[[ -f "$db_path" && "$start_epoch_ms" =~ ^[0-9]+$ && "$start_epoch_ms" -gt 0 ]] || return 1
 	if [[ -n "$persisted_session_id" ]]; then
 		persisted_session_sql="${persisted_session_id//\'/\'\'}"
-		query="SELECT (SELECT count(*) FROM message WHERE session_id = '${persisted_session_sql}' AND time_created >= ${start_epoch_ms} AND json_valid(data) AND json_extract(data, '$.role') = 'assistant' AND json_extract(data, '$.time.completed') IS NOT NULL) + (SELECT count(*) FROM part p JOIN message m ON m.id = p.message_id WHERE p.session_id = '${persisted_session_sql}' AND p.time_created >= ${start_epoch_ms} AND json_valid(m.data) AND json_extract(m.data, '$.role') = 'assistant')"
+		session_scope="= '${persisted_session_sql}'"
 	else
-		query="${_HRFF_SESSION_COUNT_QUERY_PREFIX}${start_epoch_ms}"
+		session_scope="IN (SELECT id FROM session WHERE time_created >= ${start_epoch_ms})"
 	fi
+	query="SELECT (SELECT count(*) FROM message m WHERE m.session_id ${session_scope} AND m.time_created >= ${start_epoch_ms} AND json_valid(m.data) AND json_extract(m.data, '$.role') = 'assistant' AND json_extract(m.data, '$.time.completed') IS NOT NULL) + (SELECT count(*) FROM part p JOIN message m ON m.id = p.message_id WHERE m.session_id ${session_scope} AND p.time_created >= ${start_epoch_ms} AND json_valid(m.data) AND json_extract(m.data, '$.role') = 'assistant')"
 	count=$(sqlite3 "$db_path" "$query" 2>/dev/null) || return 1
 	[[ "$count" =~ ^[0-9]+$ ]] || return 1
 	printf '%s\n' "$count"
@@ -738,7 +741,11 @@ classify_worker_exit() {
 
 	local raw_count=""
 	if [[ "$start_epoch_ms" =~ ^[0-9]+$ ]] && ((start_epoch_ms > 0)); then
-		raw_count=$(_hrff_attempt_activity_count "$active_db" "$start_epoch_ms" "$persisted_session_id") || raw_count=""
+		if [[ -n "$persisted_session_id" ]]; then
+			raw_count=$(_hrff_attempt_activity_count "$active_db" "$start_epoch_ms" "$persisted_session_id") || raw_count=""
+		else
+			raw_count=$(sqlite3 "$active_db" "${_HRFF_SESSION_COUNT_QUERY_PREFIX}${start_epoch_ms}" 2>/dev/null) || raw_count=""
+		fi
 	else
 		# No start time: count all sessions (crude fallback — may over-count)
 		raw_count=$(sqlite3 "$active_db" "SELECT count(*) FROM session" 2>/dev/null) || raw_count=""
@@ -1010,6 +1017,10 @@ _hrff_retry_class_for_reason() {
 	worker_complete | worker_draft_checkpoint)
 		printf '%s\n' "$_HRFF_RETRY_CLASS_REMEDIATION"
 		;;
+	clean)
+		# Process success without a typed terminal outcome is not remediation proof.
+		printf '%s\n' "$_HRFF_RETRY_CLASS_UNKNOWN"
+		;;
 	*)
 		if [[ "$session_count" =~ ^[1-9][0-9]*$ ]]; then
 			printf '%s\n' "$_HRFF_RETRY_CLASS_REMEDIATION"
@@ -1022,8 +1033,9 @@ _hrff_retry_class_for_reason() {
 }
 
 #######################################
-# Count model sessions created during this worker process.
-# Outputs a non-negative integer; unavailable evidence conservatively emits 0.
+# Count attempt-local model activity for the external outcome contract. The
+# function and outcome field retain their historical session_count names for
+# compatibility. Unavailable evidence conservatively emits 0.
 #######################################
 _hrff_worker_session_count() {
 	local start_epoch_ms="${_WORKER_START_EPOCH_MS:-0}"

--- a/.agents/scripts/tests/test-worker-exit-classifier.sh
+++ b/.agents/scripts/tests/test-worker-exit-classifier.sh
@@ -112,8 +112,9 @@ _insert_assistant_part() {
 _insert_session() {
 	local db_path="$1"
 	local ts_ms="$2"
+	local session_id="${3:-test-id-$(date +%s%N)}"
 	sqlite3 "$db_path" \
-		"INSERT INTO session VALUES ('test-id-$(date +%s%N)', 'test session', ${ts_ms});" \
+		"INSERT INTO session VALUES ('${session_id}', 'test session', ${ts_ms});" \
 		2>/dev/null
 	return 0
 }
@@ -179,9 +180,8 @@ test_clean_exit_zero_sessions() {
 	return 0
 }
 
-# t3050: clean exit + sessions present after start → legacy clean path.
-# Confirms the zero-session check does not regress the genuine clean case.
-test_clean_exit_with_sessions() {
+# GH#30700: a boot-only fresh session is not model activity.
+test_clean_exit_with_boot_session_only() {
 	local db_path="${TMPDIR_TEST}/clean-with-sessions.db"
 	_make_db "$db_path"
 	local start_ms
@@ -193,7 +193,55 @@ test_clean_exit_with_sessions() {
 	result=$(classify_worker_exit 0 "$start_ms")
 	unset _WORKER_ISOLATED_DB_PATH
 
-	assert_eq "clean (clean exit, session present)" "$result" "clean"
+	assert_eq "worker_noop_zero_output (clean, boot session only)" "$result" "worker_noop_zero_output"
+	return 0
+}
+
+test_clean_exit_fresh_session_with_assistant_message() {
+	local db_path="${TMPDIR_TEST}/clean-fresh-assistant-message.db"
+	_make_db "$db_path"
+	local start_ms
+	start_ms=$(_now_ms)
+	_insert_session "$db_path" "$start_ms" "fresh-message-session"
+	_insert_assistant_message "$db_path" "fresh-message-session" "$start_ms"
+
+	_WORKER_ISOLATED_DB_PATH="$db_path"
+	_WORKER_START_EPOCH_MS="$start_ms"
+	local result count
+	result=$(classify_worker_exit 0 "$start_ms")
+	count=$(_hrff_worker_session_count)
+	unset _WORKER_ISOLATED_DB_PATH _WORKER_START_EPOCH_MS
+
+	assert_eq "clean (fresh session produced assistant message)" "$result" "clean"
+	assert_eq "fresh session assistant message activity count" "$count" "1"
+	return 0
+}
+
+test_clean_exit_fresh_session_with_assistant_part() {
+	local db_path="${TMPDIR_TEST}/clean-fresh-assistant-part.db"
+	_make_db "$db_path"
+	local start_ms
+	start_ms=$(_now_ms)
+	_insert_session "$db_path" "$start_ms" "fresh-part-session"
+	_insert_assistant_part "$db_path" "fresh-part-session" "$start_ms"
+
+	_WORKER_ISOLATED_DB_PATH="$db_path"
+	local result
+	result=$(classify_worker_exit 0 "$start_ms")
+	unset _WORKER_ISOLATED_DB_PATH
+
+	assert_eq "clean (fresh session produced assistant part)" "$result" "clean"
+	return 0
+}
+
+test_clean_retry_class_requires_typed_terminal_outcome() {
+	local clean_class=""
+	local complete_class=""
+	clean_class=$(_hrff_retry_class_for_reason "clean" "1")
+	complete_class=$(_hrff_retry_class_for_reason "worker_complete" "1")
+
+	assert_eq "bare clean outcome is not remediation proof" "$clean_class" "$_HRFF_RETRY_CLASS_UNKNOWN"
+	assert_eq "typed worker completion remains remediation proof" "$complete_class" "$_HRFF_RETRY_CLASS_REMEDIATION"
 	return 0
 }
 
@@ -591,7 +639,10 @@ main() {
 	test_signal_killed_sighup
 	test_clean_exit
 	test_clean_exit_zero_sessions
-	test_clean_exit_with_sessions
+	test_clean_exit_with_boot_session_only
+	test_clean_exit_fresh_session_with_assistant_message
+	test_clean_exit_fresh_session_with_assistant_part
+	test_clean_retry_class_requires_typed_terminal_outcome
 	test_clean_exit_session_before_start
 	test_clean_exit_continued_session_with_assistant_activity
 	test_clean_exit_continued_session_placeholder_only


### PR DESCRIPTION
## Summary

Use attempt-local assistant messages and parts instead of fresh session creation to distinguish zero-work clean exits, preserve session-row evidence for non-zero fresh crash phases, and prevent bare clean outcomes from becoming remediation proof.

## Files Changed

.agents/scripts/headless-runtime-failure.sh, .agents/scripts/tests/test-worker-exit-classifier.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified after rebasing: local quality gates passed; worker exit classifier 28/28; headless failure classification 115/115; headless runtime helper 270/270; PRRTS 91/91; completion and OAuth-pool regression suites passed.

Resolves #30700


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 5h 11m and 1,724,395 tokens on this with the user in an interactive session.