### PR TITLE
GH#30825: fix(todo-sync): use immutable decline evidence

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -221,27 +221,42 @@ _mark_todo_done() {
 	return 0
 }
 
-# Mark an incomplete live TODO entry as declined after its linked issue was
-# deliberately closed as not planned. The line-number lookup excludes fenced
-# examples and comments, while preserving its existing GitHub reference.
+# Converge a live TODO row with a linked issue deliberately closed as not
+# planned. The immutable GitHub closure timestamp is the evidence marker, so
+# repeated reconciliation is byte-stable and never uses the current clock.
 _mark_todo_not_planned() {
-	local task_id="$1" todo_file="$2" ref_num="$3"
-	local line_num target_line new_line new_line_escaped today
+	local task_id="$1"
+	local issue_number="$2"
+	local todo_file="$3"
+	local closed_date="$4"
+	local task_id_ere=""
+	local line_num=""
+	local target_line=""
+	local new_line=""
+	local new_line_escaped=""
 
-	line_num=$(_todo_task_line_num "$task_id" "$todo_file")
+	[[ "$task_id" =~ ^t[0-9]+(\.[0-9]+)*$ ]] || return 1
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
+	[[ "$closed_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+	task_id_ere=$(_escape_ere "$task_id")
+	if ! line_num=$(_todo_task_line_num "$task_id" "$todo_file"); then
+		return 1
+	fi
 	[[ -n "$line_num" ]] || return 1
 	target_line=$(sed -n "${line_num}p" "$todo_file")
-	printf '%s\n' "$target_line" | grep -qE "ref:GH#${ref_num}([[:space:]]|$)" || return 1
-	printf '%s\n' "$target_line" | grep -qE '^[[:space:]]*- \[[ >]\] ' || return 0
+	if printf '%s\n' "$target_line" | grep -qE \
+		"^[[:space:]]*- \[-\] ${task_id_ere} .*ref:GH#${issue_number}([[:space:]]|$).*declined:${closed_date}([[:space:]]|$)"; then
+		return 0
+	fi
+	printf '%s\n' "$target_line" | grep -qE "^[[:space:]]*- \[[ >]\] ${task_id_ere} .*ref:GH#${issue_number}([[:space:]]|$)" || return 1
 
 	new_line=$(printf '%s\n' "$target_line" | sed -E 's/^([[:space:]]*- )\[[ >]\]/\1[-]/')
-	if ! printf '%s\n' "$new_line" | grep -qE '(cancelled|deferred|declined):[0-9]{4}-[0-9]{2}-[0-9]{2}'; then
-		today=$(date -u +%Y-%m-%d)
-		new_line="${new_line} declined:${today}"
+	if ! printf '%s\n' "$new_line" | grep -qE '(^|[[:space:]])(declined|cancelled):[0-9]{4}-[0-9]{2}-[0-9]{2}([[:space:]]|$)'; then
+		new_line="${new_line} declined:${closed_date}"
 	fi
 	new_line_escaped=$(printf '%s' "$new_line" | sed 's/[|&\\]/\\&/g')
 	sed_inplace "${line_num}s|.*|${new_line_escaped}|" "$todo_file" || return 1
-	log_verbose "Marked $task_id as [-] in TODO.md after #$ref_num was not planned"
+	log_verbose "#$issue_number ($task_id) closed as not_planned — marked TODO [-]"
 	return 0
 }
 
@@ -293,17 +308,6 @@ _mark_reopen_completed_task() {
 	fi
 	_mark_todo_done "$tid" "$todo_file" "verified:${proof_date}" || return 1
 	log_verbose "#$ref_num ($tid) has $reason — marked TODO [x]"
-	return 0
-}
-
-_mark_reopen_not_planned_task() {
-	local tid="$1" todo_file="$2" ref_num="$3"
-	if [[ "$DRY_RUN" == "true" ]]; then
-		print_info "[DRY-RUN] Would mark $tid [-] (not planned on #$ref_num)"
-		return 0
-	fi
-	_mark_todo_not_planned "$tid" "$todo_file" "$ref_num" || return 1
-	log_verbose "#$ref_num ($tid) is not planned — marked TODO [-]"
 	return 0
 }
 
@@ -551,7 +555,7 @@ cmd_close() {
 # regardless of whether a commit message prematurely closed the issue.
 #
 # Decision tree per closed issue:
-#   NOT_PLANNED         -> mark TODO cancelled (deliberately declined)
+#   NOT_PLANNED         -> mark the linked live TODO row [-] once
 #   COMPLETED + has PR  -> skip (work done, TODO needs marking [x] separately)
 #   COMPLETED + no PR   -> reopen (premature closure from commit keyword)
 _reopen_incomplete_task_line() {
@@ -563,6 +567,9 @@ _reopen_incomplete_task_line() {
 	local issue_json=""
 	local tid=""
 	local reason=""
+	local closed_at=""
+	local issue_close_fields=""
+	local closed_date=""
 	local reopen_comment_body=""
 
 	ref_num=$(echo "$line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
@@ -578,9 +585,17 @@ _reopen_incomplete_task_line() {
 	fi
 
 	tid=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
-	reason=$(printf '%s\n' "$issue_json" | jq -r 'select(type == "object") | .state_reason // .stateReason // ""' 2>/dev/null || printf '')
+	issue_close_fields=$(printf '%s\n' "$issue_json" | jq -r 'select(type == "object") | [(.state_reason // .stateReason // ""), (.closed_at // .closedAt // "")] | @tsv' 2>/dev/null || printf '')
+	reason=${issue_close_fields%%$'\t'*}
 	if _is_not_planned_state_reason "$reason"; then
-		_mark_reopen_not_planned_task "$tid" "$todo_file" "$ref_num" || return 11
+		closed_at=${issue_close_fields#*$'\t'}
+		[[ "$closed_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || return 11
+		closed_date="${closed_at%%T*}"
+		if [[ "$DRY_RUN" == "true" ]]; then
+			print_info "[DRY-RUN] Would mark $tid [-] (not_planned on #$ref_num)"
+		elif ! _mark_todo_not_planned "$tid" "$ref_num" "$todo_file" "$closed_date"; then
+			return 11
+		fi
 		return 12
 	fi
 	if _reopen_mark_if_completed "$repo" "$tid" "$ref_num" "$todo_file"; then

--- a/.agents/scripts/tests/test-issue-sync-reopen-churn.sh
+++ b/.agents/scripts/tests/test-issue-sync-reopen-churn.sh
@@ -21,8 +21,12 @@ if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/201" ]]; then
 	printf '{"number":201,"title":"plain issue"}\n'
 	exit 0
 fi
-if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/301" ]]; then
-	printf '{"number":301,"state":"closed","state_reason":"not_planned"}\n'
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/208" ]]; then
+	printf '{"number":208,"title":"declined issue","state_reason":"NOT_PLANNED","closed_at":"2026-08-20T14:15:16Z"}\n'
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/209" ]]; then
+	printf '{"number":209,"title":"declined issue without closure time","state_reason":"NOT_PLANNED"}\n'
 	exit 0
 fi
 if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/202/comments" ]]; then
@@ -70,6 +74,10 @@ export PATH="$TMPDIR:$PATH"
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HELPER_PATH="${TEST_DIR}/../issue-sync-helper-close.sh"
 
+log_verbose() { return 0; }
+
+# shellcheck source=../issue-sync-lib.sh
+source "${TEST_DIR}/../issue-sync-lib.sh"
 # shellcheck source=../issue-sync-helper-close.sh
 source "$HELPER_PATH"
 
@@ -128,67 +136,54 @@ check_success "hyphenated not-planned reason is skipped" _is_not_planned_state_r
 check_failure "completed reason is not treated as not planned" _is_not_planned_state_reason "COMPLETED"
 check_failure "missing close reason is not treated as not planned" _is_not_planned_state_reason
 
-NOT_PLANNED_TODO="$TMPDIR/not-planned-todo.md"
-DRY_RUN="false"
-cat >"$NOT_PLANNED_TODO" <<'TODO'
+todo_file="$TMPDIR/TODO.md"
+cat >"$todo_file" <<'EOF'
+# TODO
+
 ```markdown
-- [ ] t303 fenced example ref:GH#303
+- [ ] t208 example row ref:GH#208
 ```
-- [ ] t301 first live task ref:GH#301
-- [>] t302 active live task ref:GH#302
-TODO
 
-_todo_task_line_num() {
-	local task_id="$1"
-	local todo_file="$2"
-	awk -v wanted="$task_id" '
-		/^[[:space:]]*```/ { in_fence = !in_fence; next }
-		!in_fence && $0 ~ /^[[:space:]]*- \[[ >-]\] / {
-			remaining = $0
-			sub(/^[[:space:]]*- \[[ >-]\] /, "", remaining)
-			split(remaining, fields, /[[:space:]]+/)
-			if (fields[1] == wanted) { print NR; exit }
-		}
-	' "$todo_file"
-	return 0
-}
+- [ ] t208 live declined row ref:GH#208 logged:2026-08-01
+- [>] t210 claimed declined row ref:GH#210 logged:2026-08-02
+- [x] t211 completed row ref:GH#211 completed:2026-08-03
+- [ ] t209 incomplete closure evidence ref:GH#209 logged:2026-08-04
+EOF
 
-sed_inplace() {
-	local expression="$1"
-	local todo_file="$2"
-	sed -i.bak -E "$expression" "$todo_file" || return 1
-	rm -f "${todo_file}.bak"
-	return 0
-}
-
-log_verbose() {
-	return 0
-}
-
-reopen_status=0
-_reopen_incomplete_task_line "owner/repo" "$NOT_PLANNED_TODO" "" \
-	"- [ ] t301 first live task ref:GH#301" || reopen_status=$?
-if [[ "$reopen_status" -eq 12 ]]; then
-	PASS=$((PASS + 1))
-	printf 'PASS: not-planned issue terminalizes unchecked task through reopen lifecycle\n'
+export DRY_RUN=false
+reopen_rc=0
+if _reopen_incomplete_task_line "owner/repo" "$todo_file" "" \
+	'- [ ] t208 live declined row ref:GH#208 logged:2026-08-01'; then
+	reopen_rc=0
 else
-	FAIL=$((FAIL + 1))
-	printf 'FAIL: not-planned issue terminalizes unchecked task through reopen lifecycle\n'
+	reopen_rc=$?
 fi
-check_success "not-planned rows terminalize active tasks" \
-	_mark_reopen_not_planned_task "t302" "$NOT_PLANNED_TODO" "302"
-check_success "not-planned terminalization is idempotent" \
-	_mark_reopen_not_planned_task "t301" "$NOT_PLANNED_TODO" "301"
-if grep -qE '^\- \[-\] t301 first live task ref:GH#301 declined:[0-9]{4}-[0-9]{2}-[0-9]{2}$' "$NOT_PLANNED_TODO" &&
-	grep -qE '^\- \[-\] t302 active live task ref:GH#302 declined:[0-9]{4}-[0-9]{2}-[0-9]{2}$' "$NOT_PLANNED_TODO" &&
-	grep -q '^\- \[ \] t303 fenced example ref:GH#303$' "$NOT_PLANNED_TODO" &&
-	[[ "$(grep -Ec '^\- \[-\] t301 .*declined:' "$NOT_PLANNED_TODO")" -eq 1 ]]; then
-	PASS=$((PASS + 1))
-	printf 'PASS: not-planned terminalization preserves refs, skips fenced examples, and adds one proof\n'
+check_output "NOT_PLANNED reconciliation reports the terminal skip class" "12" printf '%s' "$reopen_rc"
+check_success "NOT_PLANNED reconciliation marks only the live row declined" \
+	grep -Fqx -- '- [-] t208 live declined row ref:GH#208 logged:2026-08-01 declined:2026-08-20' "$todo_file"
+check_success "NOT_PLANNED reconciliation preserves the code-fenced example" \
+	grep -Fqx -- '- [ ] t208 example row ref:GH#208' "$todo_file"
+
+check_success "claimed TODO rows converge to the same declined state" \
+	_mark_todo_not_planned "t210" "210" "$todo_file" "2026-08-21"
+before_repeat=$(grep -F -- 't210 claimed declined row' "$todo_file")
+check_success "repeated declined-row reconciliation is idempotent" \
+	_mark_todo_not_planned "t210" "210" "$todo_file" "2026-08-21"
+after_repeat=$(grep -F -- 't210 claimed declined row' "$todo_file")
+check_output "repeated reconciliation remains byte-stable" "$before_repeat" printf '%s' "$after_repeat"
+check_failure "completed TODO rows are never rewritten as declined" \
+	_mark_todo_not_planned "t211" "211" "$todo_file" "2026-08-21"
+
+missing_time_rc=0
+if _reopen_incomplete_task_line "owner/repo" "$todo_file" "" \
+	'- [ ] t209 incomplete closure evidence ref:GH#209 logged:2026-08-04'; then
+	missing_time_rc=0
 else
-	FAIL=$((FAIL + 1))
-	printf 'FAIL: not-planned terminalization preserves refs, skips fenced examples, and adds one proof\n'
+	missing_time_rc=$?
 fi
+check_output "NOT_PLANNED without deterministic closure evidence fails closed" "11" printf '%s' "$missing_time_rc"
+check_success "failed closure evidence leaves the live row unchanged" \
+	grep -Fqx -- '- [ ] t209 incomplete closure evidence ref:GH#209 logged:2026-08-04' "$todo_file"
 
 gh_find_merged_pr() {
 	local repo="$1"


### PR DESCRIPTION
## Summary

Derive declined TODO evidence from the linked issue's immutable closed_at timestamp, preserve byte-stable reconciliation, and fail closed when closure evidence is absent.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh, .agents/scripts/tests/test-issue-sync-reopen-churn.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — ShellCheck; test-issue-sync-reopen-churn.sh (26 passed); linters-local.sh.

Resolves #30825


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 2h 46m and 1,651,349 tokens on this with the user in an interactive session.