### PR TITLE
GH#30824: fix: make issue-sync first-match callers pipe-safe

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -464,7 +464,8 @@ cmd_close() {
 		return 0
 	fi
 
-	# Bulk mode: fetch all open issues, build task->issue map
+	# Bulk mode: fetch all open issues, build task->issue map. The TODO loop below
+	# consumes the complete stripped stream, so its grep consumer cannot SIGPIPE.
 	local open_json
 	open_json=$(gh_list_issues "$repo" "open" 500)
 	local map=""

--- a/.agents/scripts/issue-sync-helper-commands.sh
+++ b/.agents/scripts/issue-sync-helper-commands.sh
@@ -120,7 +120,7 @@ cmd_pull() {
 			login=$(echo "$issue_line" | jq -r '.assignees[0].login // empty' 2>/dev/null || echo "")
 			[[ -z "$login" ]] && continue
 			local tl
-			tl=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${tid_ere} " | head -1 || echo "")
+			tl=$(_first_todo_task_line_or_empty "$tid" "$todo_file") || return 1
 			[[ -z "$tl" ]] && continue
 			echo "$tl" | grep -qE 'assignee:[A-Za-z0-9._@-]+' && continue
 			if [[ "$DRY_RUN" == "true" ]]; then

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -164,15 +164,17 @@ add_pr_ref_to_todo() {
 	local pr_number="$2"
 	local todo_file="$3"
 	local task_id_ere
+	local task_line=""
 	task_id_ere=$(_escape_ere "$task_id")
+	task_line=$(_first_todo_task_line_or_empty "$task_id" "$todo_file") || return 1
 
-	# Check if pr: ref already exists outside code fences
-	if strip_code_fences <"$todo_file" | grep -qE "^\s*- \[.\] ${task_id_ere} .*pr:#${pr_number}"; then
+	# The selector consumes the parser's complete output before checking refs.
+	if [[ "$task_line" == *"pr:#${pr_number}"* ]]; then
 		return 0
 	fi
 
-	# Check if any pr: ref already exists outside code fences (don't duplicate)
-	if strip_code_fences <"$todo_file" | grep -qE "^\s*- \[.\] ${task_id_ere} .*pr:#"; then
+	# Do not duplicate a different existing PR reference.
+	if [[ "$task_line" == *"pr:#"* ]]; then
 		log_verbose "$task_id already has a pr: ref, skipping"
 		return 0
 	fi
@@ -356,12 +358,11 @@ resolve_task_gh_number() {
 			return 0
 		fi
 	fi
-	local task_id_ere
-	task_id_ere=$(_escape_ere "$task_id")
-
-	local ref="" issue_json="" issue_id="" issue_number="" issue_state="" issue_cursor=""
-	ref=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 |
-		grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
+	local ref="" issue_json="" issue_id="" issue_number="" issue_state="" issue_cursor="" task_line=""
+	task_line=$(_first_todo_task_line_or_empty "$task_id" "$todo_file") || return 1
+	if [[ "$task_line" =~ ref:GH#([0-9]+) ]]; then
+		ref="${BASH_REMATCH[1]}"
+	fi
 	[[ "$ref" =~ ^[1-9][0-9]*$ ]] || return 1
 	issue_json=$(_gh_with_timeout read gh issue view "$ref" --repo "$repo" --json id,number,state,updatedAt 2>/dev/null || true)
 	[[ -n "$issue_json" ]] || return 1
@@ -685,10 +686,10 @@ _seed_orphan_todo_line() {
 	# Guard: empty task_id cannot produce a valid TODO line
 	task_identity_validate "$task_id" || return 1
 
-	# Idempotency check: skip if any entry for this task_id already exists
-	local task_id_ere
-	task_id_ere=$(_escape_ere "$task_id")
-	if strip_code_fences <"$todo_file" | grep -qE "^\s*- \[.\] ${task_id_ere} "; then
+	# Idempotency check: the full-stream selector avoids stopping the parser early.
+	local task_line=""
+	task_line=$(_first_todo_task_line_or_empty "$task_id" "$todo_file") || return 1
+	if [[ -n "$task_line" ]]; then
 		_dedupe_todo_task_lines "$task_id" "$todo_file" || true
 		{ log_verbose "ORPHAN already seeded: $task_id (ref:GH#$num) — skipping" || true; }
 		return 1

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -588,9 +588,8 @@ _dependency_sync_has_active_status() {
 }
 
 _relationship_task_line() {
-	local task_id="$1" todo_file="$2" task_id_ere=""
-	task_id_ere=$(_escape_ere "$task_id")
-	strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || true
+	local task_id="$1" todo_file="$2"
+	_first_todo_task_line_or_empty "$task_id" "$todo_file" || return 1
 	return 0
 }
 

--- a/.agents/scripts/test-issue-sync-lib.sh
+++ b/.agents/scripts/test-issue-sync-lib.sh
@@ -597,6 +597,34 @@ else
 	fail "first TODO task selector: caller wrapper hid parser failure (status=$selector_status output=$selector_output)"
 fi
 
+# Migrated library callers must retain their positive-match behavior without
+# allowing the large parser stream to terminate at a downstream grep/head.
+caller_todo="$TMP/todo-migrated-callers.md"
+{
+	printf '%s\n' '- [ ] t13000 migrated caller target ref:GH#13000'
+	caller_i=2
+	while [[ "$caller_i" -le 12000 ]]; do
+		printf -- '- [ ] t%s migrated caller filler ref:GH#%s\n' "$caller_i" "$caller_i"
+		caller_i=$((caller_i + 1))
+	done
+} >"$caller_todo"
+
+add_pr_ref_to_todo "t13000" "2007" "$caller_todo" 2>"$TMP/add-pr-caller.err"
+if grep -q 'pr:#2007' "$caller_todo" && [[ ! -s "$TMP/add-pr-caller.err" ]]; then
+	pass "migrated add_pr_ref_to_todo: large early match remains quiet"
+else
+	fail "migrated add_pr_ref_to_todo: large early match emitted an error or missed the ref"
+fi
+
+if _seed_orphan_todo_line "13000" "t13000" "t13000: duplicate candidate" '[]' "$caller_todo" \
+	2>"$TMP/orphan-caller.err"; then
+	fail "migrated orphan selector: duplicate task was seeded"
+elif [[ ! -s "$TMP/orphan-caller.err" ]]; then
+	pass "migrated orphan selector: large early duplicate remains quiet"
+else
+	fail "migrated orphan selector: large early duplicate emitted an error"
+fi
+
 selector_calls=$(grep -c '_first_todo_task_line' \
 	"$SCRIPT_DIR/issue-sync-helper.sh" "$SCRIPT_DIR/issue-sync-helper-close.sh" | \
 	awk -F: '{ total += $2 } END { print total + 0 }')
@@ -606,6 +634,14 @@ if [[ "$selector_calls" -eq 5 ]] &&
 	pass "first TODO task selector: all enumerated issue-sync call sites migrated"
 else
 	fail "first TODO task selector: enumerated call-site migration incomplete (calls=$selector_calls)"
+fi
+
+if ! rg -U 'strip_code_fences[[:space:]]*<[^\n]+\|[[:space:]]*(grep -qE|grep -E[^\n]*\|[[:space:]]*head)' \
+	"$SCRIPT_DIR/issue-sync-lib-ref.sh" "$SCRIPT_DIR/issue-sync-helper-commands.sh" \
+	"$SCRIPT_DIR/issue-sync-relationships.sh" "$SCRIPT_DIR/issue-sync-helper-close.sh" >/dev/null; then
+	pass "first TODO task selector: residual first-match callers are pipe-safe"
+else
+	fail "first TODO task selector: residual early-closing parser pipeline remains"
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Migrated residual TODO first-match callers to the full-stream selector, documented the bulk-close safe path, and added large-fixture regressions.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh, .agents/scripts/issue-sync-helper-commands.sh, .agents/scripts/issue-sync-lib-ref.sh, .agents/scripts/issue-sync-relationships.sh, .agents/scripts/test-issue-sync-lib.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/test-issue-sync-lib.sh; bash .agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh; bash .agents/scripts/tests/test-issue-sync-relationship-deadline.sh; bash .agents/scripts/tests/test-issue-sync-close-signature.sh; .agents/scripts/linters-local.sh

Resolves #30824


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 8m and 121,031 tokens on this as a headless worker.