### PR TITLE
GH#30801: fix(pulse): bound TODO sync retry budget

### DIFF
--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -703,25 +703,78 @@ _pulse_todo_sync_repo_timeout() {
 	return 0
 }
 
+_pulse_todo_sync_retry_timeout() {
+	local repo_timeout="$1"
+	local retry_timeout="${PULSE_TODO_SYNC_RETRY_TIMEOUT:-60}"
+	[[ "$repo_timeout" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ "$retry_timeout" =~ ^[1-9][0-9]*$ ]] || retry_timeout=60
+	if [[ "$retry_timeout" -gt "$repo_timeout" ]]; then
+		retry_timeout="$repo_timeout"
+	fi
+	printf '%s\n' "$retry_timeout"
+	return 0
+}
+
+_pulse_todo_sync_deadline_remaining() {
+	local aggregate_deadline="$1"
+	local now="" remaining=0
+	local guard_seconds=5
+	[[ "$aggregate_deadline" =~ ^[1-9][0-9]*$ ]] || return 1
+	now=$(date +%s) || return 1
+	[[ "$now" =~ ^[1-9][0-9]*$ ]] || return 1
+	remaining=$((aggregate_deadline - now - guard_seconds))
+	[[ "$remaining" -gt 0 ]] || return 1
+	printf '%s\n' "$remaining"
+	return 0
+}
+
 _pulse_sync_todo_repo_bounded() {
 	local repo_slug="$1"
 	local repo_path="$2"
 	local repo_timeout="$3"
 	local job_index="$4"
-	local sync_rc=0
+	local aggregate_deadline="${5:-}"
+	local sync_rc=0 retry_timeout="" remaining_timeout="" initial_timeout="$repo_timeout"
+	retry_timeout=$(_pulse_todo_sync_retry_timeout "$repo_timeout") || return 1
+	if [[ "$aggregate_deadline" =~ ^[1-9][0-9]*$ ]]; then
+		remaining_timeout=$(_pulse_todo_sync_deadline_remaining "$aggregate_deadline") || {
+			printf '[pulse-wrapper] TODO ref sync status=skipped reason=aggregate_budget job=%s\n' \
+				"$job_index" >>"$WRAPPER_LOGFILE"
+			return 1
+		}
+		if [[ "$remaining_timeout" -le "$retry_timeout" ]]; then
+			initial_timeout=$((remaining_timeout / 2))
+		else
+			initial_timeout=$((remaining_timeout - retry_timeout))
+		fi
+		if [[ "$initial_timeout" -gt "$repo_timeout" ]]; then
+			initial_timeout="$repo_timeout"
+		fi
+		[[ "$initial_timeout" -gt 0 ]] || return 1
+	fi
 	_pulse_refresh_repo "$repo_path" || true
 	if declare -F run_stage_with_timeout >/dev/null 2>&1; then
-		run_stage_with_timeout "sync_todo_refs_repo_${job_index}" "$repo_timeout" \
+		run_stage_with_timeout "sync_todo_refs_repo_${job_index}" "$initial_timeout" \
 			sync_todo_refs_for_repo "$repo_slug" "$repo_path" || sync_rc=$?
 	else
 		sync_todo_refs_for_repo "$repo_slug" "$repo_path" || sync_rc=$?
 	fi
 	if [[ "$sync_rc" -eq 2 ]]; then
-		printf '[pulse-wrapper] TODO ref sync status=retrying repo=%s attempt=2 reason=retryable_snapshot\n' \
-			"$repo_slug" >>"$WRAPPER_LOGFILE"
+		if [[ "$aggregate_deadline" =~ ^[1-9][0-9]*$ ]]; then
+			remaining_timeout=$(_pulse_todo_sync_deadline_remaining "$aggregate_deadline") || {
+				printf '[pulse-wrapper] TODO ref sync status=retry_exhausted reason=aggregate_budget job=%s\n' \
+					"$job_index" >>"$WRAPPER_LOGFILE"
+				return 1
+			}
+			if [[ "$remaining_timeout" -lt "$retry_timeout" ]]; then
+				retry_timeout="$remaining_timeout"
+			fi
+		fi
+		printf '[pulse-wrapper] TODO ref sync status=retrying repo=%s attempt=2 reason=retryable_snapshot timeout=%ss\n' \
+			"$repo_slug" "$retry_timeout" >>"$WRAPPER_LOGFILE"
 		sync_rc=0
 		if declare -F run_stage_with_timeout >/dev/null 2>&1; then
-			run_stage_with_timeout "sync_todo_refs_repo_${job_index}" "$repo_timeout" \
+			run_stage_with_timeout "sync_todo_refs_repo_${job_index}" "$retry_timeout" \
 				sync_todo_refs_for_repo "$repo_slug" "$repo_path" || sync_rc=$?
 		else
 			sync_todo_refs_for_repo "$repo_slug" "$repo_path" || sync_rc=$?
@@ -740,18 +793,23 @@ _pulse_sync_todo_repo_bounded() {
 sync_todo_refs_all_repos() {
 	local repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 	local repo_slug="" repo_path="" pid="" job_rc=0
-	local parallelism="" repo_timeout="" scheduled=0 sync_failures=0
+	local parallelism="" repo_timeout="" stage_timeout="" aggregate_started="" aggregate_deadline="" scheduled=0 sync_failures=0
 	local -a active_pids=()
 
 	[[ -f "$repos_json" ]] || return 0
 	parallelism=$(_pulse_todo_sync_parallelism)
 	repo_timeout=$(_pulse_todo_sync_repo_timeout)
+	stage_timeout="${PRE_RUN_STAGE_TIMEOUT:-600}"
+	[[ "$stage_timeout" =~ ^[1-9][0-9]*$ ]] || stage_timeout=600
+	aggregate_started=$(date +%s) || return 1
+	[[ "$aggregate_started" =~ ^[1-9][0-9]*$ ]] || return 1
+	aggregate_deadline=$((aggregate_started + stage_timeout))
 	while IFS='|' read -r repo_slug repo_path; do
 		[[ -n "$repo_slug" && -n "$repo_path" ]] || continue
 		repo_path="${repo_path/#\~/$HOME}"
 		[[ -d "$repo_path" ]] || continue
 		scheduled=$((scheduled + 1))
-		_pulse_sync_todo_repo_bounded "$repo_slug" "$repo_path" "$repo_timeout" "$scheduled" &
+		_pulse_sync_todo_repo_bounded "$repo_slug" "$repo_path" "$repo_timeout" "$scheduled" "$aggregate_deadline" &
 		active_pids+=("$!")
 		if [[ "${#active_pids[@]}" -ge "$parallelism" ]]; then
 			pid="${active_pids[0]}"

--- a/.agents/scripts/tests/test-pulse-todo-sync-parallel.sh
+++ b/.agents/scripts/tests/test-pulse-todo-sync-parallel.sh
@@ -152,4 +152,55 @@ grep -q 'scheduled=6 failures=1 parallelism=2 per_repo_timeout=7s' "$WRAPPER_LOG
 	exit 1
 }
 
-printf 'PASS TODO reference sync uses bounded parallel jobs and preserves failures\n'
+# A retry must consume only time remaining in the aggregate stage. Simulate a
+# retryable first pass that leaves three seconds after the five-second guard;
+# the old code would incorrectly grant a fresh ten-second per-repo timeout.
+original_sync_definition=$(declare -f sync_todo_refs_for_repo)
+retry_repos_json="${TEST_ROOT}/retry-repos.json"
+jq -cn --arg slug owner/repo-retry --arg path "${TEST_ROOT}/repo-1" \
+	'{initialized_repos:[{slug:$slug,path:$path,pulse:true,local_only:false}]}' >"$retry_repos_json"
+export REPOS_JSON="$retry_repos_json"
+export PRE_RUN_STAGE_TIMEOUT=15
+export PULSE_TODO_SYNC_REPO_TIMEOUT=10
+export PULSE_TODO_SYNC_RETRY_TIMEOUT=10
+: >"$TIMEOUT_LOG"
+TEST_NOW=100
+date() {
+	local format="${1:-}"
+	if [[ "$format" == "+%s" ]]; then
+		printf '%s\n' "$TEST_NOW"
+		return 0
+	fi
+	command date "$@"
+	return $?
+}
+sync_todo_refs_for_repo() {
+	local repo_slug="$1"
+	local repo_path="$2"
+	: "$repo_slug" "$repo_path"
+	retry_attempt=$((retry_attempt + 1))
+	if [[ "$retry_attempt" -eq 1 ]]; then
+		TEST_NOW=107
+		return 2
+	fi
+	return 0
+}
+retry_attempt=0
+retry_rc=0
+sync_todo_refs_all_repos || retry_rc=$?
+eval "$original_sync_definition"
+unset -f date
+[[ "$retry_rc" -eq 0 ]] || {
+	printf 'FAIL aggregate retry did not complete within its shared budget: rc=%s\n' "$retry_rc" >&2
+	exit 1
+}
+if ! grep -qx 'sync_todo_refs_repo_1|5' "$TIMEOUT_LOG" || ! grep -qx 'sync_todo_refs_repo_1|3' "$TIMEOUT_LOG"; then
+	printf 'FAIL aggregate retry received a fresh per-repo timeout\n' >&2
+	exit 1
+fi
+grep -q 'status=retrying repo=owner/repo-retry attempt=2 reason=retryable_snapshot timeout=3s' "$WRAPPER_LOGFILE" || {
+	printf 'FAIL aggregate retry omitted remaining-budget diagnostics\n' >&2
+	exit 1
+}
+
+printf 'PASS TODO reference sync uses bounded parallel jobs and preserves aggregate retry budgets\n'


### PR DESCRIPTION
## Summary

Bound each stale-snapshot retry by the aggregate TODO-sync deadline, reserve retry capacity before the first attempt, and add a regression that verifies the retry receives only remaining budget.

## Files Changed

.agents/scripts/pulse-wrapper-cycle.sh, .agents/scripts/tests/test-pulse-todo-sync-parallel.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-todo-sync-parallel.sh; bash .agents/scripts/tests/test-issue-sync-project-root.sh; shellcheck .agents/scripts/pulse-wrapper-cycle.sh .agents/scripts/tests/test-pulse-todo-sync-parallel.sh

Resolves #30801


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 6m and 70,540 tokens on this as a headless worker.