### PR TITLE
GH#30792: fix: recover external issue trust metadata

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -949,6 +949,78 @@ _should_reconcile_external_issue_gate() {
 }
 
 #######################################
+# Recover missing legacy-cache author metadata with one bounded REST lookup.
+# The caller keeps the issue fail-closed when the lookup cannot establish an
+# association. Output is returned via _PIR_EXTERNAL_FALLBACK_* globals.
+#
+# Args: $1=slug, $2=issue number
+# Returns: 0=author metadata recovered, 1=unavailable or fallback budget spent
+#######################################
+_pir_recover_external_issue_author_metadata() {
+	local slug="$1"
+	local issue_num="$2"
+	local fallback_max="${PULSE_EXTERNAL_TRUST_FALLBACK_MAX:-25}"
+	local fallback_used="${_PIR_EXTERNAL_TRUST_FALLBACKS_USED:-0}"
+	local live_issue_json="" live_author_row=""
+
+	_PIR_EXTERNAL_FALLBACK_REASON=""
+	_PIR_EXTERNAL_FALLBACK_ASSOCIATION=""
+	_PIR_EXTERNAL_FALLBACK_LOGIN=""
+	_PIR_EXTERNAL_FALLBACK_TYPE=""
+	_PIR_EXTERNAL_FALLBACK_IS_BOT="false"
+	[[ "$slug" == */* && "$issue_num" =~ ^[1-9][0-9]*$ ]] || {
+		_PIR_EXTERNAL_FALLBACK_REASON="invalid issue identity"
+		return 1
+	}
+	[[ "$fallback_max" =~ ^[0-9]+$ ]] || fallback_max=25
+	[[ "$fallback_used" =~ ^[0-9]+$ ]] || fallback_used=0
+	if [[ "$fallback_used" -ge "$fallback_max" ]]; then
+		_PIR_EXTERNAL_FALLBACK_REASON="budget exhausted (${fallback_used}/${fallback_max})"
+		return 1
+	fi
+
+	_PIR_EXTERNAL_TRUST_FALLBACKS_USED=$((fallback_used + 1))
+	live_issue_json=$(gh api "repos/${slug}/issues/${issue_num}" 2>/dev/null) || {
+		_PIR_EXTERNAL_FALLBACK_REASON="request failed"
+		return 1
+	}
+	live_author_row=$(printf '%s' "$live_issue_json" | jq -r '[
+		(.author_association // .authorAssociation // ""),
+		(.user.login // .author.login // ""),
+		(.user.type // .author.type // ""),
+		(if ((.user.type // .author.type // "") == "Bot") then "true" else "false" end)
+	] | join("|")' 2>/dev/null) || {
+		_PIR_EXTERNAL_FALLBACK_REASON="response parse failed"
+		return 1
+	}
+	IFS='|' read -r _PIR_EXTERNAL_FALLBACK_ASSOCIATION _PIR_EXTERNAL_FALLBACK_LOGIN \
+		_PIR_EXTERNAL_FALLBACK_TYPE _PIR_EXTERNAL_FALLBACK_IS_BOT <<<"$live_author_row"
+	if [[ -z "$_PIR_EXTERNAL_FALLBACK_ASSOCIATION" ]]; then
+		_PIR_EXTERNAL_FALLBACK_REASON="response lacked author association"
+		return 1
+	fi
+	return 0
+}
+
+#######################################
+# Write at most one cache/fallback diagnostic per repository per reconcile
+# process. Repeated legacy rows are expected together and must not flood pulse.
+#
+# Args: $1=slug, $2=source reason
+#######################################
+_pir_log_external_issue_author_metadata_miss() {
+	local slug="$1"
+	local reason="$2"
+	local logged_slugs="${_PIR_EXTERNAL_TRUST_FALLBACK_DIAGNOSTIC_SLUGS:-}"
+	if [[ ",${logged_slugs}," == *",${slug},"* ]]; then
+		return 0
+	fi
+	_PIR_EXTERNAL_TRUST_FALLBACK_DIAGNOSTIC_SLUGS="${logged_slugs:+${logged_slugs},}${slug}"
+	echo "[pulse-wrapper] External issue trust reconcile: ${slug} cache author metadata missing; bounded live fallback ${reason}; failing closed (further misses this cycle suppressed)" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
 # Stage 0 action: repair a missing NMR gate from cached author metadata and
 # prevent later reconciliation stages from acting on unapproved external input.
 # Verified approvals and write-authorized collaborators continue normally.
@@ -968,8 +1040,17 @@ _action_reconcile_external_issue_gate() {
 		return 0
 	fi
 	if [[ -z "$author_association" ]]; then
-		echo "[pulse-wrapper] External issue trust reconcile: blocked #${issue_num} in ${slug}; author metadata unavailable, labels unchanged" >>"$LOGFILE"
-		return 0
+		if _pir_recover_external_issue_author_metadata "$slug" "$issue_num"; then
+			author_association="$_PIR_EXTERNAL_FALLBACK_ASSOCIATION"
+			author_login="$_PIR_EXTERNAL_FALLBACK_LOGIN"
+			if ! _should_reconcile_external_issue_gate "$author_association" \
+				"$_PIR_EXTERNAL_FALLBACK_TYPE" "$_PIR_EXTERNAL_FALLBACK_IS_BOT"; then
+				return 1
+			fi
+		else
+			_pir_log_external_issue_author_metadata_miss "$slug" "${_PIR_EXTERNAL_FALLBACK_REASON:-unavailable}"
+			return 0
+		fi
 	fi
 
 	local authority_rc=0

--- a/.agents/scripts/tests/test-pulse-external-issue-trust-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-external-issue-trust-reconcile.sh
@@ -20,10 +20,13 @@ _PIR_PERSISTENT_LABEL="persistent"
 _PIR_TRIAGE_FAILED_LABEL="triage-failed"
 AUTHORITY_RC=1
 GH_EDIT_LOG="$TEST_ROOT/edit.log"
+LIVE_ISSUE_JSON=""
+LIVE_FALLBACK_LOG="$TEST_ROOT/live-fallback.log"
 TESTS_RUN=0
 TESTS_FAILED=0
 : >"$LOGFILE"
 : >"$GH_EDIT_LOG"
+: >"$LIVE_FALLBACK_LOG"
 
 # shellcheck source=../pulse-issue-reconcile-actions.sh
 source "$ACTIONS"
@@ -40,6 +43,17 @@ _gh_actor_has_repo_write_authority() {
 gh_issue_edit_safe() {
 	printf '%s\n' "$*" >>"$GH_EDIT_LOG"
 	return 0
+}
+
+gh() {
+	local command="$1"
+	shift
+	if [[ "$command" == "api" ]]; then
+		printf '%s\n' "api" >>"$LIVE_FALLBACK_LOG"
+		printf '%s\n' "$LIVE_ISSUE_JSON"
+		return 0
+	fi
+	return 127
 }
 
 write_approval() {
@@ -59,6 +73,42 @@ record() {
 	fi
 	printf 'FAIL %s\n' "$name" >&2
 	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+test_live_author_metadata_fallback() {
+	local rc=0
+
+	write_approval NO_APPROVAL
+	: >"$GH_EDIT_LOG"
+	LIVE_ISSUE_JSON='{"author_association":"CONTRIBUTOR","user":{"login":"reporter","type":"User"}}'
+	: >"$LIVE_FALLBACK_LOG"
+	_action_reconcile_external_issue_gate owner/repo 28699 \
+		"auto-dispatch,status:available" "" "" || rc=$?
+	if [[ "$rc" -eq 0 && "$_PIR_EXTERNAL_GATE_MUTATED" -eq 1 \
+		&& "$(grep -c '^api$' "$LIVE_FALLBACK_LOG")" -eq 1 ]] \
+		&& grep -q -- '--add-label needs-maintainer-review' "$GH_EDIT_LOG"; then
+		record "missing cached metadata falls back to live external author" 0
+	else
+		record "missing cached metadata falls back to live external author" 1
+	fi
+
+	LIVE_ISSUE_JSON='{}'
+	: >"$LIVE_FALLBACK_LOG"
+	PULSE_EXTERNAL_TRUST_FALLBACK_MAX=1
+	_PIR_EXTERNAL_TRUST_FALLBACKS_USED=0
+	_PIR_EXTERNAL_TRUST_FALLBACK_DIAGNOSTIC_SLUGS=""
+	: >"$LOGFILE"
+	_action_reconcile_external_issue_gate owner/repo 28698 "status:available" "" "" || rc=$?
+	_action_reconcile_external_issue_gate owner/repo 28697 "status:available" "" "" || rc=$?
+	if [[ "$(grep -c '^api$' "$LIVE_FALLBACK_LOG")" -eq 1 ]] \
+		&& [[ "$(grep -c 'cache author metadata missing' "$LOGFILE")" -eq 1 ]] \
+		&& grep -q 'response lacked author association' "$LOGFILE"; then
+		record "missing live metadata is bounded and aggregated fail-closed" 0
+	else
+		record "missing live metadata is bounded and aggregated fail-closed" 1
+	fi
+	unset PULSE_EXTERNAL_TRUST_FALLBACK_MAX
 	return 0
 }
 
@@ -98,16 +148,7 @@ main() {
 	_should_reconcile_external_issue_gate NONE Bot true || rc=$?
 	[[ "$rc" -eq 1 ]] && record "bot metadata is skipped" 0 || record "bot metadata is skipped" 1
 
-	write_approval NO_APPROVAL
-	: >"$GH_EDIT_LOG"
-	rc=0
-	_action_reconcile_external_issue_gate owner/repo 28699 \
-		"auto-dispatch,status:available" "" "" || rc=$?
-	if [[ "$rc" -eq 0 && "$_PIR_EXTERNAL_GATE_MUTATED" -eq 0 && ! -s "$GH_EDIT_LOG" ]]; then
-		record "unknown author metadata blocks without mislabeling" 0
-	else
-		record "unknown author metadata blocks without mislabeling" 1
-	fi
+	test_live_author_metadata_fallback
 
 	AUTHORITY_RC=1
 	: >"$GH_EDIT_LOG"


### PR DESCRIPTION
## Summary

Recovers missing cached issue author metadata through a bounded live REST fallback, preserves fail-closed handling, and aggregates unavailable-metadata diagnostics per repository.

## Files Changed

.agents/scripts/pulse-issue-reconcile-actions.sh, .agents/scripts/tests/test-pulse-external-issue-trust-reconcile.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-external-issue-trust-reconcile.sh; shellcheck .agents/scripts/pulse-issue-reconcile-actions.sh .agents/scripts/tests/test-pulse-external-issue-trust-reconcile.sh

Resolves #30792


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 7m and 122,113 tokens on this as a headless worker.