### PR TITLE
GH#30805: warn on oversized npm caches

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -67,11 +67,26 @@ Reference, lease, recovery, and audit checks remain hard vetoes.
 | `~/.aidevops/recovery/worktrees` (Linux and non-macOS) | framework | recovery, unknown | Archive-first removal copies worktree and Git administrative state into an attributable bucket; exact terminal evidence supports manual plans and bounded producer-owned automatic maintenance | Preserve exact-evidence deletion, bounded scans, resumable receipts, and fail-closed handling for every protected or unknown bucket |
 | Pulse active logs and `~/.aidevops/logs/pulse-archive` | framework | active, archive | Pulse preserves active descriptors while gzip-rotating 50 MiB hot/wrapper logs and 1 MiB timing logs; cold archives converge under 1 GiB | Keep rotation producer-owned and never replace it with generic unlink-by-age cleanup |
 | OpenCode data under its application-data root | joint | active, recovery, archive, unknown | OpenCode owns session and DB formats; aidevops archive/maintenance helpers coordinate selected operations | Separate logical retention from WAL/fragmentation maintenance; report only classifications proven through OpenCode-aware queries |
-| npm and other package-manager caches | external | cache | Package manager owns lifecycle | Context-only reporting; no aidevops aggregate deletion |
+| npm and other package-manager caches | external | cache | Package manager owns lifecycle; npm cache status has a configurable 10 GiB advisory threshold | Context-only reporting; offer npm-owned verification or explicitly confirmed cleaning, never aidevops aggregate deletion |
 | OS temporary and Trash locations | external or joint | scratch, unknown | OS/runtime-specific | Reclaim only aidevops-attributable artifacts through an owner-aware migration; never broad-clean a directory |
 
 The inventory is intentionally conservative. A child implementation may split a
 row when one path contains artifacts with different owners or safety classes.
+
+### npm cache monitoring
+
+`aidevops status` gives the npm cache a bounded ten-second size probe and warns
+when an exact measurement exceeds 10 GiB. Set
+`AIDEVOPS_NPM_CACHE_WARN_BYTES` to tune that advisory threshold. A timeout stays
+visible and never becomes cleanup authority; run `npm-cache-helper.sh status`
+for an explicit longer scan after npm-heavy work.
+
+The helper keeps npm in control of every mutation. `verify` runs `npm cache
+verify`, which checks integrity and garbage-collects unneeded data. `clean` is a
+dry run unless both `--apply` and `--confirm clean-npm-cache` are present; the
+confirmed path invokes `npm cache clean --force` rather than deleting files
+directly. Neither shared inventory nor scheduled maintenance cleans external
+package-manager data automatically.
 
 ### Recoverable Worktree Archives
 

--- a/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
@@ -148,7 +148,9 @@ _status_storage_inventory() {
 	local report=""
 
 	[[ -f "$helper" ]] || return 0
-	report=$(AIDEVOPS_STORAGE_SIZE_TIMEOUT_TENTHS="${AIDEVOPS_STATUS_STORAGE_TIMEOUT_TENTHS:-3}" bash "$helper" status 2>/dev/null) || report=""
+	report=$(AIDEVOPS_STORAGE_SIZE_TIMEOUT_TENTHS="${AIDEVOPS_STATUS_STORAGE_TIMEOUT_TENTHS:-3}" \
+		AIDEVOPS_NPM_CACHE_SIZE_TIMEOUT_TENTHS="${AIDEVOPS_STATUS_NPM_CACHE_TIMEOUT_TENTHS:-100}" \
+		bash "$helper" status 2>/dev/null) || report=""
 	if [[ -n "$report" ]]; then
 		printf '%s\n\n' "$report"
 	else

--- a/.agents/scripts/npm-cache-helper.sh
+++ b/.agents/scripts/npm-cache-helper.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "$SCRIPT_DIR/shared-constants.sh"
+
+NPM_CACHE_WARN_BYTES="${AIDEVOPS_NPM_CACHE_WARN_BYTES:-10737418240}"
+NPM_CACHE_SIZE_TIMEOUT_TENTHS="${AIDEVOPS_NPM_CACHE_SIZE_TIMEOUT_TENTHS:-300}"
+NPM_CACHE_DU_COMMAND="${AIDEVOPS_NPM_CACHE_DU_COMMAND:-du}"
+NPM_CACHE_CONFIRM_TOKEN="clean-npm-cache"
+
+_npm_cache_usage() {
+	cat <<'USAGE'
+Usage: npm-cache-helper.sh [status|json|verify|clean] [options]
+
+Monitor and maintain npm's externally owned cache through npm itself.
+
+Commands:
+  status              Measure cache size and print threshold guidance
+  json                Emit the read-only status as JSON
+  verify              Run `npm cache verify` (integrity check and npm-owned GC)
+  clean               Dry run; show the explicit full-clean command
+  clean --apply --confirm clean-npm-cache
+                      Run `npm cache clean --force` through npm
+
+Environment:
+  AIDEVOPS_NPM_CACHE_DIR                  Override the measured cache path
+  AIDEVOPS_NPM_CACHE_WARN_BYTES           Warning threshold (default: 10 GiB)
+  AIDEVOPS_NPM_CACHE_SIZE_TIMEOUT_TENTHS  Size timeout in tenths (default: 300)
+
+No cleanup is automatic. The clean command requires explicit apply and confirm
+arguments and never removes files directly.
+USAGE
+	return 0
+}
+
+_npm_cache_is_nonnegative_integer() {
+	local value="$1"
+	case "$value" in
+	'' | *[!0-9]*) return 1 ;;
+	*) return 0 ;;
+	esac
+}
+
+_npm_cache_warn_bytes() {
+	if _npm_cache_is_nonnegative_integer "$NPM_CACHE_WARN_BYTES"; then
+		printf '%s' "$NPM_CACHE_WARN_BYTES"
+	else
+		printf '10737418240'
+	fi
+	return 0
+}
+
+_npm_cache_resolve_path() {
+	local cache_path="${AIDEVOPS_NPM_CACHE_DIR:-}"
+
+	if [[ -z "$cache_path" ]] && command -v npm >/dev/null 2>&1; then
+		cache_path=$(npm config get cache 2>/dev/null) || cache_path=""
+	fi
+	if [[ -z "$cache_path" ]] && [[ -n "${HOME:-}" ]]; then
+		cache_path="$HOME/.npm"
+	fi
+	case "$cache_path" in
+	/*) printf '%s' "$cache_path" ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+_npm_cache_display_path() {
+	local cache_path="$1"
+	if [[ -n "${HOME:-}" ]] && [[ "$cache_path" == "$HOME"/* ]]; then
+		printf '%s/%s' '~' "${cache_path#"$HOME/"}"
+	else
+		printf '%s' "$cache_path"
+	fi
+	return 0
+}
+
+_npm_cache_measure() {
+	local cache_path="$1"
+	local output_file=""
+	local pid=""
+	local elapsed=0
+	local kib=""
+	local ignored=""
+	local timeout_tenths="$NPM_CACHE_SIZE_TIMEOUT_TENTHS"
+
+	if [[ ! -e "$cache_path" && ! -L "$cache_path" ]]; then
+		printf '0|exact|missing'
+		return 0
+	fi
+	if [[ -L "$cache_path" ]]; then
+		printf 'null|unavailable|root-is-symlink'
+		return 0
+	fi
+	if [[ ! -r "$cache_path" ]]; then
+		printf 'null|unavailable|root-is-unreadable'
+		return 0
+	fi
+	if ! command -v "$NPM_CACHE_DU_COMMAND" >/dev/null 2>&1; then
+		printf 'null|unavailable|sizing-command-unavailable'
+		return 0
+	fi
+	if ! _npm_cache_is_nonnegative_integer "$timeout_tenths"; then
+		timeout_tenths=300
+	fi
+
+	output_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-npm-cache-size.XXXXXX") || {
+		printf 'null|unavailable|temporary-file-unavailable'
+		return 0
+	}
+	LC_ALL=C "$NPM_CACHE_DU_COMMAND" -sk "$cache_path" >"$output_file" 2>/dev/null &
+	pid=$!
+	while kill -0 "$pid" 2>/dev/null; do
+		if [[ "$elapsed" -ge "$timeout_tenths" ]]; then
+			kill "$pid" 2>/dev/null || true
+			wait "$pid" 2>/dev/null || true
+			rm -f "$output_file"
+			printf 'null|unavailable|sizing-timeout'
+			return 0
+		fi
+		sleep 0.1
+		elapsed=$((elapsed + 1))
+	done
+	if ! wait "$pid"; then
+		rm -f "$output_file"
+		printf 'null|unavailable|sizing-failed'
+		return 0
+	fi
+	IFS=$'\t ' read -r kib ignored <"$output_file" || kib=""
+	rm -f "$output_file"
+	case "$kib" in
+	'' | *[!0-9]*) printf 'null|unavailable|invalid-size-output' ;;
+	*) printf '%s|exact|' "$((kib * 1024))" ;;
+	esac
+	return 0
+}
+
+_npm_cache_json() {
+	local cache_path=""
+	local display_path="unavailable"
+	local measured="null|unavailable|cache-path-unavailable"
+	local total_bytes="null"
+	local confidence="unavailable"
+	local error="cache-path-unavailable"
+	local warn_bytes=""
+	local advisory="unavailable"
+
+	warn_bytes=$(_npm_cache_warn_bytes)
+	if cache_path=$(_npm_cache_resolve_path); then
+		display_path=$(_npm_cache_display_path "$cache_path")
+		measured=$(_npm_cache_measure "$cache_path")
+		IFS='|' read -r total_bytes confidence error <<<"$measured"
+	fi
+	if [[ "$total_bytes" != "null" ]]; then
+		if [[ "$total_bytes" -ge "$warn_bytes" ]]; then
+			advisory="warning"
+		else
+			advisory="ok"
+		fi
+	fi
+
+	jq -cn \
+		--arg path "$display_path" \
+		--arg advisory "$advisory" \
+		--arg confidence "$confidence" \
+		--arg error "$error" \
+		--argjson total_bytes "$total_bytes" \
+		--argjson warning_threshold_bytes "$warn_bytes" \
+		'{schema:"aidevops.npm-cache-status/v1",owner:"external",read_only:true,path:$path,total_bytes:$total_bytes,warning_threshold_bytes:$warning_threshold_bytes,advisory:$advisory,sizing_confidence:$confidence,error:(if $error == "" or $error == "missing" then null else $error end)}'
+	return 0
+}
+
+_npm_cache_format_bytes() {
+	local bytes="$1"
+	if [[ "$bytes" == "null" ]]; then
+		printf 'unavailable'
+	elif [[ "$bytes" -ge 1073741824 ]]; then
+		printf '%s.%s GiB' "$((bytes / 1073741824))" "$(((bytes % 1073741824) * 10 / 1073741824))"
+	elif [[ "$bytes" -ge 1048576 ]]; then
+		printf '%s.%s MiB' "$((bytes / 1048576))" "$(((bytes % 1048576) * 10 / 1048576))"
+	else
+		printf '%s KiB' "$((bytes / 1024))"
+	fi
+	return 0
+}
+
+_npm_cache_status() {
+	local report=""
+	local cache_path=""
+	local total_bytes=""
+	local warn_bytes=""
+	local advisory=""
+	local error=""
+
+	report=$(_npm_cache_json)
+	cache_path=$(printf '%s' "$report" | jq -r '.path')
+	total_bytes=$(printf '%s' "$report" | jq -r '.total_bytes | tostring')
+	warn_bytes=$(printf '%s' "$report" | jq -r '.warning_threshold_bytes')
+	advisory=$(printf '%s' "$report" | jq -r '.advisory')
+	error=$(printf '%s' "$report" | jq -r '.error // ""')
+	printf 'npm cache: %s (%s)\n' "$(_npm_cache_format_bytes "$total_bytes")" "$cache_path"
+	case "$advisory" in
+	warning)
+		print_warning "npm cache exceeds the $(_npm_cache_format_bytes "$warn_bytes") advisory threshold"
+		printf 'Safe first step: npm-cache-helper.sh verify\n'
+		printf 'If it remains oversized, review: npm-cache-helper.sh clean\n'
+		;;
+	ok) print_success "npm cache is below the advisory threshold" ;;
+	*) print_warning "npm cache size is unavailable${error:+ ($error)}" ;;
+	esac
+	printf 'No cleanup was performed. npm remains the cache owner.\n'
+	return 0
+}
+
+_npm_cache_require_npm() {
+	if command -v npm >/dev/null 2>&1; then
+		return 0
+	fi
+	print_error "npm is not available"
+	return 1
+}
+
+_npm_cache_verify() {
+	local cache_path=""
+	_npm_cache_require_npm || return 1
+	cache_path=$(_npm_cache_resolve_path) || {
+		print_error "npm cache path is unavailable"
+		return 1
+	}
+	printf 'Running npm-owned integrity verification and garbage collection...\n'
+	npm cache verify --cache "$cache_path"
+	_npm_cache_status
+	return 0
+}
+
+_npm_cache_clean() {
+	local apply=0
+	local confirm=""
+	local arg=""
+	local cache_path=""
+
+	while [[ "$#" -gt 0 ]]; do
+		arg="$1"
+		shift
+		case "$arg" in
+		--apply) apply=1 ;;
+		--confirm)
+			[[ "$#" -gt 0 ]] || {
+				print_error "--confirm requires a token"
+				return 1
+			}
+			confirm="$1"
+			shift
+			;;
+		*)
+			print_error "Unknown clean option: $arg"
+			return 1
+			;;
+		esac
+	done
+
+	_npm_cache_require_npm || return 1
+	cache_path=$(_npm_cache_resolve_path) || {
+		print_error "npm cache path is unavailable"
+		return 1
+	}
+	_npm_cache_status
+	if [[ "$apply" -ne 1 ]]; then
+		printf 'Dry run only. This would ask npm to clear its cache at %s.\n' "$(_npm_cache_display_path "$cache_path")"
+		printf 'After review, run: npm-cache-helper.sh clean --apply --confirm %s\n' "$NPM_CACHE_CONFIRM_TOKEN"
+		return 0
+	fi
+	if [[ "$confirm" != "$NPM_CACHE_CONFIRM_TOKEN" ]]; then
+		print_error "Confirmation mismatch; expected: $NPM_CACHE_CONFIRM_TOKEN"
+		return 1
+	fi
+	printf 'Running npm cache clean --force for %s...\n' "$(_npm_cache_display_path "$cache_path")"
+	npm cache clean --force --cache "$cache_path"
+	_npm_cache_status
+	return 0
+}
+
+main() {
+	local command_name="${1:-status}"
+	if [[ "$#" -gt 0 ]]; then
+		shift
+	fi
+	case "$command_name" in
+	status) _npm_cache_status ;;
+	json) _npm_cache_json ;;
+	verify) _npm_cache_verify ;;
+	clean) _npm_cache_clean "$@" ;;
+	help | --help | -h) _npm_cache_usage ;;
+	*)
+		_npm_cache_usage >&2
+		return 1
+		;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/storage-inventory-helper.sh
+++ b/.agents/scripts/storage-inventory-helper.sh
@@ -44,6 +44,8 @@ STORAGE_JOINT="joint"
 STORAGE_ACTIVE="active"
 STORAGE_ARCHIVE="archive"
 STORAGE_PRODUCER_OPENCODE="opencode"
+STORAGE_NPM_CACHE_WARN_BYTES="${AIDEVOPS_NPM_CACHE_WARN_BYTES:-10737418240}"
+STORAGE_FIELD_NONE="__none__"
 
 _storage_usage() {
 	cat <<'USAGE'
@@ -710,6 +712,61 @@ _storage_worktree_recovery_record() {
 	return 0
 }
 
+_storage_npm_cache_path() {
+	local configured_path="${AIDEVOPS_NPM_CACHE_DIR:-}"
+
+	if [[ -z "$configured_path" ]] && [[ -n "${HOME:-}" ]] && command -v npm >/dev/null 2>&1; then
+		configured_path=$(npm config get cache 2>/dev/null) || configured_path=""
+	fi
+	if [[ -z "$configured_path" ]] && [[ -n "${HOME:-}" ]]; then
+		configured_path="$HOME/.npm"
+	fi
+	case "$configured_path" in
+	/*) printf '%s' "$configured_path" ;;
+	*) printf '' ;;
+	esac
+	return 0
+}
+
+_storage_npm_cache_record() {
+	local actual_path=""
+	local measured=""
+	local total_bytes="$STORAGE_JSON_NULL"
+	local confidence="unavailable"
+	local error=""
+	local warning_threshold="$STORAGE_NPM_CACHE_WARN_BYTES"
+	local advisory="unavailable"
+	local next_action="Run npm-cache-helper.sh status for an explicit size scan"
+	local original_timeout="$STORAGE_SIZE_TIMEOUT_TENTHS"
+
+	actual_path=$(_storage_npm_cache_path)
+	case "$warning_threshold" in
+	'' | *[!0-9]*) warning_threshold=10737418240 ;;
+	esac
+	STORAGE_SIZE_TIMEOUT_TENTHS="${AIDEVOPS_NPM_CACHE_SIZE_TIMEOUT_TENTHS:-$original_timeout}"
+	measured=$(_storage_measure_path "$actual_path")
+	STORAGE_SIZE_TIMEOUT_TENTHS="$original_timeout"
+	IFS='|' read -r total_bytes confidence error <<<"$measured"
+	if [[ "$total_bytes" != "$STORAGE_JSON_NULL" ]]; then
+		if [[ "$total_bytes" -ge "$warning_threshold" ]]; then
+			advisory="warning"
+			next_action="Run npm-cache-helper.sh verify; if still oversized, review npm-cache-helper.sh clean"
+		else
+			advisory="ok"
+			next_action="No cleanup suggested; npm-cache-helper.sh status can recheck after npm-heavy work"
+		fi
+	fi
+
+	_storage_emit_measured_record "npm-cache" "npm" "npm cache" "external" "cache" \
+		"configurable byte advisory threshold; package-manager owned; no automatic cleanup" "protected" \
+		"external owner" "$next_action" "$measured" |
+		jq -c \
+			--arg advisory "$advisory" \
+			--argjson warning_threshold_bytes "$warning_threshold" \
+			'. + {advisory:$advisory,warning_threshold_bytes:$warning_threshold_bytes}'
+	return 0
+}
+
 _storage_inventory_records() {
 	local home_label="~"
 	local framework_owner="$STORAGE_OWNER_FRAMEWORK"
@@ -727,7 +784,7 @@ _storage_inventory_records() {
 	_storage_emit_record "pulse-stage-timings" "$pulse_producer" "${home_label}/.aidevops/logs/pulse-stage-timings.log" "${HOME:+$HOME/.aidevops/logs/pulse-stage-timings.log}" "$framework_owner" "$active_class" "1 MiB active-file cap with gzip archive rotation" "$protected_disposition" "$active_writer_reason" "Use pulse-owned rotate_pulse_log; never unlink the active file"
 	_storage_emit_record "pulse-log-archive" "$pulse_producer" "${home_label}/.aidevops/logs/pulse-archive" "${HOME:+$HOME/.aidevops/logs/pulse-archive}" "$framework_owner" "archive" "1 GiB combined cold archive cap; oldest archives first" "$protected_disposition" "archive already converged by producer" "Use pulse-owned rotate_pulse_log for archive pruning"
 	_storage_opencode_records
-	_storage_emit_record "npm-cache" "npm" "npm cache" "${AIDEVOPS_NPM_CACHE_DIR:-${HOME:+$HOME/.npm}}" "external" "cache" "package-manager owned; no aidevops cleanup authority" "protected" "external owner" "Use npm-owned diagnostics and cleanup explicitly"
+	_storage_npm_cache_record
 	return 0
 }
 
@@ -772,16 +829,22 @@ _storage_status() {
 	local reason=""
 	local next_action=""
 	local error=""
+	local advisory=""
 	report=$(_storage_inventory_json)
 	printf 'Storage Inventory (read-only)\n'
 	printf '%-24s %-10s %-10s %12s %12s %12s %12s %-11s\n' "Store" "Owner" "Class" "Total" "Protected" "Reclaimable" "Unknown" "Confidence"
-	printf '%s\n' "$report" | jq -r '.stores[] | [.store_id,.owner,.safety_class,(.total_bytes|tostring),(.protected_bytes|tostring),(.reclaimable_bytes|tostring),(.unknown_bytes|tostring),.sizing_confidence,.protection_reasons[0],.next_action,(.error // "")] | @tsv' |
-		while IFS=$'\t' read -r store_id owner safety_class total protected reclaimable unknown confidence reason next_action error; do
+	printf '%s\n' "$report" | jq -r --arg none "$STORAGE_FIELD_NONE" '.stores[] | [.store_id,.owner,.safety_class,(.total_bytes|tostring),(.protected_bytes|tostring),(.reclaimable_bytes|tostring),(.unknown_bytes|tostring),.sizing_confidence,.protection_reasons[0],.next_action,(.error // $none),(.advisory // $none)] | @tsv' |
+		while IFS=$'\t' read -r store_id owner safety_class total protected reclaimable unknown confidence reason next_action error advisory; do
+			[[ "$error" == "$STORAGE_FIELD_NONE" ]] && error=""
+			[[ "$advisory" == "$STORAGE_FIELD_NONE" ]] && advisory=""
 			printf '%-24s %-10s %-10s %12s %12s %12s %12s %-11s\n' \
 				"$store_id" "$owner" "$safety_class" "$(_storage_format_bytes "$total")" "$(_storage_format_bytes "$protected")" "$(_storage_format_bytes "$reclaimable")" "$(_storage_format_bytes "$unknown")" "$confidence"
 			printf '  reason: %s' "$reason"
 			[[ -n "$error" ]] && printf ' (%s)' "$error"
 			printf '\n'
+			if [[ "$advisory" == "warning" ]]; then
+				printf '  WARNING: this external cache exceeds its advisory threshold\n'
+			fi
 			printf '  next: %s\n' "$next_action"
 		done
 	printf 'No cleanup was performed. Unknown or unavailable classifications are never reclaimable.\n'

--- a/.agents/scripts/tests/test-npm-cache-helper.sh
+++ b/.agents/scripts/tests/test-npm-cache-helper.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/../npm-cache-helper.sh"
+TEST_ROOT="$(mktemp -d -t aidevops-npm-cache.XXXXXX)"
+FAKE_BIN="$TEST_ROOT/bin"
+FAKE_CACHE="$TEST_ROOT/npm-cache"
+NPM_CALLS="$TEST_ROOT/npm-calls"
+export FAKE_CACHE NPM_CALLS
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	exit 1
+}
+
+mkdir -p "$FAKE_BIN" "$FAKE_CACHE"
+printf 'cache data\n' >"$FAKE_CACHE/data"
+cat >"$FAKE_BIN/npm" <<'FAKE_NPM'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$NPM_CALLS"
+if [[ "${1:-}" == "config" ]] && [[ "${2:-}" == "get" ]] && [[ "${3:-}" == "cache" ]]; then
+	printf '%s\n' "$FAKE_CACHE"
+	return 0 2>/dev/null || exit 0
+fi
+if [[ "${1:-}" == "cache" ]] && [[ "${2:-}" == "verify" ]]; then
+	printf 'verified\n'
+	return 0 2>/dev/null || exit 0
+fi
+if [[ "${1:-}" == "cache" ]] && [[ "${2:-}" == "clean" ]] && [[ "${3:-}" == "--force" ]]; then
+	printf 'cleaned\n'
+	return 0 2>/dev/null || exit 0
+fi
+exit 1
+FAKE_NPM
+chmod +x "$FAKE_BIN/npm"
+
+report=$(PATH="$FAKE_BIN:$PATH" AIDEVOPS_NPM_CACHE_WARN_BYTES=1 bash "$HELPER" json)
+[[ "$(printf '%s' "$report" | jq -r '.schema')" == "aidevops.npm-cache-status/v1" ]] || fail "status schema missing"
+[[ "$(printf '%s' "$report" | jq -r '.owner')" == "external" ]] || fail "helper claimed npm ownership"
+[[ "$(printf '%s' "$report" | jq -r '.advisory')" == "warning" ]] || fail "oversized fixture did not warn"
+
+: >"$NPM_CALLS"
+dry_run=$(PATH="$FAKE_BIN:$PATH" bash "$HELPER" clean)
+[[ "$dry_run" == *"Dry run only"* ]] || fail "clean did not default to dry run"
+if grep -Fq 'cache clean --force' "$NPM_CALLS"; then
+	fail "dry run invoked npm cache clean"
+fi
+
+: >"$NPM_CALLS"
+if PATH="$FAKE_BIN:$PATH" bash "$HELPER" clean --apply --confirm wrong-token >/dev/null 2>&1; then
+	fail "clean accepted an invalid confirmation token"
+fi
+if grep -Fq 'cache clean --force' "$NPM_CALLS"; then
+	fail "invalid confirmation invoked npm cache clean"
+fi
+
+: >"$NPM_CALLS"
+PATH="$FAKE_BIN:$PATH" bash "$HELPER" clean --apply --confirm clean-npm-cache >/dev/null
+grep -Fxq "cache clean --force --cache $FAKE_CACHE" "$NPM_CALLS" || fail "confirmed clean did not bind npm-owned cleanup to the measured cache"
+
+: >"$NPM_CALLS"
+PATH="$FAKE_BIN:$PATH" bash "$HELPER" verify >/dev/null
+grep -Fxq "cache verify --cache $FAKE_CACHE" "$NPM_CALLS" || fail "verify did not bind npm-owned garbage collection to the measured cache"
+
+printf 'PASS: npm cache monitoring is read-only by default and cleanup is npm-owned and confirmed\n'
+exit 0

--- a/.agents/scripts/tests/test-storage-inventory-helper.sh
+++ b/.agents/scripts/tests/test-storage-inventory-helper.sh
@@ -99,6 +99,7 @@ after_checksum=$(fixture_checksum)
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "observability") | .unknown_bytes > 0')" == "true" ]] || fail "unattributed observability bytes did not fail closed"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "observability") | has("active_bytes") and has("archive_bytes") and has("candidate_bytes")')" == "true" ]] || fail "observability lifecycle byte classes missing"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "npm-cache") | .owner')" == "external" ]] || fail "npm ownership was claimed by aidevops"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "npm-cache") | .warning_threshold_bytes')" == "10737418240" ]] || fail "npm advisory threshold missing"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-active-db") | .owner')" == "joint" ]] || fail "OpenCode active DB ownership was not bounded"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-active-db") | .safety_class')" == "unknown" ]] || fail "unavailable OpenCode schema did not fail closed"
 [[ "$(printf '%s' "$report" | jq '[.stores[] | select(.store_id | startswith("opencode-")) | .reclaimable_bytes] | add')" == "0" ]] || fail "OpenCode report exposed cleanup candidates"
@@ -120,6 +121,12 @@ human=$(bash "$HELPER" status)
 [[ "$human" == *"Storage Inventory (read-only)"* ]] || fail "human report heading missing"
 [[ "$human" == *"No cleanup was performed"* ]] || fail "human report omitted non-destructive guarantee"
 [[ "$human" == *"next: Use aidevops opencode-db report"* ]] || fail "human report omitted OpenCode guidance"
+
+report=$(AIDEVOPS_NPM_CACHE_WARN_BYTES=1 bash "$HELPER" json)
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "npm-cache") | .advisory')" == "warning" ]] || fail "oversized npm cache warning missing"
+human=$(AIDEVOPS_NPM_CACHE_WARN_BYTES=1 bash "$HELPER" status)
+[[ "$human" == *"WARNING: this external cache exceeds its advisory threshold"* ]] || fail "human npm cache warning missing"
+[[ "$human" == *"npm-cache-helper.sh verify"* ]] || fail "human npm cache warning omitted npm-owned remediation"
 
 mv "$HOME/.aidevops/runtime-bundles" "$HOME/.aidevops/runtime-bundles-real"
 ln -s "$HOME/.aidevops/runtime-bundles-real" "$HOME/.aidevops/runtime-bundles"
@@ -168,7 +175,7 @@ AGENTS_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 export AGENTS_DIR
 # shellcheck source=../aidevops-cli/aidevops-status-lib.sh
 source "$SCRIPT_DIR/../aidevops-cli/aidevops-status-lib.sh"
-status_output=$(AIDEVOPS_STATUS_STORAGE_TIMEOUT_TENTHS=1 _status_storage_inventory)
+status_output=$(AIDEVOPS_STATUS_STORAGE_TIMEOUT_TENTHS=1 AIDEVOPS_STATUS_NPM_CACHE_TIMEOUT_TENTHS=1 _status_storage_inventory)
 [[ "$status_output" == *"Storage Inventory (read-only)"* ]] || fail "aidevops status integration omitted storage inventory"
 
 printf 'PASS: storage inventory is read-only, portable, explicit, and fail-closed\n'

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ git clone https://github.com/marcusquinn/aidevops.git ~/Git/aidevops
 **After installation, use the CLI:**
 
 ```bash
-aidevops status           # Check what's installed
+aidevops status           # Check installation and storage/cache health
 aidevops doctor           # Detect duplicate installs and PATH conflicts
 aidevops update           # Update framework + check registered projects
 aidevops auto-update      # Manage automatic update polling (every 10 min)


### PR DESCRIPTION
## Summary

Adds bounded npm cache size advisories to aidevops status and an npm-owned helper for verification plus confirmation-gated cleanup.

## Files Changed

.agents/reference/storage-lifecycle.md, .agents/scripts/aidevops-cli/aidevops-status-lib.sh, .agents/scripts/npm-cache-helper.sh, .agents/scripts/storage-inventory-helper.sh, .agents/scripts/tests/test-npm-cache-helper.sh, .agents/scripts/tests/test-storage-inventory-helper.sh, README.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified against an actual oversized cache; local quality suite, ShellCheck, Markdown lint, deterministic fake-npm cleanup guards, and external-owner advisory assertions pass.

Resolves #30805


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 1h 16m and 376,017 tokens on this with the user in an interactive session.