### PR TITLE
GH#30793: fix(pulse): classify triage comment write failures

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch-review.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch-review.sh
@@ -697,8 +697,44 @@ _triage_review_shape_failure_reason() {
 }
 
 #######################################
-# Post a validated triage review through a body file. Returns the GitHub write
-# status so transport failures cannot be misreported as successful reviews.
+# Produce a sanitized, bounded diagnostic for a failed triage comment write.
+#
+# Arguments:
+#   $1 - gh exit status
+#   $2 - stderr artifact path
+#######################################
+_triage_comment_write_failure_detail() {
+	local post_status="$1"
+	local stderr_file="$2"
+	local stderr_text=""
+	local category="gh-command-failed"
+	local response_status=""
+
+	if [[ -s "$stderr_file" ]]; then
+		stderr_text=$(tr '\n' ' ' <"$stderr_file")
+	fi
+	if [[ "$stderr_text" =~ (HTTP[[:space:]]+|status[=:[:space:]]+)([1-5][0-9][0-9]) ]]; then
+		response_status="${BASH_REMATCH[2]}"
+	fi
+	case "$stderr_text" in
+	*"rate limit"* | *"Rate limit"* | *"rate-limit"*) category="api-rate-limited" ;;
+	*"authentication"* | *"Authentication"* | *"Bad credentials"*) category="authentication-failed" ;;
+	*"validation failed"* | *"Validation Failed"*) category="body-validation-failed" ;;
+	*"permission"* | *"Permission"* | *"Resource not accessible"*) category="permission-denied" ;;
+	*"timeout"* | *"Timeout"* | *"timed out"*) category="network-timeout" ;;
+	*"connection"* | *"Connection"* | *"resolve host"*) category="network-failed" ;;
+	esac
+	if [[ -n "$response_status" ]]; then
+		printf 'rc=%s category=%s status=%s\n' "$post_status" "$category" "$response_status"
+	else
+		printf 'rc=%s category=%s\n' "$post_status" "$category"
+	fi
+	return 0
+}
+
+#######################################
+# Post a validated triage review through a body file. On transport failure,
+# prints a sanitized diagnostic and returns the GitHub write status.
 #
 # Arguments:
 #   $1 - issue number
@@ -713,13 +749,20 @@ _post_triage_review_comment() {
 	local signature_helper="${TRIAGE_SIGNATURE_HELPER:-${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh}"
 	local signature_footer=""
 	local comment_dir=""
+	local error_dir=""
 	comment_dir=$(_triage_create_sensitive_artifact_dir "comment") || return 1
+	error_dir=$(_triage_create_sensitive_artifact_dir "comment-error") || {
+		_triage_cleanup_sensitive_artifact_dir "$comment_dir" || true
+		return 1
+	}
 	local body_file="${comment_dir}/comment.md"
+	local stderr_file="${error_dir}/gh.stderr"
 	if [[ ! -x "$signature_helper" ]] || \
 		! signature_footer=$("$signature_helper" footer \
 			--model "pulse-triage" --issue "${repo_slug}#${issue_num}" 2>/dev/null) || \
 		[[ "$signature_footer" != *"<!-- aidevops:sig -->"* ]]; then
 		_triage_cleanup_sensitive_artifact_dir "$comment_dir" || true
+		_triage_cleanup_sensitive_artifact_dir "$error_dir" || true
 		return 1
 	fi
 	(umask 077 && printf '%s\n\n%s\n%s\n' \
@@ -727,10 +770,13 @@ _post_triage_review_comment() {
 		if ! _triage_cleanup_sensitive_artifact_dir "$comment_dir"; then
 			echo "[pulse-wrapper] Triage comment artifact cleanup failed for #${issue_num} in ${repo_slug}; guardian retained" >>"$LOGFILE"
 		fi
+		_triage_cleanup_sensitive_artifact_dir "$error_dir" || true
 		return 1
 	}
 	local post_status=0
 	local cleanup_status=0
+	local error_cleanup_status=0
+	local post_failure_detail=""
 	# The exact gh shim validates the signed body and privacy policy while this
 	# private pathname remains independently readable. Its explicit ephemeral
 	# mode opens the body, removes and verifies the managed directory, and only
@@ -738,11 +784,25 @@ _post_triage_review_comment() {
 	# REST retry because this transport is intentionally one-shot.
 	AIDEVOPS_GH_EPHEMERAL_BODY_FILE="$body_file" \
 		gh_issue_comment "$issue_num" --repo "$repo_slug" \
-			--body-file "$body_file" >/dev/null 2>&1 || post_status=$?
+			--body-file "$body_file" >/dev/null 2>"$stderr_file" || post_status=$?
+	if [[ "$post_status" -ne 0 ]]; then
+		post_failure_detail=$(_triage_comment_write_failure_detail \
+			"$post_status" "$stderr_file")
+	fi
 	_triage_cleanup_sensitive_artifact_dir "$comment_dir" || cleanup_status=$?
+	_triage_cleanup_sensitive_artifact_dir "$error_dir" || error_cleanup_status=$?
 	if [[ "$cleanup_status" -ne 0 ]]; then
 		echo "[pulse-wrapper] Triage comment artifact cleanup failed for #${issue_num} in ${repo_slug}; post treated as failed, guardian retained" >>"$LOGFILE"
+		printf 'rc=%s category=comment-artifact-cleanup-failed\n' "$post_status"
 		return 1
+	fi
+	if [[ "$error_cleanup_status" -ne 0 ]]; then
+		echo "[pulse-wrapper] Triage comment error artifact cleanup failed for #${issue_num} in ${repo_slug}; guardian retained" >>"$LOGFILE"
+		printf 'rc=%s category=comment-error-artifact-cleanup-failed\n' "$post_status"
+		return 1
+	fi
+	if [[ "$post_status" -ne 0 ]]; then
+		printf '%s\n' "$post_failure_detail"
 	fi
 	return "$post_status"
 }
@@ -837,8 +897,9 @@ _extract_and_post_triage_review() {
 		return 0
 	fi
 
-	if ! _post_triage_review_comment "$issue_num" "$repo_slug" "$review_text"; then
-		echo "[pulse-wrapper] Triage review comment write failed for #${issue_num} in ${repo_slug} — infrastructure failure, will retry" >>"$LOGFILE"
+	local comment_failure_detail=""
+	if ! comment_failure_detail=$(_post_triage_review_comment "$issue_num" "$repo_slug" "$review_text"); then
+		echo "[pulse-wrapper] Triage review comment write failed for #${issue_num} in ${repo_slug}: ${comment_failure_detail:-rc=unknown category=unknown} — infrastructure failure, will retry" >>"$LOGFILE"
 		printf 'FAILED:github-comment-write-failed\n'
 		return 0
 	fi

--- a/.agents/scripts/tests/test-triage-output-shape.sh
+++ b/.agents/scripts/tests/test-triage-output-shape.sh
@@ -38,6 +38,7 @@ TRIAGE_LIFECYCLE_LOG=""
 POSTED_BODY_LOG=""
 EPHEMERAL_BODY_LOG=""
 MOCK_COMMENT_WRITE_FAILURE=0
+MOCK_COMMENT_WRITE_STDERR=""
 MOCK_REVIEW_LABEL_WRITE_FAILURE=0
 MOCK_PR_REVISION_PAIR=""
 MOCK_LABELS_JSON=""
@@ -75,12 +76,15 @@ print_result() {
 }
 
 setup_test_env() {
-	TEST_ROOT=$(mktemp -d)
+	# The framework may set TMPDIR inside a collaborative workspace. Test
+	# sensitive artifacts require a sticky or private ancestor, so isolate this
+	# fixture under the system temporary root instead.
+	TEST_ROOT=$(TMPDIR=/tmp mktemp -d)
 	export HOME="${TEST_ROOT}/home"
 	export AIDEVOPS_TEMP_DIR="${TEST_ROOT}/managed-temp"
 	export AIDEVOPS_SENSITIVE_TEMP_DIR="$AIDEVOPS_TEMP_DIR"
-	mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/agents/scripts" \
-		"$AIDEVOPS_TEMP_DIR"
+	(umask 077 && mkdir -p "${HOME}/.aidevops/logs" \
+		"${HOME}/.aidevops/agents/scripts" "$AIDEVOPS_TEMP_DIR")
 	AIDEVOPS_TEMP_DIR=$(cd "$AIDEVOPS_TEMP_DIR" && pwd -P)
 	export AIDEVOPS_TEMP_DIR
 	LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
@@ -108,6 +112,7 @@ exit 0
 SIG_STUB
 	chmod +x "$TRIAGE_SIGNATURE_HELPER"
 	MOCK_COMMENT_WRITE_FAILURE=0
+	MOCK_COMMENT_WRITE_STDERR=""
 	MOCK_REVIEW_LABEL_WRITE_FAILURE=0
 	MOCK_PR_REVISION_PAIR=""
 	MOCK_LABELS_JSON='[{"name":"review:approve","color":"0e8a16","description":"Advisory automated triage recommendation: approve"},{"name":"review:feedback","color":"fbca04","description":"Advisory automated triage recommendation: request changes"},{"name":"review:decline","color":"d73a4a","description":"Advisory automated triage recommendation: decline"}]'
@@ -133,7 +138,17 @@ teardown_test_env() {
 # `gh_issue_comment` / `gh_pr_comment` reaches the mock below. The real
 # wrappers live in shared-constants.sh, which this test doesn't source.
 # shellcheck disable=SC2317
-gh_issue_comment() { gh issue comment "$@" && return 0 || return 1; }
+gh_issue_comment() {
+	local gh_status=0
+	gh issue comment "$@" || gh_status=$?
+	if [[ "$gh_status" -eq 0 ]]; then
+		return 0
+	fi
+	if [[ "$gh_status" -eq 73 ]]; then
+		return 73
+	fi
+	return 1
+}
 # shellcheck disable=SC2317
 gh_pr_comment() { gh pr comment "$@" && return 0 || return 1; }
 export -f gh_issue_comment gh_pr_comment
@@ -159,7 +174,8 @@ gh() {
 	done
 	if [[ "$command_name" == "issue" && "$action" == "comment" && \
 		"$MOCK_COMMENT_WRITE_FAILURE" -eq 1 ]]; then
-		return 1
+		printf '%s\n' "$MOCK_COMMENT_WRITE_STDERR" >&2
+		return 73
 	fi
 	if [[ "$command_name" == "issue" && "$action" == "edit" && \
 		"$call_args" == *"--add-label review:"* && \
@@ -261,7 +277,8 @@ load_helpers_under_test() {
 	unset _PULSE_ANCILLARY_DISPATCH_LOADED \
 		_PULSE_ANCILLARY_DISPATCH_CORE_SH_LOADED \
 		_PULSE_ANCILLARY_DISPATCH_EVIDENCE_SH_LOADED \
-		_PULSE_ANCILLARY_DISPATCH_REVIEW_SH_LOADED
+		_PULSE_ANCILLARY_DISPATCH_REVIEW_SH_LOADED \
+		_SENSITIVE_TEMP_HELPER_LOADED
 	# shellcheck disable=SC1090  # production orchestrator path is runtime-resolved
 	source "$src"
 	_triage_current_text_snapshot_hash() {
@@ -1248,6 +1265,7 @@ test_comment_write_failure_is_infrastructure() {
 	_make_opencode_json "$payload" "$(_valid_review_text)"
 	_install_headless_stub "$payload"
 	MOCK_COMMENT_WRITE_FAILURE=1
+	MOCK_COMMENT_WRITE_STDERR="HTTP 429: API rate limit exceeded"
 
 	local prompt_file=""
 	prompt_file=$(_make_managed_prompt_file "comment-write")
@@ -1261,6 +1279,10 @@ test_comment_write_failure_is_infrastructure() {
 	if ! grep -q 'github-comment-write-failed' "$LOGFILE"; then
 		ok=1
 		detail="infrastructure classification missing"
+	fi
+	if ! grep -q 'rc=73 category=api-rate-limited status=429' "$LOGFILE"; then
+		ok=1
+		detail="${detail} concrete write failure missing"
 	fi
 	if ! grep -q -- '--remove-label triage-failed' "$GH_CALL_LOG"; then
 		ok=1


### PR DESCRIPTION
## Summary

Capture sanitized triage-comment write failure categories, exit status, and HTTP response status while retaining retry semantics. Stabilize the focused fixture under a safe sensitive-artifact root.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch-review.sh, .agents/scripts/tests/test-triage-output-shape.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: bash .agents/scripts/tests/test-triage-output-shape.sh (36/36 passed); shellcheck .agents/scripts/pulse-ancillary-dispatch-review.sh .agents/scripts/tests/test-triage-output-shape.sh (passed)

Resolves #30793


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 15m and 159,524 tokens on this as a headless worker.