### PR TITLE
GH#30818: request trusted re-review after remediation

### DIFF
--- a/.agents/scripts/pr-review-thread-response-rereview.sh
+++ b/.agents/scripts/pr-review-thread-response-rereview.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Trusted, head-bound re-review finalization for PR review-thread remediation.
+
+_prrts_rereview_state_file() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local safe_slug=""
+	safe_slug="$(_prrts_safe_slug "$repo_slug")"
+	printf '%s/%s-%s.rereview\n' "$STATE_DIR" "$safe_slug" "$pr_number"
+	return 0
+}
+
+_prrts_rereview_dispatch_head() {
+	local state_file="$1"
+	local key="" value=""
+	[[ -f "$state_file" ]] || return 1
+	while IFS='=' read -r key value; do
+		if [[ "$key" == "last_head_sha" && "$value" =~ ^[0-9a-fA-F]{40}$ ]]; then
+			printf '%s\n' "$value"
+			return 0
+		fi
+	done <"$state_file"
+	return 1
+}
+
+_prrts_rereview_read_state() {
+	local state_file="$1"
+	local head_var="$2"
+	local reviewers_var="$3"
+	local key="" value="" stored_head="" stored_reviewers=""
+	if [[ -f "$state_file" ]]; then
+		while IFS='=' read -r key value; do
+			case "$key" in
+			head_sha) stored_head="$value" ;;
+			reviewers) stored_reviewers="$value" ;;
+			esac
+		done <"$state_file"
+	fi
+	[[ "$stored_head" =~ ^[0-9a-fA-F]{40}$ ]] || stored_head=""
+	printf -v "$head_var" '%s' "$stored_head"
+	printf -v "$reviewers_var" '%s' "$stored_reviewers"
+	return 0
+}
+
+_prrts_rereview_write_state() {
+	local state_file="$1"
+	local head_sha="$2"
+	local reviewers="$3"
+	local tmp_file="${state_file}.tmp.$$"
+	[[ "$state_file" == "${STATE_DIR}/"*.rereview && ! -L "$state_file" ]] || return 1
+	[[ "$head_sha" =~ ^[0-9a-fA-F]{40}$ && -n "$reviewers" ]] || return 1
+	if ! {
+		printf 'head_sha=%s\n' "$head_sha"
+		printf 'reviewers=%s\n' "$reviewers"
+	} >"$tmp_file"; then
+		rm -f "$tmp_file"
+		return 1
+	fi
+	if ! mv -f "$tmp_file" "$state_file"; then
+		rm -f "$tmp_file"
+		return 1
+	fi
+	chmod 600 "$state_file" 2>/dev/null || true
+	return 0
+}
+
+_prrts_rereview_pull_snapshot() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local response=""
+	response=$(AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="review-thread-rereview-pr-rest" \
+		_prrts_gh_call read gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || return 1
+	printf '%s' "$response" | jq -er '
+		select(type == "object")
+		| select((.state // "") != "" and (.draft | type) == "boolean")
+		| [(.state // ""), (.draft | tostring), (.head.sha // "")] | @tsv
+	' 2>/dev/null
+	return $?
+}
+
+_prrts_rereview_trusted_reviewers() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local reviewed_head="$3"
+	local response=""
+	response=$(_prrts_gh_call read gh api "repos/${repo_slug}/pulls/${pr_number}/reviews?per_page=100" \
+		--paginate --slurp 2>/dev/null) || return 1
+	printf '%s' "$response" | jq -er --arg reviewed_head "$reviewed_head" '
+		select(type == "array" and all(.[]; type == "array"))
+		| [
+			.[][]?
+			| select((.user.type // "") == "User")
+			| select((.user.login // "") | test("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"))
+		]
+		| group_by(.user.login)
+		| map(sort_by((.submitted_at // ""), (.id // 0)) | last)
+		| map(select(
+			(.state // "") == "CHANGES_REQUESTED"
+			and (.commit_id // "") == $reviewed_head
+			and ((.author_association // "") == "OWNER"
+				or (.author_association // "") == "MEMBER"
+				or (.author_association // "") == "COLLABORATOR")
+		))
+		| map(.user.login) | unique | join(",")
+	' 2>/dev/null
+	return $?
+}
+
+_prrts_rereview_pending_reviewers() {
+	local reviewers="$1"
+	local recorded_reviewers="$2"
+	local output_var="$3"
+	local remaining="$reviewers" reviewer="" pending_list=""
+	while [[ -n "$remaining" ]]; do
+		case "$remaining" in
+		*,*) reviewer="${remaining%%,*}"; remaining="${remaining#*,}" ;;
+		*) reviewer="$remaining"; remaining="" ;;
+		esac
+		[[ "$reviewer" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] || return 1
+		case ",${recorded_reviewers}," in
+		*",${reviewer},"*) ;;
+		*) pending_list="${pending_list:+${pending_list},}${reviewer}" ;;
+		esac
+	done
+	printf -v "$output_var" '%s' "$pending_list"
+	return 0
+}
+
+_prrts_rereview_union() {
+	local existing="$1"
+	local added="$2"
+	local output_var="$3"
+	local combined="$existing" pending=""
+	_prrts_rereview_pending_reviewers "$added" "$existing" pending || return 1
+	[[ -n "$pending" ]] && combined="${combined:+${combined},}${pending}"
+	printf -v "$output_var" '%s' "$combined"
+	return 0
+}
+
+_prrts_rereview_threads_converged() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local summary="" thread_count="" unused=""
+	summary=$(PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true \
+		_prrts_review_thread_summary "$repo_slug" "$pr_number") || return 1
+	IFS="$PRRTS_TSV_FIELD_SEPARATOR" read -r thread_count unused \
+		<<<"${summary//$'\t'/$PRRTS_TSV_FIELD_SEPARATOR}"
+	[[ "$thread_count" =~ ^[0-9]+$ ]] || return 1
+	[[ "$thread_count" -eq 0 ]] || return 2
+	return 0
+}
+
+_prrts_finalize_rereview_request() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local dispatch_state="" rereview_state="" prior_head="" snapshot=""
+	local pr_state="" is_draft="" current_head="" reviewers=""
+	local recorded_head="" recorded_reviewers="" pending_reviewers="" stored_reviewers=""
+	local threads_rc=0
+	dispatch_state="$(_prrts_state_file "$repo_slug" "$pr_number")"
+	prior_head="$(_prrts_rereview_dispatch_head "$dispatch_state" 2>/dev/null || true)"
+	if [[ ! "$prior_head" =~ ^[0-9a-fA-F]{40}$ ]]; then
+		_prrts_log "rereview: ${repo_slug}#${pr_number} skipped — dispatch head unavailable"
+		return 0
+	fi
+	snapshot="$(_prrts_rereview_pull_snapshot "$repo_slug" "$pr_number")" || return 1
+	IFS="$PRRTS_TSV_FIELD_SEPARATOR" read -r pr_state is_draft current_head \
+		<<<"${snapshot//$'\t'/$PRRTS_TSV_FIELD_SEPARATOR}"
+	if [[ "$pr_state" != "open" || "$is_draft" != "$PRRTS_BOOL_FALSE" || ! "$current_head" =~ ^[0-9a-fA-F]{40}$ ]]; then
+		_prrts_log "rereview: ${repo_slug}#${pr_number} skipped — PR is not an open ready head"
+		return 0
+	fi
+	if [[ "$current_head" == "$prior_head" ]]; then
+		_prrts_log "rereview: ${repo_slug}#${pr_number} skipped — remediation produced no changed head"
+		return 0
+	fi
+	_prrts_rereview_threads_converged "$repo_slug" "$pr_number" || threads_rc=$?
+	if [[ "$threads_rc" -eq 2 ]]; then
+		_prrts_log "rereview: ${repo_slug}#${pr_number} deferred — unresolved review threads remain"
+		return 0
+	fi
+	[[ "$threads_rc" -eq 0 ]] || return 1
+	reviewers="$(_prrts_rereview_trusted_reviewers "$repo_slug" "$pr_number" "$prior_head")" || return 1
+	if [[ -z "$reviewers" ]]; then
+		_prrts_log "rereview: ${repo_slug}#${pr_number} skipped — no trusted head-bound change-request reviewer"
+		return 0
+	fi
+	rereview_state="$(_prrts_rereview_state_file "$repo_slug" "$pr_number")"
+	_prrts_rereview_read_state "$rereview_state" recorded_head recorded_reviewers
+	[[ "$recorded_head" == "$current_head" ]] || recorded_reviewers=""
+	_prrts_rereview_pending_reviewers "$reviewers" "$recorded_reviewers" pending_reviewers || return 1
+	if [[ -z "$pending_reviewers" ]]; then
+		_prrts_log "rereview: ${repo_slug}#${pr_number} already requested for head ${current_head}"
+		return 0
+	fi
+	if ! _prrts_gh_call write gh pr edit "$pr_number" --repo "$repo_slug" \
+		--add-reviewer "$pending_reviewers" >/dev/null 2>&1; then
+		_prrts_log "rereview: ${repo_slug}#${pr_number} request failed for head ${current_head}"
+		return 1
+	fi
+	_prrts_rereview_union "$recorded_reviewers" "$pending_reviewers" stored_reviewers || return 1
+	_prrts_rereview_write_state "$rereview_state" "$current_head" "$stored_reviewers" || return 1
+	_prrts_log "rereview: ${repo_slug}#${pr_number} requested trusted reviewer(s) for changed head ${current_head}"
+	return 0
+}

--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -31,6 +31,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=worker-attempt-observability.sh
 [[ -f "${SCRIPT_DIR}/worker-attempt-observability.sh" ]] && source "${SCRIPT_DIR}/worker-attempt-observability.sh"
+# shellcheck source=pr-review-thread-response-rereview.sh
+[[ -f "${SCRIPT_DIR}/pr-review-thread-response-rereview.sh" ]] && source "${SCRIPT_DIR}/pr-review-thread-response-rereview.sh"
 
 LOGFILE="${LOGFILE:-${HOME}/.aidevops/logs/pr-review-thread-response-scanner.log}"
 STATE_DIR="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR:-${HOME}/.aidevops/.agent-workspace/pr-review-thread-response}"
@@ -1731,6 +1733,10 @@ cmd_mark_complete() {
 	if [[ -z "$repo_slug" || ! "$pr_number" =~ ^[0-9]+$ ]]; then
 		_prrts_usage >&2
 		return 2
+	fi
+	if ! _prrts_finalize_rereview_request "$repo_slug" "$pr_number"; then
+		_prrts_log "rereview: ${repo_slug}#${pr_number} finalization failed closed"
+		return 1
 	fi
 	_prrts_write_analysis_state "$repo_slug" "$pr_number" "$PRRTS_BOOL_TRUE" "none" "$PRRTS_BOOL_FALSE" "$reason" "$details_file"
 	return 0

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -56,12 +56,16 @@ if [[ "$1" == "api" && "${2:-}" == "rate_limit" ]]; then
 	exit 0
 fi
 if [[ "$1" == "api" && "${2:-}" == "user" ]]; then printf '%s\n' "${STUB_GH_LOGIN:-worker-login}"; exit 0; fi
+if [[ "$1" == "api" && "${2:-}" =~ ^repos/owner/repo/pulls/[0-9]+/reviews\?per_page=100$ ]]; then
+	printf '%s\n' "${STUB_REVIEWS_RESPONSE:-[[]]}"
+	exit 0
+fi
 if [[ "$1" == "api" && "${2:-}" =~ ^repos/owner/repo/pulls/[0-9]+$ ]]; then
 	[[ "${AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS:-}" == "1" ]] || exit 1
 	case "${STUB_PR_REPOSITORY_MODE:-same}" in
-	missing) printf '%s\n' '{"head":{"repo":null},"base":{"repo":{"full_name":"owner/repo"}}}' ;;
-	cross) printf '%s\n' '{"head":{"repo":{"full_name":"contributor/repo"}},"base":{"repo":{"full_name":"owner/repo"}}}' ;;
-	*) printf '%s\n' '{"head":{"repo":{"full_name":"owner/repo"}},"base":{"repo":{"full_name":"owner/repo"}}}' ;;
+	missing) printf '%s\n' '{"state":"open","draft":false,"head":{"sha":"'"${STUB_PULL_HEAD_OID:-$TEST_HEAD_OID_1}"'","repo":null},"base":{"repo":{"full_name":"owner/repo"}}}' ;;
+	cross) printf '%s\n' '{"state":"open","draft":false,"head":{"sha":"'"${STUB_PULL_HEAD_OID:-$TEST_HEAD_OID_1}"'","repo":{"full_name":"contributor/repo"}},"base":{"repo":{"full_name":"owner/repo"}}}' ;;
+	*) printf '%s\n' '{"state":"'"${STUB_PULL_STATE:-open}"'","draft":'"${STUB_PULL_DRAFT:-false}"',"head":{"sha":"'"${STUB_PULL_HEAD_OID:-$TEST_HEAD_OID_1}"'","repo":{"full_name":"owner/repo"}},"base":{"repo":{"full_name":"owner/repo"}}}' ;;
 	esac
 	exit 0
 fi
@@ -73,6 +77,11 @@ if [[ "$1" == "pr" && "${2:-}" == "view" ]]; then
 	elif [[ "$*" == *"--json isCrossRepository"* ]]; then exit 1
 	else printf '%s\n' "${STUB_PR_VIEW:-Fix active PR	feature/review	${TEST_HEAD_OID_1}	worker-bot}"
 	fi
+	exit 0
+fi
+if [[ "$1" == "pr" && "${2:-}" == "edit" && "$*" == *"--add-reviewer"* ]]; then
+	printf '%s\n' "$*" >>"${PR_EDIT_LOG:-/dev/null}"
+	[[ "${STUB_REREVIEW_REQUEST_FAIL:-false}" == "true" ]] && exit 1
 	exit 0
 fi
 if [[ "$1" == "api" && "${2:-}" == "graphql" ]]; then
@@ -427,6 +436,7 @@ WORKTREE_STUB
 setup_test_env() {
 	unset STUB_PR_LIST STUB_PR_VIEW STUB_THREADS_MODE STUB_HANG_SECONDS STUB_GRAPHQL_COST_MODE STUB_PR_REPOSITORY_MODE STUB_REMOTE_HEAD STUB_GH_LOGIN
 	unset STUB_GH_REST_FAIL STUB_GH_GRAPHQL_FAIL STUB_GH_GRAPHQL_LOGIN
+	unset STUB_PULL_HEAD_OID STUB_PULL_STATE STUB_PULL_DRAFT STUB_REVIEWS_RESPONSE STUB_REREVIEW_REQUEST_FAIL
 	unset STUB_GIT_INVALID_BRANCH STUB_GIT_FETCH_FAIL STUB_GIT_CANONICAL_FETCH_FAIL
 	unset STUB_REMOTE_HEAD_INITIAL STUB_REMOTE_HEAD_AFTER_FETCH STUB_WORKTREE_ACTUAL_HEAD STUB_WORKTREE_HELPER_FAIL
 	unset STUB_GIT_WORKTREE_DIRTY STUB_GIT_DIVERGED STUB_GIT_FAST_FORWARD_FAIL
@@ -472,12 +482,14 @@ setup_test_env() {
 	export GRAPHQL_MUTATIONS_LOG="${TEST_ROOT}/graphql-mutations.log"
 	export GRAPHQL_BODY_CAPTURE="${TEST_ROOT}/graphql-body.txt"
 	export GRAPHQL_BODY_FLAG_CAPTURE="${TEST_ROOT}/graphql-body-flag.txt"
+	export PR_EDIT_LOG="${TEST_ROOT}/pr-edit.log"
 	export PR_REVIEW_THREAD_RESPONSE_COOLDOWN=3600
 	export PR_REVIEW_THREAD_RESPONSE_INFRASTRUCTURE_FAILURE_COOLDOWN=90
 	export PRRTS_SCANNER_UNDER_TEST="$SCANNER"
 	: >"$GRAPHQL_MUTATIONS_LOG"
 	: >"$GRAPHQL_BODY_CAPTURE"
 	: >"$GRAPHQL_BODY_FLAG_CAPTURE"
+	: >"$PR_EDIT_LOG"
 	: >"$HEADLESS_LOG"
 	: >"$HEADLESS_COMPLETE_LOG"
 	: >"$DETACH_LAUNCH_LOG"
@@ -1042,6 +1054,23 @@ read_state_value() {
 		fi
 	done <"$state_file"
 	return 1
+}
+
+write_rereview_dispatch_state() {
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	{
+		printf 'fingerprint=THREAD1:https://example.invalid/thread\n'
+		printf 'dispatched_at=%s\n' "$(date +%s)"
+		printf 'thread_count=1\n'
+		printf 'attempt_count=1\n'
+		printf 'last_head_sha=%s\n' "$TEST_HEAD_OID_1"
+	} >"$state_file"
+	return 0
+}
+
+set_trusted_change_request_review() {
+	export STUB_REVIEWS_RESPONSE='[[{"id":11,"submitted_at":"2026-08-28T01:00:00Z","state":"CHANGES_REQUESTED","commit_id":"'"$TEST_HEAD_OID_1"'","author_association":"MEMBER","user":{"login":"trusted-reviewer","type":"User"}}]]'
+	return 0
 }
 
 test_scan_finds_unresolved_bot_thread() {
@@ -2229,6 +2258,112 @@ test_mark_blocked_sanitizes_reason_and_details() {
 	return 0
 }
 
+test_mark_complete_requests_trusted_rereview_once_per_changed_head() {
+	setup_test_env
+	write_rereview_dispatch_state
+	set_trusted_change_request_review
+	export STUB_PULL_HEAD_OID="$TEST_HEAD_OID_2"
+	export STUB_THREADS_MODE="none"
+	$SCANNER mark-complete owner/repo 1 repaired_head
+	$SCANNER mark-complete owner/repo 1 repaired_head
+	local rereview_state="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.rereview"
+	if [[ "$(wc -l <"$PR_EDIT_LOG")" -eq 1 ]] &&
+		grep -Fq -- '--add-reviewer trusted-reviewer' "$PR_EDIT_LOG" &&
+		grep -Fxq "head_sha=${TEST_HEAD_OID_2}" "$rereview_state" &&
+		grep -Fxq 'reviewers=trusted-reviewer' "$rereview_state"; then
+		print_result "mark-complete requests one trusted re-review per changed head" 0
+	else
+		print_result "mark-complete requests one trusted re-review per changed head" 1 \
+			"edits=$(tr '\n' ';' <"$PR_EDIT_LOG" 2>/dev/null || printf ''), state=$(tr '\n' ';' <"$rereview_state" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_mark_complete_skips_rereview_without_changed_head() {
+	setup_test_env
+	write_rereview_dispatch_state
+	set_trusted_change_request_review
+	export STUB_PULL_HEAD_OID="$TEST_HEAD_OID_1"
+	$SCANNER mark-complete owner/repo 1 no_push
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	if [[ ! -s "$PR_EDIT_LOG" ]] && grep -Fxq 'analysis_complete=true' "$state_file"; then
+		print_result "mark-complete does not request re-review without a changed head" 0
+	else
+		print_result "mark-complete does not request re-review without a changed head" 1
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_mark_complete_fails_closed_on_unknown_reviewer_identity() {
+	setup_test_env
+	write_rereview_dispatch_state
+	export STUB_PULL_HEAD_OID="$TEST_HEAD_OID_2"
+	export STUB_THREADS_MODE="none"
+	export STUB_REVIEWS_RESPONSE='[[{"id":12,"submitted_at":"2026-08-28T01:00:00Z","state":"CHANGES_REQUESTED","commit_id":"'"$TEST_HEAD_OID_1"'","author_association":"OWNER","user":{"login":"unknown reviewer","type":"User"}}]]'
+	$SCANNER mark-complete owner/repo 1 unknown_reviewer
+	if [[ ! -s "$PR_EDIT_LOG" ]]; then
+		print_result "mark-complete never requests an unvalidated reviewer identity" 0
+	else
+		print_result "mark-complete never requests an unvalidated reviewer identity" 1
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_mark_complete_defers_rereview_until_all_threads_converge() {
+	setup_test_env
+	write_rereview_dispatch_state
+	set_trusted_change_request_review
+	export STUB_PULL_HEAD_OID="$TEST_HEAD_OID_2"
+	export STUB_THREADS_MODE="human"
+	$SCANNER mark-complete owner/repo 1 partial_batch
+	if [[ ! -s "$PR_EDIT_LOG" ]] && grep -Fq 'unresolved review threads remain' "$LOGFILE"; then
+		print_result "mark-complete defers re-review while unresolved threads remain" 0
+	else
+		print_result "mark-complete defers re-review while unresolved threads remain" 1
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_mark_complete_preserves_incomplete_state_when_rereview_write_fails() {
+	setup_test_env
+	write_rereview_dispatch_state
+	set_trusted_change_request_review
+	export STUB_PULL_HEAD_OID="$TEST_HEAD_OID_2"
+	export STUB_THREADS_MODE="none"
+	export STUB_REREVIEW_REQUEST_FAIL="true"
+	local mark_rc=0
+	$SCANNER mark-complete owner/repo 1 request_failed || mark_rc=$?
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	local rereview_state="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.rereview"
+	if [[ "$mark_rc" -eq 1 && ! -f "$rereview_state" ]] &&
+		! grep -Fxq 'analysis_complete=true' "$state_file"; then
+		print_result "mark-complete fails closed when the re-review request fails" 0
+	else
+		print_result "mark-complete fails closed when the re-review request fails" 1 "rc=${mark_rc}"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_mark_blocked_never_requests_rereview() {
+	setup_test_env
+	write_rereview_dispatch_state
+	set_trusted_change_request_review
+	export STUB_PULL_HEAD_OID="$TEST_HEAD_OID_2"
+	$SCANNER mark-blocked owner/repo 1 code remediation_failed
+	if [[ ! -s "$PR_EDIT_LOG" ]]; then
+		print_result "mark-blocked never requests re-review" 0
+	else
+		print_result "mark-blocked never requests re-review" 1
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_dispatch_pr_skips_when_pr_lock_held() {
 	setup_test_env
 	local lock_dir="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.lock"
@@ -2634,6 +2769,16 @@ main_mutations() {
 	return 0
 }
 
+main_rereview() {
+	test_mark_complete_requests_trusted_rereview_once_per_changed_head
+	test_mark_complete_skips_rereview_without_changed_head
+	test_mark_complete_fails_closed_on_unknown_reviewer_identity
+	test_mark_complete_defers_rereview_until_all_threads_converge
+	test_mark_complete_preserves_incomplete_state_when_rereview_write_fails
+	test_mark_blocked_never_requests_rereview
+	return 0
+}
+
 main() {
 	test_scan_finds_unresolved_bot_thread
 	test_scan_skips_draft_prs
@@ -2705,6 +2850,7 @@ main() {
 	test_no_marker_retry_behavior_is_preserved
 	test_old_state_file_without_completion_fields_still_retries
 	test_mark_blocked_sanitizes_reason_and_details
+	main_rereview
 	test_dispatch_pr_skips_when_pr_lock_held
 	test_dispatch_pr_reports_deduplicated_dispatch
 	test_dispatch_pr_reports_active_worker_as_deferred


### PR DESCRIPTION
## Summary

Request re-review only from trusted human reviewers whose latest change request is bound to the remediated head, after a changed head and full thread convergence; persist per-head idempotency state.

## Files Changed

.agents/scripts/pr-review-thread-response-rereview.sh, .agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck passed; pr-review-thread-response-scanner suite passed 98/98; local linters passed.

Resolves #30818


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 3h 36m and 2,032,343 tokens on this with the user in an interactive session.