### PR TITLE
GH#30713: verify approvals before privileged retries

### DIFF
--- a/.agents/configs/command-policy.json
+++ b/.agents/configs/command-policy.json
@@ -29,6 +29,12 @@
       "decision": "forbid"
     },
     {
+      "id": "approval.freshness",
+      "kind": "approval_freshness",
+      "helper": "approval-helper.sh",
+      "decision": "forbid"
+    },
+    {
       "id": "github.account-mutation",
       "kind": "trusted_account_mutation",
       "authorization_env": "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION",

--- a/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
@@ -187,6 +187,9 @@ export function checkCommandSafetyGate(command, scriptsDir, cwd = process.cwd(),
   if (options.processTableFixture) {
     helperArgs.push("--process-table-fixture", options.processTableFixture);
   }
+  if (options.approvalHelper) {
+    helperArgs.push("--approval-helper", options.approvalHelper);
+  }
   const worker = options.worker ?? isWorkerContext();
   if (worker) {
     helperArgs.push(

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -4,6 +4,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import {
+  chmodSync,
   copyFileSync,
   mkdtempSync,
   mkdirSync,
@@ -472,6 +473,41 @@ test("blocks generic destructive commands through shared policy", () => {
     () => checkCommandSafetyGate("rm -rf ./build-output", scriptsDir, process.cwd()),
     /forbid, filesystem\.rm-recursive-force/,
   );
+});
+
+test("refreshes approval state before privileged approval commands", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-approval-policy-"));
+  const approvalHelper = join(root, "approval-helper.sh");
+  const command = "sudo aidevops approve issue 30700 owner/repo";
+  try {
+    writeFileSync(
+      approvalHelper,
+      "#!/usr/bin/env bash\nprintf 'NO_APPROVAL\\n'\nexit 1\n",
+    );
+    chmodSync(approvalHelper, 0o755);
+    assert.doesNotThrow(() => checkCommandSafetyGate(
+      command,
+      scriptsDir,
+      process.cwd(),
+      { approvalHelper },
+    ));
+
+    writeFileSync(
+      approvalHelper,
+      "#!/usr/bin/env bash\nprintf 'VERIFIED\\n'\nexit 0\n",
+    );
+    assert.throws(
+      () => checkCommandSafetyGate(
+        command,
+        scriptsDir,
+        process.cwd(),
+        { approvalHelper },
+      ),
+      /approval\.already-verified.*skip sudo and continue/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("blocks current runtime termination while allowing a detached sandbox group", () => {

--- a/.agents/scripts/command-policy-helper.py
+++ b/.agents/scripts/command-policy-helper.py
@@ -193,6 +193,7 @@ def _check_action(
         args.runtime_process_identity,
         args.process_table_fixture,
         args.account_mutation_workspace_root,
+        args.approval_helper,
     )
     print(json.dumps(result, sort_keys=True))
     return 0 if result["decision"] == "allow" else FORBID_EXIT

--- a/.agents/scripts/command_policy_approval.py
+++ b/.agents/scripts/command_policy_approval.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Fresh approval verification for privileged aidevops approval commands."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from command_policy_config import _decision
+
+REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+TARGET_PATTERN = re.compile(r"^[1-9][0-9]*$")
+KNOWN_VERIFY_STATES = {
+    "API_ERROR",
+    "LEGACY_APPROVAL",
+    "MALFORMED_APPROVAL",
+    "NO_APPROVAL",
+    "NO_KEY",
+    "STALE_APPROVAL",
+    "UNTRUSTED_APPROVAL",
+    "VERIFIED",
+}
+
+
+class ApprovalCommandError(ValueError):
+    """Raised when a recognized approval command is not safely parseable."""
+
+
+@dataclass(frozen=True)
+class ApprovalRequest:
+    targets: tuple[tuple[str, str], ...]
+    repository: str
+    batch: bool
+
+
+def _approval_request(argv: list[str]) -> ApprovalRequest | None:
+    if len(argv) < 3 or os.path.basename(argv[0]) != "aidevops":
+        return None
+    if argv[1] != "approve" or argv[2] not in {"issue", "pr", "batch"}:
+        return None
+    if len(argv) < 5 or not REPOSITORY_PATTERN.fullmatch(argv[-1]):
+        raise ApprovalCommandError(
+            "approval command requires targets followed by an explicit owner/repository"
+        )
+    repository = argv[-1]
+    target_args = argv[3:-1]
+    batch = argv[2] == "batch"
+    targets = (
+        _parse_batch_targets(target_args)
+        if batch
+        else _parse_same_kind_targets(argv[2], target_args)
+    )
+    return ApprovalRequest(tuple(dict.fromkeys(targets)), repository, batch)
+
+
+def _parse_same_kind_targets(
+    target_type: str, target_args: list[str]
+) -> list[tuple[str, str]]:
+    if not target_args or any(not TARGET_PATTERN.fullmatch(arg) for arg in target_args):
+        raise ApprovalCommandError("approval issue/pr targets must be positive integers")
+    return [(target_type, number) for number in target_args]
+
+
+def _parse_batch_targets(target_args: list[str]) -> list[tuple[str, str]]:
+    targets: list[tuple[str, str]] = []
+    for item in target_args:
+        target_type, separator, number = item.partition(":")
+        if (
+            separator != ":"
+            or target_type not in {"issue", "pr"}
+            or not TARGET_PATTERN.fullmatch(number)
+        ):
+            raise ApprovalCommandError(
+                "approval batch targets must use issue:<number> or pr:<number>"
+            )
+        targets.append((target_type, number))
+    if not targets:
+        raise ApprovalCommandError("approval batch requires at least one target")
+    return targets
+
+
+def _evaluate_approval_freshness(
+    invocations: list[list[str]], helper: Path
+) -> dict[str, Any] | None:
+    requests: list[ApprovalRequest] = []
+    try:
+        for argv in invocations:
+            request = _approval_request(argv)
+            if request is not None:
+                requests.append(request)
+    except ApprovalCommandError as exc:
+        return _decision("forbid", "approval.preflight-malformed", str(exc))
+    if not requests:
+        return None
+    if not helper.is_file():
+        return _decision(
+            "forbid",
+            "approval.verifier-unavailable",
+            f"Fresh approval verifier is unavailable: {helper}",
+        )
+    decisions = [_evaluate_request(request, helper) for request in requests]
+    return next(
+        (decision for decision in decisions if decision["decision"] == "forbid"),
+        decisions[0],
+    )
+
+
+def _evaluate_request(request: ApprovalRequest, helper: Path) -> dict[str, Any]:
+    states = _verify_targets(request, helper)
+    verified = [target for target in request.targets if states[target] == "VERIFIED"]
+    unapproved = [
+        target for target in request.targets if states[target] == "NO_APPROVAL"
+    ]
+    indeterminate = [
+        target
+        for target in request.targets
+        if states[target] not in {"VERIFIED", "NO_APPROVAL"}
+    ]
+    if indeterminate:
+        details = ", ".join(
+            f"{_format_target(target)}={states[target]}" for target in indeterminate
+        )
+        reason = (
+            "Fresh approval state is indeterminate; do not claim approval is missing "
+            f"or retry sudo. verified=[{_format_targets(verified)}], "
+            f"unapproved=[{_format_targets(unapproved)}], indeterminate=[{details}]"
+        )
+        return _decision("forbid", "approval.verification-indeterminate", reason)
+    if len(verified) == len(request.targets):
+        return _decision(
+            "forbid",
+            "approval.already-verified",
+            "Fresh authoritative verification confirms every target is already "
+            f"approved ({_format_targets(verified)}); skip sudo and continue the "
+            "requested workflow",
+        )
+    if verified:
+        reduced = _approval_command(request, unapproved)
+        return _decision(
+            "forbid",
+            "approval.partially-verified",
+            f"Fresh verification removed already-approved targets "
+            f"({_format_targets(verified)}); retry only genuinely unapproved targets "
+            f"with: {reduced}",
+        )
+    return _decision(
+        "allow",
+        "approval.fresh-unapproved",
+        f"Fresh verification confirms approval is absent for "
+        f"{_format_targets(unapproved)}",
+    )
+
+
+def _verify_targets(
+    request: ApprovalRequest, helper: Path
+) -> dict[tuple[str, str], str]:
+    worker_count = min(len(request.targets), 8)
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        results = executor.map(
+            lambda target: _verify_target(helper, request.repository, target),
+            request.targets,
+        )
+    return dict(zip(request.targets, results))
+
+
+def _verify_target(
+    helper: Path, repository: str, target: tuple[str, str]
+) -> str:
+    target_type, number = target
+    try:
+        result = subprocess.run(  # nosec B603 -- helper is policy-selected and target argv is strictly validated.
+            [str(helper), "verify", target_type, number, repository],
+            capture_output=True,
+            text=True,
+            timeout=8,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "API_ERROR"
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    state = lines[-1] if lines and lines[-1] in KNOWN_VERIFY_STATES else "API_ERROR"
+    if state == "VERIFIED" and result.returncode != 0:
+        return "API_ERROR"
+    if state == "NO_APPROVAL" and result.returncode != 1:
+        return "API_ERROR"
+    return state
+
+
+def _approval_command(
+    request: ApprovalRequest, targets: list[tuple[str, str]]
+) -> str:
+    if not request.batch and len({target[0] for target in targets}) == 1:
+        target_type = targets[0][0]
+        numbers = " ".join(target[1] for target in targets)
+        return f"sudo aidevops approve {target_type} {numbers} {request.repository}"
+    encoded = " ".join(_format_target(target) for target in targets)
+    return f"sudo aidevops approve batch {encoded} {request.repository}"
+
+
+def _format_target(target: tuple[str, str]) -> str:
+    return f"{target[0]}:{target[1]}"
+
+
+def _format_targets(targets: list[tuple[str, str]]) -> str:
+    return ", ".join(_format_target(target) for target in targets) or "none"

--- a/.agents/scripts/command_policy_config.py
+++ b/.agents/scripts/command_policy_config.py
@@ -94,6 +94,10 @@ def _validate_policy_guards(guards: Any) -> None:
         raise PolicyError(
             "command policy requires exactly one process-termination guard"
         )
+    if not _has_required_guard(guards, "approval_freshness", "approval-helper.sh"):
+        raise PolicyError(
+            "command policy requires exactly one approval-freshness guard"
+        )
     _validate_account_mutation_guard(guards)
 
 

--- a/.agents/scripts/command_policy_evaluation.py
+++ b/.agents/scripts/command_policy_evaluation.py
@@ -19,6 +19,7 @@ from command_policy_account_mutation import (
     _evaluate_account_mutation,
     account_mutation_authorization as _account_mutation_authorization,
 )
+from command_policy_approval import _evaluate_approval_freshness
 from command_policy_config import _decision
 from command_policy_matchers import _matches
 from command_policy_process_termination import (
@@ -52,6 +53,7 @@ class _EvaluationOptions:
     runtime_process_identity: str = ""
     process_table_fixture: str = ""
     account_mutation_workspace_root: str | None = None
+    approval_helper: str = ""
 
 
 def _evaluate_static(
@@ -164,6 +166,19 @@ def _network_guard_path(
     return (script_dir or Path(__file__).resolve().parent) / helper
 
 
+def _approval_guard_path(
+    policy: dict[str, Any], explicit: str, script_dir: Path | None = None
+) -> Path:
+    if explicit:
+        return Path(explicit)
+    helper = next(
+        guard["helper"]
+        for guard in policy["dynamic_guards"]
+        if guard["kind"] == "approval_freshness"
+    )
+    return (script_dir or Path(__file__).resolve().parent) / helper
+
+
 def _evaluate_worker_network(
     invocations: list[list[str]], cwd: str, helper: Path, worker_id: str
 ) -> dict[str, Any]:
@@ -216,7 +231,11 @@ def evaluate_invocations(
 ) -> dict[str, Any]:
     options = _evaluation_options(legacy_options, named_options)
     script_dir = Path(__file__).resolve().parent
-    decisions = [
+    approval_decision = _evaluate_approval_freshness(
+        invocations,
+        _approval_guard_path(policy, options.approval_helper, script_dir),
+    )
+    decisions = ([approval_decision] if approval_decision else []) + [
         _evaluate_static(invocations, cwd, policy),
         _evaluate_canonical_git(
             invocations,
@@ -270,6 +289,7 @@ def _evaluation_options(
         "runtime_process_identity",
         "process_table_fixture",
         "account_mutation_workspace_root",
+        "approval_helper",
     )
     if len(legacy_options) > len(names):
         maximum_arguments = len(names) + 3

--- a/.agents/scripts/command_policy_runtime.py
+++ b/.agents/scripts/command_policy_runtime.py
@@ -56,6 +56,7 @@ def _argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--runtime-pid", type=int, default=0)
     parser.add_argument("--runtime-process-identity", default="")
     parser.add_argument("--process-table-fixture", default="")
+    parser.add_argument("--approval-helper", default="")
     parser.add_argument("--worker", action="store_true")
     parser.add_argument(
         "--worker-id", default=os.environ.get("AIDEVOPS_WORKER_ID", "unknown")

--- a/.agents/scripts/tests/test-command-policy-helper.sh
+++ b/.agents/scripts/tests/test-command-policy-helper.sh
@@ -156,6 +156,63 @@ PY
 	return 0
 }
 
+assert_approval_decision() {
+	local name="$1"
+	local command_text="$2"
+	local approval_helper="$3"
+	local expected_decision="$4"
+	local expected_rule="$5"
+	local expected_status="$6"
+	local expected_pattern="${7:-}"
+	local output=""
+	local status=0
+	local actual=""
+
+	output="$(python3 "$HELPER" check-command --cwd "$TEST_ROOT" \
+		--approval-helper "$approval_helper" --command "$command_text")" || status=$?
+	actual="$(
+		python3 - "$output" <<'PY'
+import json
+import sys
+result = json.loads(sys.argv[1])
+print(f"{result.get('decision', '')}/{result.get('rule_id', '')}")
+PY
+	)"
+	if [[ "$status" -eq "$expected_status" &&
+		"$actual" == "${expected_decision}/${expected_rule}" &&
+		(-z "$expected_pattern" || "$output" == *"$expected_pattern"*) ]]; then
+		pass "$name"
+	else
+		fail "$name" "status=${status} decision=${actual} output=${output}"
+	fi
+	return 0
+}
+
+create_approval_fixture_helper() {
+	local helper="${TEST_ROOT}/approval-helper-fixture.sh"
+	cat >"$helper" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+target_type="${2:-}"
+target_number="${3:-}"
+state_name="APPROVAL_TEST_STATE_${target_type}_${target_number}"
+state="${!state_name:-API_ERROR}"
+printf '%s\n' "$state"
+case "$state" in
+VERIFIED) exit 0 ;;
+NO_APPROVAL) exit 1 ;;
+NO_KEY) exit 2 ;;
+LEGACY_APPROVAL) exit 3 ;;
+STALE_APPROVAL) exit 4 ;;
+MALFORMED_APPROVAL) exit 5 ;;
+*) exit 6 ;;
+esac
+EOF
+	chmod +x "$helper"
+	printf '%s\n' "$helper"
+	return 0
+}
+
 test_validation() {
 	if python3 "$HELPER" validate --policy "$POLICY" >/dev/null; then
 		pass "validates declarative policy and fixtures"
@@ -447,6 +504,60 @@ test_static_decisions() {
 	return 0
 }
 
+test_approval_freshness_policy() {
+	local approval_helper=""
+	approval_helper=$(create_approval_fixture_helper)
+
+	export APPROVAL_TEST_STATE_issue_30700=NO_APPROVAL
+	export APPROVAL_TEST_STATE_issue_30701=NO_APPROVAL
+	assert_approval_decision \
+		"allows a freshly unapproved batch" \
+		"sudo aidevops approve issue 30700 30701 owner/repo" \
+		"$approval_helper" allow approval.fresh-unapproved 0 "issue:30700, issue:30701"
+
+	# A fresh pass must override an earlier NO_APPROVAL result.
+	export APPROVAL_TEST_STATE_issue_30700=VERIFIED
+	export APPROVAL_TEST_STATE_issue_30701=VERIFIED
+	assert_approval_decision \
+		"suppresses a stale all-verified sudo retry" \
+		"sudo aidevops approve issue 30700 30701 owner/repo" \
+		"$approval_helper" forbid approval.already-verified 20 \
+		"skip sudo and continue the requested workflow"
+
+	export APPROVAL_TEST_STATE_issue_30701=NO_APPROVAL
+	assert_approval_decision \
+		"reduces a mixed same-kind batch to unapproved targets" \
+		"sudo aidevops approve issue 30700 30701 owner/repo" \
+		"$approval_helper" forbid approval.partially-verified 20 \
+		"sudo aidevops approve issue 30701 owner/repo"
+
+	export APPROVAL_TEST_STATE_pr_400=VERIFIED
+	export APPROVAL_TEST_STATE_issue_30701=NO_APPROVAL
+	assert_approval_decision \
+		"reduces a mixed-kind batch without dropping target kinds" \
+		"sudo aidevops approve batch pr:400 issue:30701 owner/repo" \
+		"$approval_helper" forbid approval.partially-verified 20 \
+		"sudo aidevops approve batch issue:30701 owner/repo"
+
+	export APPROVAL_TEST_STATE_issue_30701=API_ERROR
+	assert_approval_decision \
+		"fails safely when authoritative verification is indeterminate" \
+		"sudo aidevops approve issue 30700 30701 owner/repo" \
+		"$approval_helper" forbid approval.verification-indeterminate 20 \
+		"issue:30701=API_ERROR"
+
+	assert_approval_decision \
+		"rejects malformed repository-unqualified approval commands" \
+		"sudo aidevops approve issue 30700" \
+		"$approval_helper" forbid approval.preflight-malformed 20 \
+		"explicit owner/repository"
+
+	unset APPROVAL_TEST_STATE_issue_30700
+	unset APPROVAL_TEST_STATE_issue_30701
+	unset APPROVAL_TEST_STATE_pr_400
+	return 0
+}
+
 test_process_table_parser() {
 	if python3 - "$SCRIPT_DIR" <<'PY'; then
 import importlib
@@ -567,7 +678,8 @@ test_canonical_delegation() {
 	git -C "$repo" config user.email test@example.invalid
 	git -C "$repo" config commit.gpgsign false
 	printf 'seed\n' >"${repo}/README.md"
-	git -C "$repo" add README.md
+	printf '{}\n' >"${repo}/.aidevops.json"
+	git -C "$repo" add README.md .aidevops.json
 	git -C "$repo" commit -q -m seed
 	assert_decision "forbids canonical branch mutation through canonical guard" "git branch -m main renamed" forbid git.canonical-worktree 20 "$repo"
 	git -C "$repo" worktree add -q -b feature/test "$linked"
@@ -807,6 +919,7 @@ main() {
 	test_evaluate_invocations_compatibility
 	test_worker_protocol_bash_examples
 	test_static_decisions
+	test_approval_freshness_policy
 	test_process_table_parser
 	test_process_termination_policy
 	test_account_mutation_authorization


### PR DESCRIPTION
## Summary

Add a shared command-policy freshness guard that verifies every issue or PR target before privileged approval, suppresses all-verified retries, reduces mixed batches, and fails closed on indeterminate state.

## Files Changed

.agents/configs/command-policy.json, .agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs, .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs, .agents/scripts/command-policy-helper.py, .agents/scripts/command_policy_approval.py, .agents/scripts/command_policy_config.py, .agents/scripts/command_policy_evaluation.py, .agents/scripts/command_policy_runtime.py, .agents/scripts/tests/test-command-policy-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified the real GitHub verifier through the production command-policy path; passed command-policy, approval-state, full-loop author-gate, OpenCode hook tests, changed-file lint, and independent closeout review bundle 0cdb072edec3d646a8ff8516146ac9dddd8a91bbc1683b3d162babc9a6b771ac.

Resolves #30713


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 15m and 199,104 tokens on this with the user in an interactive session.