### PR TITLE
GH#30786: fix Pulse worktree precreation auth failures

### DIFF
--- a/.agents/scripts/tests/test-worktree-fresh-base.sh
+++ b/.agents/scripts/tests/test-worktree-fresh-base.sh
@@ -68,6 +68,50 @@ if compgen -G "${WORKTREES}/.canonical-fetch-*" >/dev/null; then
 fi
 printf 'PASS canonical-guard bootstrap fetch worktree is removed\n'
 
+# A background service can retain an obsolete SSH_ASKPASS path after the
+# provider application is upgraded. The fresh-base fetch must retain its SSH
+# first attempt, then use a process-scoped HTTPS rewrite with gh credentials
+# rather than mutating the configured GitHub SSH remote.
+GITHUB_AUTH_RETRY_LOG="${ROOT}/github-auth-retry.log"
+if ! (
+	cd "$CANONICAL" || exit 1
+	SCRIPT_DIR="$(cd "$(dirname "$ADD_HELPER")" && pwd)"
+	# shellcheck source=../worktree-helper-add.sh
+	source "$ADD_HELPER"
+	git() {
+		local git_args="$*"
+		case "$git_args" in
+		*" remote get-url origin"*)
+			printf '%s\n' 'git@github.com:example/repository.git'
+			return 0
+			;;
+		*"credential.helper=!gh auth git-credential"*" fetch "*)
+			printf '%s\n' "$git_args" >"$GITHUB_AUTH_RETRY_LOG"
+			return 0
+			;;
+		*" fetch "*)
+			printf '%s\n' 'ssh_askpass: exec(/missing/ssh-askpass): No such file or directory' >&2
+			return 128
+			;;
+		esac
+		"$REAL_GIT" "$@"
+		return $?
+	}
+	gh() {
+		return 0
+	}
+	_worktree_fetch_origin_branch "$CANONICAL" main
+); then
+	printf 'FAIL GitHub SSH askpass failure did not retry through gh HTTPS auth\n'
+	exit 1
+fi
+if ! grep -qF 'credential.helper=!gh auth git-credential' "$GITHUB_AUTH_RETRY_LOG" ||
+	! grep -qF 'url.https://github.com/.insteadOf=git@github.com:' "$GITHUB_AUTH_RETRY_LOG"; then
+	printf 'FAIL GitHub SSH retry omitted the transient gh HTTPS configuration\n'
+	exit 1
+fi
+printf 'PASS GitHub SSH askpass failure retries through transient gh HTTPS auth\n'
+
 # A registered sibling can exist while its index is unreadable. The fetch
 # selector must skip that candidate and use the bootstrap path instead of
 # allowing one unhealthy worktree to block all new worktree creation.

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -850,6 +850,79 @@ _cmd_add_classify_collision_branch() {
 	return $?
 }
 
+#######################################
+# Detect a GitHub SSH remote that can be retried over authenticated HTTPS.
+# Arguments:
+#   $1 - remote URL
+# Returns: 0 for supported GitHub SSH URLs, 1 otherwise
+#######################################
+_worktree_is_github_ssh_remote() {
+	local remote_url="$1"
+	case "$remote_url" in
+	git@github.com:* | ssh://git@github.com/*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+#######################################
+# Detect a non-interactive SSH authentication failure eligible for HTTPS retry.
+# Arguments:
+#   $1 - captured git stderr
+# Returns: 0 for SSH authentication/askpass failures, 1 otherwise
+#######################################
+_worktree_is_ssh_auth_failure() {
+	local stderr_text="$1"
+	case "$stderr_text" in
+	*"ssh_askpass"* | *"Permission denied (publickey)"* | *"Could not read from remote repository"*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+#######################################
+# Refresh one origin branch, retrying eligible GitHub SSH auth failures via gh.
+# The retry rewrites the URL only for this command and never mutates the remote.
+# Arguments:
+#   $1 - clean linked/bootstrap worktree path
+#   $2 - target branch
+# Returns: git fetch exit code
+#######################################
+_worktree_fetch_origin_branch() {
+	local fetch_cwd="$1"
+	local target_branch="$2"
+	local remote_url=""
+	local fetch_stderr=""
+	local fetch_rc=1
+	local rewrite_from=""
+
+	remote_url=$(git -C "$fetch_cwd" remote get-url origin 2>/dev/null || true)
+	if fetch_stderr=$(GIT_TERMINAL_PROMPT=0 git -C "$fetch_cwd" fetch --quiet --no-tags origin \
+		"+refs/heads/${target_branch}:refs/remotes/origin/${target_branch}" 2>&1); then
+		return 0
+	else
+		fetch_rc=$?
+	fi
+
+	if _worktree_is_github_ssh_remote "$remote_url" &&
+		_worktree_is_ssh_auth_failure "$fetch_stderr" &&
+		command -v gh >/dev/null 2>&1 &&
+		gh auth status --hostname github.com >/dev/null 2>&1; then
+		case "$remote_url" in
+		git@github.com:*) rewrite_from="git@github.com:" ;;
+		ssh://git@github.com/*) rewrite_from="ssh://git@github.com/" ;;
+		esac
+		GIT_TERMINAL_PROMPT=0 git -C "$fetch_cwd" \
+			-c credential.helper= \
+			-c "credential.helper=!gh auth git-credential" \
+			-c "url.https://github.com/.insteadOf=${rewrite_from}" \
+			fetch --quiet --no-tags origin \
+			"+refs/heads/${target_branch}:refs/remotes/origin/${target_branch}"
+		return $?
+	fi
+
+	[[ -n "$fetch_stderr" ]] && printf '%s\n' "$fetch_stderr" >&2
+	return "$fetch_rc"
+}
+
 # Refresh an origin branch from linked-worktree context so the canonical Git
 # guard remains intact. If no linked worktree exists yet, create a short-lived
 # detached bootstrap worktree from HEAD, fetch from there, then remove it from
@@ -901,8 +974,7 @@ _worktree_refresh_origin_branch() {
 	fi
 
 	local fetch_rc=0
-	git -C "$fetch_cwd" fetch --no-tags --quiet origin \
-		"+refs/heads/${branch}:refs/remotes/origin/${branch}" || fetch_rc=$?
+	_worktree_fetch_origin_branch "$fetch_cwd" "$branch" || fetch_rc=$?
 	if [[ -n "$bootstrap_path" ]]; then
 		git -C "$fetch_cwd" worktree remove --force "$bootstrap_path" >/dev/null 2>&1 || true
 	fi


### PR DESCRIPTION
## Summary

Retry eligible GitHub SSH fresh-base fetch authentication failures through a process-scoped HTTPS rewrite backed by gh credentials, without changing the configured remote or weakening fail-closed worktree creation.

## Files Changed

.agents/scripts/tests/test-worktree-fresh-base.sh, .agents/scripts/worktree-helper-add.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — ShellCheck and linters-local passed; test-worktree-fresh-base.sh passed with the canonical Git shim; test-precreation-failure-skip.sh passed 48/48; a real ls-remote succeeded with SSH_AUTH_SOCK and SSH_ASKPASS deliberately invalid.

Resolves #30786


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 44m and 417,465 tokens on this with the user in an interactive session.