### PR TITLE
GH#30756 GH#30757 GH#30758: fix planning PR publication

### DIFF
--- a/.agents/reference/planning-pr-publication-contract.md
+++ b/.agents/reference/planning-pr-publication-contract.md
@@ -1,0 +1,27 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Planning PR Publication Contract
+
+Protected-default planning PR bodies carry one deterministic publication
+marker and one machine-readable marker per validated changed task:
+
+```text
+<!-- aidevops:planning-publication:v1 id=<content-derived-id> -->
+<!-- aidevops:planning-task:v1 task=t123 issue=456 -->
+- For #456
+```
+
+Task candidates come from changed TODO entries and changed
+`todo/tasks/t*-brief.md` paths. Every candidate must resolve to exactly one
+current TODO entry with exactly one local `ref:GH#NNN`. The body emits each
+unique issue as a non-closing `For` reference in deterministic order. A
+single-task publication uses `plan(tNNN): ...`; multi-task publications keep
+the batch title rather than selecting an arbitrary task.
+
+The content-derived publication ID also names the planning branch. A retry
+verifies and reuses a matching pushed commit or open PR. A terminal failure
+reports `AIDEVOPS_PLANNING_RECOVERY_*` fields for the publication, branch,
+commit, remote/PR/source states, and disposable-worktree cleanup state. Caller
+planning edits and the sole durable commit are preserved; temporary worktrees
+are removed on every terminal path unless cleanup itself fails visibly.

--- a/.agents/reference/planning-publication-lifecycle.md
+++ b/.agents/reference/planning-publication-lifecycle.md
@@ -131,6 +131,9 @@ allocate ID + create issue (publication:pending)
       branch deleted before merge -> same as closed unmerged
 ```
 
+Planning PR manifest, title, receipt, and retry details are defined in
+`planning-pr-publication-contract.md`.
+
 The post-merge transition is driven by the existing default-branch push path,
 not by trusting a PR's mergeable state. A `pull_request.closed` reconciliation
 may provide faster diagnostics, but only default-branch file validation may

--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -314,6 +314,7 @@ _scaffold_contributing() {
 	c="$c"$'\n'"5. Commit with conventional commits: \`git commit -m \"feat: add new feature\"\`"
 	c="$c"$'\n'"6. Push and open a PR with the issue reference in the PR body"
 	c="$c"$'\n\n'"<!-- aidevops:issue-first-pr:start -->"
+	c="$c"$'\n'"<!-- aidevops:issue-first-pr:scope=external -->"
 	c="$c"$'\n'"## Issue-first pull requests"
 	c="$c"$'\n\n'"If you are not a repository owner, member, or collaborator, create or find a GitHub issue before opening a pull request. Maintainers monitor issues more frequently than unsolicited pull requests."
 	c="$c"$'\n\n'"Include \`Closes #NNN\`, \`Fixes #NNN\`, \`Resolves #NNN\`, \`For #NNN\`, or \`Ref #NNN\` in the PR body. External human-authored PRs without an issue reference are blocked. Bot PRs and trusted maintainer task workflows are exempt."

--- a/.agents/scripts/gh-write-policy-lib.sh
+++ b/.agents/scripts/gh-write-policy-lib.sh
@@ -12,6 +12,7 @@
 [[ -n "${_GH_WRITE_POLICY_LIB_LOADED:-}" ]] && return 0
 _GH_WRITE_POLICY_LIB_LOADED=1
 _SHIM_ORIGIN_INTERACTIVE_LABEL="origin:interactive"
+_SHIM_ISSUE_FIRST_SCOPE_EXTERNAL="external"
 _SHIM_MANAGED_LABEL_SET=""
 
 if [[ -z "${_SHIM_DIR:-}" ]]; then
@@ -870,73 +871,190 @@ _shim_target_matches_local_checkout() {
 	return $?
 }
 
-_shim_file_mentions_issue_first_policy() {
+_shim_file_issue_first_scope() {
 	local file_path="$1"
 	local content="${2:-}"
-	local policy_pattern='issue-first|linked issue|every human-authored pr'
-	local reference_pattern='closes #|fixes #|resolves #|for #|ref #'
-	if [[ -n "$content" ]]; then
-		if grep -Eiq "$policy_pattern" <<<"$content" &&
-			grep -Eiq "$reference_pattern" <<<"$content"; then
-			return 0
-		fi
-		return 1
+	local marker_lines=""
+	local marker_count=0
+	local scope=""
+	if [[ -z "$content" ]]; then
+		[[ -f "$file_path" ]] || return 1
+		content=$(<"$file_path") || return 1
 	fi
-	[[ -f "$file_path" ]] || return 1
-	content=$(<"$file_path")
-	_shim_file_mentions_issue_first_policy "$file_path" "$content"
-	return $?
-}
-
-_shim_local_policy_requires_linked_issue() {
-	local root=""
-	local tmpl=""
-	root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-	_shim_file_mentions_issue_first_policy "$root/CONTRIBUTING.md" && return 0
-	_shim_file_mentions_issue_first_policy "$root/.github/PULL_REQUEST_TEMPLATE.md" && return 0
-	_shim_file_mentions_issue_first_policy "$root/.github/pull_request_template.md" && return 0
-	for tmpl in "$root"/.github/PULL_REQUEST_TEMPLATE/*.md "$root"/.github/pull_request_template/*.md; do
-		[[ -f "$tmpl" ]] || continue
-		_shim_file_mentions_issue_first_policy "$tmpl" && return 0
-	done
+	marker_lines=$(printf '%s\n' "$content" |
+		grep -E '^[[:space:]]*<!--[[:space:]]*aidevops:issue-first-pr:scope=(external|universal)[[:space:]]*-->[[:space:]]*$' || true)
+	if [[ -n "$marker_lines" ]]; then
+		marker_count=$(printf '%s\n' "$marker_lines" | grep -c . || true)
+	fi
+	if [[ "$marker_count" -eq 1 ]]; then
+		scope=$(printf '%s\n' "$marker_lines" |
+			sed -nE 's/.*scope=(external|universal).*/\1/p')
+		case "$scope" in
+		external | universal)
+			printf '%s\n' "$scope"
+			return 0
+			;;
+		esac
+	fi
+	# Legacy prose, malformed markers, and contradictory/multiple declarations
+	# are policy-bearing but ambiguous. Preserve fail-closed behavior instead of
+	# attempting to infer exemptions from human language.
+	if [[ "$marker_count" -gt 1 ]] ||
+		grep -Eqi 'aidevops:issue-first-pr:(start|scope=)|issue-first|linked issue|every human-authored pr' <<<"$content"; then
+		printf 'universal\n'
+		return 0
+	fi
 	return 1
 }
 
-_shim_repo_requires_linked_issue_prs() {
+_shim_file_declared_issue_first_scope() {
+	local file_path="$1"
+	local all_marker_lines=""
+	local all_marker_count=0
+	local marker_lines=""
+	local marker_count=0
+	local scope=""
+	[[ -f "$file_path" ]] || return 1
+	all_marker_lines=$(grep -E 'aidevops:issue-first-pr:scope=' "$file_path" 2>/dev/null || true)
+	[[ -n "$all_marker_lines" ]] || return 1
+	all_marker_count=$(printf '%s\n' "$all_marker_lines" | grep -c . || true)
+	marker_lines=$(grep -E '^[[:space:]]*<!--[[:space:]]*aidevops:issue-first-pr:scope=(external|universal)[[:space:]]*-->[[:space:]]*$' \
+		"$file_path" 2>/dev/null || true)
+	if [[ -n "$marker_lines" ]]; then
+		marker_count=$(printf '%s\n' "$marker_lines" | grep -c . || true)
+	fi
+	if [[ "$all_marker_count" -ne 1 || "$marker_count" -ne 1 ]]; then
+		printf 'universal\n'
+		return 0
+	fi
+	scope=$(printf '%s\n' "$marker_lines" |
+		sed -nE 's/.*scope=(external|universal).*/\1/p')
+	case "$scope" in
+	external | universal)
+		printf '%s\n' "$scope"
+		return 0
+		;;
+	esac
+	printf 'universal\n'
+	return 0
+}
+
+_shim_local_issue_first_scope() {
+	local root=""
+	local tmpl=""
+	local scope=""
+	local selected_scope=""
+	local -a policy_files=()
+	root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+	policy_files+=(
+		"$root/CONTRIBUTING.md"
+		"$root/.github/PULL_REQUEST_TEMPLATE.md"
+		"$root/.github/pull_request_template.md"
+	)
+	for tmpl in "$root"/.github/PULL_REQUEST_TEMPLATE/*.md "$root"/.github/pull_request_template/*.md; do
+		[[ -f "$tmpl" ]] && policy_files+=("$tmpl")
+	done
+	# Structured declarations are authoritative. Scan them first so ordinary PR
+	# template fields cannot broaden an explicit external-only policy.
+	for tmpl in "${policy_files[@]}"; do
+		[[ -f "$tmpl" ]] || continue
+		scope=$(_shim_file_declared_issue_first_scope "$tmpl" 2>/dev/null || true)
+		[[ -n "$scope" ]] || continue
+		if [[ "$scope" == "universal" ]]; then
+			printf 'universal\n'
+			return 0
+		fi
+		selected_scope="$_SHIM_ISSUE_FIRST_SCOPE_EXTERNAL"
+	done
+	if [[ -n "$selected_scope" ]]; then
+		printf '%s\n' "$selected_scope"
+		return 0
+	fi
+
+	# Legacy policy prose has no deterministic exemption contract and therefore
+	# remains universal until a managed scope declaration is added.
+	for tmpl in "${policy_files[@]}"; do
+		[[ -f "$tmpl" ]] || continue
+		scope=$(_shim_file_issue_first_scope "$tmpl" 2>/dev/null || true)
+		[[ -n "$scope" ]] || continue
+		if [[ "$scope" == "universal" ]]; then
+			printf 'universal\n'
+			return 0
+		fi
+		selected_scope="$scope"
+	done
+	[[ -n "$selected_scope" ]] || return 1
+	printf '%s\n' "$selected_scope"
+	return 0
+}
+
+_shim_repo_issue_first_scope() {
 	local repo_slug="$1"
-	[[ "$repo_slug" == "marcusquinn/aidevops" ]] && return 0
-	_shim_target_matches_local_checkout "$repo_slug" || return 1
-	_shim_local_policy_requires_linked_issue && return 0
+	local scope=""
+	if _shim_target_matches_local_checkout "$repo_slug"; then
+		scope=$(_shim_local_issue_first_scope 2>/dev/null || true)
+		if [[ -n "$scope" ]]; then
+			printf '%s\n' "$scope"
+			return 0
+		fi
+	fi
+	# Keep the framework repository policy enforceable when the shim is invoked
+	# from another checkout. Its managed policy declaration is external-only.
+	if [[ "$repo_slug" == "marcusquinn/aidevops" ]]; then
+		printf 'external\n'
+		return 0
+	fi
+	return 1
+}
+
+_shim_authenticated_actor_has_repo_write() {
+	local repo_slug="$1"
+	local current_user=""
+	local permission=""
+	[[ -n "$repo_slug" && "$repo_slug" == */* ]] || return 1
+	#aidevops:trust-boundary -- exemption requires live GitHub identity and permission.
+	current_user=$(_shim_run_transport "$REAL_GH" rest gh_api_user 0 \
+		api user --jq '.login // empty' 2>/dev/null) || current_user=""
+	[[ -n "$current_user" && "$current_user" =~ ^[A-Za-z0-9-]+$ ]] || return 1
+	permission=$(_shim_run_transport "$REAL_GH" rest gh_api_collaborator_permission 0 \
+		api "/repos/${repo_slug}/collaborators/${current_user}/permission" \
+		--jq '.permission // .role_name // empty' 2>/dev/null) || permission=""
+	case "$permission" in
+	admin | maintain | write) return 0 ;;
+	esac
 	return 1
 }
 
 _shim_block_pr_create_without_linked_issue_if_needed() {
 	[[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "pr:create" ]] || return 0
-	if [[ "${AIDEVOPS_PR_LINKED_ISSUE_BYPASS:-0}" == "1" ]]; then
-		printf '[aidevops][pr-linked-issue][BYPASS] AIDEVOPS_PR_LINKED_ISSUE_BYPASS=1 set; allowing PR create without local linked-issue enforcement.\n' >&2
-		return 0
-	fi
 
 	local repo_slug=""
+	local policy_scope=""
 	local title=""
 	local body=""
 	repo_slug=$(_shim_target_repo_slug "${_modified_args[@]}" 2>/dev/null || true)
 	[[ -n "$repo_slug" ]] || return 0
-	_shim_repo_requires_linked_issue_prs "$repo_slug" || return 0
+	policy_scope=$(_shim_repo_issue_first_scope "$repo_slug" 2>/dev/null || true)
+	[[ -n "$policy_scope" ]] || return 0
 
 	title=$(_shim_pr_create_get_title 2>/dev/null || true)
 	body=$(_shim_pr_create_get_body 2>/dev/null || true)
 	if _shim_text_has_linked_issue_ref "${title}"$'\n'"${body}"; then
 		return 0
 	fi
+	if [[ "$policy_scope" == "$_SHIM_ISSUE_FIRST_SCOPE_EXTERNAL" ]] &&
+		_shim_authenticated_actor_has_repo_write "$repo_slug"; then
+		return 0
+	fi
 
 	printf '[aidevops][pr-linked-issue][BLOCK] PR creation for %s is missing a linked issue reference.\n' "$repo_slug" >&2
-	printf '  Target policy requires issue-first PRs. Create or find the issue first, then include one of: Closes #NNN, Fixes #NNN, Resolves #NNN, For #NNN, or Ref #NNN.\n' >&2
+	printf '  Target policy scope is %s; create or find the issue first, then include one of: Closes #NNN, Fixes #NNN, Resolves #NNN, For #NNN, or Ref #NNN.\n' "$policy_scope" >&2
+	if [[ "$policy_scope" == "$_SHIM_ISSUE_FIRST_SCOPE_EXTERNAL" ]]; then
+		printf '  GitHub could not verify admin, maintain, or write permission for the authenticated actor; the exemption fails closed.\n' >&2
+	fi
 	printf '  Task-prefixed titles such as GH#NNN: or tNNN: are also accepted when they map to the project task system.\n' >&2
 	return 1
 }
-
-
 # shellcheck disable=SC2154  # body indexes are initialized by the shim before use
 _shim_prepare_ephemeral_body_file() {
 	local requested_body_file="$_AIDEVOPS_GH_EPHEMERAL_BODY_FILE"

--- a/.agents/scripts/shared-todo-commit.sh
+++ b/.agents/scripts/shared-todo-commit.sh
@@ -258,6 +258,87 @@ _todo_changed_planning_files() {
 	return 0
 }
 
+_todo_changed_task_ids() {
+	local repo_path="$1"
+	local changed_files="$2"
+	local rel_path=""
+	local task_id=""
+	{
+		git -C "$repo_path" diff --no-ext-diff --unified=0 HEAD -- TODO.md 2>/dev/null |
+			sed -nE 's/^\+[[:space:]]*- \[[^]]\][[:space:]]+(t[1-9][0-9]*(\.[1-9][0-9]*)*).*/\1/p'
+		while IFS= read -r rel_path; do
+			case "$rel_path" in
+			todo/tasks/t*-brief.md)
+				task_id="${rel_path##*/}"
+				task_id="${task_id%-brief.md}"
+				[[ "$task_id" =~ ^t[1-9][0-9]*(\.[1-9][0-9]*)*$ ]] && printf '%s\n' "$task_id"
+				;;
+			esac
+		done <<<"$changed_files"
+	} | sort -u
+	return 0
+}
+
+_todo_changed_task_manifest() {
+	local repo_path="$1"
+	local changed_files="$2"
+	local task_ids=""
+	local task_id=""
+	local task_line=""
+	local task_count=0
+	local issue_refs=""
+	local issue_count=0
+	local issue_num=""
+	local manifest=""
+	task_ids=$(_todo_changed_task_ids "$repo_path" "$changed_files")
+	[[ -n "$task_ids" ]] || return 0
+	while IFS= read -r task_id; do
+		[[ -n "$task_id" ]] || continue
+		task_count=$(grep -Ec "^[[:space:]]*- \[[^]]\][[:space:]]+${task_id}([[:space:]]|$)" \
+			"${repo_path}/TODO.md" 2>/dev/null || true)
+		if [[ "$task_count" -ne 1 ]]; then
+			printf '[todo_commit_push] Planning publication cannot safely map %s: expected one current TODO entry, found %s.\n' \
+				"$task_id" "$task_count" >&2
+			return 2
+		fi
+		task_line=$(grep -E "^[[:space:]]*- \[[^]]\][[:space:]]+${task_id}([[:space:]]|$)" \
+			"${repo_path}/TODO.md") || return 2
+		issue_refs=$(printf '%s\n' "$task_line" | grep -Eo '(^|[[:space:]])ref:GH#[1-9][0-9]*([[:space:]]|$)' || true)
+		issue_count=$(printf '%s\n' "$issue_refs" | grep -c 'ref:GH#' || true)
+		if [[ "$issue_count" -ne 1 ]]; then
+			printf '[todo_commit_push] Planning publication cannot safely map %s: expected one same-repository ref:GH#NNN field, found %s.\n' \
+				"$task_id" "$issue_count" >&2
+			return 2
+		fi
+		issue_num="${issue_refs#*ref:GH#}"
+		issue_num="${issue_num%%[[:space:]]*}"
+		manifest="${manifest}${manifest:+$'\n'}${task_id}"$'\t'"${issue_num}"
+	done <<<"$task_ids"
+	printf '%s\n' "$manifest" | sort -u
+	return 0
+}
+
+_todo_planning_publication_id() {
+	local repo_path="$1"
+	local changed_files="$2"
+	local rel_path=""
+	local object_id=""
+	local snapshot=""
+	while IFS= read -r rel_path; do
+		[[ -n "$rel_path" ]] || continue
+		_todo_safe_planning_path "$rel_path" || continue
+		if [[ -f "${repo_path}/${rel_path}" ]]; then
+			object_id=$(git -C "$repo_path" hash-object -- "$rel_path") || return 1
+		else
+			object_id="deleted"
+		fi
+		snapshot="${snapshot}${rel_path}"$'\t'"${object_id}"$'\n'
+	done <<<"$changed_files"
+	[[ -n "$snapshot" ]] || return 1
+	printf '%s' "$snapshot" | git -C "$repo_path" hash-object --stdin
+	return $?
+}
+
 _todo_copy_planning_changes_to_worktree() {
 	local repo_path="$1"
 	local worktree_path="$2"
@@ -300,8 +381,9 @@ _todo_remove_temp_worktree() {
 	local worktree_path="$2"
 	[[ -n "$worktree_path" ]] || return 0
 	if [[ -e "${worktree_path}/.git" ]]; then
-		git -C "$repo_path" worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
+		git -C "$repo_path" worktree remove --force "$worktree_path" >/dev/null 2>&1 || return 1
 	fi
+	[[ ! -e "$worktree_path" ]] || return 1
 	return 0
 }
 
@@ -309,12 +391,36 @@ _todo_planning_pr_body() {
 	local source_branch="$1"
 	local default_branch="$2"
 	local commit_msg="$3"
+	local publication_id="$4"
+	local task_manifest="$5"
+	local task_id=""
+	local issue_num=""
+	local issue_refs=""
+	while IFS=$'\t' read -r task_id issue_num; do
+		[[ -n "$task_id" && "$issue_num" =~ ^[1-9][0-9]*$ ]] || continue
+		if ! grep -Eq "(^|[[:space:]])${issue_num}($|[[:space:]])" <<<"$issue_refs"; then
+			issue_refs="${issue_refs}${issue_refs:+ }${issue_num}"
+		fi
+	done <<<"$task_manifest"
 	cat <<EOF
 ## Planning publication
 
 - Publishes TODO.md and todo/ planning-file changes through a PR because ${default_branch} does not accept direct planning pushes.
 - Source branch at helper invocation: ${source_branch}.
 - Commit message: ${commit_msg}.
+
+## Task and issue manifest
+
+<!-- aidevops:planning-publication:v1 id=${publication_id} -->
+EOF
+	while IFS=$'\t' read -r task_id issue_num; do
+		[[ -n "$task_id" && "$issue_num" =~ ^[1-9][0-9]*$ ]] || continue
+		printf '<!-- aidevops:planning-task:v1 task=%s issue=%s -->\n' "$task_id" "$issue_num"
+	done <<<"$task_manifest"
+	for issue_num in $issue_refs; do
+		printf -- '- For #%s\n' "$issue_num"
+	done
+	cat <<EOF
 
 ## Security and architecture guardrails
 
@@ -326,6 +432,23 @@ _todo_planning_pr_body() {
 
 - Merge this planning-only PR before expecting pulse or issue-sync to see the TODO/todo changes.
 EOF
+	return 0
+}
+
+_todo_planning_pr_title() {
+	local commit_msg="$1"
+	local task_manifest="$2"
+	local manifest_count=0
+	local task_id=""
+	local subject="$commit_msg"
+	manifest_count=$(printf '%s\n' "$task_manifest" | grep -c $'^[^\t][^\t]*\t[1-9][0-9]*$' || true)
+	if [[ "$manifest_count" -eq 1 ]]; then
+		task_id="${task_manifest%%$'\t'*}"
+		subject="${commit_msg#*: }"
+		printf 'plan(%s): %s\n' "$task_id" "$subject"
+		return 0
+	fi
+	printf '%s\n' "$commit_msg"
 	return 0
 }
 
@@ -348,12 +471,15 @@ _todo_planning_pr_slug() {
 
 _TODO_PLANNING_PR_BRANCH=""
 _TODO_PLANNING_PR_WORKTREE=""
+_TODO_PLANNING_PR_COMMIT=""
+_TODO_PLANNING_PR_REUSED=0
 
 _todo_create_planning_worktree() {
 	local repo_path="$1"
 	local commit_msg="$2"
 	local default_branch="$3"
-	local log_target="$4"
+	local publication_id="$4"
+	local log_target="$5"
 
 	if git -C "$repo_path" remote get-url origin >/dev/null 2>&1; then
 		git -C "$repo_path" fetch -q origin "$default_branch" 2>>"$log_target" || {
@@ -362,26 +488,43 @@ _todo_create_planning_worktree() {
 		}
 	fi
 
-	local repo_abs parent_dir repo_name slug_part timestamp branch_name worktree_path
+	local repo_abs parent_dir repo_name slug_part branch_name worktree_path remote_commit
 	repo_abs=$(cd "$repo_path" 2>/dev/null && pwd -P) || return 1
 	parent_dir=$(dirname "$repo_abs") || return 1
 	repo_name=$(basename "$repo_abs") || return 1
 	slug_part=$(_todo_slugify_ref_fragment "$commit_msg")
-	timestamp=$(date -u +%Y%m%d%H%M%S)
-	branch_name="planning/${timestamp}-$$-${slug_part}"
-	worktree_path="${parent_dir}/${repo_name}-planning-${timestamp}-$$-${slug_part}"
+	branch_name="planning/${publication_id:0:12}-${slug_part}"
+	worktree_path="${parent_dir}/${repo_name}-planning-${publication_id:0:12}-$$-${slug_part}"
+	_TODO_PLANNING_PR_BRANCH="$branch_name"
+	_TODO_PLANNING_PR_WORKTREE=""
+	_TODO_PLANNING_PR_COMMIT=""
+	_TODO_PLANNING_PR_REUSED=0
+
+	if git -C "$repo_path" ls-remote --exit-code --heads origin "refs/heads/${branch_name}" >/dev/null 2>&1; then
+		git -C "$repo_path" fetch -q origin "+refs/heads/${branch_name}:refs/remotes/origin/${branch_name}" 2>>"$log_target" || return 1
+		remote_commit=$(git -C "$repo_path" rev-parse "refs/remotes/origin/${branch_name}" 2>/dev/null) || return 1
+		if ! git -C "$repo_path" log -1 --format=%B "$remote_commit" 2>/dev/null |
+			grep -Fqx "Planning-Publication-ID: ${publication_id}"; then
+			printf '%s\n' "[todo_commit_push] Planning publication branch collision: ${branch_name}" >>"$log_target"
+			printf '[todo_commit_push] Existing remote branch %s does not match publication %s; refusing to overwrite it.\n' \
+				"$branch_name" "$publication_id" >&2
+			return 1
+		fi
+		_TODO_PLANNING_PR_COMMIT="$remote_commit"
+		_TODO_PLANNING_PR_REUSED=1
+		return 0
+	fi
 
 	if [[ -e "$worktree_path" ]]; then
 		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: worktree path already exists" >>"$log_target"
 		return 1
 	fi
 
-	git -C "$repo_path" worktree add -b "$branch_name" "$worktree_path" "origin/${default_branch}" >/dev/null 2>>"$log_target" || {
+	git -C "$repo_path" worktree add --detach "$worktree_path" "origin/${default_branch}" >/dev/null 2>>"$log_target" || {
 		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: cannot create linked worktree" >>"$log_target"
 		return 1
 	}
 
-	_TODO_PLANNING_PR_BRANCH="$branch_name"
 	_TODO_PLANNING_PR_WORKTREE="$worktree_path"
 	return 0
 }
@@ -393,11 +536,15 @@ _todo_commit_planning_worktree() {
 	local files="$4"
 	local commit_msg="$5"
 	local branch_name="$6"
-	local log_target="$7"
+	local publication_id="$7"
+	local log_target="$8"
+	local commit_sha=""
+	if [[ "$_TODO_PLANNING_PR_REUSED" -eq 1 ]]; then
+		return 0
+	fi
 
 	if ! _todo_copy_planning_changes_to_worktree "$repo_path" "$worktree_path" "$changed_files"; then
 		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: cannot copy planning changes" >>"$log_target"
-		_todo_remove_temp_worktree "$repo_path" "$worktree_path"
 		return 1
 	fi
 
@@ -405,20 +552,21 @@ _todo_commit_planning_worktree() {
 	git -C "$worktree_path" add $files 2>>"$log_target" || true
 	if git -C "$worktree_path" diff --cached --quiet 2>/dev/null; then
 		printf '%s\n' "[todo_commit_push] No changes staged in planning PR worktree" >>"$log_target"
-		_todo_remove_temp_worktree "$repo_path" "$worktree_path"
 		TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_NOOP"
 		return 0
 	fi
 
-	git -C "$worktree_path" commit -m "$commit_msg" --no-verify >/dev/null 2>>"$log_target" || {
+	git -C "$worktree_path" commit -m "$commit_msg" \
+		-m "Planning-Publication-ID: ${publication_id}" --no-verify >/dev/null 2>>"$log_target" || {
 		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: commit failed" >>"$log_target"
-		_todo_remove_temp_worktree "$repo_path" "$worktree_path"
 		return 1
 	}
+	commit_sha=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null) || return 1
+	_TODO_PLANNING_PR_COMMIT="$commit_sha"
+	git -C "$repo_path" update-ref "refs/aidevops/planning/${publication_id}" "$commit_sha" || return 1
 
-	git -C "$worktree_path" push -u origin "$branch_name" >/dev/null 2>>"$log_target" || {
+	git -C "$worktree_path" push origin "HEAD:refs/heads/${branch_name}" >/dev/null 2>>"$log_target" || {
 		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: branch push failed" >>"$log_target"
-		_todo_remove_temp_worktree "$repo_path" "$worktree_path"
 		return 1
 	}
 	return 0
@@ -430,22 +578,91 @@ _todo_open_planning_pr() {
 	local branch_name="$3"
 	local current_branch="$4"
 	local commit_msg="$5"
-	local log_target="$6"
+	local publication_id="$6"
+	local task_manifest="$7"
+	local log_target="$8"
 
-	local pr_title pr_body pr_url
-	pr_title="$commit_msg"
-	pr_body=$(_todo_planning_pr_body "$current_branch" "$default_branch" "$commit_msg")
+	local pr_title pr_body pr_url pr_error_file pr_error
+	pr_title=$(_todo_planning_pr_title "$commit_msg" "$task_manifest")
+	pr_body=$(_todo_planning_pr_body "$current_branch" "$default_branch" "$commit_msg" \
+		"$publication_id" "$task_manifest")
+	pr_error_file=$(mktemp -t aidevops-planning-pr-error.XXXXXX 2>/dev/null) || pr_error_file=""
+	[[ -n "$pr_error_file" ]] || {
+		printf '[todo_commit_push] Planning PR fallback failed: cannot allocate diagnostic capture.\n' >&2
+		return 1
+	}
 	pr_url=$(AIDEVOPS_PR_CREATE_READY=1 gh_create_pr \
 		--repo "$slug" \
 		--base "$default_branch" \
 		--head "$branch_name" \
 		--title "$pr_title" \
-		--body "$pr_body" 2>>"$log_target") || {
+		--body "$pr_body" 2>"$pr_error_file") || {
+		pr_error=$(<"$pr_error_file") || pr_error=""
+		rm -f "$pr_error_file"
+		[[ -z "$pr_error" ]] || printf '%s\n' "$pr_error" >&2
+		[[ "$log_target" == "/dev/null" || -z "$pr_error" ]] || printf '%s\n' "$pr_error" >>"$log_target"
 		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: PR creation failed" >>"$log_target"
 		return 1
 	}
+	rm -f "$pr_error_file"
 	printf '%s\n' "$pr_url"
 	return 0
+}
+
+_todo_existing_planning_pr_url() {
+	local slug="$1"
+	local branch_name="$2"
+	local pr_url=""
+	pr_url=$(gh pr list --repo "$slug" --head "$branch_name" --state open \
+		--json url --jq '.[0].url // empty' 2>/dev/null) || pr_url=""
+	[[ -n "$pr_url" ]] || return 1
+	printf '%s\n' "$pr_url"
+	return 0
+}
+
+_todo_finalize_planning_pr() {
+	local repo_path="$1"
+	local worktree_path="$2"
+	local publication_id="$3"
+	local terminal_rc="$4"
+	local pr_state="$5"
+	local source_state="$6"
+	local log_target="$7"
+	local cleanup_state="not-created"
+	local remote_state="not-pushed"
+	if [[ -n "$worktree_path" ]]; then
+		if _todo_remove_temp_worktree "$repo_path" "$worktree_path"; then
+			cleanup_state="removed"
+		else
+			cleanup_state="retained"
+			terminal_rc=1
+		fi
+	fi
+	if [[ -n "${_TODO_PLANNING_PR_BRANCH:-}" ]] &&
+		git -C "$repo_path" ls-remote --exit-code --heads origin \
+			"refs/heads/${_TODO_PLANNING_PR_BRANCH}" >/dev/null 2>&1; then
+		remote_state="pushed"
+		git -C "$repo_path" update-ref -d "refs/aidevops/planning/${publication_id}" 2>/dev/null || true
+	elif [[ -n "${_TODO_PLANNING_PR_COMMIT:-}" ]]; then
+		remote_state="local-recovery-ref"
+	fi
+	if [[ "$terminal_rc" -ne 0 ]]; then
+		printf '[todo_commit_push] Planning publication stopped after %s; caller planning edits are %s and the disposable worktree is %s.\n' \
+			"$remote_state" "$source_state" "$cleanup_state" >&2
+		printf 'AIDEVOPS_PLANNING_RECOVERY_PUBLICATION_ID=%s\n' "$publication_id" >&2
+		printf 'AIDEVOPS_PLANNING_RECOVERY_BRANCH=%s\n' "${_TODO_PLANNING_PR_BRANCH:-}" >&2
+		printf 'AIDEVOPS_PLANNING_RECOVERY_COMMIT=%s\n' "${_TODO_PLANNING_PR_COMMIT:-}" >&2
+		printf 'AIDEVOPS_PLANNING_RECOVERY_REMOTE_STATE=%s\n' "$remote_state" >&2
+		printf 'AIDEVOPS_PLANNING_RECOVERY_PR_STATE=%s\n' "$pr_state" >&2
+		printf 'AIDEVOPS_PLANNING_RECOVERY_SOURCE_STATE=%s\n' "$source_state" >&2
+		printf 'AIDEVOPS_PLANNING_RECOVERY_WORKTREE_STATE=%s\n' "$cleanup_state" >&2
+		printf '[todo_commit_push] Retry with the same planning snapshot; publication %s reuses branch %s instead of creating a duplicate.\n' \
+			"$publication_id" "${_TODO_PLANNING_PR_BRANCH:-unknown}" >&2
+		if [[ "$log_target" != "/dev/null" ]]; then
+			printf '%s\n' "[todo_commit_push] Recovery publication=${publication_id} branch=${_TODO_PLANNING_PR_BRANCH:-} commit=${_TODO_PLANNING_PR_COMMIT:-} remote=${remote_state} pr=${pr_state} source=${source_state} worktree=${cleanup_state}" >>"$log_target"
+		fi
+	fi
+	return "$terminal_rc"
 }
 
 _todo_create_planning_pr() {
@@ -457,6 +674,8 @@ _todo_create_planning_pr() {
 	local log_target="$6"
 
 	local slug="" changed_files="" branch_name="" worktree_path="" pr_url=""
+	local task_manifest="" publication_id="" pr_state="not-created" source_state="preserved"
+	local terminal_rc=0 manifest_rc=0
 	slug=$(_todo_planning_pr_slug "$repo_path" "$log_target") || return 1
 	changed_files=$(_todo_changed_planning_files "$repo_path" "$files")
 	if [[ -z "$changed_files" ]]; then
@@ -464,18 +683,45 @@ _todo_create_planning_pr() {
 		TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_NOOP"
 		return 0
 	fi
-
-	_todo_create_planning_worktree "$repo_path" "$commit_msg" "$default_branch" "$log_target" || return 1
-	branch_name="$_TODO_PLANNING_PR_BRANCH"
-	worktree_path="$_TODO_PLANNING_PR_WORKTREE"
-	_todo_commit_planning_worktree "$repo_path" "$worktree_path" "$changed_files" "$files" "$commit_msg" "$branch_name" "$log_target" || return 1
-	pr_url=$(_todo_open_planning_pr "$slug" "$default_branch" "$branch_name" "$current_branch" "$commit_msg" "$log_target") || return 1
-
-	if ! _todo_clean_source_planning_changes "$repo_path" "$changed_files"; then
-		printf '%s\n' "[todo_commit_push] Planning PR created but source planning cleanup failed" >>"$log_target"
+	task_manifest=$(_todo_changed_task_manifest "$repo_path" "$changed_files") || manifest_rc=$?
+	if [[ "$manifest_rc" -ne 0 ]]; then
+		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: changed task/issue manifest is ambiguous" >>"$log_target"
 		return 1
 	fi
-	_todo_remove_temp_worktree "$repo_path" "$worktree_path"
+	publication_id=$(_todo_planning_publication_id "$repo_path" "$changed_files") || {
+		printf '%s\n' "[todo_commit_push] Planning PR fallback failed: cannot derive publication identity" >>"$log_target"
+		return 1
+	}
+
+	_todo_create_planning_worktree "$repo_path" "$commit_msg" "$default_branch" "$publication_id" "$log_target" || return 1
+	branch_name="$_TODO_PLANNING_PR_BRANCH"
+	worktree_path="$_TODO_PLANNING_PR_WORKTREE"
+	_todo_commit_planning_worktree "$repo_path" "$worktree_path" "$changed_files" "$files" \
+		"$commit_msg" "$branch_name" "$publication_id" "$log_target" || terminal_rc=$?
+	if [[ "$terminal_rc" -eq 0 && "$TODO_COMMIT_PUSH_RESULT" != "$TODO_COMMIT_RESULT_NOOP" ]]; then
+		pr_url=$(_todo_existing_planning_pr_url "$slug" "$branch_name" 2>/dev/null || true)
+		if [[ -n "$pr_url" ]]; then
+			pr_state="open-reused"
+		else
+			pr_url=$(_todo_open_planning_pr "$slug" "$default_branch" "$branch_name" "$current_branch" \
+				"$commit_msg" "$publication_id" "$task_manifest" "$log_target") || terminal_rc=$?
+			[[ "$terminal_rc" -eq 0 ]] && pr_state="open" || pr_state="missing"
+		fi
+	fi
+
+	if [[ "$terminal_rc" -eq 0 && "$TODO_COMMIT_PUSH_RESULT" != "$TODO_COMMIT_RESULT_NOOP" ]] &&
+		! _todo_clean_source_planning_changes "$repo_path" "$changed_files"; then
+		printf '%s\n' "[todo_commit_push] Planning PR created but source planning cleanup failed" >>"$log_target"
+		terminal_rc=1
+		source_state="modified"
+	elif [[ "$terminal_rc" -eq 0 ]]; then
+		source_state="cleaned"
+	fi
+	_todo_finalize_planning_pr "$repo_path" "$worktree_path" "$publication_id" "$terminal_rc" \
+		"$pr_state" "$source_state" "$log_target" || return $?
+	if [[ "$TODO_COMMIT_PUSH_RESULT" == "$TODO_COMMIT_RESULT_NOOP" ]]; then
+		return 0
+	fi
 	TODO_COMMIT_PUSH_RESULT="$TODO_COMMIT_RESULT_PR"
 	TODO_COMMIT_PUSH_PR_URL="$pr_url"
 	printf '%s\n' "[todo_commit_push] Planning PR created: ${pr_url}" >>"$log_target"

--- a/.agents/scripts/tests/test-gh-shim-core-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-core-cases.sh
@@ -347,7 +347,7 @@ fi
 echo ""
 echo "Test 6a: issue-first repos block PR creation without linked issue"
 _reset_log
-if "$SHIM_RUN" pr create --repo marcusquinn/aidevops --title "fix: missing issue" --body "PR body" 2>"$TMP/pr-linked-issue.err"; then
+if STUB_GH_PERMISSION=none "$SHIM_RUN" pr create --repo marcusquinn/aidevops --title "fix: missing issue" --body "PR body" 2>"$TMP/pr-linked-issue.err"; then
 	_fail "missing linked issue PR guard" "write unexpectedly passed"
 else
 	argv=$(_read_argv)
@@ -356,6 +356,106 @@ else
 	else
 		_fail "missing linked issue PR guard" "argv: $argv err: $(cat "$TMP/pr-linked-issue.err" 2>/dev/null || true)"
 	fi
+fi
+
+_reset_log
+if env STUB_GH_PERMISSION=write "$SHIM_RUN" pr create --repo marcusquinn/aidevops \
+	--title "plan: verified maintainer" --body "Planning publication" \
+	2>"$TMP/pr-linked-maintainer.err"; then
+	argv=$(_read_argv)
+	if [[ "$argv" == *"Planning publication"* ]]; then
+		_pass "external-only policy exempts API-verified write actor"
+	else
+		_fail "verified maintainer issue-first exemption" "argv: $argv"
+	fi
+else
+	argv=$(_read_argv)
+	_fail "verified maintainer issue-first exemption" \
+		"argv: $argv err: $(cat "$TMP/pr-linked-maintainer.err" 2>/dev/null || true)"
+fi
+
+_reset_log
+if env STUB_GH_USER=trusted-bot STUB_GH_PERMISSION=write "$SHIM_RUN" pr create \
+	--repo marcusquinn/aidevops --title "chore: trusted bot workflow" \
+	--body "Automated maintenance publication" 2>"$TMP/pr-linked-bot.err"; then
+	argv=$(_read_argv)
+	if [[ "$argv" == *"Automated maintenance publication"* ]]; then
+		_pass "external-only policy exempts server-verified trusted bot workflow"
+	else
+		_fail "trusted bot issue-first exemption" "argv: $argv"
+	fi
+else
+	_fail "trusted bot issue-first exemption" \
+		"err: $(cat "$TMP/pr-linked-bot.err" 2>/dev/null || true)"
+fi
+
+_reset_log
+if STUB_GH_PERMISSION=triage "$SHIM_RUN" pr create --repo marcusquinn/aidevops \
+	--title "plan: triage actor" --body "Planning publication" 2>"$TMP/pr-linked-triage.err"; then
+	_fail "external contributor linked issue guard" "triage actor unexpectedly passed"
+elif [[ ! -s "$STUB_GH_LOG" ]] && grep -q 'exemption fails closed' "$TMP/pr-linked-triage.err"; then
+	_pass "external contributor remains blocked without write permission"
+else
+	_fail "external contributor linked issue guard" "native call or diagnostic mismatch"
+fi
+
+_reset_log
+if STUB_GH_PERMISSION_FAIL=1 "$SHIM_RUN" pr create --repo marcusquinn/aidevops \
+	--title "plan: unavailable permission" --body "Planning publication" 2>"$TMP/pr-linked-api.err"; then
+	_fail "permission API failure linked issue guard" "write unexpectedly passed"
+elif [[ ! -s "$STUB_GH_LOG" ]] && grep -q 'exemption fails closed' "$TMP/pr-linked-api.err"; then
+	_pass "permission API failure preserves fail-closed external policy"
+else
+	_fail "permission API failure linked issue guard" "native call or diagnostic mismatch"
+fi
+
+policy_repo="$TMP/policy-repo"
+mkdir -p "$policy_repo"
+git -C "$policy_repo" init -q
+git -C "$policy_repo" remote add origin https://github.com/example/policy-repo.git
+printf '%s\n' '<!-- aidevops:issue-first-pr:start -->' \
+	'<!-- aidevops:issue-first-pr:scope=universal -->' \
+	'Issue-first; include For #NNN.' \
+	'<!-- aidevops:issue-first-pr:end -->' >"$policy_repo/CONTRIBUTING.md"
+_reset_log
+if (cd "$policy_repo" && env STUB_GH_PERMISSION=write "$SHIM_RUN" pr create \
+	--repo example/policy-repo --title "plan: universal" --body "Planning publication" \
+	2>"$TMP/pr-linked-universal.err"); then
+	_fail "universal linked issue policy" "verified write actor unexpectedly passed"
+elif [[ ! -s "$STUB_GH_LOG" ]]; then
+	_pass "universal policy blocks every unlinked PR"
+else
+	_fail "universal linked issue policy" "native call unexpectedly reached transport"
+fi
+
+printf '%s\n' '<!-- aidevops:issue-first-pr:start -->' \
+	'Issue-first; include For #NNN.' \
+	'<!-- aidevops:issue-first-pr:end -->' >"$policy_repo/CONTRIBUTING.md"
+_reset_log
+if (cd "$policy_repo" && env STUB_GH_PERMISSION=write "$SHIM_RUN" pr create \
+	--repo example/policy-repo --title "plan: ambiguous" --body "Planning publication" \
+	2>"$TMP/pr-linked-ambiguous.err"); then
+	_fail "ambiguous linked issue policy" "verified write actor unexpectedly passed"
+elif [[ ! -s "$STUB_GH_LOG" ]] && grep -q 'scope is universal' "$TMP/pr-linked-ambiguous.err"; then
+	_pass "ambiguous policy fails closed as universal"
+else
+	_fail "ambiguous linked issue policy" "native call or diagnostic mismatch"
+fi
+
+printf '%s\n' '<!-- aidevops:issue-first-pr:start -->' \
+	'<!-- aidevops:issue-first-pr:scope=external -->' \
+	'<!-- aidevops:issue-first-pr:scope=unknown -->' \
+	'Issue-first; include For #NNN.' \
+	'<!-- aidevops:issue-first-pr:end -->' >"$policy_repo/CONTRIBUTING.md"
+_reset_log
+if (cd "$policy_repo" && env STUB_GH_PERMISSION=write "$SHIM_RUN" pr create \
+	--repo example/policy-repo --title "plan: malformed scope" --body "Planning publication" \
+	2>"$TMP/pr-linked-malformed.err"); then
+	_fail "malformed linked issue scope" "verified write actor unexpectedly passed"
+elif [[ ! -s "$STUB_GH_LOG" ]] && grep -q 'scope is universal' "$TMP/pr-linked-malformed.err"; then
+	_pass "malformed structured scope overrides exemption and fails closed"
+else
+	_fail "malformed linked issue scope" "native call or diagnostic mismatch"
 fi
 
 _reset_log

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -75,6 +75,11 @@ if [[ "$1" == "api" && "$2" == "user" ]]; then
 	printf '%s\n' "${STUB_GH_USER:-managed}"
 	exit 0
 fi
+if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/collaborators/[^/]+/permission$ ]]; then
+	[[ "${STUB_GH_PERMISSION_FAIL:-0}" != "1" ]] || exit 44
+	printf '%s\n' "${STUB_GH_PERMISSION:-none}"
+	exit 0
+fi
 if [[ "$1" == "auth" && "$2" == "token" ]]; then
 	printf '%s\n' 'fixture-token'
 	exit 0
@@ -338,6 +343,8 @@ _reset_log() {
 	unset STUB_MANAGED_LABELS
 	unset STUB_MANAGED_LABEL_INVENTORY_FAIL
 	unset STUB_MANAGED_LABEL_CREATE_FAIL
+	unset STUB_GH_PERMISSION
+	unset STUB_GH_PERMISSION_FAIL
 	return 0
 }
 

--- a/.agents/scripts/tests/test-linked-issue-guidance.sh
+++ b/.agents/scripts/tests/test-linked-issue-guidance.sh
@@ -39,6 +39,7 @@ assert_contains "CONTRIBUTING.md" 'not a repository owner, member, or collaborat
 assert_contains "CONTRIBUTING.md" 'Closes #NNN' "CONTRIBUTING closing keyword"
 assert_contains "CONTRIBUTING.md" 'Ref #NNN' "CONTRIBUTING reference keyword"
 assert_contains ".agents/templates/issue-first-pr-contributing.md" 'aidevops:issue-first-pr:start' "managed CONTRIBUTING block start marker"
+assert_contains ".agents/templates/issue-first-pr-contributing.md" 'aidevops:issue-first-pr:scope=external' "managed CONTRIBUTING policy scope marker"
 assert_contains ".agents/templates/issue-first-pr-contributing.md" 'aidevops:issue-first-pr:end' "managed CONTRIBUTING block end marker"
 assert_contains ".github/PULL_REQUEST_TEMPLATE.md" 'Linked issue' "PR template linked issue field"
 assert_contains ".github/PULL_REQUEST_TEMPLATE.md" 'Closes #NNN' "PR template closing keyword"

--- a/.agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh
+++ b/.agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh
@@ -117,6 +117,11 @@ if [[ "${1:-}" == "api" && "${2:-}" == "repos/example/repo" ]]; then
 	exit 0
 fi
 
+if [[ "${1:-}" == "api" && "${2:-}" == "/repos/example/repo/issues/1" ]]; then
+	printf 'origin:interactive\n'
+	exit 0
+fi
+
 if [[ "${1:-}" == "api" ]]; then
 	exit 1
 fi
@@ -160,6 +165,11 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "create" ]]; then
 	printf '%s\n' "$head_branch" >"${GH_STUB_HEAD:?}"
 	printf '%s\n' "$title_text" >"${GH_STUB_TITLE:?}"
 	printf '%s\n' "$body_text" >"${GH_STUB_BODY:?}"
+	if [[ -n "${GH_STUB_PR_CREATE_FAIL_ONCE_FILE:-}" && ! -f "$GH_STUB_PR_CREATE_FAIL_ONCE_FILE" ]]; then
+		printf 'failed\n' >"$GH_STUB_PR_CREATE_FAIL_ONCE_FILE"
+		printf 'fixture PR creation rejected after branch push\n' >&2
+		exit 42
+	fi
 	printf 'https://github.com/example/repo/pull/1\n'
 	exit 0
 fi
@@ -173,14 +183,16 @@ GH
 append_planning_change() {
 	local work_dir="$1"
 	local task_id="$2"
-	printf -- '- [ ] %s Protected planning fallback #bug #auto-dispatch ~30m ref:GH#25292\n' "$task_id" >>"${work_dir}/TODO.md"
+	local issue_num="${3:-25292}"
+	printf -- '- [ ] %s Protected planning fallback #bug #auto-dispatch ~30m ref:GH#%s\n' \
+		"$task_id" "$issue_num" >>"${work_dir}/TODO.md"
 	printf 'What: protected planning fallback\nHow: update planning helper\n' >"${work_dir}/todo/tasks/${task_id}-brief.md"
 	return 0
 }
 
 test_protected_default_creates_planning_pr() {
 	local name="protected default branch creates planning PR and cleans source"
-	local tmpdir fake_bin work_dir body_file head_file title_file log_file output rc status head_branch remote_todo pr_body
+	local tmpdir fake_bin work_dir body_file head_file title_file log_file output rc status head_branch remote_todo pr_body pr_title
 	tmpdir=$(mktemp -d) || {
 		fail "$name" "mktemp failed"
 		return 0
@@ -250,7 +262,141 @@ test_protected_default_creates_planning_pr() {
 		fail "$name" "planning PR body contains a closing keyword"
 		return 0
 	fi
+	if [[ "$pr_body" != *"For #25292"* ||
+		"$pr_body" != *"aidevops:planning-task:v1 task=t999 issue=25292"* ||
+		"$pr_body" != *"aidevops:planning-publication:v1 id="* ]]; then
+		fail "$name" "PR body missing deterministic task/issue publication manifest"
+		return 0
+	fi
+	pr_title=$(<"$title_file")
+	if [[ "$pr_title" != "plan(t999): add t999 protected planning" ]]; then
+		fail "$name" "single-task PR title is not task-aware: $pr_title"
+		return 0
+	fi
 	pass "$name"
+	rm -rf "$tmpdir"
+	return 0
+}
+
+test_multi_task_manifest_is_deterministic() {
+	local name="multi-task planning PR links every unique issue without guessing title identity"
+	local tmpdir fake_bin work_dir output rc body title for_31_count
+	tmpdir=$(mktemp -d) || {
+		fail "$name" "mktemp failed"
+		return 0
+	}
+	fake_bin="${tmpdir}/bin"
+	write_fake_gh "$fake_bin" || {
+		fail "$name" "fake gh setup failed"
+		return 0
+	}
+	work_dir=$(setup_repo "$tmpdir" true) || {
+		fail "$name" "repo setup failed"
+		return 0
+	}
+	append_planning_change "$work_dir" "t2002" "32"
+	append_planning_change "$work_dir" "t2001" "31"
+	append_planning_change "$work_dir" "t2003" "31"
+	: >"${tmpdir}/gh.log"
+	rc=0
+	output=$(cd "$work_dir" && PATH="${fake_bin}:$PATH" \
+		GH_STUB_LOG="${tmpdir}/gh.log" GH_STUB_BODY="${tmpdir}/body" \
+		GH_STUB_HEAD="${tmpdir}/head" GH_STUB_TITLE="${tmpdir}/title" \
+		AIDEVOPS_PLANNING_FORCE_PR_FALLBACK=1 AIDEVOPS_PLANNING_PR_REPO_SLUG="example/repo" \
+		"$PLANNING_HELPER" "plan: publish planning batch" 2>&1) || rc=$?
+	body=$(<"${tmpdir}/body")
+	title=$(<"${tmpdir}/title")
+	for_31_count=$(printf '%s\n' "$body" | grep -c '^- For #31$' || true)
+	if [[ "$rc" -eq 0 && "$title" == "plan: publish planning batch" &&
+		"$body" == *"task=t2001 issue=31"* && "$body" == *"task=t2002 issue=32"* &&
+		"$body" == *"task=t2003 issue=31"* && "$for_31_count" -eq 1 &&
+		"$body" == *$'- For #31\n- For #32'* ]]; then
+		pass "$name"
+	else
+		fail "$name" "rc=$rc title=$title body=$body output=$output"
+	fi
+	rm -rf "$tmpdir"
+	return 0
+}
+
+test_ambiguous_task_mapping_fails_before_push() {
+	local name="ambiguous task mapping fails before creating a publication branch"
+	local tmpdir fake_bin work_dir output rc remote_refs status
+	tmpdir=$(mktemp -d) || {
+		fail "$name" "mktemp failed"
+		return 0
+	}
+	fake_bin="${tmpdir}/bin"
+	write_fake_gh "$fake_bin" || return 0
+	work_dir=$(setup_repo "$tmpdir" true) || return 0
+	printf -- '- [ ] t2100 Missing mapping #bug ~30m\n' >>"${work_dir}/TODO.md"
+	printf 'What: ambiguous mapping\n' >"${work_dir}/todo/tasks/t2100-brief.md"
+	: >"${tmpdir}/gh.log"
+	rc=0
+	output=$(cd "$work_dir" && PATH="${fake_bin}:$PATH" \
+		GH_STUB_LOG="${tmpdir}/gh.log" GH_STUB_BODY="${tmpdir}/body" \
+		GH_STUB_HEAD="${tmpdir}/head" GH_STUB_TITLE="${tmpdir}/title" \
+		AIDEVOPS_PLANNING_FORCE_PR_FALLBACK=1 AIDEVOPS_PLANNING_PR_REPO_SLUG="example/repo" \
+		"$PLANNING_HELPER" "plan: publish ambiguous task" 2>&1) || rc=$?
+	remote_refs=$(git --git-dir="${tmpdir}/remote.git" for-each-ref --format='%(refname)' refs/heads/planning/)
+	status=$(git -C "$work_dir" status --short)
+	if [[ "$rc" -ne 0 && -z "$remote_refs" && "$status" == *"TODO.md"* &&
+		"$output" == *"expected one same-repository ref:GH#NNN field"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "rc=$rc refs=$remote_refs status=$status output=$output"
+	fi
+	rm -rf "$tmpdir"
+	return 0
+}
+
+test_post_push_failure_is_recoverable_and_idempotent() {
+	local name="post-push PR failure reports recovery, cleans worktree, and reuses branch"
+	local tmpdir fake_bin work_dir fail_once output_first output_second rc_first rc_second
+	local branch_first branch_second commit_first commit_second planning_ref_count worktree_list status
+	tmpdir=$(mktemp -d) || {
+		fail "$name" "mktemp failed"
+		return 0
+	}
+	fake_bin="${tmpdir}/bin"
+	write_fake_gh "$fake_bin" || return 0
+	work_dir=$(setup_repo "$tmpdir" true) || return 0
+	append_planning_change "$work_dir" "t2200" "2200"
+	: >"${tmpdir}/gh.log"
+	fail_once="${tmpdir}/pr-create-failed"
+	rc_first=0
+	output_first=$(cd "$work_dir" && PATH="${fake_bin}:$PATH" \
+		GH_STUB_LOG="${tmpdir}/gh.log" GH_STUB_BODY="${tmpdir}/body" \
+		GH_STUB_HEAD="${tmpdir}/head" GH_STUB_TITLE="${tmpdir}/title" \
+		GH_STUB_PR_CREATE_FAIL_ONCE_FILE="$fail_once" \
+		AIDEVOPS_PLANNING_FORCE_PR_FALLBACK=1 AIDEVOPS_PLANNING_PR_REPO_SLUG="example/repo" \
+		"$PLANNING_HELPER" "plan: publish recoverable task" 2>&1) || rc_first=$?
+	branch_first=$(printf '%s\n' "$output_first" | sed -n 's/^AIDEVOPS_PLANNING_RECOVERY_BRANCH=//p')
+	commit_first=$(printf '%s\n' "$output_first" | sed -n 's/^AIDEVOPS_PLANNING_RECOVERY_COMMIT=//p')
+	worktree_list=$(git -C "$work_dir" worktree list --porcelain)
+	status=$(git -C "$work_dir" status --short)
+
+	rc_second=0
+	output_second=$(cd "$work_dir" && PATH="${fake_bin}:$PATH" \
+		GH_STUB_LOG="${tmpdir}/gh.log" GH_STUB_BODY="${tmpdir}/body" \
+		GH_STUB_HEAD="${tmpdir}/head" GH_STUB_TITLE="${tmpdir}/title" \
+		GH_STUB_PR_CREATE_FAIL_ONCE_FILE="$fail_once" \
+		AIDEVOPS_PLANNING_FORCE_PR_FALLBACK=1 AIDEVOPS_PLANNING_PR_REPO_SLUG="example/repo" \
+		"$PLANNING_HELPER" "plan: publish recoverable task" 2>&1) || rc_second=$?
+	branch_second=$(<"${tmpdir}/head")
+	commit_second=$(git --git-dir="${tmpdir}/remote.git" rev-parse "refs/heads/${branch_second}" 2>/dev/null || true)
+	planning_ref_count=$(git --git-dir="${tmpdir}/remote.git" for-each-ref --format='%(refname)' refs/heads/planning/ | wc -l | tr -d ' ')
+	if [[ "$rc_first" -ne 0 && "$output_first" == *"fixture PR creation rejected after branch push"* &&
+		"$output_first" == *"AIDEVOPS_PLANNING_RECOVERY_REMOTE_STATE=pushed"* &&
+		"$output_first" == *"AIDEVOPS_PLANNING_RECOVERY_WORKTREE_STATE=removed"* &&
+		"$worktree_list" != *"-planning-"* && "$status" == *"TODO.md"* &&
+		"$rc_second" -eq 0 && "$branch_second" == "$branch_first" &&
+		"$commit_second" == "$commit_first" && "$planning_ref_count" -eq 1 &&
+		"$output_second" == *"AIDEVOPS_PLANNING_COMMIT_RESULT=pr"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "first_rc=$rc_first second_rc=$rc_second first=$output_first second=$output_second refs=$planning_ref_count"
+	fi
 	rm -rf "$tmpdir"
 	return 0
 }
@@ -457,6 +603,9 @@ main() {
 		pass "planning helper executable"
 	fi
 	test_protected_default_creates_planning_pr
+	test_multi_task_manifest_is_deterministic
+	test_ambiguous_task_mapping_fails_before_push
+	test_post_push_failure_is_recoverable_and_idempotent
 	test_unprotected_default_keeps_direct_push
 	test_protected_default_from_linked_branch_creates_planning_pr
 	test_unprotected_default_from_linked_branch_publishes_default

--- a/.agents/templates/issue-first-pr-contributing.md
+++ b/.agents/templates/issue-first-pr-contributing.md
@@ -1,4 +1,5 @@
 <!-- aidevops:issue-first-pr:start -->
+<!-- aidevops:issue-first-pr:scope=external -->
 ## Issue-first pull requests
 
 If you are not a repository owner, member, or collaborator, create or find a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ If you cannot use the CLI command, use the issue templates on GitHub. Blank issu
 8. Push and open a PR with the linked issue reference in the PR body
 
 <!-- aidevops:issue-first-pr:start -->
+<!-- aidevops:issue-first-pr:scope=external -->
 ## Issue-first pull requests
 
 If you are not a repository owner, member, or collaborator, create or find a


### PR DESCRIPTION
## Summary

- replace prose-only issue-first scope detection with explicit external/universal policy markers and fail-closed parsing
- verify external-scope maintainer exemptions against the authenticated GitHub actor's repository permission
- derive deterministic planning task manifests, issue references, titles, publication identities, and retry branches
- preserve planning edits and emit recovery receipts when post-push PR finalization fails
- document the planning PR publication contract and extend focused shell coverage

## Linked issues

Resolves #30756
Resolves #30757
Resolves #30758

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor

## Runtime Testing

**Testing level** (select one):

- [ ] `runtime-verified` — dev environment started, smoke/stability checks passed
- [x] `self-assessed` — logic reviewed, no application runtime required for shell and documentation changes
- [ ] `untested` — not tested

**Focused verification:**

- `.agents/scripts/tests/test-gh-shim.sh` — 145 passed, 0 failed
- `.agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh` — 9 passed, 0 failed
- `.agents/scripts/tests/test-linked-issue-guidance.sh` — passed
- `.agents/scripts/tests/test-init-scope.sh` — 44 passed, 0 failed
- `.agents/scripts/linters-local.sh` — required gates passed before the final rebase; the rebase preserved the patch, and affected checks passed again afterward

## Checklist

- [x] This PR body includes linked issue references using accepted closing keywords
- [x] I have followed the commit message conventions
- [x] I have updated documentation where needed
- [x] Maintainer approval was verified for all three linked issues before implementation

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 1h 38m and 810,416 tokens on this with the user in an interactive session.