### PR TITLE
GH#30791: fix(pulse): retry stale TODO sync snapshots

### DIFF
--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -568,6 +568,20 @@ _pulse_run_issue_sync_stage() {
 	return $?
 }
 
+_pulse_todo_sync_exact_default_snapshot() {
+	local workspace="$1"
+	local default_branch="$2"
+	local expected_sha="$3"
+	local head_sha="" remote_sha=""
+	[[ -n "$workspace" && -n "$default_branch" && -n "$expected_sha" ]] || return 1
+	head_sha=$(git -C "$workspace" rev-parse HEAD 2>/dev/null) || return 1
+	[[ "$head_sha" == "$expected_sha" ]] || return 1
+	git -C "$workspace" fetch --quiet origin "$default_branch" >/dev/null 2>&1 || return 1
+	remote_sha=$(git -C "$workspace" rev-parse "refs/remotes/origin/${default_branch}" 2>/dev/null) || return 1
+	[[ "$head_sha" == "$remote_sha" ]]
+	return $?
+}
+
 #######################################
 # sync_todo_refs_for_repo
 #
@@ -631,6 +645,11 @@ sync_todo_refs_for_repo() (
 	if [[ "$sync_failed" -ne 0 ]]; then
 		return 1
 	fi
+	if ! _pulse_todo_sync_exact_default_snapshot "$workspace" "$branch_name" "$base_sha"; then
+		printf '[pulse-wrapper] TODO ref sync status=retryable_refresh stage=snapshot repo=%s base=%s action=recreate\n' \
+			"$repo_slug" "${base_sha:0:12}" >>"$WRAPPER_LOGFILE"
+		return 2
+	fi
 
 	if ! declare -F planning_publish >/dev/null 2>&1; then
 		[[ -f "${script_dir}/planning-publisher.sh" ]] || {
@@ -689,14 +708,26 @@ _pulse_sync_todo_repo_bounded() {
 	local repo_path="$2"
 	local repo_timeout="$3"
 	local job_index="$4"
+	local sync_rc=0
 	_pulse_refresh_repo "$repo_path" || true
 	if declare -F run_stage_with_timeout >/dev/null 2>&1; then
 		run_stage_with_timeout "sync_todo_refs_repo_${job_index}" "$repo_timeout" \
-			sync_todo_refs_for_repo "$repo_slug" "$repo_path"
-		return $?
+			sync_todo_refs_for_repo "$repo_slug" "$repo_path" || sync_rc=$?
+	else
+		sync_todo_refs_for_repo "$repo_slug" "$repo_path" || sync_rc=$?
 	fi
-	sync_todo_refs_for_repo "$repo_slug" "$repo_path"
-	return $?
+	if [[ "$sync_rc" -eq 2 ]]; then
+		printf '[pulse-wrapper] TODO ref sync status=retrying repo=%s attempt=2 reason=retryable_snapshot\n' \
+			"$repo_slug" >>"$WRAPPER_LOGFILE"
+		sync_rc=0
+		if declare -F run_stage_with_timeout >/dev/null 2>&1; then
+			run_stage_with_timeout "sync_todo_refs_repo_${job_index}" "$repo_timeout" \
+				sync_todo_refs_for_repo "$repo_slug" "$repo_path" || sync_rc=$?
+		else
+			sync_todo_refs_for_repo "$repo_slug" "$repo_path" || sync_rc=$?
+		fi
+	fi
+	return "$sync_rc"
 }
 
 #######################################

--- a/.agents/scripts/tests/test-issue-sync-project-root.sh
+++ b/.agents/scripts/tests/test-issue-sync-project-root.sh
@@ -102,6 +102,19 @@ printf '%s|%s|%s\n' "$command_name" "$repo" "$root" >>"$CALL_LOG"
 if [[ "$command_name" == "pull" ]]; then
 	printf '%s\n' "synced:${repo}" >>"${root}/TODO.md"
 fi
+if [[ "$command_name" == "pull" && -n "${ADVANCE_REMOTE_ON_PULL:-}" && ! -e "${ADVANCE_REMOTE_MARKER:-}" ]]; then
+	writer="${ADVANCE_REMOTE_WRITER:-}"
+	[[ -n "$writer" && -n "${ADVANCE_REMOTE_MARKER:-}" ]] || exit 4
+	git clone --quiet "$ADVANCE_REMOTE_ON_PULL" "$writer"
+	git -C "$writer" config user.email test@example.com
+	git -C "$writer" config user.name Test
+	git -C "$writer" config commit.gpgsign false
+	printf '%s\n' 'advanced default snapshot' >>"${writer}/TODO.md"
+	git -C "$writer" add TODO.md
+	git -C "$writer" commit --quiet -m advance-snapshot
+	git -C "$writer" push --quiet origin main
+	touch "$ADVANCE_REMOTE_MARKER"
+fi
 FIXTURE
 chmod +x "${fixture_scripts}/issue-sync-helper.sh"
 
@@ -206,6 +219,48 @@ grep -q 'status=retryable_failure stage=publication repo=owner/repo-c rc=1' "$WR
 if only_todo_sync_workspace >/dev/null 2>&1; then
 	fail "retryable publication failure left an automation workspace behind"
 fi
+
+# A remote default-branch advance after the isolated clone is created must be
+# retried from a newly cloned exact snapshot instead of failing the batch.
+repo_snapshot_retry="${TMP}/repo-snapshot-retry"
+remote_snapshot_retry="${TMP}/remote-snapshot-retry.git"
+setup_sync_repo "$repo_snapshot_retry" "$remote_snapshot_retry"
+export ADVANCE_REMOTE_ON_PULL="$remote_snapshot_retry"
+export ADVANCE_REMOTE_MARKER="${TMP}/remote-snapshot-advanced"
+export ADVANCE_REMOTE_WRITER="${TMP}/remote-snapshot-writer"
+retry_repos_json="${TMP}/snapshot-retry-repos.json"
+jq -n --arg slug owner/repo-snapshot-retry --arg path "$repo_snapshot_retry" \
+	'{initialized_repos:[{slug:$slug,path:$path,pulse:true,local_only:false}]}' >"$retry_repos_json"
+previous_repos_json="${REPOS_JSON:-}"
+export REPOS_JSON="$retry_repos_json"
+refresh_repo_definition=$(declare -f _pulse_refresh_repo)
+_pulse_refresh_repo() {
+	local repo_path="$1"
+	: "$repo_path"
+	return 0
+}
+snapshot_retry_rc=0
+sync_todo_refs_all_repos || snapshot_retry_rc=$?
+eval "$refresh_repo_definition"
+if [[ -n "$previous_repos_json" ]]; then
+	export REPOS_JSON="$previous_repos_json"
+else
+	unset REPOS_JSON
+fi
+[[ "$snapshot_retry_rc" -eq 0 ]] || fail "stale snapshot retry did not recover"
+[[ -e "$ADVANCE_REMOTE_MARKER" ]] || fail "stale snapshot fixture did not advance the remote"
+git --git-dir="$remote_snapshot_retry" show main:TODO.md | grep -q '^synced:owner/repo-snapshot-retry$' || \
+	fail "refreshed snapshot was not synced"
+grep -q 'status=retryable_refresh stage=snapshot repo=owner/repo-snapshot-retry' "$WRAPPER_LOGFILE" || \
+	fail "stale snapshot refresh evidence was not logged"
+grep -q 'status=retrying repo=owner/repo-snapshot-retry attempt=2 reason=retryable_snapshot' "$WRAPPER_LOGFILE" || \
+	fail "stale snapshot retry evidence was not logged"
+grep -q 'TODO ref sync batch completed scheduled=1 failures=0' "$WRAPPER_LOGFILE" || \
+	fail "recovered snapshot retry failed the sync batch"
+if only_todo_sync_workspace >/dev/null 2>&1; then
+	fail "stale snapshot retry left an automation workspace behind"
+fi
+unset ADVANCE_REMOTE_ON_PULL ADVANCE_REMOTE_MARKER ADVANCE_REMOTE_WRITER
 
 # Cleanup failure is observable without replacing the reconciliation result.
 # Use a retryable-conflict result (2) so a cleanup helper failure cannot be


### PR DESCRIPTION
## Summary

Recreate isolated TODO-sync workspaces once after an exact default-branch snapshot check detects drift.

## Files Changed

.agents/scripts/pulse-wrapper-cycle.sh, .agents/scripts/tests/test-issue-sync-project-root.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck .agents/scripts/pulse-wrapper-cycle.sh .agents/scripts/tests/test-issue-sync-project-root.sh; bash .agents/scripts/tests/test-issue-sync-project-root.sh; bash .agents/scripts/tests/test-pulse-todo-sync-parallel.sh

Resolves #30791


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 17m and 175,686 tokens on this as a headless worker.