### PR TITLE
GH#30747: prevent heuristic supersession closures

### DIFF
--- a/.agents/reference/pre-dispatch-validators.md
+++ b/.agents/reference/pre-dispatch-validators.md
@@ -67,15 +67,16 @@ When dispatch-path work is detected without one normalized `tier:thinking` label
 **Marker:** None required — uses labels/title plus cited file paths and finding keywords
 **Bypass:** `AIDEVOPS_SKIP_REVIEW_FEEDBACK_SUPERSESSION=1`
 
-Runs before generator-marker validators in `cmd_validate()`. It extracts cited file paths and compact finding keywords from the issue body, searches recently merged PRs after the issue creation timestamp, and inspects PR file lists plus title/body/diff text.
+Runs before generator-marker validators in `cmd_validate()`. It extracts qualified, non-blockquoted target paths and compact finding keywords from the issue body, searches recently merged PRs after the applicable issue/source-review timestamp, and inspects PR file lists plus title/body/diff text. Bare basenames and paths found only in quoted review prose are not file identity.
 
 Outcomes:
 
-1. Same-file PR merged after issue creation with strong finding signal (issue reference or 2+ keyword matches) → posts `<!-- review-feedback-superseded-by-merged-pr -->`, closes the issue as `not planned`, returns `10`, and skips worker dispatch.
-2. Same-file PR merged after issue creation but weak/unrelated finding signal → posts one `<!-- review-feedback-supersession-ambiguous -->` decision-ready comment and returns `0` so dispatch proceeds.
-3. No same-file candidate, missing metadata, or API error → fails open with return `0`.
+1. Existing issue + same-file merged PR that directly references the issue → posts `<!-- review-feedback-superseded-by-merged-pr -->`, closes the issue as `not planned`, returns `10`, and skips worker dispatch.
+2. Existing issue + same-file keyword-only match → posts one `<!-- review-feedback-supersession-ambiguous -->` decision-ready comment and returns `0` so dispatch proceeds. Heuristic prose overlap never closes an existing issue.
+3. Read-only post-merge precreation check + qualified same-file match with 2+ keywords → returns `10` so the scanner can suppress a duplicate issue. This caller passes issue number `0`, performs no GitHub write, and fails closed for API uncertainty.
+4. No qualified same-file candidate or missing dispatch metadata → returns `0`; normal dispatch proceeds.
 
-**Tests:** `tests/test-review-feedback-supersession-validator.sh` — clear same-file fix, ambiguous same-file unrelated change, no matching PR, and PR merged before issue creation.
+**Tests:** `.agents/scripts/tests/test-review-feedback-supersession-validator.sh` — direct-reference closure, keyword-only ambiguity, quoted/basename path rejection, precreation dedup, no matching PR, and PR merged before issue creation.
 
 ## Adding a validator
 

--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -923,12 +923,11 @@ _rf_extract_file_paths_from_text() {
 	local backtick_files=""
 	local bare_files=""
 
-	# Generated issue signatures contain a Markdown link whose visible label is
-	# `aidevops.sh`. Treating that footer as an implementation target makes every
-	# later release PR (which commonly touches aidevops.sh) look like a same-file
-	# supersession. URLs and signature metadata are evidence provenance, not files
-	# requested by the finding.
-	path_text=$(printf '%s\n' "$text" | grep -vE '^<!--[[:space:]]*aidevops:sig|^\[aidevops\.sh\]\(https?://|https?://' || true)
+	# Generated signatures and blockquoted review prose are evidence provenance,
+	# not structured target-file citations. Review producers keep their canonical
+	# inline file metadata outside blockquotes, so ignore quoted paths here while
+	# retaining the quoted prose for finding-keyword extraction.
+	path_text=$(printf '%s\n' "$text" | grep -vE '^[[:space:]]*>|^<!--[[:space:]]*aidevops:sig|^\[aidevops\.sh\]\(https?://|https?://' || true)
 
 	dir_paths=$(printf '%s' "$path_text" | grep -oE '[a-zA-Z0-9._-]+/[a-zA-Z0-9._/-]+\.[a-zA-Z]{1,10}' | sort -u || true)
 	if [[ -n "$dir_paths" ]]; then
@@ -1193,21 +1192,16 @@ _rf_find_overlapping_paths() {
 	local pr_files="$2"
 	local issue_path=""
 	local pr_path=""
-	local issue_basename=""
-	local pr_basename=""
 	local overlaps=""
 
 	while IFS= read -r issue_path; do
 		[[ -z "$issue_path" ]] && continue
-		issue_basename="${issue_path##*/}"
+		# Bare basenames are not stable file identity: unrelated directories often
+		# contain the same helper/test name. Only qualified paths can match.
+		[[ "$issue_path" == */* ]] || continue
 		while IFS= read -r pr_path; do
 			[[ -z "$pr_path" ]] && continue
-			pr_basename="${pr_path##*/}"
-			if [[ "$issue_path" == */* ]]; then
-				if [[ "$pr_path" == "$issue_path" || "$pr_path" == *"/${issue_path}" ]]; then
-					overlaps="${overlaps}${pr_path}"$'\n'
-				fi
-			elif [[ "$pr_basename" == "$issue_basename" ]]; then
+			if [[ "$pr_path" == "$issue_path" || "$pr_path" == *"/${issue_path}" ]]; then
 				overlaps="${overlaps}${pr_path}"$'\n'
 			fi
 		done <<<"$pr_files"
@@ -1452,8 +1446,17 @@ _rf_evaluate_supersession() {
 			pr_patch=""
 		fi
 		local evidence="${pr_title}"$'\n'"${pr_body}"$'\n'"${pr_patch}"
+		local clear_match=0
 		_rf_score_keywords "$keywords" "$evidence"
-		if { [[ "$issue_number" =~ ^[1-9][0-9]*$ ]] && _rf_pr_references_issue "$issue_number" "$evidence"; } || [[ "$_RF_KEYWORD_SCORE" -ge 2 ]]; then
+		if [[ "$issue_number" =~ ^[1-9][0-9]*$ ]] && _rf_pr_references_issue "$issue_number" "$evidence"; then
+			clear_match=1
+		elif [[ "$issue_number" == "0" && "$_RF_KEYWORD_SCORE" -ge 2 ]]; then
+			# Precreation has no issue number to reference and performs no GitHub
+			# mutation. Preserve its bounded heuristic dedup after qualified path
+			# matching, while existing issues require an explicit PR reference.
+			clear_match=1
+		fi
+		if [[ "$clear_match" -eq 1 ]]; then
 			_RF_SUPERSESSION_PR="$pr_number"
 			_RF_SUPERSESSION_MERGED_AT="$merged_at"
 			_RF_SUPERSESSION_OVERLAPS="$overlaps"

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -317,10 +317,10 @@ mode="${mode}"
 if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
 	if printf '%s' "\$args" | grep -qF '.body // ""'; then
 		case "\$mode" in
-			extended-extension) printf 'quality debt kotlin coroutine MainActivity.kt\n' ;;
-			review-followup-label) printf 'review followup changelog fixed \`CHANGELOG.md:18\`\n' ;;
-			source-review-scanner-label) printf 'review scanner changelog fixed \`CHANGELOG.md:18\`\n' ;;
-			whole-word) printf 'quality debt rate cache worker.sh\n' ;;
+			extended-extension) printf 'quality debt kotlin coroutine app/src/MainActivity.kt\n' ;;
+			review-followup-label) printf 'review followup changelog fixed \`docs/CHANGELOG.md:18\`\n' ;;
+			source-review-scanner-label) printf 'review scanner changelog fixed \`docs/CHANGELOG.md:18\`\n' ;;
+			whole-word) printf 'quality debt rate cache .agents/scripts/worker.sh\n' ;;
 			version-directory) printf 'quality debt setup rollout v3.14.93/setup.sh\n' ;;
 			*) printf 'unsupported review-feedback mode: %s\n' "\$mode" >&2; exit 1 ;;
 		esac
@@ -343,8 +343,8 @@ if [[ "\${1:-}" == "api" ]] && printf '%s' "\$args" | grep -qE 'pulls/99/files';
 	if printf '%s' "\$args" | grep -qF '.[].filename'; then
 		case "\$mode" in
 			extended-extension) printf 'app/src/MainActivity.kt\n' ;;
-			review-followup-label|source-review-scanner-label) printf 'CHANGELOG.md\n' ;;
-			whole-word) printf 'worker.sh\n' ;;
+			review-followup-label|source-review-scanner-label) printf 'docs/CHANGELOG.md\n' ;;
+			whole-word) printf '.agents/scripts/worker.sh\n' ;;
 			version-directory) printf 'v3.14.93/setup.sh\n' ;;
 			*) printf 'unsupported review-feedback mode: %s\n' "\$mode" >&2; exit 1 ;;
 		esac
@@ -354,10 +354,10 @@ if [[ "\${1:-}" == "api" ]] && printf '%s' "\$args" | grep -qE 'pulls/99/files';
 			printf 'app/src/MainActivity.kt\nfix kotlin coroutine reliability\n'
 			;;
 		review-followup-label|source-review-scanner-label)
-			printf 'CHANGELOG.md\nmove changelog entries to fixed section\n'
+			printf 'docs/CHANGELOG.md\nmove changelog entries to fixed section\n'
 			;;
 		whole-word)
-			printf 'worker.sh\ngenerate cache output\n'
+			printf '.agents/scripts/worker.sh\ngenerate cache output\n'
 			;;
 		version-directory)
 			printf 'v3.14.93/setup.sh\nfix setup rollout quality debt\n'
@@ -374,7 +374,7 @@ fi
 if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/pulls/99\$'; then
 	case "\$mode" in
 		extended-extension)
-			printf '2026-05-08T00:00:00Z\tfix kotlin coroutine reliability\tUpdates mobile handling\n'
+			printf '2026-05-08T00:00:00Z\tGH#47: fix kotlin coroutine reliability\tUpdates mobile handling\n'
 			;;
 		review-followup-label|source-review-scanner-label)
 			printf '2026-05-08T00:00:00Z\tdocs: clean up changelog duplicates\tMoves changelog fixes under Fixed. Refs #50 #51\n'
@@ -383,7 +383,7 @@ if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/pulls/99\$'; t
 			printf '2026-05-08T00:00:00Z\tgenerate cache output\tUpdates cache handling\n'
 			;;
 		version-directory)
-			printf '2026-05-08T00:00:00Z\tfix setup rollout quality debt\tUpdates setup handling\n'
+			printf '2026-05-08T00:00:00Z\tGH#49: fix setup rollout quality debt\tUpdates setup handling\n'
 			;;
 		*)
 			printf 'unsupported review-feedback mode: %s\n' "\$mode" >&2

--- a/.agents/scripts/tests/test-review-feedback-supersession-validator.sh
+++ b/.agents/scripts/tests/test-review-feedback-supersession-validator.sh
@@ -446,10 +446,10 @@ test_current_issue_absent_from_enumeration_fails_closed() {
 
 test_pulse_blocks_duplicate_lookup_uncertainty() {
 	# shellcheck disable=SC2016 # Match literal shell source expressions.
-	if grep -qF "if [[ \"\$_validator_rc\" -eq 30 ]]" "$PULSE_CORE" \
-		&& grep -qF '$_review_followup_validator_required" -eq 1 && "$_validator_rc" -ne 0' "$PULSE_CORE" \
-		&& grep -qF 'predispatch_validator_uncertain' "$PULSE_CORE" \
-		&& grep -qF 'return 20' "$PULSE_CORE"; then
+	if grep -qF "if [[ \"\$_validator_rc\" -eq 30 ]]" "$PULSE_CORE" &&
+		grep -qF '$_review_followup_validator_required" -eq 1 && "$_validator_rc" -ne 0' "$PULSE_CORE" &&
+		grep -qF 'predispatch_validator_uncertain' "$PULSE_CORE" &&
+		grep -qF 'return 20' "$PULSE_CORE"; then
 		print_result "pulse blocks all required review-followup validator failures and releases its claim" 0
 	else
 		print_result "pulse blocks all required review-followup validator failures and releases its claim" 1

--- a/.agents/scripts/tests/test-review-feedback-supersession-validator.sh
+++ b/.agents/scripts/tests/test-review-feedback-supersession-validator.sh
@@ -39,6 +39,10 @@ setup_test_env() {
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export GH_LOG
+	export AIDEVOPS_SIG_CLI="test"
+	export AIDEVOPS_SIG_CLI_VERSION="1"
+	export AIDEVOPS_SIG_MODEL="test/model"
+	export AIDEVOPS_SIG_TOKENS="0"
 	return 0
 }
 
@@ -66,7 +70,7 @@ arg_string="$*"
 endpoint=""
 for arg in "$@"; do
 	case "$arg" in
-	search/issues | repos/owner/repo/*)
+	search/issues | repos/owner/repo | repos/owner/repo/*)
 		endpoint="$arg"
 		break
 		;;
@@ -82,6 +86,12 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/issues/* && "$endpoin
 			;;
 		footer-path-noise)
 			printf '**Source PR**: #50\n\n**File**: `.agents/scripts/issue-sync-helper.sh`\n\nAdd an option guard before worker launch.\n\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) automated scan.\n'
+			;;
+		quoted-path)
+			printf '> > - `.agents/scripts/review-hook.sh:217`\n> above already architecture before dispatch\n'
+			;;
+		basename-only)
+			printf '## Finding\n\n`review-hook.sh` needs an event payload guard before dispatch.\n'
 			;;
 		marker-only-duplicate | duplicate-current-absent)
 			printf '<!-- aidevops:generator=review-followup source_pr=50 fingerprint=source-pr-50 -->\n\n## Files to modify\n- `.agents/scripts/review-hook.sh`\n'
@@ -123,6 +133,11 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/issues/* && "$endpoin
 	exit 0
 fi
 
+if [[ "${1:-}" == "api" && "$endpoint" == "repos/owner/repo" ]]; then
+	printf 'false\n'
+	exit 0
+fi
+
 if [[ "${1:-}" == "api" && "$endpoint" == "repos/owner/repo/issues/100/comments" ]]; then
 	printf '0\n'
 	exit 0
@@ -132,6 +147,7 @@ if [[ "${1:-}" == "api" && "$endpoint" == "search/issues" ]]; then
 	case "$scenario" in
 	precreation-search-failure) exit 1 ;;
 	clear) printf '200\n' ;;
+	direct-reference) printf '205\n' ;;
 	ambiguous) printf '201\n' ;;
 	source-clear) printf '200\n' ;;
 	malformed-source-clear) printf '200\n' ;;
@@ -139,6 +155,7 @@ if [[ "${1:-}" == "api" && "$endpoint" == "search/issues" ]]; then
 	source-fetch-failure) printf '200\n' ;;
 	no-file) printf '200\n' ;;
 	footer-path-noise) printf '204\n' ;;
+	quoted-path | basename-only) printf '200\n' ;;
 	none) printf '' ;;
 	before) printf '203\n' ;;
 	*) printf '' ;;
@@ -152,7 +169,10 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/pulls/* && "$endpoint
 		if [[ "$scenario" == "source-fetch-failure" ]]; then
 			exit 1
 		fi
-		printf '2026-05-01T09:30:00Z\n'
+		case "$arg_string" in
+		*'join("|")'*) printf 'closed|2026-05-01T09:30:00Z|2026-05-01T09:30:00Z\n' ;;
+		*) printf '2026-05-01T09:30:00Z\n' ;;
+		esac
 		exit 0
 	fi
 	case "$pr_number" in
@@ -168,6 +188,9 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/pulls/* && "$endpoint
 	204)
 		printf '2026-05-01T11:00:00Z\tfix worker launch guard\tAdds an option guard before worker launch.\n'
 		;;
+	205)
+		printf '2026-05-01T11:00:00Z\tGH#100: fix event payload guard\tResolves #100 with the event payload guard.\n'
+		;;
 	*)
 		printf '\t\t\n'
 		;;
@@ -181,14 +204,14 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/pulls/*/files ]]; the
 	case "$arg_string" in
 	*'.filename'*)
 		case "$pr_number" in
-		200 | 201 | 203) printf '.agents/scripts/review-hook.sh\n' ;;
+		200 | 201 | 203 | 205) printf '.agents/scripts/review-hook.sh\n' ;;
 		204) printf 'aidevops.sh\n' ;;
 		*) printf '' ;;
 		esac
 		;;
 	*)
 		case "$pr_number" in
-		200 | 203) printf '.agents/scripts/review-hook.sh\n+ add event payload guard before dispatch\n' ;;
+		200 | 203 | 205) printf '.agents/scripts/review-hook.sh\n+ add event payload guard before dispatch\n' ;;
 		201) printf '.agents/scripts/review-hook.sh\n+ rename log_context to context_label\n' ;;
 		204) printf 'aidevops.sh\n+ add option guard before worker launch\n' ;;
 		*) printf '' ;;
@@ -277,9 +300,16 @@ assert_log_not_contains() {
 	return 0
 }
 
-test_clear_same_file_fix() {
-	run_validator_case "clear" 10 "clear same-file supersession"
-	assert_log_contains "clear same-file supersession closes issue" "issue close 100 --repo owner/repo --reason not planned"
+test_keyword_same_file_fix_is_ambiguous() {
+	run_validator_case "clear" 0 "keyword-only same-file supersession"
+	assert_log_not_contains "keyword-only same-file supersession does not close" "issue close 100 --repo owner/repo --reason not planned"
+	assert_log_contains "keyword-only same-file supersession posts decision comment" "issue comment 100 --repo owner/repo --body"
+	return 0
+}
+
+test_direct_issue_reference_closes() {
+	run_validator_case "direct-reference" 10 "direct issue reference supersession"
+	assert_log_contains "direct issue reference closes issue" "issue close 100 --repo owner/repo --reason not planned"
 	return 0
 }
 
@@ -290,15 +320,17 @@ test_ambiguous_same_file_unrelated_change() {
 	return 0
 }
 
-test_source_pr_window_catches_pre_issue_fix() {
-	run_validator_case "source-clear" 10 "source PR window catches pre-issue supersession"
-	assert_log_contains "source PR window closes pre-issue supersession" "issue close 100 --repo owner/repo --reason not planned"
+test_source_pr_window_keyword_match_is_ambiguous() {
+	run_validator_case "source-clear" 0 "source PR window keyword-only supersession"
+	assert_log_not_contains "source PR window keyword-only match does not close" "issue close 100 --repo owner/repo --reason not planned"
+	assert_log_contains "source PR window keyword-only match posts decision comment" "issue comment 100 --repo owner/repo --body"
 	return 0
 }
 
-test_malformed_source_pr_uses_title_fallback() {
-	run_validator_case "malformed-source-clear" 10 "malformed source PR uses title fallback"
-	assert_log_contains "malformed source PR title fallback closes pre-issue supersession" "issue close 100 --repo owner/repo --reason not planned"
+test_malformed_source_pr_title_fallback_is_ambiguous() {
+	run_validator_case "malformed-source-clear" 0 "malformed source PR title fallback"
+	assert_log_not_contains "malformed source PR title fallback does not close" "issue close 100 --repo owner/repo --reason not planned"
+	assert_log_contains "malformed source PR title fallback posts decision comment" "issue comment 100 --repo owner/repo --body"
 	return 0
 }
 
@@ -324,6 +356,20 @@ test_no_file_finding_skips_supersession() {
 test_signature_footer_path_is_not_target_file() {
 	run_validator_case "footer-path-noise" 0 "signature footer path is ignored"
 	assert_log_not_contains "signature footer does not create false supersession" "issue close 100 --repo owner/repo --reason not planned"
+	return 0
+}
+
+test_blockquoted_path_is_not_target_file() {
+	run_validator_case "quoted-path" 0 "blockquoted path is ignored"
+	assert_log_not_contains "blockquoted path does not create false supersession" "issue close 100 --repo owner/repo --reason not planned"
+	assert_log_not_contains "blockquoted path does not create ambiguous candidate" "issue comment 100 --repo owner/repo --body"
+	return 0
+}
+
+test_bare_basename_is_not_file_identity() {
+	run_validator_case "basename-only" 0 "bare basename is ignored"
+	assert_log_not_contains "bare basename does not create false supersession" "issue close 100 --repo owner/repo --reason not planned"
+	assert_log_not_contains "bare basename does not create ambiguous candidate" "issue comment 100 --repo owner/repo --body"
 	return 0
 }
 
@@ -421,14 +467,17 @@ main() {
 
 	setup_test_env
 	write_gh_stub
-	test_clear_same_file_fix
+	test_keyword_same_file_fix_is_ambiguous
+	test_direct_issue_reference_closes
 	test_ambiguous_same_file_unrelated_change
-	test_source_pr_window_catches_pre_issue_fix
-	test_malformed_source_pr_uses_title_fallback
+	test_source_pr_window_keyword_match_is_ambiguous
+	test_malformed_source_pr_title_fallback_is_ambiguous
 	test_source_pr_window_ambiguous_fails_open
 	test_source_pr_fetch_failure_falls_back
 	test_no_file_finding_skips_supersession
 	test_signature_footer_path_is_not_target_file
+	test_blockquoted_path_is_not_target_file
+	test_bare_basename_is_not_file_identity
 	test_no_matching_pr
 	test_merged_pr_before_issue_creation
 	test_precreation_source_pr_window


### PR DESCRIPTION
## Summary

Prevent blockquoted paths, bare basenames, and keyword-only matches from automatically closing live review-feedback issues while preserving read-only precreation dedup.

## Files Changed

.agents/reference/pre-dispatch-validators.md, .agents/scripts/pre-dispatch-validator-helper.sh, .agents/scripts/tests/test-pre-dispatch-validator.sh, .agents/scripts/tests/test-review-feedback-supersession-validator.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with 47 review-feedback supersession fixtures and 29 pre-dispatch integration fixtures; ShellCheck, shfmt, and linters-local --changed pass.

Resolves #30747


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 28m and 387,542 tokens on this with the user in an interactive session.