### PR TITLE
GH#30826: fix: normalize reopened large-file debt labels

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -1773,7 +1773,7 @@ _close_with_rationale() {
 		cat <<EOF
 > Premise falsified. Pre-dispatch validator for generator \`${generator}\` determined the issue premise is no longer true. ${rationale_detail} Not dispatching a worker.
 
-The issue was closed automatically by the pre-dispatch validator (GH#19118, t2367). If conditions change, a new issue will be created by the next pulse cycle.
+The issue was closed automatically by the pre-dispatch validator (GH#19118, t2367). If conditions change, the next pulse cycle may reopen the canonical issue.
 
 ${sig_footer}
 EOF

--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -530,7 +530,9 @@ _large_file_gate_normalize_debt_issue() {
 	local _labels="" _stale_label
 	_labels=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || return 1
-	for _stale_label in status:done not-planned simplification-incomplete; do
+	# A reopened canonical issue must not retain any terminal exclusion labels:
+	# dispatch candidate enumeration rejects these even when auto-dispatch exists.
+	for _stale_label in status:done not-planned simplification-incomplete duplicate already-fixed wontfix; do
 		if [[ ",$_labels," == *",$_stale_label,"* ]]; then
 			if ! gh issue edit "$issue_number" --repo "$repo_slug" \
 				--remove-label "$_stale_label" >/dev/null 2>&1; then

--- a/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
+++ b/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
@@ -94,6 +94,7 @@ GH_CALLS_LOG="${TMP}/gh_calls.log"
 GH_CREATE_RESPONSE_URL=""
 GH_REMOTE_CONTENT_RESPONSE=""
 GH_REMOTE_CONTENT_FAIL=""
+GH_LABELS_RESPONSE=""
 : >"$GH_CALLS_LOG"
 
 # =============================================================================
@@ -113,7 +114,7 @@ gh_issue_list() {
 }
 
 gh_issue_view() {
-	printf ''
+	printf '%s' "$GH_LABELS_RESPONSE"
 	return 0
 }
 
@@ -267,6 +268,7 @@ GH_CLOSED_RESPONSE="18706"
 GH_CREATE_RESPONSE_URL=""
 GH_REMOTE_CONTENT_RESPONSE=$(_remote_content_json "$OVER_FILE")
 GH_REMOTE_CONTENT_FAIL=""
+GH_LABELS_RESPONSE=""
 out=$(_large_file_gate_create_debt_issue "over.sh" "9999" "owner/repo" "$TMP")
 assert_eq \
 	"closed + file over threshold → reopen canonical issue" \
@@ -281,11 +283,34 @@ assert_contains \
 	"gh issue reopen 18706 --repo owner/repo" \
 	"$(cat "$GH_CALLS_LOG")"
 
+# A prior terminal closure must not leave the reopened canonical issue
+# ineligible for candidate enumeration.
+: >"$GH_CALLS_LOG"
+GH_LABELS_RESPONSE="duplicate,already-fixed,status:done,not-planned,simplification-incomplete,wontfix"
+out=$(_large_file_gate_reopen_debt_issue "18706" "over.sh" "owner/repo")
+assert_eq \
+	"terminal-labelled canonical issue reopens" \
+	"#18706 (reopened)" \
+	"$out"
+assert_contains \
+	"reopened canonical issue removes terminal exclusion labels" \
+	"--remove-label duplicate" \
+	"$(cat "$GH_CALLS_LOG")"
+assert_contains \
+	"reopened canonical issue removes already-fixed label" \
+	"--remove-label already-fixed" \
+	"$(cat "$GH_CALLS_LOG")"
+assert_contains \
+	"reopened canonical issue restores active lifecycle labels" \
+	"--add-label file-size-debt,auto-dispatch" \
+	"$(cat "$GH_CALLS_LOG")"
+
 # ---- Test 3 — stale local OVER, remote UNDER → keep solved issue closed ----
 GH_OPEN_RESPONSE=""
 GH_CLOSED_RESPONSE="18706"
 GH_REMOTE_CONTENT_RESPONSE=$(_remote_content_json "$UNDER_FILE")
 GH_REMOTE_CONTENT_FAIL=""
+GH_LABELS_RESPONSE=""
 out=$(_large_file_gate_create_debt_issue "over.sh" "9999" "owner/repo" "$TMP")
 assert_eq \
 	"stale local over + remote under → continuation" \
@@ -301,6 +326,7 @@ GH_OPEN_RESPONSE=""
 GH_CLOSED_RESPONSE="18706"
 GH_REMOTE_CONTENT_RESPONSE=""
 GH_REMOTE_CONTENT_FAIL="1"
+GH_LABELS_RESPONSE=""
 out=$(_large_file_gate_create_debt_issue "over.sh" "9999" "owner/repo" "$TMP")
 assert_eq \
 	"local over + remote unavailable → defer reopen" \
@@ -316,6 +342,7 @@ GH_OPEN_RESPONSE=""
 GH_CLOSED_RESPONSE="18706"
 GH_CREATE_RESPONSE_URL=""
 GH_REMOTE_CONTENT_FAIL=""
+GH_LABELS_RESPONSE=""
 out=$(_large_file_gate_create_debt_issue "over.sh" "9999" "owner/repo")
 assert_eq \
 	"closed + no repo_path → continuation (backward-compat fallback)" \
@@ -326,6 +353,7 @@ assert_eq \
 GH_OPEN_RESPONSE=""
 GH_CLOSED_RESPONSE="18706"
 GH_CREATE_RESPONSE_URL=""
+GH_LABELS_RESPONSE=""
 out=$(_large_file_gate_create_debt_issue "missing.sh" "9999" "owner/repo" "$TMP")
 assert_eq \
 	"closed + file missing on disk → continuation (measurement unavailable)" \

--- a/.agents/scripts/tests/test-pre-dispatch-validator-large-file.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator-large-file.sh
@@ -417,7 +417,6 @@ test_function_marker_markdown_uses_file_lines() {
 	else
 		print_result "function_marker_markdown_uses_file_line_rationale" 1 "Expected file-line rationale without function wording"
 	fi
-
 	teardown_test_env
 	return 0
 }


### PR DESCRIPTION
## Summary

Reopened canonical large-file debt issues clear terminal exclusion labels, regain active dispatch labels, and describe durable issue reopening in validator closure notices.

## Files Changed

.agents/scripts/pre-dispatch-validator-helper.sh, .agents/scripts/pulse-dispatch-large-file-gate.sh, .agents/scripts/tests/test-large-file-gate-continuation-verify.sh, .agents/scripts/tests/test-pre-dispatch-validator-large-file.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck .agents/scripts/pulse-dispatch-large-file-gate.sh .agents/scripts/pre-dispatch-validator-helper.sh .agents/scripts/tests/test-large-file-gate-continuation-verify.sh; bash .agents/scripts/tests/test-large-file-gate-continuation-verify.sh

Resolves #30826


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 5m and 94,452 tokens on this as a headless worker.