### PR TITLE
GH#30825: fix(todo-sync): terminalize not-planned tasks

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -221,6 +221,30 @@ _mark_todo_done() {
 	return 0
 }
 
+# Mark an incomplete live TODO entry as declined after its linked issue was
+# deliberately closed as not planned. The line-number lookup excludes fenced
+# examples and comments, while preserving its existing GitHub reference.
+_mark_todo_not_planned() {
+	local task_id="$1" todo_file="$2" ref_num="$3"
+	local line_num target_line new_line new_line_escaped today
+
+	line_num=$(_todo_task_line_num "$task_id" "$todo_file")
+	[[ -n "$line_num" ]] || return 1
+	target_line=$(sed -n "${line_num}p" "$todo_file")
+	printf '%s\n' "$target_line" | grep -qE "ref:GH#${ref_num}([[:space:]]|$)" || return 1
+	printf '%s\n' "$target_line" | grep -qE '^[[:space:]]*- \[[ >]\] ' || return 0
+
+	new_line=$(printf '%s\n' "$target_line" | sed -E 's/^([[:space:]]*- )\[[ >]\]/\1[-]/')
+	if ! printf '%s\n' "$new_line" | grep -qE '(cancelled|deferred|declined):[0-9]{4}-[0-9]{2}-[0-9]{2}'; then
+		today=$(date -u +%Y-%m-%d)
+		new_line="${new_line} declined:${today}"
+	fi
+	new_line_escaped=$(printf '%s' "$new_line" | sed 's/[|&\\]/\\&/g')
+	sed_inplace "${line_num}s|.*|${new_line_escaped}|" "$todo_file" || return 1
+	log_verbose "Marked $task_id as [-] in TODO.md after #$ref_num was not planned"
+	return 0
+}
+
 _closed_issue_worker_complete_date() {
 	local repo="$1" issue_number="$2"
 	local completed_at
@@ -269,6 +293,17 @@ _mark_reopen_completed_task() {
 	fi
 	_mark_todo_done "$tid" "$todo_file" "verified:${proof_date}" || return 1
 	log_verbose "#$ref_num ($tid) has $reason — marked TODO [x]"
+	return 0
+}
+
+_mark_reopen_not_planned_task() {
+	local tid="$1" todo_file="$2" ref_num="$3"
+	if [[ "$DRY_RUN" == "true" ]]; then
+		print_info "[DRY-RUN] Would mark $tid [-] (not planned on #$ref_num)"
+		return 0
+	fi
+	_mark_todo_not_planned "$tid" "$todo_file" "$ref_num" || return 1
+	log_verbose "#$ref_num ($tid) is not planned — marked TODO [-]"
 	return 0
 }
 
@@ -515,7 +550,7 @@ cmd_close() {
 # regardless of whether a commit message prematurely closed the issue.
 #
 # Decision tree per closed issue:
-#   NOT_PLANNED         -> skip (deliberately declined)
+#   NOT_PLANNED         -> mark TODO cancelled (deliberately declined)
 #   COMPLETED + has PR  -> skip (work done, TODO needs marking [x] separately)
 #   COMPLETED + no PR   -> reopen (premature closure from commit keyword)
 _reopen_incomplete_task_line() {
@@ -544,7 +579,7 @@ _reopen_incomplete_task_line() {
 	tid=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
 	reason=$(printf '%s\n' "$issue_json" | jq -r 'select(type == "object") | .state_reason // .stateReason // ""' 2>/dev/null || printf '')
 	if _is_not_planned_state_reason "$reason"; then
-		log_verbose "#$ref_num ($tid) closed as not_planned — skipping"
+		_mark_reopen_not_planned_task "$tid" "$todo_file" "$ref_num" || return 11
 		return 12
 	fi
 	if _reopen_mark_if_completed "$repo" "$tid" "$ref_num" "$todo_file"; then
@@ -608,6 +643,6 @@ cmd_reopen() {
 		esac
 	done <<<"$unique_lines"
 
-	print_info "Reopen: $reopened reopened, $skipped failed, $not_planned not-planned, $has_pr have-merged-pr, $pr_refs pr-refs-skipped, $duplicate_comments duplicate-comments-skipped"
+	print_info "Reopen: $reopened reopened, $skipped failed, $not_planned not-planned-terminalized, $has_pr have-merged-pr, $pr_refs pr-refs-skipped, $duplicate_comments duplicate-comments-skipped"
 	return 0
 }

--- a/.agents/scripts/tests/test-issue-sync-reopen-churn.sh
+++ b/.agents/scripts/tests/test-issue-sync-reopen-churn.sh
@@ -21,6 +21,10 @@ if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/201" ]]; then
 	printf '{"number":201,"title":"plain issue"}\n'
 	exit 0
 fi
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/301" ]]; then
+	printf '{"number":301,"state":"closed","state_reason":"not_planned"}\n'
+	exit 0
+fi
 if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/202/comments" ]]; then
 	printf '[{"body":"Reopened: TODO.md still has this as `[ ]` (open) and no merged PR was found."}]\n'
 	exit 0
@@ -123,6 +127,68 @@ check_success "REST not_planned reason is skipped" _is_not_planned_state_reason 
 check_success "hyphenated not-planned reason is skipped" _is_not_planned_state_reason "not-planned"
 check_failure "completed reason is not treated as not planned" _is_not_planned_state_reason "COMPLETED"
 check_failure "missing close reason is not treated as not planned" _is_not_planned_state_reason
+
+NOT_PLANNED_TODO="$TMPDIR/not-planned-todo.md"
+DRY_RUN="false"
+cat >"$NOT_PLANNED_TODO" <<'TODO'
+```markdown
+- [ ] t303 fenced example ref:GH#303
+```
+- [ ] t301 first live task ref:GH#301
+- [>] t302 active live task ref:GH#302
+TODO
+
+_todo_task_line_num() {
+	local task_id="$1"
+	local todo_file="$2"
+	awk -v wanted="$task_id" '
+		/^[[:space:]]*```/ { in_fence = !in_fence; next }
+		!in_fence && $0 ~ /^[[:space:]]*- \[[ >-]\] / {
+			remaining = $0
+			sub(/^[[:space:]]*- \[[ >-]\] /, "", remaining)
+			split(remaining, fields, /[[:space:]]+/)
+			if (fields[1] == wanted) { print NR; exit }
+		}
+	' "$todo_file"
+	return 0
+}
+
+sed_inplace() {
+	local expression="$1"
+	local todo_file="$2"
+	sed -i.bak -E "$expression" "$todo_file" || return 1
+	rm -f "${todo_file}.bak"
+	return 0
+}
+
+log_verbose() {
+	return 0
+}
+
+reopen_status=0
+_reopen_incomplete_task_line "owner/repo" "$NOT_PLANNED_TODO" "" \
+	"- [ ] t301 first live task ref:GH#301" || reopen_status=$?
+if [[ "$reopen_status" -eq 12 ]]; then
+	PASS=$((PASS + 1))
+	printf 'PASS: not-planned issue terminalizes unchecked task through reopen lifecycle\n'
+else
+	FAIL=$((FAIL + 1))
+	printf 'FAIL: not-planned issue terminalizes unchecked task through reopen lifecycle\n'
+fi
+check_success "not-planned rows terminalize active tasks" \
+	_mark_reopen_not_planned_task "t302" "$NOT_PLANNED_TODO" "302"
+check_success "not-planned terminalization is idempotent" \
+	_mark_reopen_not_planned_task "t301" "$NOT_PLANNED_TODO" "301"
+if grep -qE '^\- \[-\] t301 first live task ref:GH#301 declined:[0-9]{4}-[0-9]{2}-[0-9]{2}$' "$NOT_PLANNED_TODO" &&
+	grep -qE '^\- \[-\] t302 active live task ref:GH#302 declined:[0-9]{4}-[0-9]{2}-[0-9]{2}$' "$NOT_PLANNED_TODO" &&
+	grep -q '^\- \[ \] t303 fenced example ref:GH#303$' "$NOT_PLANNED_TODO" &&
+	[[ "$(grep -Ec '^\- \[-\] t301 .*declined:' "$NOT_PLANNED_TODO")" -eq 1 ]]; then
+	PASS=$((PASS + 1))
+	printf 'PASS: not-planned terminalization preserves refs, skips fenced examples, and adds one proof\n'
+else
+	FAIL=$((FAIL + 1))
+	printf 'FAIL: not-planned terminalization preserves refs, skips fenced examples, and adds one proof\n'
+fi
 
 gh_find_merged_pr() {
 	local repo="$1"


### PR DESCRIPTION
## Summary

Terminalize unchecked and active TODO rows as declined when their linked issue is closed not planned, preserving refs and skipping fenced examples.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh, .agents/scripts/tests/test-issue-sync-reopen-churn.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-issue-sync-reopen-churn.sh; bash .agents/scripts/tests/test-issue-sync-completion-evidence.sh; shellcheck .agents/scripts/issue-sync-helper-close.sh .agents/scripts/tests/test-issue-sync-reopen-churn.sh

Resolves #30825


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 8m and 123,373 tokens on this as a headless worker.