### PR TITLE
GH#30766: bind approval continuity to stable timeline ordering

### DIFF
--- a/.agents/scripts/approval-helper-continuity.sh
+++ b/.agents/scripts/approval-helper-continuity.sh
@@ -44,46 +44,58 @@ _approval_continuity_is_repository_status_default() {
 	return 0
 }
 
-_approval_verify_locked_issue_continuity() {
-	local payload="$1"
+_approval_continuity_ordered_mutation_rows() {
+	local timeline_pages="$1"
+	local issued_at="$2"
+	local approval_comment_id="$3"
+
+	# #aidevops:trust-boundary — the signed approval comment is the stable
+	# timeline anchor. Flatten every page, validate the complete mutation stream,
+	# and sort by GitHub's stable (created_at, id) key before authorization.
+	jq -r --arg issued "$issued_at" --argjson approval_id "$approval_comment_id" '
+		def valid_id:
+			type == "number" and . >= 0 and floor == .;
+		def valid_timestamp:
+			type == "string"
+			and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+			and ((try (fromdateiso8601 | todateiso8601) catch "") == .);
+		def lifecycle_mutation:
+			(.event // "") as $event
+			| ["assigned","unassigned","labeled","unlabeled","milestoned","demilestoned","closed","reopened","renamed","locked","unlocked","connected","disconnected","added_to_project","moved_columns_in_project","removed_from_project","transferred","converted_to_discussion","marked_as_duplicate","unmarked_as_duplicate","pinned","unpinned"]
+			| index($event) != null;
+		[.[][]?] as $events
+		| [$events[] | select((.event // "") == "commented" and (.id // null) == $approval_id)] as $anchors
+		| [$events[] | select(lifecycle_mutation)] as $mutations
+		| if (($issued | valid_timestamp) | not)
+			or ($anchors | length) != 1
+			or (($anchors[0].id | valid_id) | not)
+			or (($anchors[0].created_at | valid_timestamp) | not)
+			or $anchors[0].created_at < $issued
+			or any($mutations[]; ((.id // null) | valid_id) | not)
+			or any($mutations[]; ((.created_at // "") | valid_timestamp) | not)
+			or (($mutations + $anchors) | sort_by(.created_at, .id) | group_by([.created_at, .id]) | any(length > 1))
+		then error("timeline ordering evidence is incomplete or ambiguous")
+		else
+			$anchors[0] as $anchor
+			| $mutations
+			| map(select(.created_at > $anchor.created_at or (.created_at == $anchor.created_at and .id > $anchor.id)))
+			| sort_by(.created_at, .id)
+			| .[]
+			| [(.event // ""), (.actor.login // ""), (.label.name // .assignee.login // ""), ((.actor.id // "") | tostring), (.actor.type // "")]
+			| @tsv
+		end
+	' <<<"$timeline_pages"
+	return $?
+}
+
+_approval_continuity_lifecycle_change_allowed() {
+	local signed_lifecycle="$1"
 	local current_snapshot="$2"
-	local signed_digest="$3"
-	local slug="$4"
-	local target_number="$5"
-	local issued_at="$6"
-	local signed_lifecycle="" current_anchor="" signed_anchor="" candidate="" candidate_digest=""
-	local timeline_pages="" mutation_rows="" event="" actor="" subject="" actor_id="" actor_type="" actor_rc=0
-	local signed_has_status=0 saw_auto_dispatch=0 saw_status_mutation=0 saw_status_default=0
 
-	# #aidevops:trust-boundary — no embedded lifecycle proof means this is a
-	# legacy exact-snapshot approval, never continuity authority.
-	signed_lifecycle=$(jq -c '.issue.lifecycle // empty' <<<"$payload" 2>/dev/null) || return 1
-	[[ -n "$signed_lifecycle" ]] || return 1
-	if ! jq -e --arg object "$APPROVAL_JSON_OBJECT" '.locked == true and (.lock_anchor | type == $object)' <<<"$signed_lifecycle" >/dev/null 2>&1; then
-		return 1
-	fi
-	signed_anchor=$(jq -c '.lock_anchor' <<<"$signed_lifecycle") || return 1
-	if jq -e '[.labels[]?.name | select(startswith("status:"))] | length > 0' <<<"$signed_lifecycle" >/dev/null 2>&1; then
-		signed_has_status=1
-	fi
-	current_anchor=$(jq -c '.lifecycle.lock_anchor // empty' <<<"$current_snapshot") || return 1
-	[[ -n "$current_anchor" && "$current_anchor" == "$signed_anchor" ]] || return 1
-	if ! jq -e '.lifecycle.locked == true' <<<"$current_snapshot" >/dev/null 2>&1; then
-		return 1
-	fi
-
-	# Replacing only lifecycle metadata must recreate the signed digest. This
-	# proves title, body, comments, references, identity, and all scope-bearing
-	# bytes remain exactly as reviewed.
-	candidate=$(jq -cS --argjson lifecycle "$signed_lifecycle" '.lifecycle = $lifecycle' <<<"$current_snapshot") || return 1
-	candidate_digest=$(approval_snapshot_v2_digest "$candidate") || return 2
-	[[ "$candidate_digest" == "$signed_digest" ]] || return 1
 	# #aidevops:trust-boundary — deterministic tier backfill may only select a
-	# canonical workload tier. Core status labels are workflow metadata rather
-	# than development scope, so continuously locked issues may traverse the full
-	# set_issue_status state machine; timeline authorization below still binds
-	# every mutation to a write-authorized actor or the one narrow bot default.
-	if ! jq -e --argjson signed "$signed_lifecycle" '
+	# canonical workload tier. Status labels remain workflow metadata, but every
+	# resulting timeline mutation still requires authorization during replay.
+	jq -e --argjson signed "$signed_lifecycle" '
 		def allowed_label: . == "needs-maintainer-review" or . == "auto-dispatch" or . == "status:available" or . == "status:queued" or . == "status:claimed" or . == "status:in-progress" or . == "status:in-review" or . == "status:done" or . == "status:blocked" or . == "tier:simple" or . == "tier:standard" or . == "tier:thinking";
 		def tier_label: . == "tier:simple" or . == "tier:standard" or . == "tier:thinking";
 		.lifecycle as $current |
@@ -104,16 +116,57 @@ _approval_verify_locked_issue_continuity() {
 		and ([$added_labels[], $removed_labels[]] | unique | all(allowed_label))
 		and (if ($added_tiers + $removed_tiers) > 0 then $signed_tiers == 0 and $current_tiers == 1 and $added_tiers == 1 and $removed_tiers == 0 else true end)
 		and ($current.assignees != $signed.assignees or $current.labels != $signed.labels)
-	' <<<"$current_snapshot" >/dev/null 2>&1; then
+	' <<<"$current_snapshot" >/dev/null 2>&1
+	return $?
+}
+
+_approval_verify_locked_issue_continuity() {
+	local payload="$1"
+	local current_snapshot="$2"
+	local signed_digest="$3"
+	local slug="$4"
+	local target_number="$5"
+	local issued_at="$6"
+	local approval_comment_id="$7"
+	local signed_lifecycle="" current_anchor="" signed_anchor="" candidate="" candidate_digest=""
+	local timeline_pages="" mutation_rows="" event="" actor="" subject="" actor_id="" actor_type="" actor_rc=0
+	local signed_has_status=0 auto_dispatch_active=0 current_auto_dispatch=0 saw_status_mutation=0 saw_status_default=0
+
+	# #aidevops:trust-boundary — no embedded lifecycle proof means this is a
+	# legacy exact-snapshot approval, never continuity authority.
+	signed_lifecycle=$(jq -c '.issue.lifecycle // empty' <<<"$payload" 2>/dev/null) || return 1
+	[[ -n "$signed_lifecycle" ]] || return 1
+	if ! jq -e --arg object "$APPROVAL_JSON_OBJECT" '.locked == true and (.lock_anchor | type == $object)' <<<"$signed_lifecycle" >/dev/null 2>&1; then
+		return 1
+	fi
+	signed_anchor=$(jq -c '.lock_anchor' <<<"$signed_lifecycle") || return 1
+	if jq -e '[.labels[]?.name | select(startswith("status:"))] | length > 0' <<<"$signed_lifecycle" >/dev/null 2>&1; then
+		signed_has_status=1
+	fi
+	if jq -e --arg auto "$_APPROVAL_AUTO_DISPATCH_LABEL" 'any(.labels[]?.name; . == $auto)' <<<"$signed_lifecycle" >/dev/null 2>&1; then
+		auto_dispatch_active=1
+	fi
+	if jq -e --arg auto "$_APPROVAL_AUTO_DISPATCH_LABEL" 'any(.lifecycle.labels[]?.name; . == $auto)' <<<"$current_snapshot" >/dev/null 2>&1; then
+		current_auto_dispatch=1
+	fi
+	current_anchor=$(jq -c '.lifecycle.lock_anchor // empty' <<<"$current_snapshot") || return 1
+	[[ -n "$current_anchor" && "$current_anchor" == "$signed_anchor" ]] || return 1
+	if ! jq -e '.lifecycle.locked == true' <<<"$current_snapshot" >/dev/null 2>&1; then
+		return 1
+	fi
+
+	# Replacing only lifecycle metadata must recreate the signed digest. This
+	# proves title, body, comments, references, identity, and all scope-bearing
+	# bytes remain exactly as reviewed.
+	candidate=$(jq -cS --argjson lifecycle "$signed_lifecycle" '.lifecycle = $lifecycle' <<<"$current_snapshot") || return 1
+	candidate_digest=$(approval_snapshot_v2_digest "$candidate") || return 2
+	[[ "$candidate_digest" == "$signed_digest" ]] || return 1
+	if ! _approval_continuity_lifecycle_change_allowed "$signed_lifecycle" "$current_snapshot"; then
 		return 1
 	fi
 
 	timeline_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/timeline?per_page=100") || return 2
-	mutation_rows=$(jq -r --arg issued "$issued_at" '
-		[.[][]? | select((.created_at // "") > $issued) | (.event // "") as $event |
-		select(["assigned","unassigned","labeled","unlabeled","milestoned","demilestoned","closed","reopened","renamed","locked","unlocked","connected","disconnected","added_to_project","moved_columns_in_project","removed_from_project","transferred","converted_to_discussion","marked_as_duplicate","unmarked_as_duplicate","pinned","unpinned"] | index($event)) |
-		[(.event // ""), (.actor.login // ""), (.label.name // .assignee.login // ""), ((.actor.id // "") | tostring), (.actor.type // "")] | @tsv][]
-	' <<<"$timeline_pages" 2>/dev/null) || return 2
+	mutation_rows=$(_approval_continuity_ordered_mutation_rows "$timeline_pages" "$issued_at" "$approval_comment_id" 2>/dev/null) || return 2
 	[[ -n "$mutation_rows" ]] || return 1
 
 	while IFS=$'\t' read -r event actor subject actor_id actor_type; do
@@ -128,7 +181,7 @@ _approval_verify_locked_issue_continuity() {
 		# exposed auto-dispatch and no status mutation has occurred. The immutable
 		# bot ID/type prevents lookalikes; this grants no generic workflow authority.
 		if _approval_continuity_is_repository_status_default "$event" "$subject" "$actor" "$actor_id" "$actor_type"; then
-			[[ "$signed_has_status" -eq 0 && "$saw_auto_dispatch" -eq 1 && "$saw_status_mutation" -eq 0 && "$saw_status_default" -eq 0 ]] || return 1
+			[[ "$signed_has_status" -eq 0 && "$auto_dispatch_active" -eq 1 && "$saw_status_mutation" -eq 0 && "$saw_status_default" -eq 0 ]] || return 1
 			saw_status_default=1
 			saw_status_mutation=1
 			continue
@@ -139,9 +192,11 @@ _approval_verify_locked_issue_continuity() {
 			[[ "$actor_rc" -eq 2 ]] && return 2
 			return 1
 		}
-		[[ "$event:$subject" == "labeled:$_APPROVAL_AUTO_DISPATCH_LABEL" ]] && saw_auto_dispatch=1
+		[[ "$event:$subject" == "labeled:$_APPROVAL_AUTO_DISPATCH_LABEL" ]] && auto_dispatch_active=1
+		[[ "$event:$subject" == "unlabeled:$_APPROVAL_AUTO_DISPATCH_LABEL" ]] && auto_dispatch_active=0
 		[[ "$subject" == status:* ]] && saw_status_mutation=1
 	done <<<"$mutation_rows"
+	[[ "$auto_dispatch_active" -eq "$current_auto_dispatch" ]] || return 1
 	return 0
 }
 
@@ -170,7 +225,7 @@ _approval_classify_digest_mismatch() {
 		return 0
 	fi
 	if [[ "$target_type" == "$APPROVAL_TARGET_ISSUE" ]]; then
-		_approval_verify_locked_issue_continuity "$payload" "$snapshot_json" "$signed_digest" "$slug" "$target_number" "$issued_at" || continuity_rc=$?
+		_approval_verify_locked_issue_continuity "$payload" "$snapshot_json" "$signed_digest" "$slug" "$target_number" "$issued_at" "$comment_id" || continuity_rc=$?
 		if [[ "$continuity_rc" -eq 0 ]]; then
 			printf 'APPROVAL_REASON: proven-locked-continuity\n' >&2
 			printf 'VERIFIED\n'

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -117,6 +117,7 @@ append_signed_comment() {
 	local comment_id="${4:-$((number * 100 + 99))}"
 	local source_timestamp_profile="${5:-stable}"
 	local comments_file="${FIXTURES}/comments-${number}.json"
+	local timeline_file="${FIXTURES}/timeline-${number}.json"
 	local payload="" signature_file="" signature="" body="" updated=""
 	payload=$(PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_payload "$kind" "$number" owner/repo "$issued_at" "" "$source_timestamp_profile") || return 1
 	signature_file="${TEST_ROOT}/signature-${number}.txt"
@@ -129,10 +130,14 @@ ${payload}
 \`\`\`
 ${signature}
 \`\`\`"
-	updated=$(jq -c --arg body "$body" --argjson id "$comment_id" '
-		.[0] += [{id:$id,node_id:("APPROVAL_" + ($id|tostring)),user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:05:00Z",updated_at:"2026-01-01T00:05:00Z",body:$body}]
+	updated=$(jq -c --arg body "$body" --arg created_at "$issued_at" --argjson id "$comment_id" '
+		.[0] += [{id:$id,node_id:("APPROVAL_" + ($id|tostring)),user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:$created_at,updated_at:$created_at,body:$body}]
 	' "$comments_file") || return 1
 	printf '%s\n' "$updated" >"$comments_file"
+	updated=$(jq -c --arg created_at "$issued_at" --argjson id "$comment_id" '
+		.[0] += [{id:$id,node_id:("APPROVAL_" + ($id|tostring)),event:"commented",created_at:$created_at,actor:{id:1,node_id:"U_1",login:"maintainer",type:"User"}}]
+	' "$timeline_file") || return 1
+	printf '%s\n' "$updated" >"$timeline_file"
 	printf '%s\n' "$payload" >"${TEST_ROOT}/payload-${number}.json"
 	return 0
 }
@@ -631,6 +636,32 @@ test_locked_issue_tier_backfill_continuity() {
 	return 0
 }
 
+test_locked_issue_stable_ordering() {
+	write_locked_issue_fixture
+	jq '.assignees = [{id:1,node_id:"U_1",login:"maintainer",type:"User"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":4200,"node_id":"EV_4200","event":"assigned","created_at":"2026-01-01T00:05:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"assignee":{"id":1,"login":"maintainer","type":"User"}}'
+	assert_verify "equal-timestamp authorized mutation after the approval anchor verifies" issue 41 VERIFIED 0
+
+	# Pre-fix, the timestamp-only cutoff omitted the unauthorized same-second
+	# assignment and the later trusted status event incorrectly yielded VERIFIED.
+	write_locked_issue_fixture
+	jq '.assignees = [{id:2,node_id:"U_2",login:"contributor",type:"User"}] | .labels += [{id:10,node_id:"L_10",name:"status:in-progress"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":4200,"node_id":"EV_4200","event":"assigned","created_at":"2026-01-01T00:05:00Z","actor":{"id":2,"login":"contributor","type":"User"},"assignee":{"id":2,"login":"contributor","type":"User"}}'
+	append_issue_timeline_event '{"id":4201,"node_id":"EV_4201","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"status:in-progress"}}'
+	assert_verify "unauthorized same-second mutation after the approval anchor is stale" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture
+	jq '.labels += [{id:10,node_id:"L_10",name:"status:in-progress"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"node_id":"EV_MISSING_ID","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"status:in-progress"}}'
+	assert_verify "missing lifecycle event ID fails closed as API uncertainty" issue 41 API_ERROR 6
+
+	write_locked_issue_fixture
+	jq '.labels += [{id:10,node_id:"L_10",name:"status:in-progress"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":4202,"node_id":"EV_4202","event":"labeled","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"status:in-progress"}}'
+	assert_verify "missing lifecycle event timestamp fails closed as API uncertainty" issue 41 API_ERROR 6
+	return 0
+}
+
 test_locked_issue_continuity() {
 	# Production regression from the first #30153 signature: approval-helper
 	# performed the trusted handoff, then the narrowly scoped repository workflow
@@ -643,10 +674,11 @@ test_locked_issue_continuity() {
 	append_issue_timeline_event '{"id":429,"node_id":"EV_429","event":"labeled","created_at":"2026-01-01T00:06:03Z","actor":{"id":41898282,"login":"github-actions[bot]","type":"Bot"},"label":{"name":"status:available"}}'
 	assert_verify "exact repository default-status automation preserves first locked issue approval" issue 41 VERIFIED 0
 
-	# GitHub documents timeline responses in chronological order; keep that API
-	# contract executable because continuity authorization is sequence-sensitive.
+	# Pagination or API transport order is not authority. Stable keys recover one
+	# deterministic replay stream before sequence-sensitive authorization.
 	jq '.[0] |= reverse' "${FIXTURES}/timeline-41.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-41.json"
-	assert_verify "out-of-order timeline data fails sequence-sensitive continuity" issue 41 STALE_APPROVAL 4
+	assert_verify "out-of-order timeline data is normalized by stable ordering" issue 41 VERIFIED 0
+	test_locked_issue_stable_ordering
 
 	write_locked_issue_fixture
 	jq '.labels += [{id:11,node_id:"L_11",name:"status:available"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
@@ -659,6 +691,13 @@ test_locked_issue_continuity() {
 	append_issue_timeline_event '{"id":4293,"node_id":"EV_4293","event":"labeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"status:queued"}}'
 	append_issue_timeline_event '{"id":4294,"node_id":"EV_4294","event":"labeled","created_at":"2026-01-01T00:06:02Z","actor":{"id":41898282,"login":"github-actions[bot]","type":"Bot"},"label":{"name":"status:available"}}'
 	assert_verify "official Actions default after another status mutation fails closed" issue 41 STALE_APPROVAL 4
+
+	write_locked_issue_fixture
+	jq '.labels += [{id:11,node_id:"L_11",name:"status:available"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	append_issue_timeline_event '{"id":4295,"node_id":"EV_4295","event":"labeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"auto-dispatch"}}'
+	append_issue_timeline_event '{"id":4296,"node_id":"EV_4296","event":"unlabeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"auto-dispatch"}}'
+	append_issue_timeline_event '{"id":4297,"node_id":"EV_4297","event":"labeled","created_at":"2026-01-01T00:06:02Z","actor":{"id":41898282,"login":"github-actions[bot]","type":"Bot"},"label":{"name":"status:available"}}'
+	assert_verify "official Actions default after auto-dispatch removal fails closed" issue 41 STALE_APPROVAL 4
 
 	write_locked_issue_fixture
 	jq '.labels += [{id:11,node_id:"L_11",name:"status:available"}]' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"


### PR DESCRIPTION
## Summary

Bind locked-issue approval replay to the signed approval comment's stable timeline identity, normalize paginated events by canonical timestamp and numeric ID, and track the live auto-dispatch state through label removal.

## Files Changed

.agents/scripts/approval-helper-continuity.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified the worktree approval helper against locked issue #30766; 74 approval content-binding cases pass; approval verify-state passes; Bash syntax, ShellCheck, complexity regression, and changed-file lint gates pass.

Resolves #30766


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 53m and 178,865 tokens on this with the user in an interactive session.