### PR TITLE
GH#30775: bound worktree recovery planning

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -107,7 +107,10 @@ zero because that aggregate report grants no deletion authority. On non-macOS sy
 legacy `$HOME/.Trash/aidevops-worktree-cleanup-*` buckets. Framework-owned
 default roots remain distinct from joint OS Trash or operator-selected roots.
 Incomplete, symlinked, unrecognised, or unsized buckets are `unknown`; inventory
-never migrates, rewrites, or deletes them.
+never migrates, rewrites, or deletes them. Entry-local sizing failures are
+reported in `sizing_error` and do not become structural `error` failures. The
+aggregate byte totals remain unavailable when any entry is unsized, while
+independently exact entries retain their own evidence.
 
 Run `worktree-helper.sh recovery plan --output <absolute-path>` to persist a
 versioned `aidevops.worktree-recovery-plan/v2` JSON review artifact. The output
@@ -117,11 +120,25 @@ publishes it atomically without replacing an existing path. Plan generation is
 read-only for every recovery root and archive; it never moves, rewrites, or
 deletes a bucket.
 
+Manual planning classifies at most 100 entries per invocation by default. It
+first inventories archive structure without running an exact size probe for
+every bucket, then performs the full evidence and one final exact-size check
+only for the selected window. Use `--max-classify <1-1000>` to tune that bound
+and `--offset <non-negative-integer>` to continue from a prior plan's
+`next_classification_offset`. A 120-second between-entry deadline bounds each
+pass further; tune it with `--deadline-seconds <1-3600>`. Entries outside the
+window or beyond the deadline remain visible as `unknown` with
+`classification-deferred` or `classification-deadline-exhausted`; they gain no
+deletion authority. The plan records classification completeness,
+classified/deferred counts, deadline state, and both cursor offsets. Repeated
+bounded plans can therefore inspect or reclaim independent windows without an
+unbounded pass or an authoritative size cache.
+
 The envelope records its producer, generation time, deterministic plan ID,
 inventory completeness/error state, source roots, reconciled entry/byte totals,
 and ordered `candidate`, `protected`, and `unknown` entries. An incomplete global
-inventory produces no candidates; a partial report downgrades its reported
-entries to unknown. Each attributable entry binds the exact physical bucket and
+inventory produces no candidates; an entry-local sizing failure downgrades only
+that entry. Each attributable entry binds the exact physical bucket and
 archive paths to its format, Git HEAD/branch, source/admin/common identity,
 archive index and completion-marker digests, expected allocated bytes, observed
 local/remote evidence, disposition, and reason codes. Unchanged evidence yields
@@ -214,8 +231,13 @@ owner-validated lock and records a policy-bound `automatic-sha256:` authority in
 its plan, journal, and receipt; it never synthesizes the manual confirmation
 token. Pending transactions under the maintenance state directory resume before
 new inventory is scanned, while completed plans and receipts remain available
-for audit. A maintenance failure leaves the affected archive intact and does not
-turn a successful broader cleanup cycle into a failure.
+for audit. Each run result includes bounded diagnostics outside the signed v1
+automatic-policy object: inventory/scanned counts, cursor movement, pass
+coverage, and fixed-cardinality reason counts for unknown and protected entries.
+This makes repeated `no-candidates` outcomes distinguishable without changing
+the destructive authority key set. A maintenance failure leaves the affected
+archive intact and does not turn a successful broader cleanup cycle into a
+failure.
 
 An originating OpenCode or Claude session identifier is recovery guidance, not
 deletion proof. Session history can reconstruct text edits and intent but may be

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -409,6 +409,126 @@ test_global_inventory_failure_is_explicit() {
 	return 0
 }
 
+test_entry_sizing_failure_is_localized() {
+	local plan=""
+	local rc=0
+
+	plan=$(
+		worktree_recovery_lifecycle_json() {
+			printf '%s\n' '{"error":null,"sizing_error":"sizing-timeout","buckets":[
+			{"role":"current","state":"attributed","path":"/recovery/exact","bytes":1024,"sizing_confidence":"exact"},
+			{"role":"current","state":"attributed","path":"/recovery/slow","bytes":null,"sizing_confidence":"unavailable"}]}'
+			return 0
+		}
+		_worktree_recovery_plan_attributed_entry_json() {
+			local role="$1"
+			local bucket_path="$2"
+			local ignored_bytes="$3"
+			local bytes=1024
+			: "$ignored_bytes"
+			if [[ "$bucket_path" == "/recovery/slow" ]]; then
+				_worktree_recovery_plan_unknown_entry_json \
+					"$role" "$bucket_path" null "sizing-unavailable"
+				return $?
+			fi
+			jq -cn --arg role "$role" --arg path "$bucket_path" --argjson bytes "$bytes" \
+				'{role:$role,path:$path,archive_path:($path + "/archive"),expected_allocated_bytes:$bytes,
+				identity:{identity_digest:"sha256:fixture"},evidence:{},disposition:"candidate",
+				reasons:["all-required-evidence-clear"]}'
+			return $?
+		}
+		worktree_recovery_plan_json "Linux"
+	) || rc=1
+	printf '%s\n' "$plan" | jq -e '
+		.inventory_complete == true and .inventory_error == null and
+		.classification_complete == true and .classified_entry_count == 2 and
+		.candidate_count == 1 and .unknown_count == 1 and
+		([.entries[] | select(.path == "/recovery/slow")][0].reasons == ["sizing-unavailable"])
+	' >/dev/null || rc=1
+	print_result "entry_sizing_failure_is_localized" "$rc" \
+		"Expected one slow size probe to remain unknown without blocking an exact peer candidate"
+	return 0
+}
+
+test_manual_plan_classification_is_bounded_and_resumable() {
+	local first_output="${TEST_DIR}/bounded-plan-first.json"
+	local second_output="${TEST_DIR}/bounded-plan-second.json"
+	local rc=0
+
+	(
+		worktree_recovery_lifecycle_json() {
+			printf '%s\n' '{"error":null,"sizing_error":null,"buckets":[
+			{"role":"current","state":"unknown","path":"/recovery/bucket-0","bytes":null,"sizing_confidence":"unavailable"},
+			{"role":"current","state":"unknown","path":"/recovery/bucket-1","bytes":null,"sizing_confidence":"unavailable"},
+			{"role":"current","state":"unknown","path":"/recovery/bucket-2","bytes":null,"sizing_confidence":"unavailable"},
+			{"role":"current","state":"unknown","path":"/recovery/bucket-3","bytes":null,"sizing_confidence":"unavailable"},
+			{"role":"current","state":"unknown","path":"/recovery/bucket-4","bytes":null,"sizing_confidence":"unavailable"}]}'
+			return 0
+		}
+		cmd_recovery plan --max-classify 2 --offset 0 --output "$first_output" >/dev/null || return 1
+		cmd_recovery plan --output "$second_output" --offset 2 --max-classify 2 >/dev/null || return 1
+	) || rc=1
+	jq -e '
+		.classification_complete == false and .classified_entry_count == 2 and
+		.deferred_entry_count == 3 and .classification_offset == 0 and
+		.next_classification_offset == 2 and
+		([.entries[] | select(.reasons == ["classification-deferred"]) | .path] ==
+		 ["/recovery/bucket-2","/recovery/bucket-3","/recovery/bucket-4"])
+	' "$first_output" >/dev/null || rc=1
+	jq -e '
+		.classification_complete == false and .classified_entry_count == 2 and
+		.deferred_entry_count == 3 and .classification_offset == 2 and
+		.next_classification_offset == 4 and
+		([.entries[] | select(.reasons == ["classification-deferred"]) | .path] ==
+		 ["/recovery/bucket-0","/recovery/bucket-1","/recovery/bucket-4"])
+	' "$second_output" >/dev/null || rc=1
+	[[ "$(jq -r '.plan_id' "$first_output")" != "$(jq -r '.plan_id' "$second_output")" ]] || rc=1
+	print_result "manual_plan_classification_is_bounded_and_resumable" "$rc" \
+		"Expected bounded plan windows to expose a deterministic continuation offset"
+	return 0
+}
+
+test_manual_plan_deadline_emits_continuation() {
+	local output_path="${TEST_DIR}/deadline-plan.json"
+	local clock_path="${TEST_DIR}/deadline-clock"
+	local rc=0
+
+	printf '0\n' >"$clock_path" || rc=1
+	(
+		worktree_recovery_lifecycle_json() {
+			printf '%s\n' '{"error":null,"sizing_error":null,"buckets":[
+			{"role":"current","state":"unknown","path":"/recovery/deadline-0","bytes":null,"sizing_confidence":"unavailable"},
+			{"role":"current","state":"unknown","path":"/recovery/deadline-1","bytes":null,"sizing_confidence":"unavailable"},
+			{"role":"current","state":"unknown","path":"/recovery/deadline-2","bytes":null,"sizing_confidence":"unavailable"}]}'
+			return 0
+		}
+		date() {
+			local call_count=0
+			if [[ "${1:-}" == "+%s" ]]; then
+				IFS= read -r call_count <"$clock_path" || return 1
+				call_count=$((call_count + 1))
+				printf '%s\n' "$call_count" >"$clock_path" || return 1
+				if [[ "$call_count" -le 2 ]]; then printf '100\n'; else printf '102\n'; fi
+				return 0
+			fi
+			command date "$@"
+			return $?
+		}
+		cmd_recovery plan --output "$output_path" --max-classify 3 \
+			--deadline-seconds 1 >/dev/null || return 1
+	) || rc=1
+	jq -e '
+		.classification_complete == false and .classified_entry_count == 1 and
+		.deferred_entry_count == 2 and .classification_deadline_seconds == 1 and
+		.classification_deadline_exhausted == true and .next_classification_offset == 1 and
+		([.entries[] | select(.reasons == ["classification-deadline-exhausted"]) | .path] ==
+		 ["/recovery/deadline-1","/recovery/deadline-2"])
+	' "$output_path" >/dev/null || rc=1
+	print_result "manual_plan_deadline_emits_continuation" "$rc" \
+		"Expected deadline exhaustion to stop new classification and preserve a continuation offset"
+	return 0
+}
+
 test_apply_removes_only_candidates_and_replays_receipt() {
 	local home_path="${TEST_DIR}/apply-home"
 	local repo_path="${TEST_DIR}/apply-repo"
@@ -902,6 +1022,12 @@ test_automatic_maintenance_is_bounded_and_policy_bound() {
 	) || rc=1
 	[[ "$(printf '%s\n' "$output" | jq -r '.outcome')" == "removed" ]] || rc=1
 	[[ "$(printf '%s\n' "$output" | jq -r '.removed')" == "1" ]] || rc=1
+	printf '%s\n' "$output" | jq -e '
+		.diagnostics.inventory_count == 3 and .diagnostics.scanned_count == 3 and
+		.diagnostics.coverage_complete == true and .diagnostics.coverage_percent == 100 and
+		.diagnostics.reason_counts.protected_evidence == 1 and
+		.diagnostics.reason_counts.protected_limit == 1
+	' >/dev/null || rc=1
 	[[ -d "$protected_bucket" ]] || rc=1
 	[[ -d "$bucket_a" ]] && removed_count=$((removed_count + 0)) || removed_count=$((removed_count + 1))
 	[[ -d "$bucket_b" ]] && removed_count=$((removed_count + 0)) || removed_count=$((removed_count + 1))
@@ -1075,6 +1201,12 @@ test_automatic_maintenance_preserves_bucket_when_exact_size_is_unavailable() {
 	) || rc=1
 	[[ "$(printf '%s\n' "$output" | jq -r '.outcome')" == "no-candidates" ]] || rc=1
 	[[ "$(printf '%s\n' "$output" | jq -r '.policy.unknown_count')" == "1" ]] || rc=1
+	printf '%s\n' "$output" | jq -e '
+		.diagnostics.inventory_count == 1 and .diagnostics.scanned_count == 1 and
+		.diagnostics.cursor_before == 0 and .diagnostics.cursor_after == 0 and
+		.diagnostics.coverage_complete == true and
+		.diagnostics.reason_counts.unknown_sizing == 1
+	' >/dev/null || rc=1
 	[[ -d "$bucket_path" ]] || rc=1
 	print_result "automatic_maintenance_preserves_bucket_when_exact_size_is_unavailable" "$rc" \
 		"Expected per-bucket sizing uncertainty to remain non-destructive"
@@ -1252,6 +1384,9 @@ test_classification_fails_closed
 test_plan_records_malformed_bucket_unknown
 test_size_drift_downgrades_only_entry
 test_global_inventory_failure_is_explicit
+test_entry_sizing_failure_is_localized
+test_manual_plan_classification_is_bounded_and_resumable
+test_manual_plan_deadline_emits_continuation
 test_apply_removes_only_candidates_and_replays_receipt
 test_apply_rejects_unsafe_manifest_and_cli_inputs
 test_apply_preflight_drift_stages_nothing

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -771,20 +771,102 @@ EOF
 	return 0
 }
 
-cmd_recovery() {
-	local action="${1:-status}"
+_cmd_recovery_plan() {
 	local output_path=""
+	local max_classify="${AIDEVOPS_WORKTREE_RECOVERY_PLAN_MAX_CLASSIFY:-100}"
+	local classification_offset="${AIDEVOPS_WORKTREE_RECOVERY_PLAN_OFFSET:-0}"
+	local deadline_seconds="${AIDEVOPS_WORKTREE_RECOVERY_PLAN_DEADLINE_SECONDS:-120}"
+	local max_classify_set=0
+	local classification_offset_set=0
+	local deadline_seconds_set=0
+	local option=""
+
+	while [[ "$#" -gt 0 ]]; do
+		option="$1"
+		shift
+		[[ "$#" -gt 0 ]] || return 1
+		case "$option" in
+		--output)
+			[[ -z "$output_path" ]] || return 1
+			output_path="$1"
+			;;
+		--max-classify)
+			[[ "$max_classify_set" -eq 0 ]] || return 1
+			max_classify="$1"
+			max_classify_set=1
+			;;
+		--offset)
+			[[ "$classification_offset_set" -eq 0 ]] || return 1
+			classification_offset="$1"
+			classification_offset_set=1
+			;;
+		--deadline-seconds)
+			[[ "$deadline_seconds_set" -eq 0 ]] || return 1
+			deadline_seconds="$1"
+			deadline_seconds_set=1
+			;;
+		*) return 1 ;;
+		esac
+		shift
+	done
+	[[ -n "$output_path" && "$max_classify" =~ ^[0-9]+$ &&
+		"${#max_classify}" -le 4 && "$max_classify" -ge 1 && "$max_classify" -le 1000 &&
+		"$classification_offset" =~ ^[0-9]+$ && "${#classification_offset}" -le 10 &&
+		"$deadline_seconds" =~ ^[0-9]+$ && "${#deadline_seconds}" -le 4 &&
+		"$deadline_seconds" -ge 1 && "$deadline_seconds" -le 3600 ]] || {
+		printf '%s\n' "Usage: worktree-helper.sh recovery plan --output <absolute-path> [--max-classify <1-1000>] [--offset <non-negative-integer>] [--deadline-seconds <1-3600>]" >&2
+		return 1
+	}
+	declare -F worktree_recovery_plan_write >/dev/null 2>&1 || return 1
+	AIDEVOPS_WORKTREE_RECOVERY_PLAN_MAX_CLASSIFY="$max_classify" \
+		AIDEVOPS_WORKTREE_RECOVERY_PLAN_OFFSET="$classification_offset" \
+		AIDEVOPS_WORKTREE_RECOVERY_PLAN_DEADLINE_SECONDS="$deadline_seconds" \
+		worktree_recovery_plan_write "$output_path" || return 1
+	return 0
+}
+
+_cmd_recovery_apply() {
 	local plan_path=""
 	local receipt_path=""
 	local confirmation=""
 	local option=""
 
+	while [[ "$#" -gt 0 ]]; do
+		option="$1"
+		shift
+		[[ "$#" -gt 0 ]] || return 1
+		case "$option" in
+		--plan)
+			[[ -z "$plan_path" ]] || return 1
+			plan_path="$1"
+			;;
+		--receipt)
+			[[ -z "$receipt_path" ]] || return 1
+			receipt_path="$1"
+			;;
+		--confirm)
+			[[ -z "$confirmation" ]] || return 1
+			confirmation="$1"
+			;;
+		*) return 1 ;;
+		esac
+		shift
+	done
+	[[ -n "$plan_path" && -n "$receipt_path" && -n "$confirmation" ]] || {
+		printf '%s\n' "Usage: worktree-helper.sh recovery apply --plan <absolute-path> --receipt <absolute-new-path> --confirm <manifest-token>" >&2
+		return 1
+	}
+	declare -F worktree_recovery_apply >/dev/null 2>&1 || return 1
+	worktree_recovery_apply "$plan_path" "$receipt_path" "$confirmation" || return 1
+	return 0
+}
+
+cmd_recovery() {
+	local action="${1:-status}"
+
 	case "$action" in
 	status)
-		[[ "$#" -eq 0 || ("$#" -eq 1 && "$1" == "status") ]] || {
-			printf '%s\n' "Usage: worktree-helper.sh recovery [plan --output <absolute-path>|apply --plan <absolute-path> --receipt <absolute-new-path> --confirm <manifest-token>]" >&2
-			return 1
-		}
+		[[ "$#" -eq 0 || ("$#" -eq 1 && "$1" == "status") ]] || return 1
 		if declare -F worktree_recovery_lifecycle_status >/dev/null 2>&1; then
 			worktree_recovery_lifecycle_status || return 1
 		else
@@ -792,48 +874,14 @@ cmd_recovery() {
 		fi
 		;;
 	plan)
-		[[ "$#" -eq 3 && "$2" == "--output" ]] || {
-			printf '%s\n' "Usage: worktree-helper.sh recovery plan --output <absolute-path>" >&2
-			return 1
-		}
-		output_path="$3"
-		declare -F worktree_recovery_plan_write >/dev/null 2>&1 || return 1
-		worktree_recovery_plan_write "$output_path" || return 1
+		shift
+		_cmd_recovery_plan "$@" || return 1
 		;;
 	apply)
 		shift
-		while [[ "$#" -gt 0 ]]; do
-			option="$1"
-			shift
-			[[ "$#" -gt 0 ]] || return 1
-			case "$option" in
-			--plan)
-				[[ -z "$plan_path" ]] || return 1
-				plan_path="$1"
-				;;
-			--receipt)
-				[[ -z "$receipt_path" ]] || return 1
-				receipt_path="$1"
-				;;
-			--confirm)
-				[[ -z "$confirmation" ]] || return 1
-				confirmation="$1"
-				;;
-			*) return 1 ;;
-			esac
-			shift
-		done
-		[[ -n "$plan_path" && -n "$receipt_path" && -n "$confirmation" ]] || {
-			printf '%s\n' "Usage: worktree-helper.sh recovery apply --plan <absolute-path> --receipt <absolute-new-path> --confirm <manifest-token>" >&2
-			return 1
-		}
-		declare -F worktree_recovery_apply >/dev/null 2>&1 || return 1
-		worktree_recovery_apply "$plan_path" "$receipt_path" "$confirmation" || return 1
+		_cmd_recovery_apply "$@" || return 1
 		;;
-	*)
-		printf '%s\n' "Usage: worktree-helper.sh recovery [plan --output <absolute-path>|apply --plan <absolute-path> --receipt <absolute-new-path> --confirm <manifest-token>]" >&2
-		return 1
-		;;
+	*) return 1 ;;
 	esac
 	return 0
 }

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -43,7 +43,16 @@ _worktree_recovery_apply_plan_material_json() {
 	printf '%s\n' "$plan_json" | jq -c \
 		--arg object_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_OBJECT" '
 		{schema:.schema,inventory_complete:.inventory_complete,
-		inventory_error:.inventory_error,entries:.entries} +
+		inventory_error:.inventory_error} +
+		(if has("classification_complete")
+		then {classification_complete:.classification_complete,
+			classified_entry_count:.classified_entry_count,
+			deferred_entry_count:.deferred_entry_count,
+			classification_offset:.classification_offset,
+			next_classification_offset:.next_classification_offset,
+			classification_deadline_seconds:.classification_deadline_seconds,
+			classification_deadline_exhausted:.classification_deadline_exhausted}
+		else {} end) + {entries:.entries} +
 		(if (.automatic_policy | type) == $object_type
 		then {automatic_policy:.automatic_policy} else {} end)'
 	return $?

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -131,15 +131,20 @@ _worktree_recovery_encode_report() {
 	local total_bytes="$9"
 	local protected_bytes="${10}"
 	local unknown_bytes="${11}"
+	local sizing_error="${12:-}"
+	local sizing_complete="${13:-true}"
 	local confidence="$WORKTREE_RECOVERY_UNAVAILABLE"
 
-	[[ -n "$report_error" ]] || confidence="$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT"
+	[[ -n "$report_error" || -n "$sizing_error" || "$sizing_complete" != "true" ]] ||
+		confidence="$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT"
 	jq -sc \
 		--arg schema "$WORKTREE_RECOVERY_INVENTORY_SCHEMA" \
 		--arg producer "$WORKTREE_RECOVERY_PRODUCER" \
 		--arg path "$display_path" \
 		--arg owner "$report_owner" \
 		--arg error "$report_error" \
+		--arg sizing_error "$sizing_error" \
+		--argjson sizing_complete "$sizing_complete" \
 		--arg confidence "$confidence" \
 		--argjson root_count "$root_count" \
 		--argjson bucket_count "$bucket_count" \
@@ -148,31 +153,64 @@ _worktree_recovery_encode_report() {
 		--argjson total_bytes "$total_bytes" \
 		--argjson protected_bytes "$protected_bytes" \
 		--argjson unknown_bytes "$unknown_bytes" \
-		'{schema:$schema,store_id:"worktree-recovery",producer:$producer,path:$path,owner:$owner,safety_class:"recovery",policy:"aggregate inventory grants no deletion authority; exact manual and automatic plans are separate",total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:0,unknown_bytes:$unknown_bytes,protection_reasons:["aggregate reporting conservatively protects attributable archives; incomplete, malformed, symlinked, or unrecognised archives remain unknown"],sizing_confidence:$confidence,next_action:"Use worktree-helper.sh recovery for bucket details; bounded maintenance independently revalidates exact terminal candidates",error:(if $error == "" then null else $error end),root_count:$root_count,bucket_count:$bucket_count,protected_count:$protected_count,reclaimable_count:0,unknown_count:$unknown_count,archive_formats:["aidevops-worktree-recovery-v1","aidevops-worktree-recovery-v2"],buckets:.}' \
+		'{schema:$schema,store_id:"worktree-recovery",producer:$producer,path:$path,owner:$owner,safety_class:"recovery",policy:"aggregate inventory grants no deletion authority; exact manual and automatic plans are separate",total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:0,unknown_bytes:$unknown_bytes,protection_reasons:["aggregate reporting conservatively protects attributable archives; incomplete, malformed, symlinked, or unrecognised archives remain unknown"],sizing_confidence:$confidence,sizing_complete:$sizing_complete,next_action:"Use worktree-helper.sh recovery for bucket details; bounded maintenance independently revalidates exact terminal candidates",error:(if $error == "" then null else $error end),sizing_error:(if $sizing_error == "" then null else $sizing_error end),root_count:$root_count,bucket_count:$bucket_count,protected_count:$protected_count,reclaimable_count:0,unknown_count:$unknown_count,archive_formats:["aidevops-worktree-recovery-v1","aidevops-worktree-recovery-v2"],buckets:.}' \
 		"$entries_file"
 	return $?
+}
+
+_worktree_recovery_encode_bucket() {
+	local role="$1"
+	local state="$2"
+	local path="$3"
+	local confidence="$4"
+	local error="$5"
+	local bytes="$6"
+
+	jq -cn --arg role "$role" --arg state "$state" --arg path "$path" \
+		--arg confidence "$confidence" --arg error "$error" --argjson bytes "$bytes" \
+		'{role:$role,state:$state,path:$path,bytes:$bytes,sizing_confidence:$confidence,error:(if $error == "" then null else $error end)}'
+	return $?
+}
+
+_worktree_recovery_finalize_report() {
+	local entries_file="$1"
+	local display_path="$2"
+	local report_owner="$3"
+	local report_error="$4"
+	local report_sizing_error="$5"
+	local sizing_complete="$6"
+	local root_count="$7"
+	local bucket_count="$8"
+	local protected_count="$9"
+	local unknown_count="${10}"
+	local total_bytes="${11}"
+	local protected_bytes="${12}"
+	local unknown_bytes="${13}"
+	local jq_status=0
+
+	if [[ -n "$report_error" || -n "$report_sizing_error" || "$sizing_complete" != "true" ]]; then
+		total_bytes=null
+		protected_bytes=null
+		unknown_bytes=null
+	fi
+	_worktree_recovery_encode_report "$entries_file" "$display_path" "$report_owner" "$report_error" \
+		"$root_count" "$bucket_count" "$protected_count" "$unknown_count" \
+		"$total_bytes" "$protected_bytes" "$unknown_bytes" "$report_sizing_error" "$sizing_complete"
+	jq_status=$?
+	rm -f "$entries_file"
+	return "$jq_status"
 }
 
 worktree_recovery_lifecycle_json() {
 	local platform="${1:-}"
 	local display_path="" inventory="" entries_file="" raw_record=""
 	local record_type="" store_role="" owner="" state="" path=""
-	local extra_one=""
-	local extra_two=""
-	local measured=""
-	local bytes=""
-	local confidence=""
-	local measure_error=""
-	local report_owner="framework"
-	local report_error=""
-	local root_count=0
-	local bucket_count=0
-	local protected_count=0
-	local unknown_count=0
-	local protected_bytes=0
-	local unknown_bytes=0
-	local total_bytes=0
-	local jq_status=0
+	local extra_one="" extra_two="" measured="" bytes="" confidence="" measure_error=""
+	local report_owner="framework" report_error="" report_sizing_error=""
+	local plan_inventory_mode="${AIDEVOPS_WORKTREE_RECOVERY_PLAN_INVENTORY:-0}"
+	local sizing_complete=true
+	local root_count=0 bucket_count=0 protected_count=0 unknown_count=0
+	local protected_bytes=0 unknown_bytes=0 total_bytes=0
 
 	if [[ -z "$platform" ]]; then
 		platform=$(uname -s 2>/dev/null) || platform="$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN"
@@ -214,10 +252,17 @@ worktree_recovery_lifecycle_json() {
 		bucket)
 			IFS=$'\t' read -r record_type store_role owner state path <<<"$raw_record"
 			bucket_count=$((bucket_count + 1))
-			measured=$(_worktree_recovery_measure_path "$path")
+			if [[ "$plan_inventory_mode" == "1" ]]; then
+				measured="null|deferred|"
+				sizing_complete=false
+			else
+				measured=$(_worktree_recovery_measure_path "$path")
+			fi
 			IFS='|' read -r bytes confidence measure_error <<<"$measured"
 			if [[ "$bytes" == "$WORKTREE_RECOVERY_PLAN_JSON_NULL" ]]; then
-				report_error="${measure_error:-sizing-unavailable}"
+				if [[ "$confidence" != "deferred" ]]; then
+					report_sizing_error="${measure_error:-sizing-unavailable}"
+				fi
 				unknown_count=$((unknown_count + 1))
 			else
 				total_bytes=$((total_bytes + bytes))
@@ -232,26 +277,19 @@ worktree_recovery_lifecycle_json() {
 					;;
 				esac
 			fi
-			jq -cn --arg role "$store_role" --arg state "$state" --arg path "$path" \
-				--arg confidence "$confidence" --arg error "$measure_error" --argjson bytes "$bytes" \
-				'{role:$role,state:$state,path:$path,bytes:$bytes,sizing_confidence:$confidence,error:(if $error == "" then null else $error end)}' \
-				>>"$entries_file" || report_error="entry-encoding-failed"
+			_worktree_recovery_encode_bucket "$store_role" "$state" "$path" \
+				"$confidence" "$measure_error" "$bytes" >>"$entries_file" ||
+				report_error="entry-encoding-failed"
 			;;
 		'') ;;
 		*) report_error="$WORKTREE_RECOVERY_INVALID_RECORD" ;;
 		esac
 	done <<<"$inventory"
-	if [[ -n "$report_error" ]]; then
-		total_bytes=null
-		protected_bytes=null
-		unknown_bytes=null
-	fi
-	_worktree_recovery_encode_report "$entries_file" "$display_path" "$report_owner" "$report_error" \
-		"$root_count" "$bucket_count" "$protected_count" "$unknown_count" \
-		"$total_bytes" "$protected_bytes" "$unknown_bytes"
-	jq_status=$?
-	rm -f "$entries_file"
-	return "$jq_status"
+	_worktree_recovery_finalize_report "$entries_file" "$display_path" "$report_owner" \
+		"$report_error" "$report_sizing_error" "$sizing_complete" "$root_count" \
+		"$bucket_count" "$protected_count" "$unknown_count" "$total_bytes" \
+		"$protected_bytes" "$unknown_bytes"
+	return $?
 }
 
 _worktree_recovery_format_bytes() {
@@ -753,9 +791,16 @@ _worktree_recovery_plan_attributed_entry_json() {
 	identity_after=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
 	measured_after=$(_worktree_recovery_measure_path "$bucket_path") || return 1
 	IFS='|' read -r bytes_after confidence_after measure_error_after <<<"$measured_after"
-	if [[ "$identity_before" == "$identity_after" &&
-		"$confidence_after" == "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" &&
-		"$bytes_after" == "$expected_bytes" ]]; then
+	if [[ "$confidence_after" != "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" ||
+		! "$bytes_after" =~ ^[0-9]+$ ]]; then
+		_worktree_recovery_plan_unknown_entry_json \
+			"$role" "$bucket_path" "$WORKTREE_RECOVERY_PLAN_JSON_NULL" "sizing-unavailable"
+		return $?
+	fi
+	if [[ "$expected_bytes" == "$WORKTREE_RECOVERY_PLAN_JSON_NULL" ]]; then
+		expected_bytes="$bytes_after"
+	fi
+	if [[ "$identity_before" == "$identity_after" && "$bytes_after" == "$expected_bytes" ]]; then
 		stable=true
 	fi
 	classification_json=$(_worktree_recovery_plan_classification_json \
@@ -779,14 +824,46 @@ _worktree_recovery_plan_unknown_entry_json() {
 	return $?
 }
 
+_worktree_recovery_plan_window() {
+	local row_count="$1"
+	local classification_limit="${AIDEVOPS_WORKTREE_RECOVERY_PLAN_MAX_CLASSIFY:-100}"
+	local classification_offset="${AIDEVOPS_WORKTREE_RECOVERY_PLAN_OFFSET:-0}"
+	local classification_deadline_seconds="${AIDEVOPS_WORKTREE_RECOVERY_PLAN_DEADLINE_SECONDS:-120}"
+
+	case "$classification_limit" in
+	'' | *[!0-9]*) classification_limit=100 ;;
+	esac
+	[[ "${#classification_limit}" -le 4 ]] || classification_limit=100
+	[[ "$classification_limit" -ge 1 ]] || classification_limit=1
+	[[ "$classification_limit" -le 1000 ]] || classification_limit=1000
+	case "$classification_offset" in
+	'' | *[!0-9]*) classification_offset=0 ;;
+	esac
+	[[ "${#classification_offset}" -le 10 ]] || classification_offset=0
+	case "$classification_deadline_seconds" in
+	'' | *[!0-9]*) classification_deadline_seconds=120 ;;
+	esac
+	[[ "${#classification_deadline_seconds}" -le 4 ]] || classification_deadline_seconds=120
+	[[ "$classification_deadline_seconds" -ge 1 ]] || classification_deadline_seconds=1
+	[[ "$classification_deadline_seconds" -le 3600 ]] || classification_deadline_seconds=3600
+	if [[ "$row_count" -gt 0 ]]; then
+		classification_offset=$((classification_offset % row_count))
+	fi
+	printf '%s|%s|%s\n' "$classification_limit" "$classification_offset" \
+		"$classification_deadline_seconds"
+	return 0
+}
+
 _worktree_recovery_plan_entries_json() {
 	local platform="$1"
 	local inventory_json="" inventory_error="" entries_file="" rows_file=""
-	local entry_json="" entries_json=""
-	local row_json="" role="" state="" bucket_path="" bytes="" confidence=""
-	local result_status=0
-
-	inventory_json=$(worktree_recovery_lifecycle_json "$platform") || return 1
+	local entry_json="" entries_json="" row_json="" role="" state="" bucket_path="" bytes=""
+	local row_count=0 row_index=0 relative_index=0
+	local classification_limit="" classification_offset="" classification_deadline_seconds="" classification_window=""
+	local classification_deadline_epoch=0 classification_now=0 classification_deadline_exhausted=false
+	local classified_count=0 next_classification_offset=0 classification_complete=false result_status=0
+	inventory_json=$(AIDEVOPS_WORKTREE_RECOVERY_PLAN_INVENTORY=1 \
+		worktree_recovery_lifecycle_json "$platform") || return 1
 	inventory_error=$(printf '%s\n' "$inventory_json" | jq -r '.error // empty') || return 1
 	entries_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/aidevops-worktree-recovery-plan-entries.XXXXXX") || return 1
 	rows_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/aidevops-worktree-recovery-plan-rows.XXXXXX") || {
@@ -798,42 +875,82 @@ _worktree_recovery_plan_entries_json() {
 		rm -f "$entries_file" "$rows_file"
 		return 1
 	fi
+	row_count=$(wc -l <"$rows_file" | tr -d ' ') || row_count=""
+	[[ "$row_count" =~ ^[0-9]+$ ]] || {
+		rm -f "$entries_file" "$rows_file"
+		return 1
+	}
+	classification_window=$(_worktree_recovery_plan_window "$row_count") || {
+		rm -f "$entries_file" "$rows_file"
+		return 1
+	}
+	IFS='|' read -r classification_limit classification_offset \
+		classification_deadline_seconds <<<"$classification_window"
+	classification_now=$(date +%s) || {
+		rm -f "$entries_file" "$rows_file"
+		return 1
+	}
+	classification_deadline_epoch=$((classification_now + classification_deadline_seconds))
 	while IFS= read -r row_json; do
 		role=$(printf '%s\n' "$row_json" | jq -r '.role') || result_status=1
 		state=$(printf '%s\n' "$row_json" | jq -r '.state') || result_status=1
 		bucket_path=$(printf '%s\n' "$row_json" | jq -r '.path') || result_status=1
 		bytes=$(printf '%s\n' "$row_json" | jq -r --arg null_value "$WORKTREE_RECOVERY_PLAN_JSON_NULL" '.bytes // $null_value') || result_status=1
-		confidence=$(printf '%s\n' "$row_json" | jq -r '.sizing_confidence') || result_status=1
 		[[ "$result_status" -eq 0 ]] || break
 		if [[ -n "$inventory_error" ]]; then
 			entry_json=$(_worktree_recovery_plan_unknown_entry_json \
 				"$role" "$bucket_path" "$bytes" "inventory-report-incomplete") || result_status=1
-		elif [[ "$state" == "attributed" || "$state" == "attributed-legacy" ]]; then
-			if [[ "$bytes" == "$WORKTREE_RECOVERY_PLAN_JSON_NULL" ||
-				"$confidence" != "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" ]]; then
+		elif [[ "$row_count" -gt 0 ]]; then
+			relative_index=$(((row_index - classification_offset + row_count) % row_count))
+			if [[ "$relative_index" -ge "$classification_limit" ]]; then
 				entry_json=$(_worktree_recovery_plan_unknown_entry_json \
-					"$role" "$bucket_path" "$bytes" "sizing-unavailable") || result_status=1
-			elif ! entry_json=$(_worktree_recovery_plan_attributed_entry_json \
-				"$role" "$bucket_path" "$bytes"); then
-				entry_json=$(_worktree_recovery_plan_unknown_entry_json \
-					"$role" "$bucket_path" "$bytes" "classification-unavailable") || result_status=1
+					"$role" "$bucket_path" "$bytes" "classification-deferred") || result_status=1
+			else
+				classification_now=$(date +%s) || result_status=1
+				if [[ "$result_status" -eq 0 && "$classification_now" -ge "$classification_deadline_epoch" ]]; then
+					classification_deadline_exhausted=true
+					entry_json=$(_worktree_recovery_plan_unknown_entry_json \
+						"$role" "$bucket_path" "$bytes" "classification-deadline-exhausted") || result_status=1
+				elif [[ "$result_status" -eq 0 ]]; then
+					classified_count=$((classified_count + 1))
+					if [[ "$state" == "attributed" || "$state" == "attributed-legacy" ]]; then
+						if ! entry_json=$(_worktree_recovery_plan_attributed_entry_json \
+							"$role" "$bucket_path" "$WORKTREE_RECOVERY_PLAN_JSON_NULL"); then
+							entry_json=$(_worktree_recovery_plan_unknown_entry_json \
+								"$role" "$bucket_path" "$bytes" "classification-unavailable") || result_status=1
+						fi
+					else
+						entry_json=$(_worktree_recovery_plan_unknown_entry_json \
+							"$role" "$bucket_path" "$bytes" "archive-unrecognised-or-incomplete") || result_status=1
+					fi
+				fi
 			fi
-		else
-			entry_json=$(_worktree_recovery_plan_unknown_entry_json \
-				"$role" "$bucket_path" "$bytes" "archive-unrecognised-or-incomplete") || result_status=1
 		fi
 		[[ "$result_status" -eq 0 ]] || break
 		printf '%s\n' "$entry_json" >>"$entries_file" || {
 			result_status=1
 			break
 		}
+		row_index=$((row_index + 1))
 	done <"$rows_file"
+	if [[ -z "$inventory_error" && "$classified_count" -eq "$row_count" ]]; then
+		classification_complete=true
+	fi
+	if [[ "$row_count" -gt 0 ]]; then
+		next_classification_offset=$(((classification_offset + classified_count) % row_count))
+	fi
 	if [[ "$result_status" -eq 0 ]]; then
 		entries_json=$(jq -sc 'sort_by(.path)' "$entries_file") || result_status=1
 	fi
 	if [[ "$result_status" -eq 0 ]]; then
 		printf '%s\n' "$entries_json" | jq -c --arg error "$inventory_error" \
-			'. as $entries | {inventory_complete:($error == ""),inventory_error:(if $error == "" then null else $error end),entries:$entries}' || result_status=1
+			--argjson classification_complete "$classification_complete" \
+			--argjson classified_count "$classified_count" \
+			--argjson classification_offset "$classification_offset" \
+			--argjson next_classification_offset "$next_classification_offset" \
+			--argjson classification_deadline_seconds "$classification_deadline_seconds" \
+			--argjson classification_deadline_exhausted "$classification_deadline_exhausted" \
+			'. as $entries | {inventory_complete:($error == ""),inventory_error:(if $error == "" then null else $error end),classification_complete:$classification_complete,classified_entry_count:$classified_count,deferred_entry_count:([$entries[] | select(.reasons | IN(["classification-deferred"],["classification-deadline-exhausted"]))] | length),classification_offset:$classification_offset,next_classification_offset:$next_classification_offset,classification_deadline_seconds:$classification_deadline_seconds,classification_deadline_exhausted:$classification_deadline_exhausted,entries:$entries}' || result_status=1
 	fi
 	rm -f "$entries_file" "$rows_file"
 	return "$result_status"
@@ -842,6 +959,9 @@ _worktree_recovery_plan_entries_json() {
 worktree_recovery_plan_json() {
 	local platform="${1:-}"
 	local entries_bundle="" entries_json="" inventory_complete="" inventory_error=""
+	local classification_complete="" classified_entry_count="" deferred_entry_count=""
+	local classification_offset="" next_classification_offset=""
+	local classification_deadline_seconds="" classification_deadline_exhausted=""
 	local plan_material="" plan_digest="" generated_at="" plan_json=""
 	local candidate_count="" candidate_bytes="" confirmation_token=""
 
@@ -853,9 +973,23 @@ worktree_recovery_plan_json() {
 	entries_json=$(printf '%s\n' "$entries_bundle" | jq -c '.entries') || return 1
 	inventory_complete=$(printf '%s\n' "$entries_bundle" | jq -c '.inventory_complete') || return 1
 	inventory_error=$(printf '%s\n' "$entries_bundle" | jq -r '.inventory_error // empty') || return 1
+	classification_complete=$(printf '%s\n' "$entries_bundle" | jq -c '.classification_complete') || return 1
+	classified_entry_count=$(printf '%s\n' "$entries_bundle" | jq -r '.classified_entry_count') || return 1
+	deferred_entry_count=$(printf '%s\n' "$entries_bundle" | jq -r '.deferred_entry_count') || return 1
+	classification_offset=$(printf '%s\n' "$entries_bundle" | jq -r '.classification_offset') || return 1
+	next_classification_offset=$(printf '%s\n' "$entries_bundle" | jq -r '.next_classification_offset') || return 1
+	classification_deadline_seconds=$(printf '%s\n' "$entries_bundle" | jq -r '.classification_deadline_seconds') || return 1
+	classification_deadline_exhausted=$(printf '%s\n' "$entries_bundle" | jq -c '.classification_deadline_exhausted') || return 1
 	plan_material=$(printf '%s\n' "$entries_json" | jq -c --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
 		--arg error "$inventory_error" --argjson complete "$inventory_complete" \
-		'. as $entries | {schema:$schema,inventory_complete:$complete,inventory_error:(if $error == "" then null else $error end),entries:$entries}') || return 1
+		--argjson classification_complete "$classification_complete" \
+		--argjson classified_entry_count "$classified_entry_count" \
+		--argjson deferred_entry_count "$deferred_entry_count" \
+		--argjson classification_offset "$classification_offset" \
+		--argjson next_classification_offset "$next_classification_offset" \
+		--argjson classification_deadline_seconds "$classification_deadline_seconds" \
+		--argjson classification_deadline_exhausted "$classification_deadline_exhausted" \
+		'. as $entries | {schema:$schema,inventory_complete:$complete,inventory_error:(if $error == "" then null else $error end),classification_complete:$classification_complete,classified_entry_count:$classified_entry_count,deferred_entry_count:$deferred_entry_count,classification_offset:$classification_offset,next_classification_offset:$next_classification_offset,classification_deadline_seconds:$classification_deadline_seconds,classification_deadline_exhausted:$classification_deadline_exhausted,entries:$entries}') || return 1
 	plan_digest=$(_worktree_recovery_plan_sha256_text "$plan_material") || return 1
 	generated_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 	plan_json=$(printf '%s\n' "$entries_json" | jq -c --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
@@ -864,11 +998,23 @@ worktree_recovery_plan_json() {
 		--arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
 		--arg protected "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" \
 		--arg unknown "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
-		--arg error "$inventory_error" --argjson complete "$inventory_complete" '
+		--arg error "$inventory_error" --argjson complete "$inventory_complete" \
+		--argjson classification_complete "$classification_complete" \
+		--argjson classified_entry_count "$classified_entry_count" \
+		--argjson deferred_entry_count "$deferred_entry_count" \
+		--argjson classification_offset "$classification_offset" \
+		--argjson next_classification_offset "$next_classification_offset" \
+		--argjson classification_deadline_seconds "$classification_deadline_seconds" \
+		--argjson classification_deadline_exhausted "$classification_deadline_exhausted" '
 		def parent_path: .[0:rindex("/")];
 		. as $entries |
 		{schema:$schema,producer:$producer,plan_id:$plan_id,generated_at:$generated_at,read_only:true,
 		inventory_complete:$complete,inventory_error:(if $error == "" then null else $error end),
+		classification_complete:$classification_complete,classified_entry_count:$classified_entry_count,
+		deferred_entry_count:$deferred_entry_count,classification_offset:$classification_offset,
+		next_classification_offset:$next_classification_offset,
+		classification_deadline_seconds:$classification_deadline_seconds,
+		classification_deadline_exhausted:$classification_deadline_exhausted,
 		source_roots:([$entries[].path | parent_path] | unique),
 		entry_count:($entries | length),
 		sized_entry_count:([$entries[] | select(.expected_allocated_bytes | type == "number")] | length),

--- a/.agents/scripts/worktree-recovery-maintenance-helper.sh
+++ b/.agents/scripts/worktree-recovery-maintenance-helper.sh
@@ -20,6 +20,16 @@ WORKTREE_RECOVERY_MAINTENANCE_PROTECTED=0
 WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=0
 WORKTREE_RECOVERY_MAINTENANCE_SELECTED=0
 WORKTREE_RECOVERY_MAINTENANCE_SELECTED_BYTES=0
+WORKTREE_RECOVERY_MAINTENANCE_BUCKET_COUNT=0
+WORKTREE_RECOVERY_MAINTENANCE_CURSOR_BEFORE=0
+WORKTREE_RECOVERY_MAINTENANCE_CURSOR_AFTER=0
+WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_ARCHIVE=0
+WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING=0
+WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION=0
+WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_AGE=0
+WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE=0
+WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_POLICY=0
+WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_LIMIT=0
 
 _worktree_recovery_maintenance_uint() {
 	local value="$1"
@@ -243,6 +253,7 @@ _worktree_recovery_maintenance_scan() {
 	local confidence=""
 	local entry_json=""
 	local disposition=""
+	local primary_reason=""
 	local age_seconds=""
 	local selected_reason=""
 
@@ -251,6 +262,13 @@ _worktree_recovery_maintenance_scan() {
 	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=0
 	WORKTREE_RECOVERY_MAINTENANCE_SELECTED=0
 	WORKTREE_RECOVERY_MAINTENANCE_SELECTED_BYTES=0
+	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_ARCHIVE=0
+	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING=0
+	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION=0
+	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_AGE=0
+	WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE=0
+	WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_POLICY=0
+	WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_LIMIT=0
 	: >"$selected_path" || return 1
 	while IFS= read -r raw_record; do
 		[[ "$WORKTREE_RECOVERY_MAINTENANCE_SCANNED" -lt "$max_scan" ]] || break
@@ -258,28 +276,39 @@ _worktree_recovery_maintenance_scan() {
 		WORKTREE_RECOVERY_MAINTENANCE_SCANNED=$((WORKTREE_RECOVERY_MAINTENANCE_SCANNED + 1))
 		if [[ "$state" != "attributed" ]]; then
 			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
+			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_ARCHIVE=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_ARCHIVE + 1))
 			continue
 		fi
 		measured=$(_worktree_recovery_measure_path "$bucket_path") || return 1
 		IFS='|' read -r bytes confidence _ <<<"$measured"
 		if [[ "$confidence" != "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" || ! "$bytes" =~ ^[0-9]+$ ]]; then
 			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
+			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING + 1))
 			continue
 		fi
 		if ! entry_json=$(_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" "$bytes"); then
 			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
+			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION + 1))
 			continue
 		fi
 		disposition=$(printf '%s\n' "$entry_json" | jq -r '.disposition') || return 1
 		if [[ "$disposition" == "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" ]]; then
 			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
+			primary_reason=$(printf '%s\n' "$entry_json" | jq -r '.reasons[0] // empty') || return 1
+			if [[ "$primary_reason" == "sizing-unavailable" ]]; then
+				WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING + 1))
+			else
+				WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION + 1))
+			fi
 			continue
 		elif [[ "$disposition" != "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" ]]; then
 			WORKTREE_RECOVERY_MAINTENANCE_PROTECTED=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED + 1))
+			WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE + 1))
 			continue
 		fi
 		if ! age_seconds=$(_worktree_recovery_maintenance_age_seconds "$entry_json"); then
 			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
+			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_AGE=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_AGE + 1))
 			continue
 		fi
 		selected_reason=""
@@ -288,9 +317,15 @@ _worktree_recovery_maintenance_scan() {
 		elif [[ "$pressure_active" == "true" ]]; then
 			selected_reason="pressure"
 		fi
-		if [[ -z "$selected_reason" || "$WORKTREE_RECOVERY_MAINTENANCE_SELECTED" -ge "$max_candidates" ||
+		if [[ -z "$selected_reason" ]]; then
+			WORKTREE_RECOVERY_MAINTENANCE_PROTECTED=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED + 1))
+			WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_POLICY=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_POLICY + 1))
+			continue
+		fi
+		if [[ "$WORKTREE_RECOVERY_MAINTENANCE_SELECTED" -ge "$max_candidates" ||
 			$((WORKTREE_RECOVERY_MAINTENANCE_SELECTED_BYTES + bytes)) -gt "$max_bytes" ]]; then
 			WORKTREE_RECOVERY_MAINTENANCE_PROTECTED=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED + 1))
+			WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_LIMIT=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_LIMIT + 1))
 			continue
 		fi
 		printf '%s\n' "$entry_json" | jq -c --arg reason "$selected_reason" \
@@ -428,6 +463,9 @@ _worktree_recovery_maintenance_prepare_selection() {
 		[[ "$offset" =~ ^[0-9]+$ ]] || offset=0
 	fi
 	if [[ "$bucket_count" -gt 0 ]]; then offset=$((offset % bucket_count)); else offset=0; fi
+	WORKTREE_RECOVERY_MAINTENANCE_BUCKET_COUNT="$bucket_count"
+	WORKTREE_RECOVERY_MAINTENANCE_CURSOR_BEFORE="$offset"
+	WORKTREE_RECOVERY_MAINTENANCE_CURSOR_AFTER=0
 	if ! _worktree_recovery_maintenance_order_inventory "$inventory_path" "$ordered_path" "$offset" ||
 		! _worktree_recovery_maintenance_scan "$ordered_path" "$selected_path" "$max_scan" \
 			"$max_candidates" "$max_bytes" "$retention_seconds" "$pressure_active"; then
@@ -435,7 +473,8 @@ _worktree_recovery_maintenance_prepare_selection() {
 		return 1
 	fi
 	if [[ "$bucket_count" -gt 0 ]]; then
-		printf '%s\n' "$(((offset + WORKTREE_RECOVERY_MAINTENANCE_SCANNED) % bucket_count))" >"$cursor_path" || {
+		WORKTREE_RECOVERY_MAINTENANCE_CURSOR_AFTER=$(((offset + WORKTREE_RECOVERY_MAINTENANCE_SCANNED) % bucket_count))
+		printf '%s\n' "$WORKTREE_RECOVERY_MAINTENANCE_CURSOR_AFTER" >"$cursor_path" || {
 			rm -f "$inventory_path" "$ordered_path" "$selected_path"
 			return 1
 		}
@@ -467,6 +506,41 @@ _worktree_recovery_maintenance_prepare_selection() {
 	fi
 	rm -f "$inventory_path" "$ordered_path" "$selected_path"
 	return 0
+}
+
+_worktree_recovery_maintenance_diagnostics_json() {
+	local coverage_complete=false
+	local coverage_percent=100
+
+	if [[ "$WORKTREE_RECOVERY_MAINTENANCE_BUCKET_COUNT" -gt 0 ]]; then
+		coverage_percent=$((WORKTREE_RECOVERY_MAINTENANCE_SCANNED * 100 / WORKTREE_RECOVERY_MAINTENANCE_BUCKET_COUNT))
+		[[ "$coverage_percent" -le 100 ]] || coverage_percent=100
+	fi
+	if [[ "$WORKTREE_RECOVERY_MAINTENANCE_SCANNED" -ge "$WORKTREE_RECOVERY_MAINTENANCE_BUCKET_COUNT" ]]; then
+		coverage_complete=true
+	fi
+	jq -cn \
+		--argjson inventory_count "$WORKTREE_RECOVERY_MAINTENANCE_BUCKET_COUNT" \
+		--argjson scanned_count "$WORKTREE_RECOVERY_MAINTENANCE_SCANNED" \
+		--argjson cursor_before "$WORKTREE_RECOVERY_MAINTENANCE_CURSOR_BEFORE" \
+		--argjson cursor_after "$WORKTREE_RECOVERY_MAINTENANCE_CURSOR_AFTER" \
+		--argjson coverage_complete "$coverage_complete" \
+		--argjson coverage_percent "$coverage_percent" \
+		--argjson unknown_archive "$WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_ARCHIVE" \
+		--argjson unknown_sizing "$WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING" \
+		--argjson unknown_classification "$WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION" \
+		--argjson unknown_age "$WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_AGE" \
+		--argjson protected_evidence "$WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE" \
+		--argjson protected_policy "$WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_POLICY" \
+		--argjson protected_limit "$WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_LIMIT" \
+		'{inventory_count:$inventory_count,scanned_count:$scanned_count,
+		cursor_before:$cursor_before,cursor_after:$cursor_after,
+		coverage_complete:$coverage_complete,coverage_percent:$coverage_percent,
+		reason_counts:{unknown_archive:$unknown_archive,unknown_sizing:$unknown_sizing,
+		unknown_classification:$unknown_classification,unknown_age:$unknown_age,
+		protected_evidence:$protected_evidence,protected_policy:$protected_policy,
+		protected_limit:$protected_limit}}'
+	return $?
 }
 
 _worktree_recovery_maintenance_write_new() {
@@ -528,6 +602,36 @@ _worktree_recovery_maintenance_resume_pending() {
 	return 0
 }
 
+_worktree_recovery_maintenance_no_candidates_json() {
+	local policy_json="$1"
+	local diagnostics_json="$2"
+
+	printf '%s\n' "$policy_json" | jq -c \
+		--arg schema "$WORKTREE_RECOVERY_MAINTENANCE_RUN_SCHEMA" \
+		--argjson diagnostics "$diagnostics_json" \
+		'{schema:$schema,outcome:"no-candidates",reclaimed_bytes:0,policy:.,diagnostics:$diagnostics}'
+	return $?
+}
+
+_worktree_recovery_maintenance_removed_json() {
+	local completed_dir="$1"
+	local reclaimed_bytes="$2"
+	local diagnostics_json="$3"
+
+	jq -cn --arg schema "$WORKTREE_RECOVERY_MAINTENANCE_RUN_SCHEMA" \
+		--arg outcome "removed" --arg receipt "${completed_dir}/receipt.json" \
+		--argjson diagnostics "$diagnostics_json" \
+		--argjson scanned "$WORKTREE_RECOVERY_MAINTENANCE_SCANNED" \
+		--argjson protected "$WORKTREE_RECOVERY_MAINTENANCE_PROTECTED" \
+		--argjson unknown "$WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN" \
+		--argjson removed "$WORKTREE_RECOVERY_MAINTENANCE_SELECTED" \
+		--argjson reclaimed_bytes "$reclaimed_bytes" \
+		'{schema:$schema,outcome:$outcome,scanned:$scanned,protected:$protected,
+		unknown:$unknown,removed:$removed,reclaimed_bytes:$reclaimed_bytes,receipt:$receipt,
+		diagnostics:$diagnostics}'
+	return $?
+}
+
 worktree_recovery_maintenance_run() {
 	local platform=""
 	local state_dir=""
@@ -541,6 +645,7 @@ worktree_recovery_maintenance_run() {
 	local receipt_path=""
 	local completed_dir=""
 	local reclaimed_bytes=""
+	local diagnostics_json=""
 	local resume_status=0
 	local run_status=0
 
@@ -588,9 +693,12 @@ worktree_recovery_maintenance_run() {
 		return 1
 	fi
 	policy_json="$WORKTREE_RECOVERY_MAINTENANCE_POLICY_JSON"
+	diagnostics_json=$(_worktree_recovery_maintenance_diagnostics_json) || {
+		_worktree_recovery_maintenance_release_lock || true
+		return 1
+	}
 	if [[ "$WORKTREE_RECOVERY_MAINTENANCE_SELECTED" -eq 0 ]]; then
-		printf '%s\n' "$policy_json" | jq -c --arg schema "$WORKTREE_RECOVERY_MAINTENANCE_RUN_SCHEMA" \
-			'{schema:$schema,outcome:"no-candidates",reclaimed_bytes:0,policy:.}'
+		_worktree_recovery_maintenance_no_candidates_json "$policy_json" "$diagnostics_json"
 		_worktree_recovery_maintenance_release_lock || return 1
 		return 0
 	fi
@@ -617,15 +725,8 @@ worktree_recovery_maintenance_run() {
 	fi
 	_worktree_recovery_maintenance_release_lock || run_status=1
 	[[ "$run_status" -eq 0 ]] || return 1
-	jq -cn --arg schema "$WORKTREE_RECOVERY_MAINTENANCE_RUN_SCHEMA" \
-		--arg outcome "removed" --arg receipt "${completed_dir}/receipt.json" \
-		--argjson scanned "$WORKTREE_RECOVERY_MAINTENANCE_SCANNED" \
-		--argjson protected "$WORKTREE_RECOVERY_MAINTENANCE_PROTECTED" \
-		--argjson unknown "$WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN" \
-		--argjson removed "$WORKTREE_RECOVERY_MAINTENANCE_SELECTED" \
-		--argjson reclaimed_bytes "$reclaimed_bytes" \
-		'{schema:$schema,outcome:$outcome,scanned:$scanned,protected:$protected,
-		unknown:$unknown,removed:$removed,reclaimed_bytes:$reclaimed_bytes,receipt:$receipt}'
+	_worktree_recovery_maintenance_removed_json "$completed_dir" "$reclaimed_bytes" \
+		"$diagnostics_json"
 	return $?
 }
 


### PR DESCRIPTION
## Summary

Localize per-entry sizing failures, bound manual classification by count and deadline with resumable offsets, and expose maintenance cursor/coverage reason diagnostics without changing automatic deletion authority.

## Files Changed

.agents/reference/storage-lifecycle.md, .agents/scripts/tests/test-worktree-recovery-lifecycle.sh, .agents/scripts/worktree-helper-cmds.sh, .agents/scripts/worktree-recovery-apply-helper.sh, .agents/scripts/worktree-recovery-lifecycle-helper.sh, .agents/scripts/worktree-recovery-maintenance-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Recovery lifecycle tests pass 26/26; async cleanup tests pass 13/13; linters-local.sh passes all required local gates.

Resolves #30775


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.290 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 1h 40m and 634,210 tokens on this with the user in an interactive session.