### PR TITLE
GH#30812: fix: refresh idle supervisor dashboards hourly

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -40,7 +40,10 @@ _STATS_HEALTH_DASHBOARD_LOADED=1
 # see existing ones.
 readonly _HEALTH_QUERY_FAILED_SENTINEL="__QUERY_FAILED__"
 readonly _HEALTH_CROSS_REPO_MAX_REPOS=30
-readonly _HEALTH_IDLE_REFRESH_INTERVAL_DEFAULT=43200
+# An otherwise-idle Pulse still proves the supervisor is alive. Keep its
+# dashboard marker within one stats cycle so the single-glance surface does
+# not contradict a fresh local heartbeat for up to one hour.
+readonly _HEALTH_IDLE_REFRESH_INTERVAL_DEFAULT=3600
 readonly _HEALTH_ACTIVITY_STATE_ACTIVE="active"
 readonly _HEALTH_ACTIVITY_STATE_IDLE="idle"
 # The framework dashboard is the primary operator health surface. Refresh it
@@ -106,8 +109,8 @@ _resolve_current_gh_login_or_fallback() {
 #######################################
 # Activity guard — returns 0 to proceed, 1 to skip.
 # Active repositories refresh on the hourly stats cadence. Idle repositories
-# publish their transition to idle immediately, then refresh every 12 hours by
-# default. This keeps the dashboard well inside the 48-hour freshness watchdog
+# publish their transition to idle immediately, then refresh every hour by
+# default. This keeps the dashboard closely aligned with the local heartbeat
 # while avoiding full activity scans and GitHub writes for unchanged idle repos.
 #######################################
 _check_health_issue_activity_guard() {
@@ -178,7 +181,12 @@ _check_health_issue_activity_guard() {
 		return 0
 	fi
 
-	echo "[stats] Health issue: deferring unchanged idle dashboard for ${repo_slug} (interval=${idle_interval}s)" \
+	local dashboard_issue="unknown"
+	if [[ -f "$health_issue_file" ]]; then
+		dashboard_issue=$(<"$health_issue_file") || dashboard_issue="unknown"
+		[[ "$dashboard_issue" =~ ^[0-9]+$ ]] || dashboard_issue="unknown"
+	fi
+	echo "[stats] Health issue: deferring unchanged idle dashboard for ${repo_slug} (operator=${runner_user} issue=#${dashboard_issue} reason=idle-refresh-interval interval=${idle_interval}s)" \
 		>>"${LOGFILE:-/dev/null}"
 	return 1
 }

--- a/.agents/scripts/tests/test-stats-functions-characterization.sh
+++ b/.agents/scripts/tests/test-stats-functions-characterization.sh
@@ -291,6 +291,26 @@ test_resolve_current_gh_login_rejects_leading_hyphen_fallback() {
 }
 
 #######################################
+# Test 2c: idle dashboards must refresh within one bounded interval and leave
+# an operator/actionable diagnostic when the activity guard defers a write.
+#######################################
+test_idle_dashboard_freshness_contract() {
+	local dashboard_script diagnostic_pattern
+	dashboard_script="${STATS_SCRIPTS_DIR}/stats-health-dashboard.sh"
+	diagnostic_pattern="operator=\${runner_user} issue=#\${dashboard_issue} reason=idle-refresh-interval"
+
+	if grep -Fq 'readonly _HEALTH_IDLE_REFRESH_INTERVAL_DEFAULT=3600' "$dashboard_script" \
+		&& grep -Fq "$diagnostic_pattern" "$dashboard_script"; then
+		print_result "idle dashboard refreshes hourly with an actionable defer diagnostic" 0
+		return 0
+	fi
+
+	print_result "idle dashboard refreshes hourly with an actionable defer diagnostic" 1 \
+		"expected one-hour default plus repo/operator/issue defer reason"
+	return 0
+}
+
+#######################################
 # Test 3: _persist_role_cache -- writes role to a deterministic file path.
 # Signature: _persist_role_cache runner_user repo_slug role
 # Verify the file is created with expected content in the sandbox.
@@ -381,6 +401,7 @@ main() {
 	test_source_and_function_existence
 	test_validate_repo_slug
 	test_resolve_current_gh_login_rejects_leading_hyphen_fallback
+	test_idle_dashboard_freshness_contract
 	test_persist_role_cache
 	test_sourcing_idempotency
 	test_sweep_state_round_trip


### PR DESCRIPTION
## Summary

Refresh idle supervisor health dashboards hourly and record the operator, issue, and skip reason when the activity guard defers a write.

## Files Changed

.agents/scripts/stats-health-dashboard.sh, .agents/scripts/tests/test-stats-functions-characterization.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-stats-functions-characterization.sh; bash .agents/scripts/tests/test-dashboard-freshness-check.sh; shellcheck .agents/scripts/stats-health-dashboard.sh .agents/scripts/tests/test-stats-functions-characterization.sh

Resolves #30812


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 7m and 147,300 tokens on this as a headless worker.