### PR TITLE
GH#30759: split approval command display

### DIFF
--- a/.agents/scripts/approval-helper-commands.sh
+++ b/.agents/scripts/approval-helper-commands.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# approval-helper-commands.sh — Status and help commands for approval-helper.
+# =============================================================================
+# Sourced by approval-helper.sh to keep command-display concerns separate from
+# approval signing, verification, and lifecycle behavior.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+[[ -n "${_APPROVAL_HELPER_COMMANDS_LOADED:-}" ]] && return 0
+_APPROVAL_HELPER_COMMANDS_LOADED=1
+readonly _APPROVAL_COMMANDS_SETUP_HINT="  Run: sudo aidevops approve setup"
+
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+	_approval_commands_lib_path="${BASH_SOURCE[0]%/*}"
+	[[ "$_approval_commands_lib_path" == "${BASH_SOURCE[0]}" ]] && _approval_commands_lib_path="."
+	SCRIPT_DIR="$(cd "$_approval_commands_lib_path" && pwd)"
+	unset _approval_commands_lib_path
+fi
+
+_approval_commands_blank_line() {
+	printf '\n'
+	return 0
+}
+
+# ── Status ───────────────────────────────────────────────────────────────────
+
+cmd_status() {
+	_approval_commands_blank_line
+	echo "Approval key status"
+	echo "==================="
+	_approval_commands_blank_line
+
+	if [[ -f "$APPROVAL_PUB" ]]; then
+		_print_ok "Public key exists: $APPROVAL_PUB"
+		echo "  Fingerprint: $(ssh-keygen -lf "$APPROVAL_PUB" 2>/dev/null || echo "unknown")"
+	else
+		_print_warn "No approval public key found"
+		echo "$_APPROVAL_COMMANDS_SETUP_HINT"
+	fi
+
+	_approval_commands_blank_line
+	if [[ -d "$APPROVAL_PRIVATE_DIR" ]]; then
+		local owner perms
+		owner=$(_file_owner "$APPROVAL_PRIVATE_DIR")
+		perms=$(_file_perms "$APPROVAL_PRIVATE_DIR")
+		if [[ "$owner" == "root" && "$perms" == "700" ]]; then
+			_print_ok "Private key directory is root-protected (owner=$owner, mode=$perms)"
+		else
+			_print_warn "Private key directory permissions may be insecure (owner=$owner, mode=$perms)"
+			echo "  Expected: owner=root, mode=700"
+			echo "$_APPROVAL_COMMANDS_SETUP_HINT"
+		fi
+	else
+		_print_warn "No private key directory found"
+		echo "$_APPROVAL_COMMANDS_SETUP_HINT"
+	fi
+
+	_approval_commands_blank_line
+	return 0
+}
+
+# ── Help ─────────────────────────────────────────────────────────────────────
+
+cmd_help() {
+	echo "approval-helper.sh — Cryptographic approval gate covering external issues/PRs"
+	_approval_commands_blank_line
+	echo "Commands (require sudo):"
+	echo "  setup                      Generate root-protected approval key pair"
+	echo "  issue <number...> [slug]   Approve one or more issues with one confirmation"
+	echo "  pr <number...> [slug]      Approve one or more PRs with one confirmation"
+	echo "  batch <kind:number...> [slug] Approve mixed issues/PRs with one confirmation"
+	echo "  permissions issue|pr <number> [slug] --request perm-<id>"
+	_approval_commands_blank_line
+	echo "Commands (no sudo needed):"
+	echo "  verify [issue|pr] <number> [slug] [--expect-head SHA] [--require-authority]"
+	echo "  verify-permissions issue|pr <number> [slug]"
+	echo "  reconcile issue|pr <number> [slug]"
+	echo "  status                     Show approval key setup status"
+	echo "  help                       Show this help"
+	_approval_commands_blank_line
+	echo "Examples:"
+	echo "  sudo aidevops approve setup"
+	echo "  sudo aidevops approve issue 17438 <owner/repo>"
+	echo "  sudo aidevops approve issue 17438 17440 17442 <owner/repo>"
+	echo "  sudo aidevops approve pr 17439 17441 <owner/repo>"
+	echo "  sudo aidevops approve batch issue:17438 pr:17439 pr:17441 <owner/repo>"
+	echo "  sudo aidevops approve permissions issue 17438 <owner/repo> --request perm-0123456789abcdef"
+	echo "  aidevops approve verify 17438"
+	echo "  aidevops approve verify pr 17439 <owner/repo> --expect-head <sha>"
+	_approval_commands_blank_line
+	echo "Security: The approval signing key is stored root-only. Workers run as your"
+	echo "user account and cannot access it, even with the same GitHub credentials."
+	return 0
+}

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -98,6 +98,10 @@ source "${SCRIPT_DIR}/approval-snapshot-v2.sh"
 # shellcheck disable=SC1091  # module resolved at runtime via SCRIPT_DIR
 source "${SCRIPT_DIR}/approval-helper-permissions.sh"
 
+# shellcheck source=./approval-helper-commands.sh
+# shellcheck disable=SC1091  # module resolved at runtime via SCRIPT_DIR
+source "${SCRIPT_DIR}/approval-helper-commands.sh"
+
 _permission_comments_endpoint() {
 	local slug="$1"
 	local target_number="$2"
@@ -1948,77 +1952,6 @@ cmd_reconcile() {
 		return 8
 	fi
 	printf 'RECONCILED\n'
-	return 0
-}
-
-# ── Status ───────────────────────────────────────────────────────────────────
-
-cmd_status() {
-	echo ""
-	echo "Approval key status"
-	echo "==================="
-	echo ""
-
-	if [[ -f "$APPROVAL_PUB" ]]; then
-		_print_ok "Public key exists: $APPROVAL_PUB"
-		echo "  Fingerprint: $(ssh-keygen -lf "$APPROVAL_PUB" 2>/dev/null || echo "unknown")"
-	else
-		_print_warn "No approval public key found"
-		echo "  Run: sudo aidevops approve setup"
-	fi
-
-	echo ""
-	if [[ -d "$APPROVAL_PRIVATE_DIR" ]]; then
-		local owner perms
-		owner=$(_file_owner "$APPROVAL_PRIVATE_DIR")
-		perms=$(_file_perms "$APPROVAL_PRIVATE_DIR")
-		if [[ "$owner" == "root" && "$perms" == "700" ]]; then
-			_print_ok "Private key directory is root-protected (owner=$owner, mode=$perms)"
-		else
-			_print_warn "Private key directory permissions may be insecure (owner=$owner, mode=$perms)"
-			echo "  Expected: owner=root, mode=700"
-			echo "  Run: sudo aidevops approve setup"
-		fi
-	else
-		_print_warn "No private key directory found"
-		echo "  Run: sudo aidevops approve setup"
-	fi
-
-	echo ""
-	return 0
-}
-
-# ── Help ─────────────────────────────────────────────────────────────────────
-
-cmd_help() {
-	echo "approval-helper.sh — Cryptographic approval gate covering external issues/PRs"
-	echo ""
-	echo "Commands (require sudo):"
-	echo "  setup                      Generate root-protected approval key pair"
-	echo "  issue <number...> [slug]   Approve one or more issues with one confirmation"
-	echo "  pr <number...> [slug]      Approve one or more PRs with one confirmation"
-	echo "  batch <kind:number...> [slug] Approve mixed issues/PRs with one confirmation"
-	echo "  permissions issue|pr <number> [slug] --request perm-<id>"
-	echo ""
-	echo "Commands (no sudo needed):"
-	echo "  verify [issue|pr] <number> [slug] [--expect-head SHA] [--require-authority]"
-	echo "  verify-permissions issue|pr <number> [slug]"
-	echo "  reconcile issue|pr <number> [slug]"
-	echo "  status                     Show approval key setup status"
-	echo "  help                       Show this help"
-	echo ""
-	echo "Examples:"
-	echo "  sudo aidevops approve setup"
-	echo "  sudo aidevops approve issue 17438 <owner/repo>"
-	echo "  sudo aidevops approve issue 17438 17440 17442 <owner/repo>"
-	echo "  sudo aidevops approve pr 17439 17441 <owner/repo>"
-	echo "  sudo aidevops approve batch issue:17438 pr:17439 pr:17441 <owner/repo>"
-	echo "  sudo aidevops approve permissions issue 17438 <owner/repo> --request perm-0123456789abcdef"
-	echo "  aidevops approve verify 17438"
-	echo "  aidevops approve verify pr 17439 <owner/repo> --expect-head <sha>"
-	echo ""
-	echo "Security: The approval signing key is stored root-only. Workers run as your"
-	echo "user account and cannot access it, even with the same GitHub credentials."
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Split the approval helper's status and help commands into a focused sibling library. The original helper falls from 2053 to 1986 lines without changing the `aidevops approve` command interface.

## Changes

- Add `.agents/scripts/approval-helper-commands.sh` with include guard and `SCRIPT_DIR` fallback.
- Source the module from `.agents/scripts/approval-helper.sh` using ShellCheck runtime-source directives.
- Move `cmd_status` and `cmd_help` without behavior changes.

## Testing

- `shellcheck .agents/scripts/approval-helper.sh .agents/scripts/approval-helper-commands.sh`
- `.agents/scripts/tests/test-approval-wrappers-available.sh`
- `.agents/scripts/tests/test-approval-helper-verify-state.sh`
- `.agents/scripts/complexity-regression-helper.sh check --base origin/main` (`function-complexity: base=0, head=0, new=0`)
- `wc -l .agents/scripts/approval-helper.sh` (`1986`)

## Complexity Bump Justification

No override is needed: the split moves only status/help commands and the local scanner reports `function-complexity: base=0, head=0, new=0`. The original file-size debt is resolved at `.agents/scripts/approval-helper.sh:1` by reducing the file from 2053 to 1986 lines.

## Related

Resolves #30759

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 7m and 143,260 tokens on this as a headless worker. Overall, 12m since this issue was created.
