### PR TITLE
GH#30819: fix(opencode): classify explicit pre-edit targets

### DIFF
--- a/.agents/plugins/opencode-aidevops/pre-edit-check-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/pre-edit-check-tool.mjs
@@ -94,6 +94,22 @@ function targetIsRepositoryLocal({ policy, lexicallyRepositoryLocal }) {
   return lexicallyRepositoryLocal || ["canonical", "linked"].includes(policy.target?.classification);
 }
 
+function resolveRepositoryTargetScope(classifications) {
+  const repositoryTargets = classifications.filter(targetIsRepositoryLocal);
+  const targetWorkdir = repositoryTargets[0]?.policy.target?.repo_root;
+  if (typeof targetWorkdir !== "string" || !targetWorkdir) {
+    throw new Error("target repository root is missing or indeterminate");
+  }
+  if (repositoryTargets.some(({ policy }) => policy.target?.repo_root !== targetWorkdir)) {
+    throw new Error("explicit repository targets span multiple worktrees");
+  }
+  return {
+    repositoryTarget: repositoryTargets[0].targetPath,
+    targetWorkdir,
+    terminalResponse: "",
+  };
+}
+
 function resolveExplicitTargetScope(targetPaths, scriptsDir, targetWorkdir) {
   const classifications = classifyExplicitTargets(targetPaths, scriptsDir, targetWorkdir);
   const deniedTarget = classifications.find(targetIsUnsafe);
@@ -101,13 +117,12 @@ function resolveExplicitTargetScope(targetPaths, scriptsDir, targetWorkdir) {
     throw new Error(deniedTarget.policy.reason || "unsafe explicit target");
   }
   if (classifications.every(targetIsExternal)) {
-    return { repositoryTarget: "", terminalResponse: EXTERNAL_TARGET_RESPONSE };
+    return { repositoryTarget: "", targetWorkdir, terminalResponse: EXTERNAL_TARGET_RESPONSE };
   }
-  const repositoryTarget = classifications.find(targetIsRepositoryLocal)?.targetPath || "";
-  if (!repositoryTarget) {
+  if (!classifications.some(targetIsRepositoryLocal)) {
     throw new Error("target scope is mixed or indeterminate");
   }
-  return { repositoryTarget, terminalResponse: "" };
+  return resolveRepositoryTargetScope(classifications);
 }
 
 function requirePreEditScript(scriptsDir) {
@@ -140,7 +155,7 @@ function preparePreEditInvocation(args, scriptsDir) {
   const requestedWorkdir = args.workdir || process.cwd();
   const targetWorkdir = requireTargetWorktree(requestedWorkdir);
   const targetPaths = normalizeTargetPaths(args.targetPaths === undefined ? [] : args.targetPaths);
-  let targetScope = { repositoryTarget: "", terminalResponse: "" };
+  let targetScope = { repositoryTarget: "", targetWorkdir, terminalResponse: "" };
   try {
     if (targetPaths.length > 0) {
       targetScope = resolveExplicitTargetScope(targetPaths, scriptsDir, targetWorkdir);
@@ -148,7 +163,7 @@ function preparePreEditInvocation(args, scriptsDir) {
   } catch (error) {
     throw new PreEditRequestError(explicitTargetFailure(error));
   }
-  return { script, targetWorkdir, ...targetScope };
+  return { script, ...targetScope };
 }
 
 /**

--- a/.agents/plugins/opencode-aidevops/pre-edit-check-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/pre-edit-check-tool.mjs
@@ -11,6 +11,11 @@ const PRE_EDIT_GUIDANCE = {
   3: "WARNING — proceed with caution.",
 };
 const MAX_TARGET_PATHS = 32;
+const EXTERNAL_TARGET_RESPONSE =
+  "Git isolation not applicable: all explicit targetPaths resolve outside Git worktrees.\n"
+  + "This result does not authorize file writes; runtime path, secret, destructive-operation, and managed-directory policies still apply.";
+
+class PreEditRequestError extends Error {}
 
 function pathIsWithin(candidate, parent) {
   const relation = relative(parent, candidate);
@@ -25,41 +30,125 @@ function parsePolicyPayload(raw) {
   return payload;
 }
 
-function classifyExplicitTargets(targetPaths, scriptsDir, workdir) {
-  if (!Array.isArray(targetPaths) || targetPaths.length > MAX_TARGET_PATHS
-    || targetPaths.some((targetPath) => typeof targetPath !== "string" || !targetPath.trim())) {
+function validateTargetPaths(targetPaths) {
+  if (!Array.isArray(targetPaths) || targetPaths.length > MAX_TARGET_PATHS) {
+    throw new TypeError(`targetPaths must contain 1-${MAX_TARGET_PATHS} non-empty strings`);
+  }
+  if (targetPaths.some((targetPath) => typeof targetPath !== "string" || !targetPath.trim())) {
     throw new TypeError(`targetPaths must contain 1-${MAX_TARGET_PATHS} non-empty strings`);
   }
   if (targetPaths.some((targetPath) => targetPath.split(/[\\/]+/).includes(".."))) {
     throw new TypeError("targetPaths containing parent traversal are ambiguous and must be normalized by the caller");
   }
+}
+
+function classifyExplicitTarget(helper, targetPath, workdir) {
+  const raw = execFileSync(
+    "python3",
+    [helper, "check-write", "--cwd", workdir, "--path", targetPath],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 10000,
+    },
+  );
+  const policy = parsePolicyPayload(raw);
+  const repoRoot = policy.context?.repo_root;
+  const lexicalTarget = resolve(workdir, targetPath);
+  const lexicallyRepositoryLocal = typeof repoRoot === "string"
+    && repoRoot !== ""
+    && pathIsWithin(lexicalTarget, repoRoot);
+  return { policy, targetPath, lexicallyRepositoryLocal };
+}
+
+function classifyExplicitTargets(targetPaths, scriptsDir, workdir) {
+  validateTargetPaths(targetPaths);
   const helper = join(scriptsDir, "canonical-write-policy-helper.py");
   if (!existsSync(helper)) {
     throw new Error("required canonical-write policy helper is missing");
   }
-  return targetPaths.map((targetPath) => {
-    const raw = execFileSync(
-      "python3",
-      [helper, "check-write", "--cwd", workdir, "--path", targetPath],
-      {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: 10000,
-      },
-    );
-    const policy = parsePolicyPayload(raw);
-    const repoRoot = policy.context?.repo_root;
-    const lexicalTarget = resolve(workdir, targetPath);
-    const lexicallyRepositoryLocal = typeof repoRoot === "string"
-      && repoRoot !== ""
-      && pathIsWithin(lexicalTarget, repoRoot);
-    return { policy, targetPath, lexicallyRepositoryLocal };
-  });
+  return targetPaths.map((targetPath) => classifyExplicitTarget(helper, targetPath, workdir));
 }
 
 function explicitTargetFailure(error) {
   const detail = error?.stderr?.toString().trim() || error?.message || "target classification failed";
   return `Pre-edit check exit 1: explicit target path classification failed closed\n${detail}`;
+}
+
+function targetIsUnsafe({ policy, lexicallyRepositoryLocal }) {
+  if (policy.decision === "allow") return false;
+  const sameCanonicalRepository = policy.context?.classification === "canonical"
+    && policy.target?.classification === "canonical"
+    && policy.context?.common_dir === policy.target?.common_dir
+    && lexicallyRepositoryLocal;
+  return !sameCanonicalRepository;
+}
+
+function targetIsExternal({ policy, lexicallyRepositoryLocal }) {
+  return policy.decision === "allow"
+    && policy.target?.classification === "outside"
+    && !lexicallyRepositoryLocal;
+}
+
+function targetIsRepositoryLocal({ policy, lexicallyRepositoryLocal }) {
+  return lexicallyRepositoryLocal || ["canonical", "linked"].includes(policy.target?.classification);
+}
+
+function resolveExplicitTargetScope(targetPaths, scriptsDir, targetWorkdir) {
+  const classifications = classifyExplicitTargets(targetPaths, scriptsDir, targetWorkdir);
+  const deniedTarget = classifications.find(targetIsUnsafe);
+  if (deniedTarget) {
+    throw new Error(deniedTarget.policy.reason || "unsafe explicit target");
+  }
+  if (classifications.every(targetIsExternal)) {
+    return { repositoryTarget: "", terminalResponse: EXTERNAL_TARGET_RESPONSE };
+  }
+  const repositoryTarget = classifications.find(targetIsRepositoryLocal)?.targetPath || "";
+  if (!repositoryTarget) {
+    throw new Error("target scope is mixed or indeterminate");
+  }
+  return { repositoryTarget, terminalResponse: "" };
+}
+
+function requirePreEditScript(scriptsDir) {
+  const script = join(scriptsDir, "pre-edit-check.sh");
+  if (!existsSync(script)) {
+    throw new PreEditRequestError("pre-edit-check.sh not found — cannot verify git safety");
+  }
+  return script;
+}
+
+function requireTargetWorktree(requestedWorkdir) {
+  const targetWorkdir = resolveGitWorktree(requestedWorkdir);
+  if (!targetWorkdir) {
+    throw new PreEditRequestError(
+      `Pre-edit check exit 1: target workdir must resolve to an existing Git worktree\n${requestedWorkdir}`,
+    );
+  }
+  return targetWorkdir;
+}
+
+function normalizeTargetPaths(targetPaths) {
+  if (!Array.isArray(targetPaths)) {
+    throw new PreEditRequestError(explicitTargetFailure(new TypeError("targetPaths must be an array")));
+  }
+  return targetPaths;
+}
+
+function preparePreEditInvocation(args, scriptsDir) {
+  const script = requirePreEditScript(scriptsDir);
+  const requestedWorkdir = args.workdir || process.cwd();
+  const targetWorkdir = requireTargetWorktree(requestedWorkdir);
+  const targetPaths = normalizeTargetPaths(args.targetPaths === undefined ? [] : args.targetPaths);
+  let targetScope = { repositoryTarget: "", terminalResponse: "" };
+  try {
+    if (targetPaths.length > 0) {
+      targetScope = resolveExplicitTargetScope(targetPaths, scriptsDir, targetWorkdir);
+    }
+  } catch (error) {
+    throw new PreEditRequestError(explicitTargetFailure(error));
+  }
+  return { script, targetWorkdir, ...targetScope };
 }
 
 /**
@@ -129,55 +218,18 @@ export function createPreEditCheckTool(tool, z, scriptsDir, timeoutMs = 120000) 
       targetPaths: z.array(z.string()).optional().describe('Optional intended write paths, resolved relative to workdir'),
     },
     async execute(args) {
-      args = args && typeof args === "object" ? args : {};
-      const script = join(scriptsDir, "pre-edit-check.sh");
-      if (!existsSync(script)) {
-        return "pre-edit-check.sh not found — cannot verify git safety";
+      const normalizedArgs = args && typeof args === "object" ? args : {};
+      let invocation;
+      try {
+        invocation = preparePreEditInvocation(normalizedArgs, scriptsDir);
+      } catch (error) {
+        return error instanceof PreEditRequestError ? error.message : explicitTargetFailure(error);
       }
-      const requestedWorkdir = args.workdir || process.cwd();
-      const targetWorkdir = resolveGitWorktree(requestedWorkdir);
-      if (!targetWorkdir) {
-        return `Pre-edit check exit 1: target workdir must resolve to an existing Git worktree\n${requestedWorkdir}`;
-      }
-      const targetPaths = args.targetPaths === undefined ? [] : args.targetPaths;
-      if (!Array.isArray(targetPaths)) {
-        return explicitTargetFailure(new TypeError("targetPaths must be an array"));
-      }
-      let repositoryTarget = "";
-      if (targetPaths.length > 0) {
-        let classifications;
-        try {
-          classifications = classifyExplicitTargets(targetPaths, scriptsDir, targetWorkdir);
-        } catch (error) {
-          return explicitTargetFailure(error);
-        }
-        const deniedTarget = classifications.find(({ policy, lexicallyRepositoryLocal }) => {
-          if (policy.decision === "allow") return false;
-          return !(policy.context?.classification === "canonical"
-            && policy.target?.classification === "canonical"
-            && policy.context?.common_dir === policy.target?.common_dir
-            && lexicallyRepositoryLocal);
-        });
-        if (deniedTarget) {
-          return explicitTargetFailure(new Error(deniedTarget.policy.reason || "unsafe explicit target"));
-        }
-        const allExternal = classifications.every(({ policy, lexicallyRepositoryLocal }) =>
-          policy.decision === "allow"
-          && policy.target?.classification === "outside"
-          && !lexicallyRepositoryLocal);
-        if (allExternal) {
-          return "Git isolation not applicable: all explicit targetPaths resolve outside Git worktrees.\n"
-            + "This result does not authorize file writes; runtime path, secret, destructive-operation, and managed-directory policies still apply.";
-        }
-        repositoryTarget = classifications.find(({ policy, lexicallyRepositoryLocal }) =>
-          lexicallyRepositoryLocal || ["canonical", "linked"].includes(policy.target?.classification))?.targetPath || "";
-        if (!repositoryTarget) {
-          return explicitTargetFailure(new Error("target scope is mixed or indeterminate"));
-        }
-      }
+      if (invocation.terminalResponse) return invocation.terminalResponse;
+      const { script, targetWorkdir, repositoryTarget } = invocation;
       const taskArgs = repositoryTarget
-        ? [...(args.task ? ["--loop-mode"] : []), "--file", repositoryTarget]
-        : (args.task ? ["--loop-mode", "--task", args.task] : []);
+        ? [...(normalizedArgs.task ? ["--loop-mode"] : []), "--file", repositoryTarget]
+        : (normalizedArgs.task ? ["--loop-mode", "--task", normalizedArgs.task] : []);
       const result = await runPreEditCheck(script, taskArgs, targetWorkdir, timeoutMs);
       return formatPreEditCheckResult(result, timeoutMs);
     },

--- a/.agents/plugins/opencode-aidevops/pre-edit-check-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/pre-edit-check-tool.mjs
@@ -3,13 +3,64 @@
 
 import { execFileSync, spawn } from "child_process";
 import { existsSync, realpathSync, statSync } from "fs";
-import { join } from "path";
+import { isAbsolute, join, relative, resolve, sep } from "path";
 
 const PRE_EDIT_GUIDANCE = {
   1: "STOP — you are on main/master branch. Create a worktree first.",
   2: "Create a worktree before proceeding with edits.",
   3: "WARNING — proceed with caution.",
 };
+const MAX_TARGET_PATHS = 32;
+
+function pathIsWithin(candidate, parent) {
+  const relation = relative(parent, candidate);
+  return relation === "" || (relation !== ".." && !relation.startsWith(`..${sep}`) && !isAbsolute(relation));
+}
+
+function parsePolicyPayload(raw) {
+  const payload = JSON.parse(raw);
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new TypeError("policy returned a non-object payload");
+  }
+  return payload;
+}
+
+function classifyExplicitTargets(targetPaths, scriptsDir, workdir) {
+  if (!Array.isArray(targetPaths) || targetPaths.length > MAX_TARGET_PATHS
+    || targetPaths.some((targetPath) => typeof targetPath !== "string" || !targetPath.trim())) {
+    throw new TypeError(`targetPaths must contain 1-${MAX_TARGET_PATHS} non-empty strings`);
+  }
+  if (targetPaths.some((targetPath) => targetPath.split(/[\\/]+/).includes(".."))) {
+    throw new TypeError("targetPaths containing parent traversal are ambiguous and must be normalized by the caller");
+  }
+  const helper = join(scriptsDir, "canonical-write-policy-helper.py");
+  if (!existsSync(helper)) {
+    throw new Error("required canonical-write policy helper is missing");
+  }
+  return targetPaths.map((targetPath) => {
+    const raw = execFileSync(
+      "python3",
+      [helper, "check-write", "--cwd", workdir, "--path", targetPath],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 10000,
+      },
+    );
+    const policy = parsePolicyPayload(raw);
+    const repoRoot = policy.context?.repo_root;
+    const lexicalTarget = resolve(workdir, targetPath);
+    const lexicallyRepositoryLocal = typeof repoRoot === "string"
+      && repoRoot !== ""
+      && pathIsWithin(lexicalTarget, repoRoot);
+    return { policy, targetPath, lexicallyRepositoryLocal };
+  });
+}
+
+function explicitTargetFailure(error) {
+  const detail = error?.stderr?.toString().trim() || error?.message || "target classification failed";
+  return `Pre-edit check exit 1: explicit target path classification failed closed\n${detail}`;
+}
 
 /**
  * Resolve and validate a requested Git worktree path.
@@ -71,10 +122,11 @@ function formatPreEditCheckResult(result, timeoutMs) {
 export function createPreEditCheckTool(tool, z, scriptsDir, timeoutMs = 120000) {
   return tool({
     description:
-      'Run the pre-edit git safety check before modifying files. Returns exit code and guidance. Args: task (optional string for loop mode), workdir (optional target Git worktree)',
+      'Run the pre-edit git safety check before modifying files. Returns exit code and guidance. Args: task (optional string for loop mode), workdir (optional target Git worktree), targetPaths (optional intended write paths)',
     args: {
       task: z.string().optional().describe('Optional task description for loop-mode worktree guidance'),
       workdir: z.string().optional().describe('Optional target Git worktree to validate'),
+      targetPaths: z.array(z.string()).optional().describe('Optional intended write paths, resolved relative to workdir'),
     },
     async execute(args) {
       args = args && typeof args === "object" ? args : {};
@@ -87,7 +139,45 @@ export function createPreEditCheckTool(tool, z, scriptsDir, timeoutMs = 120000) 
       if (!targetWorkdir) {
         return `Pre-edit check exit 1: target workdir must resolve to an existing Git worktree\n${requestedWorkdir}`;
       }
-      const taskArgs = args.task ? ["--loop-mode", "--task", args.task] : [];
+      const targetPaths = args.targetPaths === undefined ? [] : args.targetPaths;
+      if (!Array.isArray(targetPaths)) {
+        return explicitTargetFailure(new TypeError("targetPaths must be an array"));
+      }
+      let repositoryTarget = "";
+      if (targetPaths.length > 0) {
+        let classifications;
+        try {
+          classifications = classifyExplicitTargets(targetPaths, scriptsDir, targetWorkdir);
+        } catch (error) {
+          return explicitTargetFailure(error);
+        }
+        const deniedTarget = classifications.find(({ policy, lexicallyRepositoryLocal }) => {
+          if (policy.decision === "allow") return false;
+          return !(policy.context?.classification === "canonical"
+            && policy.target?.classification === "canonical"
+            && policy.context?.common_dir === policy.target?.common_dir
+            && lexicallyRepositoryLocal);
+        });
+        if (deniedTarget) {
+          return explicitTargetFailure(new Error(deniedTarget.policy.reason || "unsafe explicit target"));
+        }
+        const allExternal = classifications.every(({ policy, lexicallyRepositoryLocal }) =>
+          policy.decision === "allow"
+          && policy.target?.classification === "outside"
+          && !lexicallyRepositoryLocal);
+        if (allExternal) {
+          return "Git isolation not applicable: all explicit targetPaths resolve outside Git worktrees.\n"
+            + "This result does not authorize file writes; runtime path, secret, destructive-operation, and managed-directory policies still apply.";
+        }
+        repositoryTarget = classifications.find(({ policy, lexicallyRepositoryLocal }) =>
+          lexicallyRepositoryLocal || ["canonical", "linked"].includes(policy.target?.classification))?.targetPath || "";
+        if (!repositoryTarget) {
+          return explicitTargetFailure(new Error("target scope is mixed or indeterminate"));
+        }
+      }
+      const taskArgs = repositoryTarget
+        ? [...(args.task ? ["--loop-mode"] : []), "--file", repositoryTarget]
+        : (args.task ? ["--loop-mode", "--task", args.task] : []);
       const result = await runPreEditCheck(script, taskArgs, targetWorkdir, timeoutMs);
       return formatPreEditCheckResult(result, timeoutMs);
     },

--- a/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
@@ -26,6 +26,7 @@ test("pre-edit tool validates the explicitly targeted Git worktree", async () =>
   const root = mkdtempSync(join(tmpdir(), "t27909-pre-edit-tool-"));
   const repo = join(root, "repo");
   const linked = join(root, "linked");
+  const otherLinked = join(root, "other-linked");
   const nonGit = join(root, "not-git");
   const injectionMarker = join(root, "injected");
 
@@ -40,6 +41,7 @@ test("pre-edit tool validates the explicitly targeted Git worktree", async () =>
     git(repo, ["add", "README.md"]);
     git(repo, ["commit", "--no-gpg-sign", "-m", "init"]);
     git(repo, ["worktree", "add", "-b", "bugfix/fixture", linked]);
+    git(repo, ["worktree", "add", "-b", "bugfix/other-fixture", otherLinked]);
 
     const preEditTool = createTools(scriptsDir, () => "").aidevops_pre_edit_check;
     const canonicalResult = await preEditTool.execute({ workdir: repo });
@@ -52,6 +54,14 @@ test("pre-edit tool validates the explicitly targeted Git worktree", async () =>
     });
     assert.match(linkedResult, /Pre-edit check PASSED \(exit 0\)/);
     assert.equal(existsSync(injectionMarker), false, "task text must remain one argv value");
+
+    const otherLinkedResult = await preEditTool.execute({
+      workdir: linked,
+      targetPaths: [join(otherLinked, "README.md")],
+    });
+    assert.match(otherLinkedResult, /Pre-edit check PASSED \(exit 0\)/);
+    assert.match(otherLinkedResult, /bugfix\/other-fixture/);
+    assert.doesNotMatch(otherLinkedResult, /bugfix\/fixture[^-]/);
 
     const invalidResult = await preEditTool.execute({ workdir: nonGit, task: "fix fixture" });
     assert.match(invalidResult, /target workdir must resolve to an existing Git worktree/);

--- a/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
@@ -4,7 +4,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -55,6 +55,67 @@ test("pre-edit tool validates the explicitly targeted Git worktree", async () =>
 
     const invalidResult = await preEditTool.execute({ workdir: nonGit, task: "fix fixture" });
     assert.match(invalidResult, /target workdir must resolve to an existing Git worktree/);
+
+    const worktreesBefore = git(repo, ["worktree", "list", "--porcelain"]);
+    const externalResult = await preEditTool.execute({
+      workdir: repo,
+      task: "update personal configuration",
+      targetPaths: [join(nonGit, "custom.sh"), join(root, "LaunchAgents", "fixture.plist")],
+    });
+    assert.match(externalResult, /Git isolation not applicable/);
+    assert.match(externalResult, /does not authorize file writes/);
+    assert.equal(git(repo, ["worktree", "list", "--porcelain"]), worktreesBefore);
+
+    const repositoryResult = await preEditTool.execute({
+      workdir: repo,
+      targetPaths: [join(repo, "nested", "..", "README.md")],
+    });
+    assert.match(repositoryResult, /Pre-edit check exit [12]:/);
+    assert.doesNotMatch(repositoryResult, /Git isolation not applicable/);
+
+    const mixedResult = await preEditTool.execute({
+      workdir: repo,
+      targetPaths: [join(nonGit, "custom.sh"), join(repo, "README.md")],
+    });
+    assert.match(mixedResult, /Pre-edit check exit [12]:/);
+    assert.doesNotMatch(mixedResult, /Git isolation not applicable/);
+
+    const linkedToCanonicalResult = await preEditTool.execute({
+      workdir: linked,
+      targetPaths: [join(repo, "README.md")],
+    });
+    assert.match(linkedToCanonicalResult, /failed closed/);
+    assert.doesNotMatch(linkedToCanonicalResult, /Pre-edit check PASSED/);
+
+    const symlinkEscape = join(repo, "external-link");
+    symlinkSync(nonGit, symlinkEscape);
+    const symlinkResult = await preEditTool.execute({
+      workdir: repo,
+      targetPaths: [join(symlinkEscape, "custom.sh")],
+    });
+    assert.match(symlinkResult, /failed closed/);
+    assert.doesNotMatch(symlinkResult, /Git isolation not applicable/);
+
+    const traversalResult = await preEditTool.execute({
+      workdir: repo,
+      targetPaths: ["../not-git/custom.sh"],
+    });
+    assert.match(traversalResult, /parent traversal.*ambiguous/);
+    assert.doesNotMatch(traversalResult, /Git isolation not applicable/);
+
+    const repositoryLink = join(nonGit, "repository-link");
+    symlinkSync(repo, repositoryLink);
+    const repositorySymlinkResult = await preEditTool.execute({
+      workdir: repo,
+      targetPaths: [join(repositoryLink, "README.md")],
+    });
+    assert.match(repositorySymlinkResult, /Pre-edit check exit [12]:/);
+    assert.doesNotMatch(repositorySymlinkResult, /Git isolation not applicable/);
+
+    const malformedResult = await preEditTool.execute({ workdir: repo, targetPaths: [""] });
+    assert.match(malformedResult, /failed closed/);
+    const malformedArrayResult = await preEditTool.execute({ workdir: repo, targetPaths: {} });
+    assert.match(malformedArrayResult, /targetPaths must be an array/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
@@ -63,6 +63,13 @@ test("pre-edit tool validates the explicitly targeted Git worktree", async () =>
     assert.match(otherLinkedResult, /bugfix\/other-fixture/);
     assert.doesNotMatch(otherLinkedResult, /bugfix\/fixture[^-]/);
 
+    const multipleWorktreesResult = await preEditTool.execute({
+      workdir: linked,
+      targetPaths: [join(linked, "README.md"), join(otherLinked, "README.md")],
+    });
+    assert.match(multipleWorktreesResult, /explicit repository targets span multiple worktrees/);
+    assert.doesNotMatch(multipleWorktreesResult, /Pre-edit check PASSED/);
+
     const invalidResult = await preEditTool.execute({ workdir: nonGit, task: "fix fixture" });
     assert.match(invalidResult, /target workdir must resolve to an existing Git worktree/);
 

--- a/.agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs
@@ -30,6 +30,7 @@ describe("aidevops plugin tool schemas", () => {
     assert.ok(tools.aidevops.args.command?._zod, "aidevops.command must be Zod");
     assert.ok(tools.aidevops_pre_edit_check.args.task?._zod, "pre-edit task must be Zod");
     assert.ok(tools.aidevops_pre_edit_check.args.workdir?._zod, "pre-edit workdir must be Zod");
+    assert.ok(tools.aidevops_pre_edit_check.args.targetPaths?._zod, "pre-edit targetPaths must be Zod");
     assert.ok(tools.aidevops_hook_status.args.workdir?._zod, "hook-status workdir must be Zod");
     assert.ok(pool.args.action?._zod, "pool action must be Zod");
     assert.ok(pool.args.provider?._zod, "pool provider must be Zod");

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -14,6 +14,7 @@ const FALLBACK_SCHEMA_NODE = {
   },
 };
 const FALLBACK_TOOL_SCHEMA = {
+  array: () => FALLBACK_SCHEMA_NODE,
   enum: () => FALLBACK_SCHEMA_NODE,
   string: () => FALLBACK_SCHEMA_NODE,
   number: () => FALLBACK_SCHEMA_NODE,

--- a/.agents/workflows/pre-edit.md
+++ b/.agents/workflows/pre-edit.md
@@ -18,6 +18,15 @@ Run before any file edits:
 
 Pass `--file <path>` when the target file is known — this enables path-based enforcement (t1712). `--task` description heuristics are a fallback for callers that don't know the target path.
 
+OpenCode callers may pass `targetPaths` to `aidevops_pre_edit_check`. Paths are
+resolved relative to `workdir`. If every verified target is outside Git
+worktrees, the tool reports **Git isolation not applicable** and does not create
+an unrelated repository worktree. This result covers only Git isolation: it
+does not authorize the external writes or bypass runtime path, secret,
+destructive-operation, or managed-directory policy. Repository-local, mixed,
+ambiguous, traversal, and symlinked scopes retain the stricter worktree gate or
+fail closed. Callers without target paths retain the task-only fallback.
+
 ## Mode-Scoped Main-Branch Write Allowlist (t1712, t1990)
 
 Interactive sessions have no `main`/`master` exception: every edit uses a linked worktree. For headless supervisor/routine/issue-sync bookkeeping and explicitly planning-only worker tasks, `pre-edit-check.sh` may allow these paths without a linked worktree:


### PR DESCRIPTION
## Summary

Implementation for issue #30819.

## Files Changed

.agents/plugins/opencode-aidevops/pre-edit-check-tool.mjs, .agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs, .agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs, .agents/plugins/opencode-aidevops/tools.mjs, .agents/workflows/pre-edit.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30819


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 4h 26m and 2,486,126 tokens on this with the user in an interactive session.