### PR TITLE
GH#30706: fix: preflight external PR approval authorities

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -376,7 +376,6 @@ cmd_pre_merge_gate() {
 	case "$rbg_status" in
 	PASS | PASS_ADVISORY | SKIP | PASS_RATE_LIMITED)
 		print_success "Review bot gate: ${rbg_status} — safe to merge PR #${pr_number}"
-		return 0
 		;;
 	*)
 		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="review-bot"
@@ -385,6 +384,28 @@ cmd_pre_merge_gate() {
 		return 1
 		;;
 	esac
+
+	#aidevops:trust-boundary GH#17671/GH#28622 -- resolve every authority target
+	# from the final live PR snapshot. This diagnostic never grants authority; the
+	# merge transport repeats the same evaluation immediately before its write.
+	if ! _merge_collect_external_authority_gaps "$pr_number" "$repo"; then
+		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="external-authority"
+		FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="unable to verify external/fork authority"
+		return 1
+	fi
+	if [[ "${#FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS[@]}" -gt 0 ]]; then
+		local approval_targets=""
+		approval_targets="${FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS[*]}"
+		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="external-authority"
+		FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="${approval_targets}"
+		print_error "External/fork PR #${pr_number} has missing cryptographic development authority"
+		print_info "After finalizing all approval-bound PR metadata, run this one command:"
+		printf 'sudo aidevops approve batch %s %s\n' "$approval_targets" "$repo"
+		return 1
+	fi
+
+	print_success "External/fork authority preflight: no approval required for PR #${pr_number}"
+	return 0
 }
 
 # --- Argument Parsing ---

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -29,6 +29,7 @@
 _FULL_LOOP_MERGE_LIB_LOADED=1
 FULL_LOOP_MERGE_SUBJECT_FLAG="--subject"
 FULL_LOOP_MERGE_BODY_FILE_FLAG="--body-file"
+FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS=()
 
 _flm_gh_read() {
 	local rc=0
@@ -435,7 +436,7 @@ _merge_author_has_write_authority() {
 	esac
 }
 
-_merge_linked_issue_authority_clear() {
+_merge_collect_linked_issue_authority_gaps() {
 	local issue_numbers="$1"
 	local repo="$2"
 	local require_crypto="$3"
@@ -455,16 +456,13 @@ _merge_linked_issue_authority_clear() {
 		fi
 		if [[ "$require_crypto" -eq 1 ]] &&
 			! _merge_target_crypto_approved issue "$issue_number" "$repo"; then
-			print_error "Merge blocked: external/fork PR linked issue #${issue_number} lacks current cryptographic development authority"
-			return 1
+			FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS+=("issue:${issue_number}")
 		fi
 	done <<<"$issue_numbers"
 	return 0
 }
 
-# Legacy name retained for sourced callers and tests. This is now the common
-# final authority guard for every full-loop merge mode, not only --admin.
-_merge_guard_admin_merge_maintainer_review() {
+_merge_collect_external_authority_gaps() {
 	local pr_number="$1"
 	local repo="$2"
 	local expected_head_sha="${3:-}"
@@ -472,6 +470,7 @@ _merge_guard_admin_merge_maintainer_review() {
 	local issue_numbers=""
 	local author_rc=0 treat_as_external=0 trusted_dependabot=0 trusted_issue_sync=0
 
+	FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS=()
 	if ! pr_json=$(gh pr view "$pr_number" --repo "$repo" \
 		--json author,labels,isCrossRepository,headRefOid,closingIssuesReferences,body 2>/dev/null); then
 		print_error "Merge blocked: unable to verify PR #${pr_number} authority metadata"
@@ -534,17 +533,8 @@ _merge_guard_admin_merge_maintainer_review() {
 		return 1
 	}
 
-	_merge_linked_issue_authority_clear "$issue_numbers" "$repo" "$treat_as_external" || return 1
-	if [[ "$trusted_dependabot" -eq 1 ]]; then
-		print_info "Trusted Dependabot authority verified for PR #${pr_number} at ${current_head_sha}"
-		return 0
-	fi
-	if [[ "$trusted_issue_sync" -eq 1 ]]; then
-		print_info "Trusted repository-generated Issue Sync authority verified for PR #${pr_number} at ${current_head_sha}"
-		return 0
-	fi
-
-	if [[ "$treat_as_external" -eq 0 ]]; then
+	_merge_collect_linked_issue_authority_gaps "$issue_numbers" "$repo" "$treat_as_external" || return 1
+	if [[ "$trusted_dependabot" -eq 1 || "$trusted_issue_sync" -eq 1 || "$treat_as_external" -eq 0 ]]; then
 		return 0
 	fi
 	if [[ -z "$issue_numbers" ]]; then
@@ -552,9 +542,49 @@ _merge_guard_admin_merge_maintainer_review() {
 		return 1
 	fi
 	if ! _merge_target_crypto_approved pr "$pr_number" "$repo" "$current_head_sha"; then
-		print_error "Merge blocked: external/fork PR #${pr_number} lacks V2 merge authority for the current head"
-		return 1
+		FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS+=("pr:${pr_number}")
 	fi
+
+	return 0
+}
+
+# Legacy name retained for sourced callers and tests. This is now the common
+# final authority guard for every full-loop merge mode, not only --admin.
+_merge_linked_issue_authority_clear() {
+	local issue_numbers="$1"
+	local repo="$2"
+	local require_crypto="$3"
+	local target=""
+
+	FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS=()
+	_merge_collect_linked_issue_authority_gaps "$issue_numbers" "$repo" "$require_crypto" || return 1
+	for target in "${FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS[@]}"; do
+		print_error "Merge blocked: external/fork PR linked issue #${target#issue:} lacks current cryptographic development authority"
+		return 1
+	done
+	return 0
+}
+
+# Legacy name retained for sourced callers and tests. This is now the common
+# final authority guard for every full-loop merge mode, not only --admin.
+_merge_guard_admin_merge_maintainer_review() {
+	local pr_number="$1"
+	local repo="$2"
+	local expected_head_sha="${3:-}"
+	local target=""
+
+	_merge_collect_external_authority_gaps "$pr_number" "$repo" "$expected_head_sha" || return 1
+	for target in "${FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS[@]}"; do
+		case "$target" in
+		issue:*)
+			print_error "Merge blocked: external/fork PR linked issue #${target#issue:} lacks current cryptographic development authority"
+			;;
+		pr:*)
+			print_error "Merge blocked: external/fork PR #${target#pr:} lacks V2 merge authority for the current head"
+			;;
+		esac
+		return 1
+	done
 
 	return 0
 }

--- a/.agents/scripts/tests/test-full-loop-merge-authority-guard.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-authority-guard.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MERGE_SCRIPT="${SCRIPT_DIR}/../full-loop-helper-merge.sh"
+COMMIT_SCRIPT="${SCRIPT_DIR}/../full-loop-helper-commit.sh"
 TEST_ROOT="$(mktemp -d -t full-loop-merge-authority.XXXXXX)"
 EXTRACTED="${TEST_ROOT}/functions.sh"
 CRYPTO_CALLS="${TEST_ROOT}/crypto-calls.log"
@@ -20,6 +21,10 @@ ISSUE_SYNC_HELPER="${TEST_ROOT}/review-bot-gate-helper.sh"
 export ISSUE_SYNC_TRUST_CALLS
 cat >"$ISSUE_SYNC_HELPER" <<'EOF'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "check" ]]; then
+	printf 'PASS\n'
+	exit 0
+fi
 printf '%s\n' "$*" >>"${ISSUE_SYNC_TRUST_CALLS}"
 [[ "${1:-}" == "is-trusted-issue-sync-pr" && -n "${4:-}" && "${FIXTURE_TRUSTED_ISSUE_SYNC:-0}" == "1" ]]
 EOF
@@ -59,12 +64,24 @@ extract_function() {
 	return 0
 }
 
+extract_commit_function() {
+	local function_name="$1"
+	awk -v fn="$function_name" '
+      index($0, fn "() {") == 1 { capture = 1 }
+      capture { print }
+      capture && $0 == "}" { exit }
+    ' "$COMMIT_SCRIPT" >>"$EXTRACTED"
+	return 0
+}
+
 load_functions() {
 	: >"$EXTRACTED"
 	extract_function _merge_linked_issue_numbers
 	extract_function _merge_issue_requires_maintainer_review
 	extract_function _merge_author_has_write_authority
 	extract_function _merge_is_trusted_issue_sync_pr
+	extract_function _merge_collect_linked_issue_authority_gaps
+	extract_function _merge_collect_external_authority_gaps
 	extract_function _merge_linked_issue_authority_clear
 	extract_function _merge_guard_admin_merge_maintainer_review
 	extract_function _merge_resolve_conventional_type_from_commits
@@ -74,6 +91,7 @@ load_functions() {
 	extract_function _merge_rest_fallback
 	extract_function _merge_revalidate_transport_authority
 	extract_function _merge_execute
+	extract_commit_function cmd_pre_merge_gate
 	# shellcheck source=/dev/null
 	source "$EXTRACTED"
 	return 0
@@ -111,6 +129,23 @@ print_success() {
 	local message="$1"
 	printf 'OK %s\n' "$message" >&2
 	return 0
+}
+
+_flm_gh_write() {
+	"$@"
+	return $?
+}
+
+_merge_run_bounded_write() {
+	local pr_number="$1"
+	local repo="$2"
+	local expected_head_sha="$3"
+	local write_rc=0
+	: "$pr_number" "$repo" "$expected_head_sha"
+	shift 3
+	_MERGE_WRITE_OUTPUT=""
+	_MERGE_WRITE_OUTPUT=$(_flm_gh_write "$@" 2>&1) || write_rc=$?
+	return "$write_rc"
 }
 
 gh() {
@@ -185,6 +220,10 @@ _is_trusted_dependabot_update_pr() {
 
 _full_loop_review_bot_gate_helper_path() {
 	printf '%s\n' "$ISSUE_SYNC_HELPER"
+	return 0
+}
+
+_full_loop_verify_pr_readiness() {
 	return 0
 }
 
@@ -416,6 +455,50 @@ test_authority_guard() {
 	return 0
 }
 
+test_pre_merge_authority_preflight() {
+	local output=""
+	local actual_rc=0
+
+	reset_fixture
+	set_pr_fixture external '[]' false '[{"number":42},{"number":43}]' 'Resolves #42\nResolves #43'
+	FIXTURE_PERMISSION="none"
+	output=$(cmd_pre_merge_gate 900 owner/repo 2>&1) || actual_rc=$?
+	if [[ "$actual_rc" -eq 1 ]] &&
+		grep -qF 'sudo aidevops approve batch issue:42 issue:43 pr:900 owner/repo' <<<"$output"; then
+		print_result "preflight reports all missing issue and exact-head PR authorities in one command" 0
+	else
+		print_result "preflight reports all missing issue and exact-head PR authorities in one command" 1 \
+			"rc=$actual_rc output=$output"
+	fi
+
+	reset_fixture
+	set_pr_fixture external '[]' false '[{"number":42},{"number":43}]' 'Resolves #42\nResolves #43'
+	FIXTURE_PERMISSION="none"
+	FIXTURE_ISSUE_APPROVED=1
+	FIXTURE_PR_APPROVED=1
+	actual_rc=0
+	output=$(cmd_pre_merge_gate 900 owner/repo 2>&1) || actual_rc=$?
+	if [[ "$actual_rc" -eq 0 ]] && ! grep -qF 'aidevops approve batch' <<<"$output"; then
+		print_result "preflight passes without an approval prompt when all authority is current" 0
+	else
+		print_result "preflight passes without an approval prompt when all authority is current" 1 \
+			"rc=$actual_rc output=$output"
+	fi
+
+	reset_fixture
+	set_pr_fixture external '[]' false '[{"number":42}]' 'Resolves #42'
+	FIXTURE_PERMISSION_FAIL=1
+	actual_rc=0
+	output=$(cmd_pre_merge_gate 900 owner/repo 2>&1) || actual_rc=$?
+	if [[ "$actual_rc" -eq 1 ]] && ! grep -qF 'aidevops approve batch' <<<"$output"; then
+		print_result "API uncertainty emits no incomplete final approval command" 0
+	else
+		print_result "API uncertainty emits no incomplete final approval command" 1 \
+			"rc=$actual_rc output=$output"
+	fi
+	return 0
+}
+
 _merge_guard_admin_merge_maintainer_review_for_mode_test() {
 	local pr_number="$1"
 	local repo="$2"
@@ -500,7 +583,7 @@ test_secondary_merge_transports_refresh_authority() {
 	actual_rc=0
 	_merge_execute 900 owner/repo --squash 0 0 >/dev/null 2>&1 || actual_rc=$?
 	if [[ "$actual_rc" -eq 1 && "$(wc -l <"$GUARD_CALLS")" -eq 2 &&
-		"$(wc -l <"$MERGE_CALLS")" -eq 1 ]]; then
+	"$(wc -l <"$MERGE_CALLS")" -eq 1 ]]; then
 		print_result "stale-cache retry refreshes and honors revoked authority" 0
 	else
 		print_result "stale-cache retry refreshes and honors revoked authority" 1 \
@@ -515,7 +598,7 @@ test_secondary_merge_transports_refresh_authority() {
 	actual_rc=0
 	_merge_execute 900 owner/repo --squash 0 0 >/dev/null 2>&1 || actual_rc=$?
 	if [[ "$actual_rc" -eq 1 && "$(wc -l <"$GUARD_CALLS")" -eq 2 &&
-		"$(wc -l <"$MERGE_CALLS")" -eq 1 ]] &&
+	"$(wc -l <"$MERGE_CALLS")" -eq 1 ]] &&
 		! grep -q '^REST ' "$MERGE_CALLS"; then
 		print_result "REST fallback refreshes and honors revoked authority" 0
 	else
@@ -570,6 +653,7 @@ main() {
 	test_trusted_issue_sync_authority
 	test_trusted_dependabot_authority
 	test_authority_guard
+	test_pre_merge_authority_preflight
 	test_all_merge_modes_use_guard
 	test_secondary_merge_transports_refresh_authority
 	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-full-loop-remote-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-remote-evidence.sh
@@ -128,6 +128,11 @@ print_info() { return 0; }
 print_warning() { return 0; }
 print_success() { return 0; }
 source '${SCRIPTS_DIR}/full-loop-helper-commit.sh'
+FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS=()
+_merge_collect_external_authority_gaps() {
+	FULL_LOOP_EXTERNAL_AUTHORITY_TARGETS=()
+	return 0
+}
 gh_pr_checks_exact_json() {
 	local repo_slug="\$1"
 	local pr_number="\$2"

--- a/.agents/workflows/review.md
+++ b/.agents/workflows/review.md
@@ -38,6 +38,21 @@ Follow `workflows/review-issue-pr.md`. That workflow owns problem validation,
 temporal duplicates, root cause, architecture, disposition, and durable comments.
 The legacy `/review-issue-pr` command remains an alias for this policy.
 
+### External PR authority preflight
+
+Before requesting cryptographic approval for an external or fork PR, complete
+every approval-bound body, closing-linkage, and metadata repair. Then run:
+
+```bash
+full-loop-helper.sh pre-merge-gate <PR_NUMBER> <OWNER/REPO>
+```
+
+When the read-only preflight reports missing targets, provide its one mixed
+`sudo aidevops approve batch issue:N pr:N... OWNER/REPO` command unchanged.
+Regenerate the command after any PR head, body, linkage, or metadata change;
+the final merge-time guard independently rechecks the live snapshot. Do not
+request approval when the preflight reports that no authority is required.
+
 ## Local, branch, and commit targets
 
 1. Build the exact bundle:


### PR DESCRIPTION
## Summary

Aggregate every missing linked-issue and exact-head PR cryptographic authority target in the read-only pre-merge gate, while retaining live fail-closed merge enforcement.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/tests/test-full-loop-merge-authority-guard.sh, .agents/scripts/tests/test-full-loop-remote-evidence.sh, .agents/workflows/review.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Live read-only production-path verification against external PR #30677 returned issue:29938 and pr:30677 consistently on two runs; authority guard 39/39; remote-evidence suite passed; linters-local passed; independent closeout review found no P0/P1 defects (bundle 6c32b7d5016c5120fd4b194326403af1a572f6182f9f0de5cf5574ff129ccfd8).

Resolves #30706


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 3h 10m and 443,582 tokens on this with the user in an interactive session.