### PR TITLE
GH#30768: refactor pulse merge function complexity

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1183,24 +1183,13 @@ Do not close this parent until the remaining acceptance criteria are covered by 
 	return 0
 }
 
-_handle_post_merge_actions() {
+_pm_close_primary_linked_issue() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local linked_issue="$3"
-	local merge_summary="$4"
-	local pr_labels="${5:-}"
-	local pr_base_ref_name="${6:-main}"
+	local closing_comment="$4"
+	local labels_supplied="$5"
 
-	local closing_comment
-	closing_comment=$(_pm_build_closing_comment "$pr_number" "$repo_slug" \
-		"$linked_issue" "$merge_summary" "$pr_base_ref_name")
-
-	# Upsert one canonical PR closeout across concurrent runner accounts. Linked
-	# PR conversation locks are not owned by worker lifecycle cleanup (GH#30280).
-	_pm_upsert_pr_closing_comment "$pr_number" "$repo_slug" "$closing_comment"
-
-	# Close linked issue with the same closing comment
-	if [[ -n "$linked_issue" ]]; then
 		# t2099 / GH#19032: parent-task close guard. Parent roadmap issues must
 		# stay open until ALL phase children merge (t2046). The PR-body keyword
 		# guard prevents workers from writing Closes/Resolves/Fixes against a
@@ -1213,10 +1202,9 @@ _handle_post_merge_actions() {
 		#     status update on the parent).
 		#   - SKIP the `gh issue close` call.
 		#   - SKIP fast_fail_reset and unlock (both tied to closing).
-		local _parent_task_guard=0
+		_parent_task_guard=0
 		local _pm_li_api
 		_pm_li_api=$(_pm_issue_api "$repo_slug" "$linked_issue")
-		local _linked_labels
 		_linked_labels=$(gh api "${_pm_li_api}" \
 			--jq '[.labels[].name] | join(",")' 2>/dev/null) || _linked_labels=""
 		if [[ ",${_linked_labels}," == *"${_PM_PARENT_TASK_LABEL_NEEDLE}"* ]]; then
@@ -1238,7 +1226,7 @@ _handle_post_merge_actions() {
 		fi
 
 		if [[ "$_parent_task_guard" -eq 0 ]]; then
-			if [[ $# -lt 5 ]]; then
+			if [[ "$labels_supplied" -eq 0 ]]; then
 				pr_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 					--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || pr_labels=""
 			fi
@@ -1258,13 +1246,18 @@ _handle_post_merge_actions() {
 			# t1934: Unlock the issue (locked at dispatch time)
 			unlock_issue_after_worker "$linked_issue" "$repo_slug"
 		fi
+	return 0
+}
 
-		# GH#22964: if the merged PR resolved a superseded worker PR, also close
-		# the original issue that the superseded PR was created to resolve.
-		local _superseded_original_issue
-		_superseded_original_issue=$(_pm_resolve_superseded_original_issue \
-			"$pr_number" "$repo_slug" "$linked_issue") || _superseded_original_issue=""
-		if [[ -n "$_superseded_original_issue" ]]; then
+_pm_close_superseded_original_issue() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local closing_comment="$4"
+	local _superseded_original_issue
+	_superseded_original_issue=$(_pm_resolve_superseded_original_issue \
+		"$pr_number" "$repo_slug" "$linked_issue") || _superseded_original_issue=""
+	if [[ -n "$_superseded_original_issue" ]]; then
 			local _sup_api _sup_labels _sup_parent_guard=0 _sup_dedup_count
 			_sup_api=$(_pm_issue_api "$repo_slug" "$_superseded_original_issue")
 			_sup_labels=$(gh api "${_sup_api}" \
@@ -1297,7 +1290,35 @@ _handle_post_merge_actions() {
 				fast_fail_reset "$_superseded_original_issue" "$repo_slug" || true
 				unlock_issue_after_worker "$_superseded_original_issue" "$repo_slug"
 			fi
-		fi
+	fi
+	return 0
+}
+
+_handle_post_merge_actions() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local merge_summary="$4"
+	local pr_labels="${5:-}"
+	local pr_base_ref_name="${6:-main}"
+	local labels_supplied=0
+	local _parent_task_guard=0 _linked_labels=""
+	[[ $# -ge 5 ]] && labels_supplied=1
+
+	local closing_comment
+	closing_comment=$(_pm_build_closing_comment "$pr_number" "$repo_slug" \
+		"$linked_issue" "$merge_summary" "$pr_base_ref_name")
+
+	# Upsert one canonical PR closeout across concurrent runner accounts. Linked
+	# PR conversation locks are not owned by worker lifecycle cleanup (GH#30280).
+	_pm_upsert_pr_closing_comment "$pr_number" "$repo_slug" "$closing_comment"
+
+	if [[ -n "$linked_issue" ]]; then
+		_pm_close_primary_linked_issue "$pr_number" "$repo_slug" "$linked_issue" \
+			"$closing_comment" "$labels_supplied"
+		# GH#22964: close the original issue resolved by a superseded worker PR.
+		_pm_close_superseded_original_issue "$pr_number" "$repo_slug" "$linked_issue" \
+			"$closing_comment"
 	fi
 
 	# Post partial parent closeout if a For/Ref reference exists (GH#23937).

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -441,52 +441,15 @@ _handle_changes_requested_review_gate() {
 #       $6=pr_labels (optional), $7=expected_head_sha (optional),
 #       $8=review_gate_mode (optional: merge|ci-rebase-only|ci-repair-only)
 #######################################
-_check_pr_merge_gates() {
-	local pr_number="$1"
-	local repo_slug="$2"
-	local pr_author="$3"
-	local pr_review="$4"
-	local linked_issue="$5"
-	local pr_labels="${6:-}"
-	local expected_head_sha="${7:-}"
-	local review_gate_mode="${8:-merge}"
-	local _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
-	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
-	local _ci_repair_only="${PULSE_REVIEW_GATE_MODE_CI_REPAIR_ONLY:-ci-repair-only}"
-	local _dependabot_intake_rc=0
-	_PULSE_REVIEW_GATE_EVIDENCE=""
-	if [[ -n "$linked_issue" ]] &&
-		_interactive_claim_fence_blocks_merge "$linked_issue" "$repo_slug" "$expected_head_sha"; then
-		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} has a live interactive owner with different unmerged work (GH#30274)" >>"$LOGFILE"
-		return 1
-	fi
-
-	# Skip CHANGES_REQUESTED — needs a fix worker, not a merge.
-	#
-	# t2093: For worker-authored PRs with a linked issue, the "skip and hope"
-	# path leaks stuck PRs indefinitely — no human owns worker PRs, the
-	# dispatch-dedup guard blocks re-dispatch while the PR is open, and the
-	# review-followup pipeline only fires on *merged* PRs. Route the review
-	# feedback to the linked issue body and close the PR so the next pulse
-	# cycle picks the issue up with fresh context. Interactive PRs are
-	# always left alone (their humans own the feedback loop); external
-	# contributors go through their own crypto-approval flow.
-	#
-	# t2179: coderabbit-nits-ok override — if the maintainer applied the
-	# label and EVERY CHANGES_REQUESTED reviewer is coderabbitai[bot],
-	# auto-dismiss those reviews and fall through to the next gate. If any
-	# human reviewer is also blocking, the label is ignored.
+_pm_gate_review_mode() {
+	local pr_number="$1" repo_slug="$2" pr_review="$3" linked_issue="$4" pr_labels="$5"
+	local review_gate_mode="$6" changes_requested="$7" ci_rebase_only="$8" ci_repair_only="$9"
 	case "$review_gate_mode" in
 	merge)
-		if ! _handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$linked_issue" "$pr_labels"; then
-			return 1
-		fi
+		_handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$linked_issue" "$pr_labels" || return 1
 		;;
-	"$_ci_rebase_only" | "$_ci_repair_only")
-		# The early review gate already proved remediation converged. Skip only
-		# repeated review routing so the normal non-review trust gates can run.
-		# The caller must remain on the repair-only path and return before merge.
-		if [[ "$pr_review" != "$_changes_requested" ]]; then
+	"$ci_rebase_only" | "$ci_repair_only")
+		if [[ "$pr_review" != "$changes_requested" ]]; then
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — ${review_gate_mode} review mode requires CHANGES_REQUESTED" >>"$LOGFILE"
 			return 1
 		fi
@@ -496,183 +459,166 @@ _check_pr_merge_gates() {
 		return 1
 		;;
 	esac
+	return 0
+}
 
-	# Skip external contributor PRs (non-collaborator).
-	# t3063 crypto-approval bypass: a verified maintainer signature on the PR
-	# or its linked issue is a stronger trust signal than author-association
-	# (requires root-owned SSH key that workers cannot forge). Symmetric with
-	# t3052 which extended the worker-briefed gate the same way (PR #21767).
-	local _author_collab_rc=0 _trusted_issue_sync=0
-	local _author_collab_permission=""
+_pm_gate_author_trust() {
+	local pr_number="$1" repo_slug="$2" pr_author="$3" expected_head_sha="$4"
+	local trusted_dest="$5" permission_dest="$6" author_collab_rc=0 permission="" trusted=0
 	if [[ "$pr_author" == "app/github-actions" || "$pr_author" == "github-actions[bot]" ]] &&
 		_pulse_is_trusted_issue_sync_pr "$pr_number" "$repo_slug" "$expected_head_sha"; then
-		_trusted_issue_sync=1
-		_author_collab_permission="write"
+		trusted=1
+		permission="write"
 		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is trusted repository-generated Issue Sync automation, proceeding" >>"$LOGFILE"
 	else
 		_is_collaborator_author "$pr_author" "$repo_slug"
-		_author_collab_rc=$?
-		_author_collab_permission="${_PULSE_AUTHOR_PERMISSION_VALUE:-}"
+		author_collab_rc=$?
+		permission="${_PULSE_AUTHOR_PERMISSION_VALUE:-}"
 	fi
-	if [[ "$_trusted_issue_sync" -eq 0 && "$_author_collab_rc" -eq 2 ]]; then
-		if [[ "${DRY_RUN:-0}" != "1" ]]; then
-			check_permission_failure_pr "$pr_number" "$repo_slug" "$pr_author" "${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}" || true
-		fi
+	printf -v "$trusted_dest" '%s' "$trusted"
+	printf -v "$permission_dest" '%s' "$permission"
+	if [[ "$trusted" -eq 0 && "$author_collab_rc" -eq 2 ]]; then
+		[[ "${DRY_RUN:-0}" == "1" ]] || check_permission_failure_pr "$pr_number" "$repo_slug" "$pr_author" "${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}" || true
 		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — permission check failed for author ${pr_author} (HTTP ${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown})" >>"$LOGFILE"
 		return 1
 	fi
-	if [[ "$_trusted_issue_sync" -eq 0 && "$_author_collab_rc" -ne 0 ]]; then
+	if [[ "$trusted" -eq 0 && "$author_collab_rc" -ne 0 ]]; then
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha"; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is trusted Dependabot with allowlisted dependency update, proceeding (GH#24473)" >>"$LOGFILE"
 		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$expected_head_sha"; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator but has maintainer crypto-approval, proceeding (t3063)" >>"$LOGFILE"
 		else
-			_pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha" "policy-ineligible" || _dependabot_intake_rc=$?
-			case "$_dependabot_intake_rc" in
-			0)
-				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — authentic Dependabot PR is outside automatic merge policy; routed to worker intake (GH#30351)" >>"$LOGFILE"
-				;;
-			3)
-				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — authentic Dependabot PR has an explicit maintainer-review hold; preserving it without worker intake (GH#30389)" >>"$LOGFILE"
-				;;
-			4)
-				if [[ "${DRY_RUN:-0}" == "1" ]]; then
-					echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — would close superseded Dependabot source after verified replacement PR #${_PULSE_DEPENDABOT_SUPERSEDING_PR:-unknown} (GH#30478)" >>"$LOGFILE"
-				else
-					echo "[pulse-wrapper] Merge pass: closed superseded Dependabot source PR #${pr_number} in ${repo_slug} after verified replacement PR #${_PULSE_DEPENDABOT_SUPERSEDING_PR:-unknown} (GH#30478)" >>"$LOGFILE"
-				fi
-				;;
-			*)
-				echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE"
-				;;
-			esac
+			_pm_gate_route_ineligible_author "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha"
 			return 1
 		fi
 	fi
+	return 0
+}
 
-	# Skip PRs modifying workflow files when we lack the scope
-	if check_pr_modifies_workflows "$pr_number" "$repo_slug" 2>/dev/null; then
-		if ! check_gh_workflow_scope 2>/dev/null; then
-			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — modifies workflow files but token lacks workflow scope" >>"$LOGFILE"
-			return 1
+_pm_gate_route_ineligible_author() {
+	local pr_number="$1" repo_slug="$2" pr_author="$3" expected_head_sha="$4" intake_rc=0
+	_pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha" "policy-ineligible" || intake_rc=$?
+	case "$intake_rc" in
+	0) echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — authentic Dependabot PR is outside automatic merge policy; routed to worker intake (GH#30351)" >>"$LOGFILE" ;;
+	3) echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — authentic Dependabot PR has an explicit maintainer-review hold; preserving it without worker intake (GH#30389)" >>"$LOGFILE" ;;
+	4)
+		if [[ "${DRY_RUN:-0}" == "1" ]]; then
+			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — would close superseded Dependabot source after verified replacement PR #${_PULSE_DEPENDABOT_SUPERSEDING_PR:-unknown} (GH#30478)" >>"$LOGFILE"
+		else
+			echo "[pulse-wrapper] Merge pass: closed superseded Dependabot source PR #${pr_number} in ${repo_slug} after verified replacement PR #${_PULSE_DEPENDABOT_SUPERSEDING_PR:-unknown} (GH#30478)" >>"$LOGFILE"
 		fi
-	fi
+		;;
+	*) echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE" ;;
+	esac
+	return 0
+}
 
-	# Maintainer-gate: a live NMR label is an explicit hold. Approval marker
-	# presence is not authority and never overrides the current label state.
+_pm_gate_repository_and_issue() {
+	local pr_number="$1" repo_slug="$2" linked_issue="$3" expected_head_sha="$4" trusted_issue_sync="$5"
+	local issue_labels="" pr_labels_for_ext="" ext_linked_for_log="" li_api=""
+	if check_pr_modifies_workflows "$pr_number" "$repo_slug" 2>/dev/null && ! check_gh_workflow_scope 2>/dev/null; then
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — modifies workflow files but token lacks workflow scope" >>"$LOGFILE"
+		return 1
+	fi
 	if [[ -n "$linked_issue" ]]; then
-		local _li_api
-		_li_api=$(_pm_issue_api "$repo_slug" "$linked_issue")
-		local issue_labels
-		issue_labels=$(gh api "${_li_api}" \
-			--jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
+		li_api=$(_pm_issue_api "$repo_slug" "$linked_issue")
+		issue_labels=$(gh api "$li_api" --jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
 		if [[ "$issue_labels" == *"needs-maintainer-review"* ]]; then
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} has needs-maintainer-review" >>"$LOGFILE"
 			return 1
 		fi
 	fi
-
-	# ── External contributor gate (t1958) ──
-	# Requires linked issue + crypto approval (defence-in-depth after _is_collaborator_author).
-	local pr_labels_for_ext
-	pr_labels_for_ext=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json labels \
-		--jq '[.labels[].name] | join(",")' 2>/dev/null) || pr_labels_for_ext=""
-	if [[ "$_trusted_issue_sync" -eq 0 && "$pr_labels_for_ext" == *"external-contributor"* ]]; then
-		if ! _external_pr_has_linked_issue "$pr_number" "$repo_slug"; then
+	pr_labels_for_ext=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || pr_labels_for_ext=""
+	if [[ "$trusted_issue_sync" -eq 0 && "$pr_labels_for_ext" == *"external-contributor"* ]]; then
+		_external_pr_has_linked_issue "$pr_number" "$repo_slug" || {
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — external-contributor PR has no linked issue (t1958)" >>"$LOGFILE"
 			return 1
-		fi
+		}
 		if ! _external_pr_linked_issue_crypto_approved "$pr_number" "$repo_slug"; then
-			local ext_linked_for_log
 			ext_linked_for_log=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || ext_linked_for_log="unknown"
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — external-contributor PR linked issue #${ext_linked_for_log} lacks crypto approval (t1958)" >>"$LOGFILE"
 			return 1
 		fi
-		if ! _external_pr_current_head_crypto_approved "$pr_number" "$repo_slug" "$expected_head_sha"; then
+		_external_pr_current_head_crypto_approved "$pr_number" "$repo_slug" "$expected_head_sha" || {
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — external-contributor PR lacks V2 crypto approval for current head" >>"$LOGFILE"
 			return 1
-		fi
+		}
 	fi
+	return 0
+}
 
-	# ── origin:interactive gates (t2411/GH#23238) ──
-	# Draft, hold-for-review, and throughput-preference checks for interactive PRs. Applies
-	# to all interactive PRs regardless of author role (OWNER, MEMBER, or
-	# COLLABORATOR). COLLABORATORs that pass these checks still go through the
-	# review bot gate and normal merge path without an ownership fast-path.
-	local _oi_info_json _oi_labels_str _oi_is_draft
-	_oi_info_json=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json labels,isDraft 2>/dev/null) || _oi_info_json=""
-	_oi_labels_str=$(printf '%s' "$_oi_info_json" \
-		| jq -r '[.labels[].name] | join(",")' 2>/dev/null) || _oi_labels_str=""
-	_oi_is_draft=$(printf '%s' "$_oi_info_json" \
-		| jq -r '.isDraft // false' 2>/dev/null) || _oi_is_draft="false"
-	if [[ "$_oi_labels_str" == *"origin:interactive"* ]]; then
-		if ! _check_interactive_pr_gates "$pr_number" "$repo_slug" "$_oi_labels_str" "$_oi_is_draft"; then
-			return 1
-		fi
+_pm_gate_origin_authority() {
+	local pr_number="$1" repo_slug="$2" linked_issue="$3" pr_author="$4"
+	local trusted_issue_sync="$5" author_permission="$6" info_json="" labels_str="" is_draft="false"
+	info_json=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json labels,isDraft 2>/dev/null) || info_json=""
+	labels_str=$(printf '%s' "$info_json" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || labels_str=""
+	is_draft=$(printf '%s' "$info_json" | jq -r '.isDraft // false' 2>/dev/null) || is_draft="false"
+	if [[ "$labels_str" == *"origin:interactive"* ]]; then
+		_check_interactive_pr_gates "$pr_number" "$repo_slug" "$labels_str" "$is_draft" || return 1
 	fi
-
-	# ── origin:worker worker-briefed gates (t2449) ──
-	# Symmetric to the origin:interactive auto-merge gate (t2411). When a
-	# worker PR is backed by a maintainer-briefed issue (OWNER/MEMBER author),
-	# the trust chain is equivalent to an interactive session. This gate
-	# validates the additional criteria beyond the general gates.
-	#
-	# Uses comma-delimited matching: ",origin:worker," does NOT match
-	# ",origin:worker-takeover," (substring-safe).
-	if [[ -n "${_OW_LABEL_PAT:-}" && ",${_oi_labels_str}," == *"${_OW_LABEL_PAT:-}"* && "$_trusted_issue_sync" -eq 0 ]]; then
-		if ! _attempt_worker_briefed_auto_merge "$pr_number" "$repo_slug" "$_oi_labels_str" "$_oi_is_draft" "$linked_issue" "$_author_collab_permission" "$pr_author"; then
-			return 1
-		fi
-	elif [[ "$_trusted_issue_sync" -eq 1 ]]; then
+	if [[ -n "${_OW_LABEL_PAT:-}" && ",${labels_str}," == *"${_OW_LABEL_PAT:-}"* && "$trusted_issue_sync" -eq 0 ]]; then
+		_attempt_worker_briefed_auto_merge "$pr_number" "$repo_slug" "$labels_str" "$is_draft" "$linked_issue" "$author_permission" "$pr_author" || return 1
+	elif [[ "$trusted_issue_sync" -eq 1 ]]; then
 		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — exact-head Issue Sync trust satisfies worker authority without a linked issue" >>"$LOGFILE"
 	fi
+	return 0
+}
 
-	# A converged CHANGES_REQUESTED remediation may perform a branch repair,
-	# but it cannot satisfy review. Preserve the existing narrow rebase-only
-	# boundary; broader CI repair must also pass current-head review-bot evidence
-	# below before it receives worker-dispatch authority.
-	if [[ "$review_gate_mode" == "$_ci_rebase_only" ]]; then
+_pm_gate_review_bot() {
+	local pr_number="$1" repo_slug="$2" pr_author="$3" expected_head_sha="$4"
+	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
+	local rbg_observed_at="" rbg_result="" rbg_status=""
+	[[ -f "$rbg_helper" ]] || return 0
+	if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha"; then
+		rbg_observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+		_PULSE_REVIEW_GATE_EVIDENCE=$(jq -nc --arg schema "$PULSE_REVIEW_EVIDENCE_SCHEMA" --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" --arg author "$pr_author" --arg observed_at "$rbg_observed_at" \
+			'{schema:$schema,repo:$repo,pr:$pr,head_sha:$head,status:"SKIP_TRUSTED_DEPENDABOT",author:{login:$author,association:"BOT",class:"trusted-bot"},permitted:true,reason:"trusted_dependabot_policy",state:"pass",merge_gate:"clear",exit_code:0,observed_at:$observed_at}')
+		echo "[pulse-wrapper] Review bot gate: SKIP for trusted Dependabot dependency update PR #${pr_number} in ${repo_slug} (GH#24473)" >>"$LOGFILE"
+		return 0
+	fi
+	rbg_result=$(bash "$rbg_helper" status-json "$pr_number" "$repo_slug" 2>/dev/null) || rbg_result=""
+	rbg_status=$(jq -r --arg unknown "$PULSE_UNKNOWN_STATE" '.status // $unknown' <<<"$rbg_result" 2>/dev/null) || rbg_status="$PULSE_UNKNOWN_STATE"
+	# #aidevops:trust-boundary — only exact-head permitted evidence can pass.
+	if jq -e --arg schema "$PULSE_REVIEW_EVIDENCE_SCHEMA" --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" '
+		.schema == $schema and .repo == $repo and (.pr | tostring) == $pr
+		and .head_sha == $head and .permitted == true
+		and .state == "pass" and .merge_gate == "clear"
+	' <<<"$rbg_result" >/dev/null 2>&1; then
+		rbg_observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+		_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS --arg observed_at "$rbg_observed_at" '.observed_at = $observed_at' <<<"$rbg_result") || return 1
+		echo "[pulse-wrapper] Review bot gate: ${rbg_status} for PR #${pr_number} in ${repo_slug} (typed current-head evidence)" >>"$LOGFILE"
+		return 0
+	fi
+	echo "[pulse-wrapper] Review bot gate: ${rbg_status:-${PULSE_UNKNOWN_STATE}} for PR #${pr_number} in ${repo_slug} — missing or unpermitted current-head evidence; skipping merge" >>"$LOGFILE"
+	return 1
+}
+
+_check_pr_merge_gates() {
+	local pr_number="$1" repo_slug="$2" pr_author="$3" pr_review="$4" linked_issue="$5"
+	local pr_labels="${6:-}" expected_head_sha="${7:-}" review_gate_mode="${8:-merge}"
+	local changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
+	local ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
+	local ci_repair_only="${PULSE_REVIEW_GATE_MODE_CI_REPAIR_ONLY:-ci-repair-only}"
+	local trusted_issue_sync=0 author_permission=""
+	_PULSE_REVIEW_GATE_EVIDENCE=""
+	if [[ -n "$linked_issue" ]] && _interactive_claim_fence_blocks_merge "$linked_issue" "$repo_slug" "$expected_head_sha"; then
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} has a live interactive owner with different unmerged work (GH#30274)" >>"$LOGFILE"
+		return 1
+	fi
+	_pm_gate_review_mode "$pr_number" "$repo_slug" "$pr_review" "$linked_issue" "$pr_labels" \
+		"$review_gate_mode" "$changes_requested" "$ci_rebase_only" "$ci_repair_only" || return 1
+	_pm_gate_author_trust "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha" \
+		trusted_issue_sync author_permission || return 1
+	_pm_gate_repository_and_issue "$pr_number" "$repo_slug" "$linked_issue" "$expected_head_sha" "$trusted_issue_sync" || return 1
+	_pm_gate_origin_authority "$pr_number" "$repo_slug" "$linked_issue" "$pr_author" \
+		"$trusted_issue_sync" "$author_permission" || return 1
+	if [[ "$review_gate_mode" == "$ci_rebase_only" ]]; then
 		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} passed non-review trust gates for ${review_gate_mode} evaluation; CHANGES_REQUESTED remains blocking" >>"$LOGFILE"
 		return 0
 	fi
-	if [[ "$review_gate_mode" == "$_ci_repair_only" ]]; then
-		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} passed non-review trust gates for ${review_gate_mode} evaluation; requiring current-head review-bot evidence before CI repair" >>"$LOGFILE"
-	fi
-
-	# ── Review bot gate (GH#17490) ──
-	# --admin bypasses branch protection; enforce in code (see review-bot-gate-helper.sh).
-	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
-	local rbg_observed_at=""
-	if [[ -f "$rbg_helper" ]]; then
-		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha"; then
-			rbg_observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
-			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -nc --arg schema "$PULSE_REVIEW_EVIDENCE_SCHEMA" --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" --arg author "$pr_author" --arg observed_at "$rbg_observed_at" \
-				'{schema:$schema,repo:$repo,pr:$pr,head_sha:$head,status:"SKIP_TRUSTED_DEPENDABOT",author:{login:$author,association:"BOT",class:"trusted-bot"},permitted:true,reason:"trusted_dependabot_policy",state:"pass",merge_gate:"clear",exit_code:0,observed_at:$observed_at}')
-			echo "[pulse-wrapper] Review bot gate: SKIP for trusted Dependabot dependency update PR #${pr_number} in ${repo_slug} (GH#24473)" >>"$LOGFILE"
-			return 0
-		fi
-		local rbg_result="" rbg_status=""
-		rbg_result=$(bash "$rbg_helper" status-json "$pr_number" "$repo_slug" 2>/dev/null) || rbg_result=""
-		rbg_status=$(jq -r --arg unknown "$PULSE_UNKNOWN_STATE" '.status // $unknown' <<<"$rbg_result" 2>/dev/null) || rbg_status="$PULSE_UNKNOWN_STATE"
-		# #aidevops:trust-boundary — persist only typed, permitted evidence for
-		# this exact repository, PR, and head. External SKIP/rate-limit outcomes
-		# and malformed helper output fail closed.
-		if jq -e --arg schema "$PULSE_REVIEW_EVIDENCE_SCHEMA" --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" '
-			.schema == $schema
-			and .repo == $repo and (.pr | tostring) == $pr and .head_sha == $head
-			and .permitted == true and .state == "pass" and .merge_gate == "clear"
-		' <<<"$rbg_result" >/dev/null 2>&1; then
-			rbg_observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
-			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS --arg observed_at "$rbg_observed_at" '.observed_at = $observed_at' <<<"$rbg_result") || return 1
-			echo "[pulse-wrapper] Review bot gate: ${rbg_status} for PR #${pr_number} in ${repo_slug} (typed current-head evidence)" >>"$LOGFILE"
-		else
-			echo "[pulse-wrapper] Review bot gate: ${rbg_status:-${PULSE_UNKNOWN_STATE}} for PR #${pr_number} in ${repo_slug} — missing or unpermitted current-head evidence; skipping merge" >>"$LOGFILE"
-			return 1
-		fi
-	fi
-
-	return 0
+	[[ "$review_gate_mode" != "$ci_repair_only" ]] || echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} passed non-review trust gates for ${review_gate_mode} evaluation; requiring current-head review-bot evidence before CI repair" >>"$LOGFILE"
+	_pm_gate_review_bot "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha"
+	return $?
 }
 
 #######################################

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1422,23 +1422,9 @@ _pulse_merge_failure_is_terminal() {
 #   3 = merge failed
 #   4 = native auto-merge requested/deferred; no merge completed this cycle
 #######################################
-_process_single_ready_pr() {
-	local repo_slug="$1"
-	local pr_obj="$2"
-	local timing_prefix="${3:-}"
-
-	local pr_number="" pr_state="" pr_mergeable="" pr_review="" pr_author="" pr_title="" pr_updated_at="" pr_head_ref_oid="" pr_head_ref_name="" pr_base_ref_name="" pr_labels="" pr_is_draft="false"
-	local _mergeability_start="" _branch_protection_start="" _ruleset_start=""
-	# Consolidate into a single jq pass to reduce process-spawn overhead.
-	# CRITICAL: use non-whitespace delimiter (ASCII 0x1E record separator)
-	# instead of \t. Bash read collapses consecutive IFS whitespace chars
-	# (tab, space, newline) — if ANY field is empty the subsequent fields
-	# shift left. reviewDecision is routinely "" (empty string, which jq //
-	# does NOT catch — it only triggers on null/false). The field shift
-	# caused pr_author to receive the PR title, breaking the collaborator
-	# check and blocking ALL merges across every repo (observed downstream).
-	local _RS=$'\x1e'
-	IFS="$_RS" read -r pr_number pr_state pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid pr_head_ref_name pr_base_ref_name pr_labels pr_is_draft < <(
+_pmp_stage_parse_and_validate() {
+	local record_separator=$'\x1e'
+	IFS="$record_separator" read -r pr_number pr_state pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid pr_head_ref_name pr_base_ref_name pr_labels pr_is_draft < <(
 		printf '%s' "$pr_obj" | jq -r --arg unknown "$PULSE_UNKNOWN_STATE" \
 			'"\(.number // "")\u001e\(.state // "")\u001e\(.mergeable // $unknown)\u001e\(if ((has("reviewDecision") | not) or .reviewDecision == null or (.reviewDecision | tostring | length) == 0) then $unknown else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")\u001e\(.updatedAt // "")\u001e\(.headRefOid // "")\u001e\(.headRefName // "")\u001e\(.baseRefName // "")\u001e\([(.labels // [])[].name] | join(","))\u001e\(.isDraft // false | tostring)"'
 	)
@@ -1446,7 +1432,6 @@ _process_single_ready_pr() {
 	_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
 	_pmp_normalize_review_decision_into pr_review "$pr_review"
 	[[ -n "$timing_prefix" ]] && _mergeability_start=$(_pmp_now_epoch)
-
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
 	if [[ "$pr_state" != "OPEN" ]]; then
 		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — state=${pr_state:-missing} is not OPEN (GH#28279)" >>"$LOGFILE"
@@ -1460,242 +1445,130 @@ _process_single_ready_pr() {
 		echo "[pulse-wrapper] Merge pass: deferring protected release PR #${pr_number} in ${repo_slug} to provenance-preserving exact-merge reconciliation" >>"$LOGFILE"
 		return 4
 	fi
-	if [[ "$repo_slug" == "${AIDEVOPS_RELEASE_LANE_COORDINATED_REPO:-marcusquinn/aidevops}" ]]; then
-		if ! release_lane_merge_guard "$repo_slug" "$pr_number" "$pr_base_ref_name" "$pr_head_ref_name"; then
-			echo "[pulse-wrapper] Merge pass: deferring PR #${pr_number} in ${repo_slug} for active exact-tip release lane" >>"$LOGFILE"
+	if [[ "$repo_slug" == "${AIDEVOPS_RELEASE_LANE_COORDINATED_REPO:-marcusquinn/aidevops}" ]] \
+		&& ! release_lane_merge_guard "$repo_slug" "$pr_number" "$pr_base_ref_name" "$pr_head_ref_name"; then
+		echo "[pulse-wrapper] Merge pass: deferring PR #${pr_number} in ${repo_slug} for active exact-tip release lane" >>"$LOGFILE"
+		return 1
+	fi
+	# GH#24634: refresh REST-first UNKNOWN state before conflict handling.
+	[[ "$pr_mergeable" != UNKNOWN && -n "$pr_mergeable" ]] || _pmp_refresh_unknown_mergeable_state_into pr_mergeable "$pr_number" "$repo_slug" "$pr_mergeable"
+	_pmp_review_decision_is_unknown "$pr_review" && _pmp_refresh_unknown_review_decision_into pr_review "$pr_number" "$repo_slug" "$pr_review"
+	return 10
+}
+
+_pmp_stage_handle_conflict() {
+	local conflict_linked_issue="" conflict_issue_labels="" refetched_mergeable="" conflict_route_rc=0
+	[[ "$pr_mergeable" == "CONFLICTING" && "$PULSE_MERGE_CLOSE_CONFLICTING" == "$PULSE_MERGE_BOOL_TRUE" ]] || return 10
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} is CONFLICTING; would evaluate rebase, repair routing, or protected close" >>"$LOGFILE"
+		return 2
+	fi
+	conflict_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug")
+	if [[ -n "$conflict_linked_issue" ]]; then
+		conflict_issue_labels=$(gh api "repos/${repo_slug}/issues/${conflict_linked_issue}" --jq '[.labels[].name] | join(",")' 2>/dev/null) || conflict_issue_labels=""
+		if [[ "$conflict_issue_labels" == *"needs-maintainer-review"* ]]; then
+			echo "[pulse-wrapper] Merge pass: skipping CONFLICTING-close of PR #${pr_number} in ${repo_slug} — linked issue #${conflict_linked_issue} has needs-maintainer-review (t2116)" >>"$LOGFILE"
+			_post_rebase_nudge_on_worker_conflicting "$pr_number" "$repo_slug" "" "" 2>/dev/null || true
+			[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 			return 1
 		fi
 	fi
-
-	# REST-first PR lists cannot preserve GraphQL-only mergeable state, so a
-	# truly conflicting PR may enter this function as UNKNOWN. Refresh that
-	# value before the CONFLICTING branch; otherwise the later non-MERGEABLE
-	# skip makes conflict remediation unreachable (GH#24634).
-	if [[ "$pr_mergeable" == UNKNOWN || -z "$pr_mergeable" ]]; then
-		_pmp_refresh_unknown_mergeable_state_into pr_mergeable "$pr_number" "$repo_slug" "$pr_mergeable"
+	if _attempt_pr_update_branch "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+		refetched_mergeable=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json mergeable --jq ".mergeable // \"${PULSE_UNKNOWN_STATE}\"" 2>/dev/null) || refetched_mergeable="$PULSE_UNKNOWN_STATE"
+		pr_mergeable="$refetched_mergeable"
+		_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
+		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — update-branch succeeded, refetched mergeable=${pr_mergeable} (t2116)" >>"$LOGFILE"
 	fi
-	if _pmp_review_decision_is_unknown "$pr_review"; then
-		_pmp_refresh_unknown_review_decision_into pr_review "$pr_number" "$repo_slug" "$pr_review"
+	[[ "$pr_mergeable" == "CONFLICTING" ]] || return 10
+	_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$conflict_linked_issue" "conflict" "$pr_labels" "$pr_title" "$pr_updated_at" "$pr_head_ref_oid" || conflict_route_rc=$?
+	if [[ "$conflict_route_rc" -eq 0 ]]; then
+		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+		return 2
 	fi
-
-	# CONFLICTING handling (t2116): before closing, attempt to salvage the
-	# PR via GitHub's REST update-branch endpoint, which fast-forwards the base branch into
-	# the PR's branch when the conflict is purely due to base advancement
-	# (common case: ratchet PRs on a file that other PRs also touched, docs
-	# simplifications on adjacent sections). If update-branch succeeds, the
-	# PR may now be MERGEABLE and we re-fetch its state so the normal merge
-	# path can take over in the same cycle.
-	#
-	# This reorders the original flow: we now also check the maintainer gate
-	# BEFORE closing, so PRs waiting on `needs-maintainer-review` are never
-	# discarded as CONFLICTING during their wait (previous behaviour punished
-	# maintainer review latency by throwing away worker work — see t2116
-	# post-mortem for PR #18988, #19083).
-	if [[ "$pr_mergeable" == "CONFLICTING" && "$PULSE_MERGE_CLOSE_CONFLICTING" == "$PULSE_MERGE_BOOL_TRUE" ]]; then
-		if [[ "${DRY_RUN:-0}" == "1" ]]; then
-			echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} is CONFLICTING; would evaluate rebase, repair routing, or protected close" >>"$LOGFILE"
-			return 2
-		fi
-		# Skip CONFLICTING-close entirely for PRs whose linked issue has
-		# needs-maintainer-review — they are parked legitimately waiting for
-		# a human and MUST NOT be auto-closed (t2116). Post the one-time
-		# rebase nudge so the maintainer has a visible signal.
-		local _t2116_linked_issue _t2116_issue_labels
-		_t2116_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug")
-		if [[ -n "$_t2116_linked_issue" ]]; then
-			_t2116_issue_labels=$(gh api "repos/${repo_slug}/issues/${_t2116_linked_issue}" \
-				--jq '[.labels[].name] | join(",")' 2>/dev/null) || _t2116_issue_labels=""
-			if [[ "$_t2116_issue_labels" == *"needs-maintainer-review"* ]]; then
-				echo "[pulse-wrapper] Merge pass: skipping CONFLICTING-close of PR #${pr_number} in ${repo_slug} — linked issue #${_t2116_linked_issue} has needs-maintainer-review (t2116)" >>"$LOGFILE"
-				_post_rebase_nudge_on_worker_conflicting "$pr_number" "$repo_slug" "" "" 2>/dev/null || true
-				[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
-				return 1
-			fi
-		fi
-
-		# Attempt auto-rebase via the REST update-branch endpoint. This is idempotent
-		# and cheap: on success the branch is fast-forwarded and the next
-		# mergeable re-fetch returns MERGEABLE; on failure (true semantic
-		# conflict) we fall through to the close path.
-		if _attempt_pr_update_branch "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
-			# Re-fetch mergeable state after update-branch; GitHub needs a
-			# moment to recompute it. _resolve_pr_mergeable_status already
-			# has a UNKNOWN-retry loop so we reuse it.
-			local _refetched_mergeable
-			_refetched_mergeable=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-				--json mergeable --jq ".mergeable // \"${PULSE_UNKNOWN_STATE}\"" 2>/dev/null) || _refetched_mergeable="$PULSE_UNKNOWN_STATE"
-			pr_mergeable="$_refetched_mergeable"
-			_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
-			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — update-branch succeeded, refetched mergeable=${pr_mergeable} (t2116)" >>"$LOGFILE"
-			# If still CONFLICTING after a successful update-branch, the
-			# conflict is semantic and unsalvageable. Fall through to close.
-		fi
-
-			if [[ "$pr_mergeable" == "CONFLICTING" ]]; then
-			# Conflict resolution feedback: route worker PRs and stale interactive
-			# PRs to fix workers before the protected-close precheck. Active
-			# interactive PRs remain protected because _route_pr_to_fix_worker only
-			# accepts origin:interactive after _interactive_pr_is_stale passes.
-				local _conflict_route_rc=0
-				_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_t2116_linked_issue" "conflict" "$pr_labels" "$pr_title" "$pr_updated_at" "$pr_head_ref_oid" || _conflict_route_rc=$?
-				if [[ "$_conflict_route_rc" -eq 0 ]]; then
-					[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
-					return 2
-				fi
-				if [[ "$_conflict_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
-					|| "$_conflict_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
-					[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
-					return 1
-				fi
-				if _pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$pr_head_ref_oid" "merge-conflict"; then
-					echo "[pulse-wrapper] Merge pass: preserving authentic Dependabot PR #${pr_number} in ${repo_slug} after routing its merge conflict to worker intake (GH#30351)" >>"$LOGFILE"
-					[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
-					return 1
-				fi
-
-			# GH#23371: some PRs are already known to be protected from
-			# automated close handling from the PR list metadata (draft,
-			# origin:interactive, no-auto-dispatch, external-contributor).
-			# Skip them before the close-conflict ownership guard so pulse
-			# does not repeatedly hit the noisy metadata-fetch path.
-				if _close_conflicting_pr_skip_protected_precheck "$pr_number" "$repo_slug" "$pr_obj"; then
-					[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
-					return 1
-				fi
-
-				_close_conflicting_pr "$pr_number" "$repo_slug" "$pr_title"
-				[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
-				return 2
-			fi
-		# Otherwise pr_mergeable is now MERGEABLE/UNKNOWN — continue through
-		# the normal merge path below.
+	if [[ "$conflict_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" || "$conflict_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
+		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+		return 1
 	fi
+	if _pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$pr_head_ref_oid" "merge-conflict"; then
+		echo "[pulse-wrapper] Merge pass: preserving authentic Dependabot PR #${pr_number} in ${repo_slug} after routing its merge conflict to worker intake (GH#30351)" >>"$LOGFILE"
+		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+		return 1
+	fi
+	if _close_conflicting_pr_skip_protected_precheck "$pr_number" "$repo_slug" "$pr_obj"; then
+		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+		return 1
+	fi
+	_close_conflicting_pr "$pr_number" "$repo_slug" "$pr_title"
+	[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+	return 2
+}
 
-	# Review feedback routing is terminal for worker PRs and must not wait for
-	# GitHub's mergeable cache to resolve. Keep this narrow: conflict handling
-	# above retains precedence, and the helper only routes/skips CHANGES_REQUESTED
-	# via the same origin-label and stale-handover checks used by the later gate.
-	local _review_gate_mode="merge"
-	local _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
-	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
-	local _ci_repair_only="${PULSE_REVIEW_GATE_MODE_CI_REPAIR_ONLY:-ci-repair-only}"
+_pmp_stage_review_and_gates() {
+	local early_linked_issue="" early_dismissed="0"
 	if [[ "$pr_review" == "$_changes_requested" ]]; then
 		if [[ "${DRY_RUN:-0}" == "1" ]]; then
 			echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} has CHANGES_REQUESTED; would evaluate review remediation or repair routing" >>"$LOGFILE"
 			return 1
 		fi
-		local _early_review_linked_issue=""
-		local _early_review_dismissed="0"
-		_early_review_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || _early_review_linked_issue=""
-		if ! _handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$_early_review_linked_issue" "$pr_labels" _early_review_dismissed _review_gate_mode; then
+		early_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || early_linked_issue=""
+		if ! _handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$early_linked_issue" "$pr_labels" early_dismissed _review_gate_mode; then
 			if [[ "$_review_gate_mode" != "$_ci_rebase_only" && "$_review_gate_mode" != "$_ci_repair_only" ]]; then
 				[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 				return 1
 			fi
 		fi
-		# Avoid re-processing stale CHANGES_REQUESTED metadata in the later merge
-		# gate after the CodeRabbit-only dismissal path has already succeeded.
-		if [[ "$_early_review_dismissed" == "1" ]]; then
-			pr_review="NONE"
-		fi
+		[[ "$early_dismissed" != "1" ]] || pr_review="NONE"
 	fi
 	if _pmp_review_decision_is_unknown "$pr_review"; then
 		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision unavailable after refresh (GH#26218)" >>"$LOGFILE"
 		return 1
 	fi
-
-	# Resolve UNKNOWN mergeable state with one retry; skip if not MERGEABLE
 	if ! _resolve_pr_mergeable_status "$pr_number" "$repo_slug" "$pr_mergeable"; then
 		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 		return 1
 	fi
 	[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
-
-	# Fetch linked issue once — used in gate checks, CI repair routing, and
-	# post-merge close. Do this before CI repair routing so red/pending PRs are
-	# only re-queued after the same maintainer/security/review-bot gates that
-	# would have allowed a green merge have passed.
-	local linked_issue
 	linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug")
-
-	# Run all skip-gate checks (review decision, collaborator, workflow scope,
-	# maintainer gate, external-contributor gate, review bot gate) before both
-	# merge and CI-repair paths. This preserves the security boundary for PRs
-	# that are red but would not be trusted if green.
-	if ! _check_pr_merge_gates "$pr_number" "$repo_slug" "$pr_author" "$pr_review" "$linked_issue" "$pr_labels" "$pr_head_ref_oid" "$_review_gate_mode"; then
-		return 1
-	fi
-
-	# Repair-only mode must reach its strict update guard without any terminal PR
-	# mutation; CHANGES_REQUESTED still owns the PR lifecycle in this cycle.
+	_check_pr_merge_gates "$pr_number" "$repo_slug" "$pr_author" "$pr_review" "$linked_issue" "$pr_labels" "$pr_head_ref_oid" "$_review_gate_mode" || return 1
 	if [[ "$_review_gate_mode" != "$_ci_rebase_only" && "$_review_gate_mode" != "$_ci_repair_only" ]] \
 		&& [[ "${DRY_RUN:-0}" != "1" ]] \
 		&& declare -F _pm_close_superseded_duplicate_pr_if_issue_solved >/dev/null 2>&1 \
 		&& _pm_close_superseded_duplicate_pr_if_issue_solved "$pr_number" "$repo_slug" "$linked_issue" "$pr_labels"; then
 		return 1
 	fi
-
-	# A converged response-remediation cycle does not clear CHANGES_REQUESTED.
-	# It authorizes only the typed, non-merge repair path selected above. Always
-	# return after that evaluation so green, pending, or indeterminate CI can
-	# never turn review remediation into a merge bypass.
 	if [[ "$_review_gate_mode" == "$_ci_rebase_only" || "$_review_gate_mode" == "$_ci_repair_only" ]]; then
 		[[ -n "$timing_prefix" ]] && _branch_protection_start=$(_pmp_now_epoch)
-		_handle_review_blocked_ci_repair "$pr_number" "$repo_slug" "$pr_base_ref_name" "$pr_head_ref_oid" \
-			"$linked_issue" "$pr_labels" "$pr_updated_at" "$_review_gate_mode" || true
+		_handle_review_blocked_ci_repair "$pr_number" "$repo_slug" "$pr_base_ref_name" "$pr_head_ref_oid" "$linked_issue" "$pr_labels" "$pr_updated_at" "$_review_gate_mode" || true
 		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
 		return 1
 	fi
+	return 10
+}
 
-	# CI failure fix-up: when required checks fail on a worker/trusted PR with a
-	# linked issue, collect check details, append to issue body, close the PR,
-	# and set the issue to status:available for re-dispatch.
-	# The next worker sees the CI failure context and can fix it. t2189:
-	# idle interactive PRs are handed over via origin:worker-takeover and
-	# then routed through the same pipeline — human session must be gone
-	# (no status, no claim stamp, >24h idle) for handover to fire.
+_pmp_stage_required_checks() {
+	local required_labels="$pr_labels" ci_route_rc=0
 	[[ -n "$timing_prefix" ]] && _branch_protection_start=$(_pmp_now_epoch)
 	if ! _pr_required_checks_pass "$pr_number" "$repo_slug"; then
-		# t2922: For origin:worker PRs, phantom-pending non-required checks
-		# (CodeRabbit, qlty, linked-issue-check, url-allowlist, etc.) can
-		# report null status indefinitely and cause _pr_required_checks_pass
-		# to fail-closed via an API quirk. Cross-check with the branch
-		# protection API (authoritative required-context list). If every
-		# required-by-protection context is passing, bypass this block and
-		# let the worker-briefed trust-chain gates run. Non-worker PRs
-		# (external contributors, interactive sessions) take the normal
-		# CI-failure routing path, preserving the contributor security gate.
-		local _rcl_labels
-		_rcl_labels="$pr_labels"
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author" "$pr_head_ref_oid" \
 			&& _trusted_dependabot_non_review_checks_green "$pr_number" "$repo_slug" "$pr_obj"; then
 			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: _pr_required_checks_pass bypassed for trusted Dependabot — all non-review-bot checks are green (GH#24477)" >>"$LOGFILE"
-		elif [[ -n "${_OW_LABEL_PAT:-}" && ",${_rcl_labels}," == *"${_OW_LABEL_PAT:-}"* ]] \
+		elif [[ -n "${_OW_LABEL_PAT:-}" && ",${required_labels}," == *"${_OW_LABEL_PAT:-}"* ]] \
 			&& _check_required_checks_passing "$repo_slug" "$pr_number"; then
 			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: _pr_required_checks_pass bypassed for origin:worker — branch-protection required contexts all pass (t2922)" >>"$LOGFILE"
-			# Fall through to linked-issue fetch and merge gate checks
 		else
 			if [[ "${DRY_RUN:-0}" == "1" ]]; then
 				echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} has non-passing required checks; would evaluate CI-drift rebase or repair routing" >>"$LOGFILE"
 				return 1
 			fi
-			# t2805: try cheap rebase first if PR is behind base — pre-existing
-			# failures in unrelated tests are often fixed by base advancement.
-			# If rebase succeeds, skip fix-worker routing — next pulse cycle
-			# will re-check CI on the rebased HEAD.
 			if _attempt_pr_ci_rebase_retry "$pr_number" "$repo_slug" "$pr_base_ref_name" "$pr_head_ref_oid"; then
 				[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
 				return 1
 			fi
-			# CI failure: route to fix worker if applicable (t2203: consolidated).
-			local _ci_route_rc=0
-			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" || _ci_route_rc=$?
-			if [[ "$_ci_route_rc" -eq 1 ]] \
-				&& _pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$pr_head_ref_oid" "terminal-ci-failure"; then
+			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" || ci_route_rc=$?
+			if [[ "$ci_route_rc" -eq 1 ]] && _pulse_route_dependabot_pr_to_worker_issue "$pr_number" "$repo_slug" "$pr_author" "$pr_head_ref_oid" "terminal-ci-failure"; then
 				echo "[pulse-wrapper] Merge pass: authentic Dependabot PR #${pr_number} in ${repo_slug} has terminal CI failures; routed to worker intake (GH#30351)" >>"$LOGFILE"
 			fi
-			if [[ "$_ci_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
-				|| "$_ci_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
+			if [[ "$ci_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" || "$ci_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
 				echo "[pulse-wrapper] Merge pass: CI feedback route for PR #${pr_number} in ${repo_slug} remains partial; preserving the PR for retry or maintainer review" >>"$LOGFILE"
 			fi
 			[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
@@ -1703,36 +1576,18 @@ _process_single_ready_pr() {
 		fi
 	fi
 	[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
+	return 10
+}
 
-	# Dry-run must stop before every write side effect. The standalone merge
-	# routine advertises DRY_RUN=1 as no-side-effects, but the historical path
-	# continued into auto-approval, native auto-merge, admin merge, closing
-	# comments, and issue closure. Keep all read-only eligibility checks above
-	# so dry-run still proves whether the PR would pass gates, then return before
-	# any GitHub write.
+_pmp_stage_pre_merge() {
+	local preflight_route_rc=0 native_auto_rc=0
 	if [[ "${DRY_RUN:-0}" == "1" ]]; then
-		if ! _pulse_merge_preflight_snapshot_gate "$repo_slug" "$pr_number" "$pr_head_ref_oid"; then
-			return 1
-		fi
+		_pulse_merge_preflight_snapshot_gate "$repo_slug" "$pr_number" "$pr_head_ref_oid" || return 1
 		echo "[pulse-wrapper] DRY-RUN: would merge PR #${pr_number} in ${repo_slug} (linked_issue=#${linked_issue:-none})" >>"$LOGFILE"
 		return 0
 	fi
-
-	# GH#24839/GH#24840: existing native auto-merge requests can wedge when
-	# GitHub reports MERGEABLE+BEHIND with all required checks green. Update the
-	# branch before the t3070 native-auto defer path, otherwise pulse keeps
-	# waiting for GitHub to do work that GitHub requires a branch update for.
-	if _attempt_existing_auto_merge_behind_update_branch "$pr_number" "$repo_slug"; then
-		return 1
-	fi
-	# GH#26659: repos with native auto-merge disabled still need green+BEHIND
-	# branches updated before admin/direct merge attempts, otherwise rulesets and
-	# branch-protection "head branch is not up to date" errors can loop forever.
-	if _attempt_green_behind_update_branch "$pr_number" "$repo_slug"; then
-		return 1
-	fi
-
-	# Approve (satisfies REVIEW_REQUIRED for collaborator PRs)
+	_attempt_existing_auto_merge_behind_update_branch "$pr_number" "$repo_slug" && return 1
+	_attempt_green_behind_update_branch "$pr_number" "$repo_slug" && return 1
 	approve_collaborator_pr "$pr_number" "$repo_slug" "$pr_author" "$pr_head_ref_oid" 2>/dev/null || true
 	[[ -n "$timing_prefix" ]] && _ruleset_start=$(_pmp_now_epoch)
 	if ! _check_ruleset_required_reviews_passing "$repo_slug" "$pr_number" "$pr_author" "$pr_head_ref_oid"; then
@@ -1740,207 +1595,168 @@ _process_single_ready_pr() {
 		return 1
 	fi
 	[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}ruleset_s" "$_ruleset_start"
-
-	# Extract merge summary: MERGE_SUMMARY comment → PR body → generic fallback
-	local merge_summary
 	merge_summary=$(_extract_merge_summary "$pr_number" "$repo_slug")
-
-	# Retarget any open PRs stacked on this branch before --delete-branch
-	# kills their base. GitHub auto-closes children without warning when their
-	# base branch disappears; retargeting to the default branch prevents this.
-	# (t2412 / GH#20005)
 	_retarget_stacked_children "$pr_number" "$repo_slug" "$pr_head_ref_name"
-
-	# Defense-in-depth (t2934). Refuse `--admin` merge for external/fork PRs
-	# without crypto approval, evaluated at the bypass call site so that any
-	# future regression in upstream gate ordering, label-application timing,
-	# or new code paths cannot re-open the threat addressed by PR #17868
-	# (the 2026-04-07 incident: #17671, #17685, #3846 merged via Check 0
-	# bypass). Returns 1 (skipped) — same semantics as a gate failure above.
-	# #aidevops:trust-boundary — the combined final gate revalidates external
-	# authority, typed review evidence, and the terminal current-head snapshot.
+	# #aidevops:trust-boundary — revalidate exact-head authority before mutation.
 	if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
 		_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 		if [[ "${_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON:-[]}" != "[]" ]]; then
-			local _preflight_route_rc=0
-			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" \
-				"$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" \
-				"$_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON" || _preflight_route_rc=$?
-			if [[ "$_preflight_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
-				|| "$_preflight_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
+			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" "$_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON" || preflight_route_rc=$?
+			if [[ "$preflight_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" || "$preflight_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
 				echo "[pulse-wrapper] Merge pass: preflight feedback route for PR #${pr_number} in ${repo_slug} remains partial" >>"$LOGFILE"
 			fi
 		fi
 		return 1
 	fi
-
-	# Native auto-merge fast-track (t3070): if CI is still pending and the
-	# repo has allow_auto_merge enabled, hand the merge over to GitHub —
-	# it merges within seconds of green instead of waiting for the next
-	# pulse poll cycle (~120s). Falls through to --admin immediate merge
-	# when CI is already green, repo opts out, or the API call fails.
-	local _native_auto_rc=0
-	_set_native_auto_merge_or_skip "$pr_number" "$repo_slug" \
-		"${_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE:-0}" "$pr_review" \
-		"$pr_head_ref_oid" || _native_auto_rc=$?
-	case "$_native_auto_rc" in
-		0)
-			return 4
-			;;
-		2)
-			return 1
-			;;
-		3)
-			return 1
-			;;
-	esac
+	_set_native_auto_merge_or_skip "$pr_number" "$repo_slug" "${_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE:-0}" "$pr_review" "$pr_head_ref_oid" || native_auto_rc=$?
+	case "$native_auto_rc" in 0) return 4 ;; 2 | 3) return 1 ;; esac
 	if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
 		_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 		return 1
 	fi
+	return 10
+}
 
-	# Merge. Prefer the historical admin path for owned repos, but fall back to
-	# protection-respecting merge paths when repository rulesets reject admin
-	# bypass. GitHub reports ruleset blocks as a generic GraphQL error; retrying
-	# the same --admin call every pulse cycle creates a zero-progress loop even
-	# when the PR is otherwise green. First ask GitHub to enqueue/auto-merge the
-	# PR without admin bypass, then fall back to a direct non-admin merge for repos
-	# whose rulesets allow immediate maintainer merges.
-	local merge_output="" _merge_exit=0 _auto_merge_output="" _auto_merge_exit=0
-	local merge_failure_context=""
+_pmp_stage_admin_merge() {
+	local original_output="" missing_output="" missing_exit=0
 	merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin --match-head-commit "$pr_head_ref_oid" 2>&1)
 	_merge_exit=$?
 	if [[ $_merge_exit -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$merge_output" "pulse merge PR #${pr_number} in ${repo_slug}" "$LOGFILE"; then
-		local _merge_original_output="$merge_output"
+		original_output="$merge_output"
 		if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
 			_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 			return 1
 		fi
 		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin --match-head-commit "$pr_head_ref_oid" 2>&1)
 		_merge_exit=$?
-		if [[ $_merge_exit -ne 0 ]]; then
-			merge_output="${_merge_original_output}
+		[[ $_merge_exit -eq 0 ]] || merge_output="${original_output}
 
 [retry after stale gh cache remediation]
 ${merge_output}"
-		fi
 	fi
-	if [[ $_merge_exit -ne 0 ]]; then
-		merge_failure_context="[admin merge]
+	[[ $_merge_exit -eq 0 ]] || merge_failure_context="[admin merge]
 ${merge_output}"
-	fi
 	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Required status check"* \
 		&& ( "$merge_output" == *" is expected"* || "$merge_output" == *" is pending"* ) ]]; then
-		local _missing_check_update_output=""
-		local _missing_check_update_exit=0
-		_missing_check_update_output=$(_pmp_update_branch_rest "$pr_number" "$repo_slug" "$pr_head_ref_oid" 2>&1)
-		_missing_check_update_exit=$?
-		if [[ $_missing_check_update_exit -eq 0 ]]; then
+		missing_output=$(_pmp_update_branch_rest "$pr_number" "$repo_slug" "$pr_head_ref_oid" 2>&1)
+		missing_exit=$?
+		if [[ $missing_exit -eq 0 ]]; then
 			echo "[pulse-wrapper] Deterministic merge: admin merge reported an expected/pending required status check for PR #${pr_number} in ${repo_slug}; update-branch requested and merge deferred (GH#26899): ${merge_output}" >>"$LOGFILE"
 			return 4
 		fi
 		merge_failure_context="${merge_failure_context}
 
 [missing required-check update-branch fallback]
-${_missing_check_update_output}"
+${missing_output}"
 	fi
-	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]]; then
-		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; evaluating protection-respecting fallbacks (GH#24438): ${merge_output}" >>"$LOGFILE"
-		if [[ "${_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE:-0}" == "1" ]]; then
-			_auto_merge_output="native auto-merge skipped: mutable external approval state requires synchronous final revalidation"
-			_auto_merge_exit=1
-		elif ! _repo_allows_auto_merge "$repo_slug"; then
-			_auto_merge_output="native auto-merge skipped: repository does not allow auto-merge (GH#27879)"
-			_auto_merge_exit=1
-		else
-			if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
-				_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
-				return 1
-			fi
-			_auto_merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
-			_auto_merge_exit=$?
+	return 10
+}
+
+_pmp_stage_ruleset_fallback() {
+	local auto_output="" auto_exit=0 direct_original=""
+	[[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]] || return 10
+	echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; evaluating protection-respecting fallbacks (GH#24438): ${merge_output}" >>"$LOGFILE"
+	if [[ "${_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE:-0}" == "1" ]]; then
+		auto_output="native auto-merge skipped: mutable external approval state requires synchronous final revalidation"
+		auto_exit=1
+	elif ! _repo_allows_auto_merge "$repo_slug"; then
+		auto_output="native auto-merge skipped: repository does not allow auto-merge (GH#27879)"
+		auto_exit=1
+	else
+		if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+			_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
+			return 1
 		fi
-		if [[ $_auto_merge_exit -eq 0 ]]; then
-			echo "[pulse-wrapper] Deterministic merge: enabled native auto-merge for PR #${pr_number} in ${repo_slug} after ruleset blocked admin bypass (GH#24438)" >>"$LOGFILE"
-			return 0
-		fi
-		merge_failure_context="${merge_failure_context}
+		auto_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
+		auto_exit=$?
+	fi
+	if [[ $auto_exit -eq 0 ]]; then
+		echo "[pulse-wrapper] Deterministic merge: enabled native auto-merge for PR #${pr_number} in ${repo_slug} after ruleset blocked admin bypass (GH#24438)" >>"$LOGFILE"
+		return 0
+	fi
+	merge_failure_context="${merge_failure_context}
 
 [native auto-merge fallback]
-${_auto_merge_output}"
-		echo "[pulse-wrapper] Deterministic merge: native auto-merge fallback unavailable or failed for PR #${pr_number} in ${repo_slug}; retrying direct merge without --admin (GH#23087): ${_auto_merge_output}" >>"$LOGFILE"
+${auto_output}"
+	echo "[pulse-wrapper] Deterministic merge: native auto-merge fallback unavailable or failed for PR #${pr_number} in ${repo_slug}; retrying direct merge without --admin (GH#23087): ${auto_output}" >>"$LOGFILE"
+	if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+		_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
+		return 1
+	fi
+	merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
+	_merge_exit=$?
+	if [[ $_merge_exit -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$merge_output" "pulse direct merge PR #${pr_number} in ${repo_slug}" "$LOGFILE"; then
+		direct_original="$merge_output"
 		if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
 			_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 			return 1
 		fi
 		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
 		_merge_exit=$?
-		if [[ $_merge_exit -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$merge_output" "pulse direct merge PR #${pr_number} in ${repo_slug}" "$LOGFILE"; then
-			local _direct_merge_original_output="$merge_output"
-			if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
-				_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
-				return 1
-			fi
-			merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
-			_merge_exit=$?
-			if [[ $_merge_exit -ne 0 ]]; then
-				merge_output="${_direct_merge_original_output}
+		[[ $_merge_exit -eq 0 ]] || merge_output="${direct_original}
 
 [retry after stale gh cache remediation]
 ${merge_output}"
-			fi
-		fi
-		if [[ $_merge_exit -ne 0 ]]; then
-			merge_failure_context="${merge_failure_context}
+	fi
+	[[ $_merge_exit -eq 0 ]] || merge_failure_context="${merge_failure_context}
 
 [direct merge fallback]
 ${merge_output}"
-		fi
-	fi
+	return 10
+}
 
+_pmp_stage_finalize_merge() {
+	local labels="$pr_labels" role="collaborator" final_output="$merge_output"
 	if [[ $_merge_exit -eq 0 ]]; then
 		echo "[pulse-wrapper] Deterministic merge: merged PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
-		if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
-			_pulse_merge_invalidate_pr_list_cache "$repo_slug" "merged PR #${pr_number}"
-		fi
+		declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1 && _pulse_merge_invalidate_pr_list_cache "$repo_slug" "merged PR #${pr_number}"
 		_pmp_record_deterministic_progress_now 1 0
 	fi
-
-	# Rate-limit: 1 second between merges to avoid GitHub API abuse. Persist a
-	# successful mutation before this interruptible wait (GH#28285).
 	sleep 1
-
 	if [[ $_merge_exit -eq 0 ]]; then
-		# t2411: emit audit log for origin:interactive auto-merges
-		local _ipr_labels="$pr_labels"
-		if [[ "$_ipr_labels" == *"origin:interactive"* ]]; then
-			local _ipr_role="collaborator"
-			_is_owner_or_member_author "$pr_author" "$repo_slug" \
-				&& _ipr_role="owner-or-member" || true
-			echo "[pulse-merge] auto-merged origin:interactive PR #${pr_number} (author=${pr_author}, role=${_ipr_role})" >>"$LOGFILE"
+		if [[ "$labels" == *"origin:interactive"* ]]; then
+			_is_owner_or_member_author "$pr_author" "$repo_slug" && role="owner-or-member" || true
+			echo "[pulse-merge] auto-merged origin:interactive PR #${pr_number} (author=${pr_author}, role=${role})" >>"$LOGFILE"
 		fi
-		# t2449: emit audit log for origin:worker worker-briefed auto-merges
-		if [[ -n "${_OW_LABEL_PAT:-}" && ",${_ipr_labels}," == *"${_OW_LABEL_PAT:-}"* ]]; then
+		if [[ -n "${_OW_LABEL_PAT:-}" && ",${labels}," == *"${_OW_LABEL_PAT:-}"* ]]; then
 			echo "[pulse-merge] auto-merged origin:worker (worker-briefed) PR #${pr_number} (author=${pr_author}, linked_issue=#${linked_issue:-unknown})" >>"$LOGFILE"
 		fi
-		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$_ipr_labels" "$pr_base_ref_name"
+		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$labels" "$pr_base_ref_name"
 		return 0
-	elif [[ "$merge_output" == *"Merge already in progress"* ]]; then
-		echo "[pulse-wrapper] Deterministic merge: PR #${pr_number} in ${repo_slug} already has a merge in progress; counting as merge progress (GH#24383): ${merge_output}" >>"$LOGFILE"
-		local _ipr_labels="$pr_labels"
-		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$_ipr_labels" "$pr_base_ref_name"
-		return $?
-	else
-		if declare -F _pulse_merge_failure_is_terminal >/dev/null 2>&1 \
-			&& _pulse_merge_failure_is_terminal "$pr_number" "$repo_slug"; then
-			return 1
-		fi
-		local final_merge_output="$merge_output"
-		[[ -n "$merge_failure_context" ]] && final_merge_output="$merge_failure_context"
-		echo "[pulse-wrapper] Deterministic merge: FAILED PR #${pr_number} in ${repo_slug}: ${final_merge_output}" >>"$LOGFILE"
-		_pulse_merge_maybe_dispatch_review_thread_remediation "$pr_number" "$repo_slug" "$final_merge_output"
-		return 3
 	fi
+	if [[ "$merge_output" == *"Merge already in progress"* ]]; then
+		echo "[pulse-wrapper] Deterministic merge: PR #${pr_number} in ${repo_slug} already has a merge in progress; counting as merge progress (GH#24383): ${merge_output}" >>"$LOGFILE"
+		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$labels" "$pr_base_ref_name"
+		return $?
+	fi
+	if declare -F _pulse_merge_failure_is_terminal >/dev/null 2>&1 && _pulse_merge_failure_is_terminal "$pr_number" "$repo_slug"; then
+		return 1
+	fi
+	[[ -z "$merge_failure_context" ]] || final_output="$merge_failure_context"
+	echo "[pulse-wrapper] Deterministic merge: FAILED PR #${pr_number} in ${repo_slug}: ${final_output}" >>"$LOGFILE"
+	_pulse_merge_maybe_dispatch_review_thread_remediation "$pr_number" "$repo_slug" "$final_output"
+	return 3
+}
+
+_process_single_ready_pr() {
+	local repo_slug="$1" pr_obj="$2" timing_prefix="${3:-}" stage_rc=0
+	local pr_number="" pr_state="" pr_mergeable="" pr_review="" pr_author="" pr_title="" pr_updated_at=""
+	local pr_head_ref_oid="" pr_head_ref_name="" pr_base_ref_name="" pr_labels="" pr_is_draft="false"
+	local _mergeability_start="" _branch_protection_start="" _ruleset_start=""
+	local _review_gate_mode="merge" _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
+	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
+	local _ci_repair_only="${PULSE_REVIEW_GATE_MODE_CI_REPAIR_ONLY:-ci-repair-only}"
+	local linked_issue="" merge_summary="" merge_output="" merge_failure_context="" _merge_exit=0
+	local stage=""
+	for stage in _pmp_stage_parse_and_validate _pmp_stage_handle_conflict \
+		_pmp_stage_review_and_gates _pmp_stage_required_checks _pmp_stage_pre_merge \
+		_pmp_stage_admin_merge _pmp_stage_ruleset_fallback; do
+		stage_rc=0
+		"$stage" || stage_rc=$?
+		[[ "$stage_rc" -eq 10 ]] || return "$stage_rc"
+	done
+	_pmp_stage_finalize_merge
+	return $?
 }
 
 #######################################

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -377,12 +377,24 @@ extract_merge_gate_functions() {
 	return 0
 }
 
+extract_process_stage_functions() {
+	local source_file="$1"
+	local fn_name=""
+	for fn_name in _pmp_stage_parse_and_validate _pmp_stage_handle_conflict \
+		_pmp_stage_review_and_gates _pmp_stage_required_checks _pmp_stage_pre_merge \
+		_pmp_stage_admin_merge _pmp_stage_ruleset_fallback _pmp_stage_finalize_merge; do
+		extract_function "$fn_name" "$source_file"
+	done
+	return 0
+}
+
 define_process_helper() {
-	local fn_src="" repair_helper_src="" review_gate_src=""
+	local fn_src="" process_stage_src="" repair_helper_src="" review_gate_src=""
 	review_gate_src=$(extract_function _handle_changes_requested_review_gate "$MERGE_SCRIPT")
 	repair_helper_src=$(extract_function _handle_review_blocked_ci_repair "$PROCESS_SCRIPT")
+	process_stage_src=$(extract_process_stage_functions "$MERGE_SCRIPT")
 	fn_src=$(extract_function _process_single_ready_pr "$MERGE_SCRIPT")
-	[[ -n "$review_gate_src" && -n "$repair_helper_src" && -n "$fn_src" ]] || return 1
+	[[ -n "$review_gate_src" && -n "$repair_helper_src" && -n "$process_stage_src" && -n "$fn_src" ]] || return 1
 
 	_OW_LABEL_PAT=",origin:worker,"
 	PULSE_MERGE_BOOL_TRUE="true"
@@ -462,6 +474,8 @@ define_process_helper() {
 	eval "$review_gate_src"
 	# shellcheck disable=SC1090
 	eval "$repair_helper_src"
+	# shellcheck disable=SC1090
+	eval "$process_stage_src"
 	# shellcheck disable=SC1090
 	eval "$fn_src"
 	return 0

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -366,6 +366,17 @@ extract_function() {
 	return 0
 }
 
+extract_merge_gate_functions() {
+	local source_file="$1"
+	local fn_name=""
+	for fn_name in _pm_gate_review_mode _pm_gate_author_trust \
+		_pm_gate_route_ineligible_author _pm_gate_repository_and_issue \
+		_pm_gate_origin_authority _pm_gate_review_bot _check_pr_merge_gates; do
+		extract_function "$fn_name" "$source_file"
+	done
+	return 0
+}
+
 define_process_helper() {
 	local fn_src="" repair_helper_src="" review_gate_src=""
 	review_gate_src=$(extract_function _handle_changes_requested_review_gate "$MERGE_SCRIPT")
@@ -676,7 +687,7 @@ test_ci_rebase_only_gate_stops_before_review_bot_boundary() {
 	define_process_helper || { print_result "defines repair-only gate helper" 1 "could not extract review gate"; teardown_test_env; return 0; }
 	local gate_src="" gate_rc=0 review_bot_calls=0
 	local old_agents_dir="${AGENTS_DIR:-}"
-	gate_src=$(extract_function _check_pr_merge_gates "$MERGE_SCRIPT")
+	gate_src=$(extract_merge_gate_functions "$MERGE_SCRIPT")
 	if [[ -z "$gate_src" ]]; then
 		print_result "repair-only gate stops before review-bot boundary" 1 "could not extract _check_pr_merge_gates"
 		teardown_test_env
@@ -726,7 +737,7 @@ test_ci_repair_only_gate_requires_review_bot_boundary() {
 	local gate_src="" gate_rc=0
 	local old_agents_dir="${AGENTS_DIR:-}"
 	local review_bot_log="${TEST_ROOT}/review-bot.log"
-	gate_src=$(extract_function _check_pr_merge_gates "$MERGE_SCRIPT")
+	gate_src=$(extract_merge_gate_functions "$MERGE_SCRIPT")
 	if [[ -z "$gate_src" ]]; then
 		print_result "CI repair-only gate requires review-bot boundary" 1 "could not extract _check_pr_merge_gates"
 		teardown_test_env

--- a/.agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh
+++ b/.agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh
@@ -40,7 +40,15 @@ print_result() {
 	return 0
 }
 
-gate_src=$(awk '/^_check_pr_merge_gates\(\) \{/,/^}$/ { print }' "$MERGE_SCRIPT")
+gate_src=$(awk '
+	/^_pm_gate_review_mode\(\) \{/,/^}$/ { print }
+	/^_pm_gate_author_trust\(\) \{/,/^}$/ { print }
+	/^_pm_gate_route_ineligible_author\(\) \{/,/^}$/ { print }
+	/^_pm_gate_repository_and_issue\(\) \{/,/^}$/ { print }
+	/^_pm_gate_origin_authority\(\) \{/,/^}$/ { print }
+	/^_pm_gate_review_bot\(\) \{/,/^}$/ { print }
+	/^_check_pr_merge_gates\(\) \{/,/^}$/ { print }
+' "$MERGE_SCRIPT")
 [[ -n "$gate_src" ]] || {
 	printf 'FAIL could not extract _check_pr_merge_gates\n' >&2
 	exit 1

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -716,7 +716,7 @@ test_native_auto_defer_not_counted_as_completed_merge() {
 		/^_pmp_record_processed_pr_result\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	merge_src=$(awk '
-		/^_process_single_ready_pr\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+		/^_pmp_stage_pre_merge\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$MERGE_SCRIPT")
 
 	if [[ -z "$process_src" || -z "$merge_src" ]]; then
@@ -727,7 +727,7 @@ test_native_auto_defer_not_counted_as_completed_merge() {
 
 	if [[ "$merge_src" != *'return 4'* ]]; then
 		print_result "Native auto defer returns distinct non-merged code" 1 \
-			"Expected _process_single_ready_pr native-auto branch to return 4"
+			"Expected _pmp_stage_pre_merge native-auto branch to return 4"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh
@@ -106,10 +106,22 @@ EOF
 	set_solved_label() { return 0; }
 	auto_file_next_phase() { return 0; }
 	_pm_handle_partial_parent_closeout() { return 0; }
+	_pm_routing_feedback() { return 1; }
 	clear_terminal_issue_dispatch_labels() { return 0; }
+	solved_actor_from_pr_labels() { return 1; }
+	set_issue_status() { return 0; }
+	reconcile_dependants_after_verified_closure() { return 0; }
+	_gh_with_timeout() {
+		local access_mode="$1"
+		shift
+		[[ -n "$access_mode" ]] || return 1
+		"$@"
+		return $?
+	}
 	export -f unlock_issue_after_worker fast_fail_reset _release_interactive_claim_on_merge \
-		set_solved_label auto_file_next_phase _pm_handle_partial_parent_closeout \
-		clear_terminal_issue_dispatch_labels 2>/dev/null || true
+		set_solved_label auto_file_next_phase _pm_handle_partial_parent_closeout _pm_routing_feedback \
+		clear_terminal_issue_dispatch_labels solved_actor_from_pr_labels set_issue_status \
+		reconcile_dependants_after_verified_closure _gh_with_timeout 2>/dev/null || true
 
 	# Shim shared-gh-wrappers.sh wrappers → gh binary stub. The function was
 	# refactored post-GH#21595 to use gh_pr_comment / gh_issue_comment instead
@@ -150,7 +162,12 @@ define_function_under_test() {
 	fn_src=$(awk '
 		/^_pm_issue_api\(\) \{/,/^}$/ { print }
 		/^_pm_build_closing_comment\(\) \{/,/^}$/ { print }
+		/^_pm_select_pr_closeout_comment_id\(\) \{/,/^}$/ { print }
+		/^_pm_reconcile_pr_closeout_comments\(\) \{/,/^}$/ { print }
+		/^_pm_upsert_pr_closing_comment\(\) \{/,/^}$/ { print }
 		/^_pm_resolve_superseded_original_issue\(\) \{/,/^}$/ { print }
+		/^_pm_close_primary_linked_issue\(\) \{/,/^}$/ { print }
+		/^_pm_close_superseded_original_issue\(\) \{/,/^}$/ { print }
 		/^_handle_post_merge_actions\(\) \{/,/^}$/ { print }
 		/^_unblock_circuit_breaker_meta_pr\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")

--- a/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
@@ -125,6 +125,8 @@ define_function_under_test() {
 		/^_pm_reconcile_pr_closeout_comments\(\) \{/,/^}$/ { print }
 		/^_pm_upsert_pr_closing_comment\(\) \{/,/^}$/ { print }
 		/^_pm_resolve_superseded_original_issue\(\) \{/,/^}$/ { print }
+		/^_pm_close_primary_linked_issue\(\) \{/,/^}$/ { print }
+		/^_pm_close_superseded_original_issue\(\) \{/,/^}$/ { print }
 		/^_handle_post_merge_actions\(\) \{/,/^}$/ { print }
 		/^_extract_linked_issue\(\) \{/,/^}$/ { print }
 	' "$MERGE_FILE")

--- a/.agents/scripts/tests/test-pulse-merge-retarget-stacked.sh
+++ b/.agents/scripts/tests/test-pulse-merge-retarget-stacked.sh
@@ -312,24 +312,24 @@ test_provided_head_ref_context_skips_view() {
 }
 
 # ---------------------------------------------------------------
-# Test 7: Static check — _retarget_stacked_children called before
-#         gh pr merge in _process_single_ready_pr
+# Test 7: Static check — pre-merge retarget stage runs before merge stage.
 # ---------------------------------------------------------------
 test_retarget_called_before_merge() {
 	local func_body
 	func_body=$(awk '
-		/^_process_single_ready_pr\(\) \{/,/^}$/ { print }
+		/^_pmp_stage_pre_merge\(\) \{/,/^}$/ { print }
+		/^_pmp_stage_admin_merge\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 
 	if [[ -z "$func_body" ]]; then
 		print_result "retarget called before merge in _process_single_ready_pr" 1 \
-			"Could not extract _process_single_ready_pr from pulse-merge.sh"
+			"Could not extract pre-merge and admin-merge stages from pulse-merge.sh"
 		return 0
 	fi
 
 	if [[ "$func_body" != *"_retarget_stacked_children"* ]]; then
 		print_result "retarget called before merge in _process_single_ready_pr" 1 \
-			"_retarget_stacked_children not found in _process_single_ready_pr"
+			"_retarget_stacked_children not found in _pmp_stage_pre_merge"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -179,6 +179,14 @@ define_function_under_test() {
 		/^_pulse_merge_failure_is_terminal\(\) \{/,/^\}$/ { print }
 	' "$MERGE_SCRIPT")
 	src_process=$(awk '
+		/^_pmp_stage_parse_and_validate\(\) \{/,/^\}$/ { print }
+		/^_pmp_stage_handle_conflict\(\) \{/,/^\}$/ { print }
+		/^_pmp_stage_review_and_gates\(\) \{/,/^\}$/ { print }
+		/^_pmp_stage_required_checks\(\) \{/,/^\}$/ { print }
+		/^_pmp_stage_pre_merge\(\) \{/,/^\}$/ { print }
+		/^_pmp_stage_admin_merge\(\) \{/,/^\}$/ { print }
+		/^_pmp_stage_ruleset_fallback\(\) \{/,/^\}$/ { print }
+		/^_pmp_stage_finalize_merge\(\) \{/,/^\}$/ { print }
 		/^_process_single_ready_pr\(\) \{/,/^\}$/ { print }
 	' "$MERGE_SCRIPT")
 	src_webhook_process=$(awk '

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -594,7 +594,7 @@ echo ""
 # detector can file false collapse issues while GitHub is completing the merge.
 TESTS_RUN=$((TESTS_RUN + 1))
 if grep -q "Merge already in progress" "$MERGE_SCRIPT" &&
-	grep -Fq "_handle_post_merge_actions \"\$pr_number\" \"\$repo_slug\" \"\$linked_issue\" \"\$merge_summary\" \"\$_ipr_labels\"" "$MERGE_SCRIPT" &&
+	grep -Fq "_handle_post_merge_actions \"\$pr_number\" \"\$repo_slug\" \"\$linked_issue\" \"\$merge_summary\" \"\$labels\"" "$MERGE_SCRIPT" &&
 	grep -Fq "return \$?" "$MERGE_SCRIPT"; then
 	echo "${TEST_GREEN}PASS${TEST_NC}: 6d: merge-in-progress is counted as zero-progress-breaking progress"
 else

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -39,6 +39,7 @@ TESTS_FAILED=0
 TEST_ROOT=""
 LAST_GH_ARGS_FILE=""
 LAST_GH_QUOTA_FILE=""
+_PMP_ORIGIN_INTERACTIVE_PATTERN=',origin:interactive,'
 
 print_result() {
 	local test_name="$1"
@@ -415,8 +416,8 @@ test_refresh_unknown_mergeable_surfaces_conflicting() {
 }
 
 # ---------------------------------------------------------------
-# Static analysis of the t2116 block in _process_single_ready_pr.
-# The full control-flow of _process_single_ready_pr depends on many
+# Static analysis of the extracted t2116 conflict stage.
+# The full control-flow of the orchestrator depends on many
 # helpers that are too heavy to mock reliably; instead we assert the
 # exact structural properties that must hold for the fix to work:
 #
@@ -429,19 +430,15 @@ test_refresh_unknown_mergeable_surfaces_conflicting() {
 # ---------------------------------------------------------------
 
 test_nmr_guard_exists_before_close() {
-	# Extract the CONFLICTING handling block from _process_single_ready_pr.
+	# Extract the CONFLICTING handling block from its focused stage.
 	local block
 	block=$(awk '
-		/^_process_single_ready_pr\(\) \{/,/^}$/ {
-			if ($0 ~ /pr_mergeable.*CONFLICTING/) { capturing=1 }
-			if (capturing) print
-			if (capturing && /^	fi$/ && ++fi_count == 3) { exit }
-		}
+		/^_pmp_stage_handle_conflict\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 
 	if [[ -z "$block" ]]; then
 		print_result "NMR guard + update-branch structure present" 1 \
-			"Could not extract CONFLICTING block from _process_single_ready_pr"
+			"Could not extract _pmp_stage_handle_conflict"
 		return 0
 	fi
 
@@ -483,7 +480,7 @@ test_nmr_guard_exists_before_close() {
 test_stale_route_runs_before_protected_precheck() {
 	local block
 	block=$(awk '
-		/^_process_single_ready_pr\(\) \{/ { in_fn=1 }
+		/^_pmp_stage_handle_conflict\(\) \{/ { in_fn=1 }
 		in_fn && /_attempt_pr_update_branch/ { capturing=1 }
 		capturing { print }
 		capturing && /^[[:space:]]*_close_conflicting_pr "/ { exit }
@@ -532,17 +529,16 @@ test_mergeable_refetch_after_update_branch() {
 test_unknown_mergeable_refreshed_before_conflict_handler() {
 	local function_src refresh_pos conflict_pos
 	function_src=$(awk '
-		/^_process_single_ready_pr\(\) \{/ { in_fn=1 }
-		in_fn { print }
-		in_fn && /^\}$/ { exit }
+		/^_pmp_stage_parse_and_validate\(\) \{/,/^}$/ { print }
+		/^_pmp_stage_handle_conflict\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 
 	refresh_pos=$(printf '%s\n' "$function_src" | awk '/GH#24634/ { print NR; exit }')
-	conflict_pos=$(printf '%s\n' "$function_src" | awk '/if \[\[ "\$pr_mergeable" == "CONFLICTING"/ { print NR; exit }')
+	conflict_pos=$(printf '%s\n' "$function_src" | awk '/\[\[ "\$pr_mergeable" == "CONFLICTING"/ { print NR; exit }')
 
 	if [[ -z "$refresh_pos" || -z "$conflict_pos" ]]; then
 		print_result "UNKNOWN mergeable refresh precedes CONFLICTING branch" 1 \
-			"Expected GH#24634 refresh and CONFLICTING branch in _process_single_ready_pr (refresh=${refresh_pos}, conflict=${conflict_pos})"
+			"Expected GH#24634 refresh before _pmp_stage_handle_conflict (refresh=${refresh_pos}, conflict=${conflict_pos})"
 		return 0
 	fi
 


### PR DESCRIPTION
## Summary

- Split the three oversized pulse-merge functions into focused stage and gate helpers.
- Preserve merge authorization, repair routing, conflict handling, return codes, timing, and post-merge closeout behavior.
- Update extraction-based regression harnesses to follow the new helper boundaries.

## Complexity Bump Justification

Issue #30768 records three existing functions above the 100-line function-complexity threshold. The extracted gate, closeout, and processing stages begin at `.agents/scripts/pulse-merge.sh:444`, `.agents/scripts/pulse-merge.sh:1132`, and `.agents/scripts/pulse-merge.sh:1425`. This behavior-preserving decomposition gives each phase a focused helper identity and leaves no new function-complexity violations. The `complexity-bump-ok` label covers extraction-related scanner identity changes; measurements are `base=3, head=0, new=0`.

## Testing

- `bash -n` and ShellCheck on modified shell files
- `.agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD --metric function-complexity` (`base: 3 head: 0 new: 0`)
- `.agents/scripts/linters-local.sh`
- Relevant pulse-merge post-merge, parent-task, issue-sync, CI routing, ruleset fallback, native-auto, retarget, update-branch, stuck, timing, routine, review-thread, REST-readiness, CodeRabbit, admin-safety, and preflight regression suites

Resolves #30768
For #30763
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 24m and 1,134,560 tokens on this as a headless worker.