### PR TITLE
GH#30770: prevent false complexity stall sweeps

### DIFF
--- a/.agents/scripts/complexity-scan-helper.sh
+++ b/.agents/scripts/complexity-scan-helper.sh
@@ -738,6 +738,28 @@ cmd_sweep_check() {
 					echo "not-needed|debt at ${current_debt} but ${recent_closures} issues closed in ${stall_hours}h (active throughput)"
 					return 1
 				fi
+				# GH#30770: a flat debt count is also healthy when every open item
+				# is already queued, running, or awaiting PR review. Keep this
+				# standalone check aligned with the pulse inline sweep guard.
+				local debt_issues_json=""
+				debt_issues_json=$(gh issue list --repo "$repo_slug" \
+					--label "function-complexity-debt" --state open --limit 500 \
+					--json number,title,labels 2>/dev/null) || debt_issues_json=""
+				local actionable_count=""
+				local active_count=""
+				if [[ -n "$debt_issues_json" ]]; then
+					actionable_count=$(printf '%s' "$debt_issues_json" | jq '[.[] | select(.title | test("stalled|LLM sweep") | not)] | length' 2>/dev/null) || actionable_count=""
+					active_count=$(printf '%s' "$debt_issues_json" | jq '
+						[.[] | select(.title | test("stalled|LLM sweep") | not)] |
+						[.[] | select(.labels | map(.name) |
+							(index("status:queued") or index("status:in-progress") or index("status:in-review")))] |
+						length' 2>/dev/null) || active_count=""
+				fi
+				if [[ "$actionable_count" =~ ^[0-9]+$ && "$active_count" =~ ^[0-9]+$ && "$actionable_count" -gt 0 && "$active_count" -ge "$actionable_count" ]]; then
+					echo "${now_epoch}|${current_debt}" >"$SWEEP_DEBT_SNAPSHOT"
+					echo "not-needed|all ${actionable_count} debt issues are active or in review"
+					return 1
+				fi
 				# Zero throughput — genuine stall, sweep needed
 				echo "needed|debt stalled at ${current_debt} for ${stall_hours}h+ (was ${snapshot_count}, 0 closures)"
 				# Update snapshot for next check

--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -228,22 +228,24 @@ _complexity_llm_sweep_due() {
 		return 1
 	fi
 
-	# GH#17536: Skip sweep when all remaining debt issues are already dispatched.
-	# If every open function-complexity-debt issue (excluding sweep meta-issues) has
-	# status:queued or status:in-progress, the pipeline is working — no sweep needed.
-	local dispatched_count
-	dispatched_count=$(gh_issue_list --repo "$aidevops_slug" \
-		--label "function-complexity-debt" --state open \
-		--json number,title,labels --jq '
-		[.[] | select(.title | test("stalled|LLM sweep") | not)] |
-		if length == 0 then 0
-		else
-			[.[] | select(.labels | map(.name) | (index("status:queued") or index("status:in-progress")))] | length
-		end' 2>/dev/null) || dispatched_count=""
-	local actionable_count
-	actionable_count=$(gh_issue_list --repo "$aidevops_slug" \
-		--label "function-complexity-debt" --state open \
-		--json number,title --jq '[.[] | select(.title | test("stalled|LLM sweep") | not)] | length' 2>/dev/null) || actionable_count=""
+	# GH#17536/GH#30770: Skip sweep when every remaining debt issue is already
+	# advancing through the worker/PR lifecycle. status:in-review is active work,
+	# not an undispatched backlog item; omitting it created false stall reviews
+	# while an exact issue-linked PR was awaiting checks or merge.
+	local debt_issues_json=""
+	debt_issues_json=$(gh_issue_list --repo "$aidevops_slug" \
+		--label "function-complexity-debt" --state open --limit 500 \
+		--json number,title,labels 2>/dev/null) || debt_issues_json=""
+	local dispatched_count=""
+	local actionable_count=""
+	if [[ -n "$debt_issues_json" ]]; then
+		actionable_count=$(printf '%s' "$debt_issues_json" | jq '[.[] | select(.title | test("stalled|LLM sweep") | not)] | length' 2>/dev/null) || actionable_count=""
+		dispatched_count=$(printf '%s' "$debt_issues_json" | jq '
+			[.[] | select(.title | test("stalled|LLM sweep") | not)] |
+			[.[] | select(.labels | map(.name) |
+				(index("status:queued") or index("status:in-progress") or index("status:in-review")))] |
+			length' 2>/dev/null) || dispatched_count=""
+	fi
 	if [[ "$actionable_count" =~ ^[0-9]+$ && "$dispatched_count" =~ ^[0-9]+$ && "$actionable_count" -gt 0 && "$dispatched_count" -ge "$actionable_count" ]]; then
 		echo "[pulse-wrapper] Complexity LLM sweep: all ${actionable_count} debt issues are dispatched — sweep not needed" >>"$LOGFILE"
 		printf '%s\n' "$now_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"

--- a/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
@@ -10,6 +10,7 @@
 #   - _complexity_llm_sweep_due: returns 1 when interval not elapsed
 #   - _complexity_llm_sweep_due: returns 1 when debt count decreased
 #   - _complexity_llm_sweep_due: returns 0 when interval elapsed and debt stalled
+#   - _complexity_llm_sweep_due: treats in-review debt as active work
 #   - _complexity_llm_sweep_due: tolerates an unset sweep interval under set -u
 #   - _complexity_recent_debt_closures: tolerates empty arithmetic inputs under set -u
 #   - _complexity_run_llm_sweep: creates meta reviews outside measured function debt
@@ -333,6 +334,26 @@ test_llm_sweep_due_when_zero_recent_closures() {
 	return 0
 }
 
+test_llm_sweep_skips_when_all_debt_is_in_review() {
+	install_fake_gh_for_sweep
+	local now_epoch
+	now_epoch=$(date +%s)
+	local old_epoch=$((now_epoch - ${COMPLEXITY_LLM_SWEEP_INTERVAL:-0} - 60))
+	printf '%s\n' "$old_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
+	printf '1\n' >"$COMPLEXITY_DEBT_COUNT_FILE"
+	export GH_OPEN_DEBT_COUNT=1
+	export GH_RECENT_CLOSURES=0
+	export GH_ISSUE_LIST_JSON='[{"number":42,"title":"simplification: active debt","labels":[{"name":"function-complexity-debt"},{"name":"status:in-review"}]}]'
+
+	if ! _complexity_llm_sweep_due "$now_epoch" "test/repo" 2>/dev/null; then
+		print_result "_complexity_llm_sweep_due: in-review debt suppresses stall sweep" 0
+	else
+		print_result "_complexity_llm_sweep_due: in-review debt suppresses stall sweep" 1 "expected 1 (not due)"
+	fi
+	unset GH_OPEN_DEBT_COUNT GH_RECENT_CLOSURES GH_ISSUE_LIST_JSON
+	return 0
+}
+
 test_llm_sweep_meta_review_is_not_measured_debt() {
 	install_fake_gh_for_sweep
 	: >"$GH_ISSUE_LIST_LOG"
@@ -473,6 +494,7 @@ main() {
 	test_llm_sweep_check_interval_guard
 	test_llm_sweep_skips_when_recent_closures_exist
 	test_llm_sweep_due_when_zero_recent_closures
+	test_llm_sweep_skips_when_all_debt_is_in_review
 	test_llm_sweep_meta_review_is_not_measured_debt
 	test_both_stall_issue_creators_use_meta_label
 	test_recent_closures_defaults_empty_arithmetic_inputs


### PR DESCRIPTION
## Summary

Treat function-complexity debt in PR review as active work in both sweep decision paths, avoiding false stall-review issues while all debt is already advancing.

## Files Changed

.agents/scripts/complexity-scan-helper.sh, .agents/scripts/pulse-simplification-scan.sh, .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 18 focused complexity-scan tests pass; ShellCheck passes on all changed shell files; changed-file local preflight passes; review evidence bundle 51c8b0a5d41c7f33404d991e3b2152442219f403993ab064cb50e864a1309d22 is clean.

Resolves #30770


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 6m and 116,614 tokens on this with the user in an interactive session.