### PR TITLE
GH#30827: fix(pulse): shallow TODO sync clones

### DIFF
--- a/.agents/scripts/pulse-todo-sync-workspace.sh
+++ b/.agents/scripts/pulse-todo-sync-workspace.sh
@@ -24,6 +24,7 @@ _PTSW_LEGACY_COMMAND_SNAPSHOT=""
 _PTSW_LEGACY_COMMAND_STATUS=1
 _PTSW_LEGACY_SNAPSHOTS_READY=0
 _PTSW_LEGACY_CAP_LOGGED=0
+_PTSW_CLONE_DIAGNOSTIC_MAX_CHARS=512
 _PULSE_TODO_SYNC_WORKSPACE=""
 _PULSE_TODO_SYNC_WORKSPACE_ROOT=""
 _PULSE_TODO_SYNC_OWNER_PID=""
@@ -166,12 +167,38 @@ _ptsw_read_owner_marker() {
 	return 0
 }
 
+_ptsw_sanitize_clone_diagnostic() {
+	local diagnostic="$1"
+	local sanitized=""
+
+	# Strip URL authorities first, then known credential-shaped tokens. This
+	# fallback keeps the workspace helper safe when sourced without the full
+	# shared-constants bootstrap used by Pulse.
+	sanitized=$(printf '%s' "$diagnostic" |
+		sed -E 's|([A-Za-z][A-Za-z0-9+.-]*://)[^/@[:space:]]+@|\1|g') || return 1
+	if declare -F scrub_credentials >/dev/null 2>&1; then
+		sanitized=$(scrub_credentials "$sanitized") || return 1
+	else
+		sanitized=$(printf '%s' "$sanitized" |
+			sed -E 's/(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g') || return 1
+	fi
+	sanitized=$(printf '%s' "$sanitized" |
+		LC_ALL=C tr '\r\n\t' '   ' |
+		cut -c "1-${_PTSW_CLONE_DIAGNOSTIC_MAX_CHARS}") || return 1
+	[[ -n "$sanitized" ]] || sanitized="clone failed without diagnostic output"
+	printf '%s' "$sanitized"
+	return 0
+}
+
 _ptsw_create_workspace() {
 	local remote_url="$1"
 	local temp_root=""
 	local workspace_root=""
 	local marker_path=""
 	local marker_tmp=""
+	local clone_error_file=""
+	local clone_error=""
+	local clone_rc=0
 	local owner_pid="${BASHPID:-}"
 	local owner_start=""
 	local owner_created=""
@@ -214,9 +241,19 @@ _ptsw_create_workspace() {
 	_PULSE_TODO_SYNC_WORKSPACE="${workspace_root}/repo"
 	_PULSE_TODO_SYNC_OWNER_PID="$owner_pid"
 	_PULSE_TODO_SYNC_OWNER_START="$owner_start"
-	# TODO ref sync needs only the remote default branch tip; preserve clone errors
-	# on stderr so retry telemetry can be diagnosed by the pulse wrapper log.
-	git clone --quiet --no-tags --depth 1 --single-branch "$remote_url" "$_PULSE_TODO_SYNC_WORKSPACE" || return 1
+	clone_error_file="${workspace_root}/clone.stderr"
+	# TODO ref sync needs only the remote default branch tip. Capture clone
+	# errors so only a bounded, credential-scrubbed diagnostic reaches logs.
+	git clone --quiet --no-tags --depth 1 --single-branch \
+		"$remote_url" "$_PULSE_TODO_SYNC_WORKSPACE" 2>"$clone_error_file" || clone_rc=$?
+	if [[ "$clone_rc" -ne 0 ]]; then
+		clone_error=$(dd if="$clone_error_file" bs=512 count=2 2>/dev/null || true)
+		rm -f "$clone_error_file" 2>/dev/null || true
+		clone_error=$(_ptsw_sanitize_clone_diagnostic "$clone_error") || clone_error="clone diagnostic unavailable"
+		printf '[pulse-wrapper] TODO ref sync clone failed detail=%s\n' "$clone_error" >&2
+		return 1
+	fi
+	rm -f "$clone_error_file" 2>/dev/null || true
 	return 0
 }
 

--- a/.agents/scripts/pulse-todo-sync-workspace.sh
+++ b/.agents/scripts/pulse-todo-sync-workspace.sh
@@ -214,7 +214,9 @@ _ptsw_create_workspace() {
 	_PULSE_TODO_SYNC_WORKSPACE="${workspace_root}/repo"
 	_PULSE_TODO_SYNC_OWNER_PID="$owner_pid"
 	_PULSE_TODO_SYNC_OWNER_START="$owner_start"
-	git clone --quiet --no-tags "$remote_url" "$_PULSE_TODO_SYNC_WORKSPACE" >/dev/null 2>&1 || return 1
+	# TODO ref sync needs only the remote default branch tip; preserve clone errors
+	# on stderr so retry telemetry can be diagnosed by the pulse wrapper log.
+	git clone --quiet --no-tags --depth 1 --single-branch "$remote_url" "$_PULSE_TODO_SYNC_WORKSPACE" || return 1
 	return 0
 }
 

--- a/.agents/scripts/tests/test-issue-sync-project-root.sh
+++ b/.agents/scripts/tests/test-issue-sync-project-root.sh
@@ -135,6 +135,16 @@ source "$fixture_scripts/pulse-wrapper-cycle.sh"
 # shellcheck source=/dev/null
 source "$fixture_scripts/planning-publisher.sh"
 
+# Workspace creation must clone only the remote default branch tip.
+_ptsw_create_workspace "file://${remote_a}" || fail "shallow workspace clone failed"
+[[ $(git -C "$_PULSE_TODO_SYNC_WORKSPACE" rev-parse --is-shallow-repository) == "true" ]] ||
+	fail "TODO-sync workspace clone was not shallow"
+[[ $(git -C "$_PULSE_TODO_SYNC_WORKSPACE" branch -r | grep -Evc 'origin/HEAD') -eq 1 ]] ||
+	fail "TODO-sync workspace clone fetched more than the default branch"
+_ptsw_remove_owned_workspace "$_PULSE_TODO_SYNC_WORKSPACE_ROOT" \
+	"$_PULSE_TODO_SYNC_OWNER_PID" "$_PULSE_TODO_SYNC_OWNER_START" ||
+	fail "shallow workspace fixture cleanup failed"
+
 wait_for_file() {
 	local file_path="$1"
 	local max_attempts="${2:-100}"
@@ -187,6 +197,33 @@ sync_todo_refs_for_repo owner/repo-b "$repo_b"
 git --git-dir="$remote_b" show main:TODO.md | grep -q '^synced:owner/repo-b$' || fail "repo B remote was not synced"
 if only_todo_sync_workspace >/dev/null 2>&1; then
 	fail "successful reconciliation left an automation workspace behind"
+fi
+
+# Clone failures emit bounded diagnostics without exposing URL authorities or
+# credential-shaped values, clean their workspace, and remain retryable.
+original_git_definition=$(declare -f git)
+export TEST_CLONE_TOKEN="ghp_""1234567890abcdef"
+git() {
+	if [[ "${1:-}" == "clone" ]]; then
+		printf 'fatal: unable to access https://user:%s@example.invalid/private.git\n' "$TEST_CLONE_TOKEN" >&2
+		printf 'credential %s rejected; detail=%0600d\n' "$TEST_CLONE_TOKEN" 0 >&2
+		return 128
+	fi
+	/usr/bin/git "$@"
+	return $?
+}
+clone_failure_rc=0
+clone_failure_output=$(sync_todo_refs_for_repo owner/repo-clone-failure "$repo_a" 2>&1) || clone_failure_rc=$?
+eval "$original_git_definition"
+unset TEST_CLONE_TOKEN
+[[ "$clone_failure_rc" -eq 1 ]] || fail "clone failure was not retryable"
+[[ "$clone_failure_output" != *"1234567890abcdef"* && "$clone_failure_output" != *"user:"* ]] ||
+	fail "clone failure diagnostic exposed credentials"
+[[ "$clone_failure_output" == *"[redacted-credential]"* ]] ||
+	fail "clone failure diagnostic omitted redaction evidence"
+[[ ${#clone_failure_output} -le 600 ]] || fail "clone failure diagnostic exceeded its output bound"
+if only_todo_sync_workspace >/dev/null 2>&1; then
+	fail "clone failure left an automation workspace behind"
 fi
 [[ $(trap -p EXIT) == "$parent_exit_trap_before" ]] || fail "sync scope replaced the caller EXIT trap"
 [[ $(trap -p TERM) == "$parent_term_trap_before" ]] || fail "sync scope replaced the caller TERM trap"


### PR DESCRIPTION
## Summary

Uses a shallow, single-branch clone for the remote default branch and preserves clone diagnostics on stderr.

## Files Changed

.agents/scripts/pulse-todo-sync-workspace.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — shellcheck .agents/scripts/pulse-todo-sync-workspace.sh; bash .agents/scripts/tests/test-issue-sync-project-root.sh

Resolves #30827


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 4m and 68,854 tokens on this as a headless worker.