### PR TITLE
GH#30797: fix: classify failed worker launches

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -1845,17 +1845,23 @@ _dispatch_record_nonzero_dispatch_result() {
 	local recent_lines=""
 
 	echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — dispatch_with_dedup returned rc=${dispatch_rc}" >>"$LOGFILE"
+	if [[ -n "${LOGFILE:-}" && -f "$LOGFILE" ]]; then
+		recent_lines=$(awk -v issue="#${issue_number}" -v repo="$repo_slug" '
+			index($0, issue) && index($0, repo) { lines[++n] = $0 }
+			END {
+				start = n - 20
+				if (start < 1) { start = 1 }
+				for (i = start; i <= n; i++) { print lines[i] }
+			}
+		' "$LOGFILE" 2>/dev/null) || recent_lines=""
+	fi
+	if [[ "$recent_lines" == *"worker_launch_rc_"* ]]; then
+		echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) launch failed before validation" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_worker_launch_failed"
+		_dispatch_stats_increment_candidate_failed "launch_error"
+		return 0
+	fi
 	if [[ "$dispatch_rc" -eq 2 ]]; then
-		if [[ -n "${LOGFILE:-}" && -f "$LOGFILE" ]]; then
-			recent_lines=$(awk -v issue="#${issue_number}" -v repo="$repo_slug" '
-				index($0, issue) && index($0, repo) { lines[++n] = $0 }
-				END {
-					start = n - 20
-					if (start < 1) { start = 1 }
-					for (i = start; i <= n; i++) { print lines[i] }
-				}
-			' "$LOGFILE" 2>/dev/null) || recent_lines=""
-		fi
 		if [[ "$recent_lines" == *"blocked_by_native_lookup_unavailable"* ]]; then
 			echo "[pulse-wrapper] Dispatch_max: #${issue_number} (${repo_slug}) pre-launch failure reason=blocked_by_native_lookup_unavailable" >>"$LOGFILE"
 			_dispatch_stats_increment_candidate_failed "blocked_by_native_lookup_unavailable"

--- a/.agents/scripts/tests/test-pulse-dispatch-stage-rc-adapter.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-stage-rc-adapter.sh
@@ -94,4 +94,21 @@ if grep -q 'Stage failed: dispatch_candidate_123' "$LOGFILE" 2>/dev/null; then
 	exit 1
 fi
 
+DISPATCH_COUNTERS=""
+pulse_stats_increment() {
+	local counter_name="$1"
+	DISPATCH_COUNTERS="${DISPATCH_COUNTERS}${counter_name}"$'\n'
+	return 0
+}
+printf '[dispatch_with_dedup] Launch failed for #123 in owner/repo: worker_launch_rc_1\n' >>"$LOGFILE"
+_dispatch_record_nonzero_dispatch_result "123" "owner/repo" 1
+if [[ "$DISPATCH_COUNTERS" != *$'dispatch_worker_launch_failed\n'* ]]; then
+	printf 'FAIL worker launch failure did not record launch-validation evidence\n' >&2
+	exit 1
+fi
+if [[ "$DISPATCH_COUNTERS" != *$'dispatch_candidate_failed_reason_launch_error\n'* ]]; then
+	printf 'FAIL worker launch failure did not record the launch-error reason\n' >&2
+	exit 1
+fi
+
 printf 'PASS pulse-dispatch-stage-rc-adapter\n'


### PR DESCRIPTION
## Summary

Classifies non-zero dispatches marked worker_launch_rc_* as launch-validation failures so pulse accounting excludes them from unaccounted launch findings.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/tests/test-pulse-dispatch-stage-rc-adapter.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-pulse-dispatch-stage-rc-adapter.sh; .agents/scripts/tests/test-pulse-check-helper.sh; shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-pulse-dispatch-stage-rc-adapter.sh

Resolves #30797


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 6m and 113,111 tokens on this as a headless worker.