### PR TITLE
GH#30773: suppress false simplification stall sweeps

### DIFF
--- a/.agents/scripts/complexity-scan-helper.sh
+++ b/.agents/scripts/complexity-scan-helper.sh
@@ -644,6 +644,34 @@ cmd_scan() {
 }
 
 #######################################
+# Count actionable debt issues and those already in the delivery lifecycle.
+# Arguments: $1 - repo_slug
+# Outputs globals: _SWEEP_DISPATCHED_COUNT, _SWEEP_ACTIONABLE_COUNT
+#######################################
+_sweep_load_dispatched_debt_counts() {
+	local repo_slug="$1"
+	local counts=""
+
+	# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell.
+	counts=$(gh issue list --repo "$repo_slug" \
+		--label "function-complexity-debt" --state open \
+		--limit 500 \
+		--json number,title,labels --jq '
+		[.[] | select(.title | test("stalled|LLM sweep") | not)] as $actionable |
+		[
+			([$actionable[] | select(.labels | map(.name) |
+				(index("status:queued") or index("status:in-progress") or index("status:in-review")))] | length),
+			($actionable | length)
+		] | join("|")' 2>/dev/null) || return 1
+
+	_SWEEP_DISPATCHED_COUNT="${counts%%|*}"
+	_SWEEP_ACTIONABLE_COUNT="${counts##*|}"
+	[[ "$_SWEEP_DISPATCHED_COUNT" =~ ^[0-9]+$ ]] || return 1
+	[[ "$_SWEEP_ACTIONABLE_COUNT" =~ ^[0-9]+$ ]] || return 1
+	return 0
+}
+
+#######################################
 # Sweep check — determine if daily LLM sweep is needed.
 # Conditions for sweep:
 #   1. Last sweep was >24h ago (or never run)
@@ -736,6 +764,16 @@ cmd_sweep_check() {
 					# Active throughput — system is working, not stalled. Update snapshot.
 					echo "${now_epoch}|${current_debt}" >"$SWEEP_DEBT_SNAPSHOT"
 					echo "not-needed|debt at ${current_debt} but ${recent_closures} issues closed in ${stall_hours}h (active throughput)"
+					return 1
+				fi
+				# A debt item in PR review remains active delivery. Treat queued,
+				# in-progress, and in-review issues as dispatched so the helper path
+				# matches the inline pulse guard and avoids false stall reviews.
+				if _sweep_load_dispatched_debt_counts "$repo_slug" &&
+					[[ "$_SWEEP_ACTIONABLE_COUNT" -gt 0 ]] &&
+					[[ "$_SWEEP_DISPATCHED_COUNT" -ge "$_SWEEP_ACTIONABLE_COUNT" ]]; then
+					echo "${now_epoch}|${current_debt}" >"$SWEEP_DEBT_SNAPSHOT"
+					echo "not-needed|all ${_SWEEP_ACTIONABLE_COUNT} debt issues are dispatched or in review"
 					return 1
 				fi
 				# Zero throughput — genuine stall, sweep needed

--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -230,19 +230,22 @@ _complexity_llm_sweep_due() {
 
 	# GH#17536: Skip sweep when all remaining debt issues are already dispatched.
 	# If every open function-complexity-debt issue (excluding sweep meta-issues) has
-	# status:queued or status:in-progress, the pipeline is working — no sweep needed.
+	# status:queued, status:in-progress, or status:in-review, the pipeline is
+	# working — no sweep needed. Review is still active delivery, not a stall.
 	local dispatched_count
 	dispatched_count=$(gh_issue_list --repo "$aidevops_slug" \
 		--label "function-complexity-debt" --state open \
+		--limit 500 \
 		--json number,title,labels --jq '
 		[.[] | select(.title | test("stalled|LLM sweep") | not)] |
 		if length == 0 then 0
 		else
-			[.[] | select(.labels | map(.name) | (index("status:queued") or index("status:in-progress")))] | length
+			[.[] | select(.labels | map(.name) | (index("status:queued") or index("status:in-progress") or index("status:in-review")))] | length
 		end' 2>/dev/null) || dispatched_count=""
 	local actionable_count
 	actionable_count=$(gh_issue_list --repo "$aidevops_slug" \
 		--label "function-complexity-debt" --state open \
+		--limit 500 \
 		--json number,title --jq '[.[] | select(.title | test("stalled|LLM sweep") | not)] | length' 2>/dev/null) || actionable_count=""
 	if [[ "$actionable_count" =~ ^[0-9]+$ && "$dispatched_count" =~ ^[0-9]+$ && "$actionable_count" -gt 0 && "$dispatched_count" -ge "$actionable_count" ]]; then
 		echo "[pulse-wrapper] Complexity LLM sweep: all ${actionable_count} debt issues are dispatched — sweep not needed" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 SCAN_SCRIPT="${SCRIPT_DIR}/../pulse-simplification-scan.sh"
 ORCHESTRATION_SCRIPT="${SCRIPT_DIR}/../pulse-simplification-orchestration.sh"
+COMPLEXITY_HELPER="${SCRIPT_DIR}/../complexity-scan-helper.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -133,18 +134,30 @@ case "$cmd" in
 				"${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" \
 				"${AIDEVOPS_GH_ROUTE_DECISION:-}" "$args" >>"${GH_GRAPHQL_LOG}"
 			if [[ "$args" == *"search(query"* ]]; then
-				printf '{"data":{"search":{"issueCount":%s},"rateLimit":{"cost":1}}}\n' \
-					"${GH_RECENT_CLOSURES:-0}"
+				if [[ "$args" == *"--jq"* ]]; then
+					printf '%s\n' "${GH_RECENT_CLOSURES:-0}"
+				else
+					printf '{"data":{"search":{"issueCount":%s},"rateLimit":{"cost":1}}}\n' \
+						"${GH_RECENT_CLOSURES:-0}"
+				fi
 			else
-				printf '{"data":{"repository":{"issues":{"totalCount":%s}},"rateLimit":{"cost":1}}}\n' \
-					"${GH_OPEN_DEBT_COUNT:-0}"
+				if [[ "$args" == *"--jq"* ]]; then
+					printf '%s\n' "${GH_OPEN_DEBT_COUNT:-0}"
+				else
+					printf '{"data":{"repository":{"issues":{"totalCount":%s}},"rateLimit":{"cost":1}}}\n' \
+						"${GH_OPEN_DEBT_COUNT:-0}"
+				fi
 			fi
 			exit 0
 		fi
 		;;
 	issue)
 		if [[ "$subcmd" == "list" ]]; then
-			printf '%s\n' "${GH_ISSUE_LIST_JSON:-[]}"
+			if [[ "$args" == *'join("|")'* ]]; then
+				printf '%s\n' "${GH_ISSUE_COUNTS:-0|0}"
+			else
+				printf '%s\n' "${GH_ISSUE_LIST_JSON:-[]}"
+			fi
 			exit 0
 		fi
 		;;
@@ -313,6 +326,51 @@ test_llm_sweep_skips_when_recent_closures_exist() {
 	return 0
 }
 
+test_llm_sweep_skips_when_all_debt_is_in_review() {
+	install_fake_gh_for_sweep
+	: >"$GH_ISSUE_LIST_LOG"
+	local now_epoch
+	now_epoch=$(date +%s)
+	local old_epoch=$((now_epoch - ${COMPLEXITY_LLM_SWEEP_INTERVAL:-0} - 60))
+	printf '%s\n' "$old_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
+	printf '10\n' >"$COMPLEXITY_DEBT_COUNT_FILE"
+	export GH_OPEN_DEBT_COUNT=10
+	export GH_RECENT_CLOSURES=0
+	# The fake gh returns the post-jq count. The logged jq expression proves
+	# status:in-review participates in that count.
+	export GH_ISSUE_LIST_JSON='1'
+
+	if ! _complexity_llm_sweep_due "$now_epoch" "test/repo" 2>/dev/null &&
+		grep -qF 'status:in-review' "$GH_ISSUE_LIST_LOG"; then
+		print_result "_complexity_llm_sweep_due: in-review debt suppresses stall sweep" 0
+	else
+		print_result "_complexity_llm_sweep_due: in-review debt suppresses stall sweep" 1 "expected 1 (not due) with in-review included in dispatched count"
+	fi
+	unset GH_OPEN_DEBT_COUNT GH_RECENT_CLOSURES GH_ISSUE_LIST_JSON
+	return 0
+}
+
+test_helper_sweep_skips_when_all_debt_is_in_review() {
+	install_fake_gh_for_sweep
+	local now_epoch helper_snapshot output="" rc=0
+	now_epoch=$(date +%s)
+	helper_snapshot="${HOME}/.aidevops/logs/complexity-debt-snapshot"
+	rm -f "$COMPLEXITY_LLM_SWEEP_LAST_RUN"
+	printf '%s|10\n' "$((now_epoch - 21660))" >"$helper_snapshot"
+	export GH_OPEN_DEBT_COUNT=10
+	export GH_RECENT_CLOSURES=0
+	export GH_ISSUE_COUNTS='1|1'
+
+	output=$("$COMPLEXITY_HELPER" sweep-check "test/repo" --stall-hours 6 2>/dev/null) || rc=$?
+	if [[ "$rc" -eq 1 && "$output" == "not-needed|all 1 debt issues are dispatched or in review" ]]; then
+		print_result "complexity-scan-helper: in-review debt suppresses stall sweep" 0
+	else
+		print_result "complexity-scan-helper: in-review debt suppresses stall sweep" 1 "expected not-needed, got rc=${rc} output='${output}'"
+	fi
+	unset GH_OPEN_DEBT_COUNT GH_RECENT_CLOSURES GH_ISSUE_COUNTS
+	return 0
+}
+
 test_llm_sweep_due_when_zero_recent_closures() {
 	install_fake_gh_for_sweep
 	local now_epoch
@@ -472,6 +530,8 @@ main() {
 	test_llm_sweep_not_due_when_interval_not_elapsed
 	test_llm_sweep_check_interval_guard
 	test_llm_sweep_skips_when_recent_closures_exist
+	test_llm_sweep_skips_when_all_debt_is_in_review
+	test_helper_sweep_skips_when_all_debt_is_in_review
 	test_llm_sweep_due_when_zero_recent_closures
 	test_llm_sweep_meta_review_is_not_measured_debt
 	test_both_stall_issue_creators_use_meta_label


### PR DESCRIPTION
## Summary

Treat queued, in-progress, and in-review complexity debt as active delivery in both stall-sweep paths, bounded to the configured 500-item debt cap.

## Files Changed

.agents/scripts/complexity-scan-helper.sh, .agents/scripts/pulse-simplification-scan.sh, .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 19 focused complexity-scan tests pass; ShellCheck passes for all changed shell files; local preflight linters pass.

Resolves #30773


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 12m and 180,071 tokens on this with the user in an interactive session.