### PR TITLE
GH#30803: fix(pulse): scan past blocked dispatch candidates

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -96,6 +96,9 @@ fi
 : "${PULSE_LLM_STALL_THRESHOLD:=3600}"
 : "${PULSE_RATE_LIMIT_FLAG:=${HOME}/.aidevops/logs/pulse-graphql-rate-limited.flag}"
 : "${PULSE_RUNNABLE_ISSUE_LIMIT:=1000}"
+# Dispatch must inspect a broad candidate window: benign per-issue blocks in a
+# small runnable-count sample must not starve later eligible work.
+: "${PULSE_DISPATCH_CANDIDATE_SCAN_LIMIT:=1000}"
 : "${PULSE_DISPATCH_AGE_BONUS_PER_DAY:=25}"
 : "${PULSE_DISPATCH_AGE_BONUS_CAP:=900}"
 : "${AIDEVOPS_PULSE_CAMPAIGN_SHADOW_ENABLED:=0}"
@@ -520,7 +523,7 @@ dispatch_max() {
 	# GH#29255: ranked candidates are the launch-path backlog source. Do not run
 	# the broad all-repository issue+PR diagnostic counters before this snapshot.
 	local candidates_json candidate_count
-	candidates_json=$(_dispatch_ranked_candidates_json "$PULSE_RUNNABLE_ISSUE_LIMIT" "$dependency_normalization_mode") || candidates_json='[]'
+	candidates_json=$(_dispatch_ranked_candidates_json "$PULSE_DISPATCH_CANDIDATE_SCAN_LIMIT" "$dependency_normalization_mode") || candidates_json='[]'
 	candidate_count=$(printf '%s' "$candidates_json" | jq 'length' 2>/dev/null) || candidate_count=0
 	[[ "$candidate_count" =~ ^[0-9]+$ ]] || candidate_count=0
 	if [[ "$candidate_count" -eq 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-dispatch-candidate-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-candidate-snapshot.sh
@@ -91,4 +91,43 @@ fifth=$(_dispatch_ranked_candidates_json 50)
 	exit 1
 }
 
+# A small runnable-count diagnostic sample must not limit dispatch scanning.
+# Three benignly blocked candidates must not hide a later eligible candidate.
+dispatch_log="${TEST_ROOT}/dispatch-scan.log"
+: >"$dispatch_log"
+_dispatch_compute_capacity() { printf '2 0 2\n'; return 0; }
+_dispatch_ranked_candidates_json() {
+	printf 'scan_limit=%s\n' "$1" >>"$dispatch_log"
+	printf '%s\n' '[
+		{"number":9101}, {"number":9102}, {"number":9103}, {"number":9104}
+	]'
+	return 0
+}
+_dispatch_run_prepasses() { printf '%s 0 0\n' "$1"; return 0; }
+_dispatch_order_idle_borrowing_candidates() { printf '%s\n' "$1"; return 0; }
+_dispatch_max_compute_parallel() { printf '1\n'; return 0; }
+_dispatch_graphql_budget_allows_next() { return 0; }
+_dispatch_rest_core_progress_allows_next() { return 0; }
+_dispatch_maybe_engage_throttle() { return 0; }
+_dispatch_process_candidate() {
+	printf '%s\n' "$1" >>"$dispatch_log"
+	case "$1" in
+	*'"number":9101'* | *'"number":9102'* | *'"number":9103'*) return 3 ;;
+	esac
+	return 0
+}
+gh() {
+	if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
+		printf 'testuser\n'
+	fi
+	return 0
+}
+PULSE_RUNNABLE_ISSUE_LIMIT=3
+dispatch_count=$(dispatch_max)
+scan_limit=$(grep -o 'scan_limit=[0-9]*' "$dispatch_log" | cut -d= -f2)
+grep -q '"number":9104' "$dispatch_log" && [[ "$dispatch_count" == "1" && "$scan_limit" == "1000" ]] || {
+	printf 'FAIL dispatch did not scan past benign head blocks: count=%s scan_limit=%s log=%s\n' "$dispatch_count" "$scan_limit" "$(tr '\n' ',' <"$dispatch_log")" >&2
+	exit 1
+}
+
 printf 'PASS dispatch candidate snapshots reuse enumeration, preserve modes, and invalidate on state mutation\n'


### PR DESCRIPTION
## Summary

Separates the broad dispatch candidate scan from the runnable-count diagnostic limit so benignly blocked head entries cannot hide later eligible work.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/tests/test-pulse-dispatch-candidate-snapshot.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-pulse-dispatch-candidate-snapshot.sh; .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh; ShellCheck

Resolves #30803


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 6m and 107,465 tokens on this as a headless worker.