### PR TITLE
GH#30820: fix(pulse): type PR lookup uncertainty

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2647,6 +2647,10 @@ classify_dispatch_blocker_reason() {
 			printf 'blocked_by_native_lookup_unavailable\n'
 			return 0
 			;;
+		*pr_lookup_uncertain* | *pr_lookup_result=uncertain*)
+			printf 'pr_lookup_uncertain\n'
+			return 0
+			;;
 		*canary*failed*)
 			printf 'canary_failed\n'
 			return 0

--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -11,7 +11,8 @@
 # Exports:
 #   has_open_pr <issue> <slug> [issue-title]
 #     Check whether an issue already has open or merged PR evidence.
-#     Exit 0 = PR evidence exists (do NOT dispatch), exit 1 = no evidence.
+#     Exit 0 = PR evidence exists or lookup is uncertain (do NOT dispatch).
+#     Exit 1 = complete lookup with no evidence.
 
 _ddpr_gh_read() {
 	local rc=0
@@ -21,6 +22,71 @@ _ddpr_gh_read() {
 		"$@" || rc=$?
 	fi
 	return "$rc"
+}
+
+_DDPR_LOOKUP_RC_RESPONSE_INVALID=13
+_DDPR_LOOKUP_RESULT_UNCERTAIN="PR_LOOKUP_RESULT=uncertain"
+_DDPR_LOOKUP_SCOPE_TASK_ID_TITLE="task_id_title"
+
+_ddpr_bounded_gh_read() {
+	local max_attempts="${AIDEVOPS_DDPR_LOOKUP_ATTEMPTS:-2}"
+	local retry_delay="${AIDEVOPS_DDPR_LOOKUP_RETRY_DELAY:-1}"
+	local attempt=1
+	local rc=1
+
+	[[ "$max_attempts" =~ ^[1-9][0-9]*$ ]] || max_attempts=2
+	[[ "$max_attempts" -le 2 ]] || max_attempts=2
+	[[ "$retry_delay" =~ ^[0-9]+$ ]] || retry_delay=1
+	[[ "$retry_delay" -le 5 ]] || retry_delay=1
+
+	while [[ "$attempt" -le "$max_attempts" ]]; do
+		if _ddpr_gh_read "$@"; then
+			return 0
+		else
+			rc=$?
+		fi
+		# Exit 75 is a local budget/cooldown refusal. Retrying it would add
+		# pressure without obtaining new evidence.
+		[[ "$rc" -eq 75 ]] && return "$rc"
+		if [[ "$attempt" -lt "$max_attempts" && "$retry_delay" -gt 0 ]]; then
+			sleep "$retry_delay"
+		fi
+		attempt=$((attempt + 1))
+	done
+	return "$rc"
+}
+
+_ddpr_lookup_failure_reason() {
+	local rc="$1"
+	case "$rc" in
+	75) printf 'local_budget_or_cooldown' ;;
+	124) printf 'timeout' ;;
+	"$_DDPR_LOOKUP_RC_RESPONSE_INVALID") printf 'response_validation_failed' ;;
+	*) printf 'api_request_failed' ;;
+	esac
+	return 0
+}
+
+_ddpr_emit_lookup_uncertain() {
+	local scope="$1"
+	local issue_number="$2"
+	local repo_slug="$3"
+	local rc="$4"
+	local reason=""
+	reason=$(_ddpr_lookup_failure_reason "$rc")
+	printf 'PR_LOOKUP_UNCERTAIN: %s lookup failed for issue #%s in %s (reason=%s); dispatch is blocked\n' \
+		"$scope" "$issue_number" "$repo_slug" "$reason"
+	printf '%s reason=%s scope=%s\n' "$_DDPR_LOOKUP_RESULT_UNCERTAIN" "$reason" "$scope"
+	return 0
+}
+
+_ddpr_read_json_array() {
+	local response=""
+	local rc=0
+	response=$(_ddpr_bounded_gh_read "$@") || rc=$?
+	[[ "$rc" -eq 0 ]] || return "$rc"
+	printf '%s' "$response" | jq -ce 'select(type == "array")' 2>/dev/null || return "$_DDPR_LOOKUP_RC_RESPONSE_INVALID"
+	return 0
 }
 
 #######################################
@@ -111,7 +177,7 @@ _ddpr_graphql_open_siblings() {
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="dispatch-dedup-open-siblings-exact-cost" \
-		_ddpr_gh_read gh api graphql -F queryString="$search_query" -f query='
+		_ddpr_bounded_gh_read gh api graphql -F queryString="$search_query" -f query='
 		query($queryString: String!) {
 			search(type: ISSUE, query: $queryString, first: 20) {
 				nodes {
@@ -132,7 +198,7 @@ _ddpr_graphql_open_siblings() {
 			}
 			rateLimit { cost }
 		}
-	' 2>/dev/null) || return 1
+	' 2>/dev/null) || return $?
 
 	pr_json=$(printf '%s' "$response" | jq -ce \
 		--arg array_type "$_DDPR_JSON_ARRAY_TYPE" --arg number_type "$_DDPR_JSON_NUMBER_TYPE" '
@@ -163,7 +229,7 @@ _ddpr_graphql_open_siblings() {
 			files: (.files.nodes // []),
 			labels: (.labels.nodes // [])
 		})
-	' 2>/dev/null) || return 1
+	' 2>/dev/null) || return "$_DDPR_LOOKUP_RC_RESPONSE_INVALID"
 	printf '%s' "$pr_json"
 	return 0
 }
@@ -185,7 +251,7 @@ _ddpr_graphql_open_commits() {
 	# shellcheck disable=SC2016
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="dispatch-dedup-open-commits-exact-cost" \
-		_ddpr_gh_read gh api graphql -f owner="$owner" -f name="$repo" -f query='
+		_ddpr_bounded_gh_read gh api graphql -f owner="$owner" -f name="$repo" -f query='
 		query($owner: String!, $name: String!) {
 			repository(owner: $owner, name: $name) {
 				pullRequests(
@@ -204,7 +270,7 @@ _ddpr_graphql_open_commits() {
 			}
 			rateLimit { cost }
 		}
-	' 2>/dev/null) || return 1
+	' 2>/dev/null) || return $?
 
 	pr_json=$(printf '%s' "$response" | jq -ce \
 		--arg array_type "$_DDPR_JSON_ARRAY_TYPE" --arg number_type "$_DDPR_JSON_NUMBER_TYPE" '
@@ -227,7 +293,7 @@ _ddpr_graphql_open_commits() {
 			isDraft,
 			commits: [.commits.nodes[].commit | {messageHeadline}]
 		})
-	' 2>/dev/null) || return 1
+	' 2>/dev/null) || return "$_DDPR_LOOKUP_RC_RESPONSE_INVALID"
 	printf '%s' "$pr_json"
 	return 0
 }
@@ -250,11 +316,12 @@ _has_open_pr_check_healthy_sibling() {
 	local repo_slug="$2"
 
 	local pr_json match_pr draft_pr draft_pr_number draft_pr_kind
-	pr_json=$(_ddpr_graphql_open_siblings "$issue_number" "$repo_slug") || {
-		printf 'PR_LOOKUP_UNCERTAIN: open PR lookup failed for issue #%s in %s; dispatch is blocked\n' \
-			"$issue_number" "$repo_slug"
+	local lookup_rc=0
+	pr_json=$(_ddpr_graphql_open_siblings "$issue_number" "$repo_slug") || lookup_rc=$?
+	if [[ "$lookup_rc" -ne 0 ]]; then
+		_ddpr_emit_lookup_uncertain "open_siblings" "$issue_number" "$repo_slug" "$lookup_rc"
 		return 0
-	}
+	fi
 
 	local issue_ref_pattern healthy_state_pattern blocked_state_pattern
 	issue_ref_pattern="([^[:alnum:]_]|^)((close[sd]?|fix(e[sd])?|resolve[sd]?|for|refs?):?[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}|GH#${issue_number}|#${issue_number})([^[:alnum:]_]|$)"
@@ -341,11 +408,12 @@ _has_open_pr_check_open_commits() {
 	local repo_slug="$2"
 
 	local open_pr_json open_pr_count
-	open_pr_json=$(_ddpr_graphql_open_commits "$repo_slug") || {
-		printf 'PR_LOOKUP_UNCERTAIN: open PR commit lookup failed for issue #%s in %s; dispatch is blocked\n' \
-			"$issue_number" "$repo_slug"
+	local lookup_rc=0
+	open_pr_json=$(_ddpr_graphql_open_commits "$repo_slug") || lookup_rc=$?
+	if [[ "$lookup_rc" -ne 0 ]]; then
+		_ddpr_emit_lookup_uncertain "open_commits" "$issue_number" "$repo_slug" "$lookup_rc"
 		return 0
-	}
+	fi
 	open_pr_count=$(printf '%s' "$open_pr_json" | jq 'length' 2>/dev/null) || open_pr_count=0
 	[[ "$open_pr_count" =~ ^[0-9]+$ ]] || open_pr_count=0
 	[[ "$open_pr_count" -eq 0 ]] && return 1
@@ -401,11 +469,16 @@ _has_open_pr_check_open_body_keyword() {
 	local repo_slug="$2"
 
 	local pr_json match_pr
+	local lookup_rc=0
 	# Fetch up to 20 open PRs mentioning the issue in the body; body is
 	# included in this single request to avoid separate gh pr view calls.
-	pr_json=$(gh pr list --repo "$repo_slug" --state open \
+	pr_json=$(_ddpr_read_json_array gh pr list --repo "$repo_slug" --state open \
 		--search "#${issue_number} in:body" --limit 20 \
-		--json number,body,isDraft 2>/dev/null) || pr_json="[]"
+		--json number,body,isDraft 2>/dev/null) || lookup_rc=$?
+	if [[ "$lookup_rc" -ne 0 ]]; then
+		_ddpr_emit_lookup_uncertain "open_body" "$issue_number" "$repo_slug" "$lookup_rc"
+		return 0
+	fi
 
 	# Match: closing keyword + optional whitespace + #NNN or owner/repo#NNN
 	# followed by a non-word char or end-of-string (GH#18641 semantics).
@@ -414,7 +487,10 @@ _has_open_pr_check_open_body_keyword() {
 
 	match_pr=$(printf '%s' "$pr_json" | jq -r --arg pattern "$close_pattern" \
 		'[.[] | select((.isDraft // false | not) and (.body // "" | test($pattern; "i")))] | .[0].number // empty' \
-		2>/dev/null) || match_pr=""
+		2>/dev/null) || {
+		_ddpr_emit_lookup_uncertain "open_body" "$issue_number" "$repo_slug" "$_DDPR_LOOKUP_RC_RESPONSE_INVALID"
+		return 0
+	}
 
 	if [[ -n "$match_pr" ]]; then
 		printf 'open PR #%s closes issue #%s via keyword in body\n' "$match_pr" "$issue_number"
@@ -442,11 +518,16 @@ _has_open_pr_check_merged_keywords() {
 	local repo_slug="$2"
 
 	local pr_json match_pr
+	local lookup_rc=0
 	# Fetch up to 20 merged PRs mentioning the issue in the body; body is
 	# included in this single request to avoid separate gh pr view calls.
-	pr_json=$(gh pr list --repo "$repo_slug" --state merged \
+	pr_json=$(_ddpr_read_json_array gh pr list --repo "$repo_slug" --state merged \
 		--search "#${issue_number} in:body" --limit 20 \
-		--json number,body 2>/dev/null) || pr_json="[]"
+		--json number,body 2>/dev/null) || lookup_rc=$?
+	if [[ "$lookup_rc" -ne 0 ]]; then
+		_ddpr_emit_lookup_uncertain "merged_body" "$issue_number" "$repo_slug" "$lookup_rc"
+		return 0
+	fi
 
 	# Match: closing keyword + optional whitespace + #NNN or owner/repo#NNN
 	# followed by a non-word char or end-of-string (GH#18641 semantics).
@@ -455,7 +536,10 @@ _has_open_pr_check_merged_keywords() {
 
 	match_pr=$(printf '%s' "$pr_json" | jq -r --arg pattern "$close_pattern" \
 		'[.[] | select(.body // "" | test($pattern; "i"))] | .[0].number // empty' \
-		2>/dev/null) || match_pr=""
+		2>/dev/null) || {
+		_ddpr_emit_lookup_uncertain "merged_body" "$issue_number" "$repo_slug" "$_DDPR_LOOKUP_RC_RESPONSE_INVALID"
+		return 0
+	}
 
 	if [[ -n "$match_pr" ]]; then
 		printf 'merged PR #%s references issue #%s via keyword\n' "$match_pr" "$issue_number"
@@ -497,11 +581,22 @@ _has_open_pr_check_task_id_title() {
 	[[ -z "$task_id" ]] && return 1
 
 	local query pr_json pr_count pr_number
+	local lookup_rc=0
 	query="${task_id} in:title"
 	# Fetch number+body in one request to avoid a separate gh pr view call (GH#19124)
-	pr_json=$(gh pr list --repo "$repo_slug" --state merged --search "$query" --limit 1 --json number,body 2>/dev/null) || pr_json="[]"
-	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+	pr_json=$(_ddpr_read_json_array gh pr list --repo "$repo_slug" --state merged --search "$query" --limit 1 --json number,body 2>/dev/null) || lookup_rc=$?
+	if [[ "$lookup_rc" -ne 0 ]]; then
+		_ddpr_emit_lookup_uncertain "$_DDPR_LOOKUP_SCOPE_TASK_ID_TITLE" "$issue_number" "$repo_slug" "$lookup_rc"
+		return 0
+	fi
+	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || {
+		_ddpr_emit_lookup_uncertain "$_DDPR_LOOKUP_SCOPE_TASK_ID_TITLE" "$issue_number" "$repo_slug" "$_DDPR_LOOKUP_RC_RESPONSE_INVALID"
+		return 0
+	}
+	if [[ ! "$pr_count" =~ ^[0-9]+$ ]]; then
+		_ddpr_emit_lookup_uncertain "$_DDPR_LOOKUP_SCOPE_TASK_ID_TITLE" "$issue_number" "$repo_slug" "$_DDPR_LOOKUP_RC_RESPONSE_INVALID"
+		return 0
+	fi
 	[[ "$pr_count" -eq 0 ]] && return 1
 
 	pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
@@ -559,13 +654,19 @@ _has_open_pr_check_superseded_issue_pr() {
 	[[ -n "$issue_body" ]] || return 1
 
 	local related_issue="" pr_json="" match_pr=""
+	local lookup_rc=0
 	while IFS= read -r related_issue; do
 		[[ "$related_issue" =~ ^[0-9]+$ ]] || continue
 		[[ "$related_issue" != "$issue_number" ]] || continue
 
-		pr_json=$(gh pr list --repo "$repo_slug" --state merged \
+		lookup_rc=0
+		pr_json=$(_ddpr_read_json_array gh pr list --repo "$repo_slug" --state merged \
 			--search "#${related_issue}" --limit 20 \
-			--json number,title,body,author 2>/dev/null) || pr_json="[]"
+			--json number,title,body,author 2>/dev/null) || lookup_rc=$?
+		if [[ "$lookup_rc" -ne 0 ]]; then
+			_ddpr_emit_lookup_uncertain "superseded_issue" "$issue_number" "$repo_slug" "$lookup_rc"
+			return 0
+		fi
 
 		local ref_pattern="(^|[^0-9])#${related_issue}([^0-9]|$)|GH#${related_issue}([^0-9]|$)"
 		local planning_pattern="planning-only|pure planning|brief-only|brief for|files the brief|no code changes"
@@ -586,7 +687,10 @@ _has_open_pr_check_superseded_issue_pr() {
 						(($author == "dependabot[bot]") or ($author == "renovate[bot]")) and
 						($title | test($bump_title_pattern; "i"))
 					) | not))
-			] | .[0].number // empty' 2>/dev/null) || match_pr=""
+			] | .[0].number // empty' 2>/dev/null) || {
+			_ddpr_emit_lookup_uncertain "superseded_issue" "$issue_number" "$repo_slug" "$_DDPR_LOOKUP_RC_RESPONSE_INVALID"
+			return 0
+		}
 
 		if [[ -n "$match_pr" ]]; then
 			printf 'merged PR #%s references superseded issue #%s for consolidated issue #%s\n' \
@@ -612,10 +716,10 @@ _has_open_pr_check_superseded_issue_pr() {
 #   $2 = repo slug (owner/repo)
 #   $3 = issue title (optional; used for task-id fallback)
 # Returns:
-#   exit 0 if PR evidence exists — open OR merged (do NOT dispatch)
-#   exit 1 if no PR evidence (safe to dispatch)
+#   exit 0 if PR evidence exists or any lookup is uncertain (do NOT dispatch)
+#   exit 1 if every lookup completed and no PR evidence exists (safe to dispatch)
 # Outputs:
-#   single-line reason when evidence is found
+#   evidence reason, or sanitized PR_LOOKUP_RESULT=uncertain diagnostics
 # CALLERS: For issue closing, verify mergedAt after this returns 0.
 #######################################
 has_open_pr() {
@@ -682,12 +786,27 @@ has_open_pr() {
 	wait "$_pr_pid4" 2>/dev/null || true
 	wait "$_pr_pid5" 2>/dev/null || true
 
-	# Check results — any hit means PR evidence exists
+	# Uncertainty takes precedence over positive evidence. A partial API view is
+	# not sufficient to classify the block as an active claim or known PR.
 	local _check_file _check_output
 	for _check_file in "${_pr_tmpdir}/check0.out" "${_pr_tmpdir}/check1.out" "${_pr_tmpdir}/check1b.out" \
 		"${_pr_tmpdir}/check2.out" "${_pr_tmpdir}/check3.out" "${_pr_tmpdir}/check4.out"; do
 		if [[ -f "$_check_file" ]]; then
-			_check_output=$(cat "$_check_file" 2>/dev/null) || _check_output=""
+			_check_output=$(<"$_check_file") || _check_output=""
+			if [[ "$_check_output" == *"$_DDPR_LOOKUP_RESULT_UNCERTAIN"* ]]; then
+				printf '%s\n' "$_check_output"
+				rm -rf "$_pr_tmpdir" 2>/dev/null || true
+				return 0
+			fi
+		fi
+	done
+
+	# No lookup was uncertain; any remaining non-empty result is known PR
+	# evidence and keeps the existing dispatch-block contract.
+	for _check_file in "${_pr_tmpdir}/check0.out" "${_pr_tmpdir}/check1.out" "${_pr_tmpdir}/check1b.out" \
+		"${_pr_tmpdir}/check2.out" "${_pr_tmpdir}/check3.out" "${_pr_tmpdir}/check4.out"; do
+		if [[ -f "$_check_file" ]]; then
+			_check_output=$(<"$_check_file") || _check_output=""
 			if [[ -n "$_check_output" ]]; then
 				printf '%s\n' "$_check_output"
 				rm -rf "$_pr_tmpdir" 2>/dev/null || true

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -211,8 +211,15 @@ _dedup_layer4_pr_evidence() {
 	local issue_title="$3"
 	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
 	local dedup_helper_output=""
+	local dedup_helper_rc=0
 	if [[ -x "$dedup_helper" ]]; then
-		if dedup_helper_output=$("$dedup_helper" has-open-pr "$issue_number" "$repo_slug" "$issue_title" 2>>"$LOGFILE"); then
+		dedup_helper_output=$("$dedup_helper" has-open-pr "$issue_number" "$repo_slug" "$issue_title" 2>>"$LOGFILE") || dedup_helper_rc=$?
+		if [[ "$dedup_helper_output" == *"PR_LOOKUP_RESULT=uncertain"* ]]; then
+			echo "[pulse-wrapper] Dedup: ${dedup_helper_output}" >>"$LOGFILE"
+			printf 'pr_lookup_uncertain\n'
+			return 0
+		fi
+		if [[ "$dedup_helper_rc" -eq 0 ]]; then
 			if [[ -n "$dedup_helper_output" ]]; then
 				echo "[pulse-wrapper] Dedup: ${dedup_helper_output}" >>"$LOGFILE"
 			else
@@ -221,6 +228,11 @@ _dedup_layer4_pr_evidence() {
 			if [[ "$dedup_helper_output" == WORKER_DRAFT_CHECKPOINT:* ]]; then
 				return 2
 			fi
+			return 0
+		fi
+		if [[ "$dedup_helper_rc" -ne 1 ]]; then
+			echo "[pulse-wrapper] Dedup: PR_LOOKUP_RESULT=uncertain reason=helper_exit_${dedup_helper_rc} scope=aggregate" >>"$LOGFILE"
+			printf 'pr_lookup_uncertain\n'
 			return 0
 		fi
 	fi

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -283,7 +283,7 @@ _dispatch_stats_increment() {
 _dispatch_stats_increment_candidate_failed() {
 	local reason="$1"
 	case "$reason" in
-		blocked_by_native_lookup_unavailable | blocked_by_unresolved | canary_failed | consolidated | cooldown_no_worker_process | cost_budget_exceeded | dedup_active_claim | dirty_worktree_recovery | ever_nmr_without_approval | footprint_overlap | graphql_circuit_breaker | healthy_pr_backlog | interactive_review_hold | issue_closed | launch_error | local_capacity_gate | missing_worker_context | no_auto_dispatch | no_dispatchable_evidence | no_recent_log_evidence | parent_task | policy_gate | pr_target_not_dispatchable | provider_rate_limit_pressure | renovate_dependency_dashboard | repeated_failure_pressure | runner_health_circuit_breaker | unclassified_signal)
+		blocked_by_native_lookup_unavailable | blocked_by_unresolved | canary_failed | consolidated | cooldown_no_worker_process | cost_budget_exceeded | dedup_active_claim | dirty_worktree_recovery | ever_nmr_without_approval | footprint_overlap | graphql_circuit_breaker | healthy_pr_backlog | interactive_review_hold | issue_closed | launch_error | local_capacity_gate | missing_worker_context | no_auto_dispatch | no_dispatchable_evidence | no_recent_log_evidence | parent_task | policy_gate | pr_lookup_uncertain | pr_target_not_dispatchable | provider_rate_limit_pressure | renovate_dependency_dashboard | repeated_failure_pressure | runner_health_circuit_breaker | unclassified_signal)
 			;;
 		*)
 			reason="unclassified_signal"

--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -1226,6 +1226,12 @@ _pir_lookup_oimp_pr_for_issue() {
 #   2 = reset action taken (used by _action_rsd_single: reset to available)
 ##############################################
 
+_pir_pr_lookup_uncertain() {
+	local dedup_output="$1"
+	[[ "$dedup_output" == *"PR_LOOKUP_RESULT=uncertain"* ]] || return 1
+	return 0
+}
+
 #######################################
 # Stage 1 action: close an issue whose work is done via a merged PR.
 # (Per-issue body of close_issues_with_merged_prs — no slug loop.)
@@ -1239,6 +1245,10 @@ _action_ciw_single() {
 
 	local dedup_output=""
 	dedup_output=$("$dedup_helper" has-open-pr "$issue_num" "$slug" "$issue_title" 2>/dev/null) || return 1
+	if _pir_pr_lookup_uncertain "$dedup_output"; then
+		echo "[pulse-wrapper] Deferred auto-close #${issue_num} in ${slug} — PR lookup uncertain" >>"$LOGFILE"
+		return 1
+	fi
 
 	local pr_ref="" pr_num="" merged_at=""
 	pr_ref=$(printf '%s' "$dedup_output" | grep -o '#[0-9]*' | head -1) || pr_ref=""
@@ -1285,6 +1295,10 @@ _action_rsd_single() {
 
 	local dedup_output=""
 	if dedup_output=$("$dedup_helper" has-open-pr "$issue_num" "$slug" "$issue_title" 2>/dev/null); then
+		if _pir_pr_lookup_uncertain "$dedup_output"; then
+			echo "[pulse-wrapper] Reconcile done: deferred #${issue_num} in ${slug} — PR lookup uncertain" >>"$LOGFILE"
+			return 1
+		fi
 		local pr_ref="" pr_num="" merged_at=""
 		pr_ref=$(printf '%s' "$dedup_output" | grep -o '#[0-9]*' | head -1) || pr_ref=""
 		pr_num=$(printf '%s' "$pr_ref" | tr -d '#')

--- a/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
+++ b/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
@@ -33,6 +33,7 @@ assert_reason 'blocked by local capacity gate (ever-nmr check not run)' 'local_c
 assert_reason 'review-followup exemption: skipping historical ever-NMR check (GH#18648)' 'unclassified_signal'
 assert_reason 'skipping historical ever-NMR check for bot-generated cleanup issue (GH#18648)' 'unclassified_signal'
 assert_reason 'DISPATCH_BLOCK_REASON reason=blocked_by_native_lookup_unavailable signal=native blockedBy lookup unavailable and no body blocked-by markers found' 'blocked_by_native_lookup_unavailable'
+assert_reason 'PR_LOOKUP_RESULT=uncertain reason=timeout scope=open_siblings' 'pr_lookup_uncertain'
 assert_reason 'pre-dispatch validator failed: missing worker context; needs-brief label present' 'missing_worker_context'
 assert_reason 'dedup.worktree_cap blocked by max worktree count' 'local_capacity_gate'
 assert_reason 'dedup guard blocked #303 in some-org/infrastructure' 'dedup_active_claim'

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -47,10 +47,10 @@ _write_gh_stub() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Response-metered GraphQL replacements for the two rich native PR-list shapes.
+	# Response-metered GraphQL replacements for the two rich native PR-list shapes.
 if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
 	if [[ "${GH_PR_LIST_FAIL:-0}" == "1" ]]; then
-		exit 1
+		exit "${GH_PR_LIST_FAIL_RC:-1}"
 	fi
 	query_text=""
 	query_string=""
@@ -168,7 +168,7 @@ _append_gh_stub_native_reads() {
 # gh pr list — returns fixture JSON for (repo, state, search) lookup.
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
 	if [[ "${GH_PR_LIST_FAIL:-0}" == "1" ]]; then
-		exit 1
+		exit "${GH_PR_LIST_FAIL_RC:-1}"
 	fi
 	local_repo=""
 	local_state=""
@@ -250,6 +250,10 @@ setup_test_env() {
 	export GH_FIXTURE_FILE
 	export GH_PR_VIEW_FIXTURE_FILE
 	export GH_GRAPHQL_CALL_LOG
+	export AIDEVOPS_DDPR_LOOKUP_RETRY_DELAY=0
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="${TEST_ROOT}/gh-secondary-cooldown.json"
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE="${TEST_ROOT}/gh-cooldown-events.jsonl"
+	export AIDEVOPS_GH_READ_RAMP_STATE_FILE="${TEST_ROOT}/gh-read-ramp-state.tsv"
 
 	_write_gh_stub "${TEST_ROOT}/bin/gh"
 
@@ -263,6 +267,8 @@ teardown_test_env() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
 	fi
+	unset AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE \
+		AIDEVOPS_GH_READ_RAMP_STATE_FILE
 	return 0
 }
 
@@ -520,13 +526,59 @@ test_has_open_pr_fails_closed_when_sibling_lookup_fails() {
 	output=$("$HELPER_SCRIPT" has-open-pr 18782 marcusquinn/aidevops 'lookup uncertainty') || rc=$?
 	unset GH_PR_LIST_FAIL
 
-	if [[ "$rc" -eq 0 && "$output" == PR_LOOKUP_UNCERTAIN:* ]]; then
+	if [[ "$rc" -eq 0 && "$output" == *"PR_LOOKUP_RESULT=uncertain reason=api_request_failed scope=open_siblings"* &&
+		"$output" == *"PR_LOOKUP_UNCERTAIN:"* ]]; then
 		print_result "has-open-pr fails closed when sibling lookup is uncertain" 0
 		return 0
 	fi
 
 	print_result "has-open-pr fails closed when sibling lookup is uncertain" 1 \
 		"rc=${rc} output=${output}"
+	return 0
+}
+
+test_has_open_pr_recovers_after_lookup_uncertainty() {
+	export GH_PR_LIST_FAIL=1
+	local uncertain_output=""
+	local recovered_output=""
+	local uncertain_rc=0
+	local recovered_rc=0
+	uncertain_output=$("$HELPER_SCRIPT" has-open-pr 18786 marcusquinn/aidevops 'lookup recovery') || uncertain_rc=$?
+	unset GH_PR_LIST_FAIL
+	set_gh_fixtures ''
+	recovered_output=$("$HELPER_SCRIPT" has-open-pr 18786 marcusquinn/aidevops 'lookup recovery') || recovered_rc=$?
+
+	if [[ "$uncertain_rc" -eq 0 && "$uncertain_output" == *"PR_LOOKUP_RESULT=uncertain"* &&
+		"$recovered_rc" -eq 1 && -z "$recovered_output" ]]; then
+		print_result "has-open-pr becomes dispatchable after a valid empty lookup" 0
+		return 0
+	fi
+
+	print_result "has-open-pr becomes dispatchable after a valid empty lookup" 1 \
+		"uncertain_rc=${uncertain_rc} uncertain=${uncertain_output} recovered_rc=${recovered_rc} recovered=${recovered_output}"
+	return 0
+}
+
+test_has_open_pr_classifies_sanitized_lookup_failures() {
+	local timeout_output=""
+	local cooldown_output=""
+	local timeout_rc=0
+	local cooldown_rc=0
+	export GH_PR_LIST_FAIL=1
+	export GH_PR_LIST_FAIL_RC=124
+	timeout_output=$("$HELPER_SCRIPT" has-open-pr 18787 marcusquinn/aidevops 'timeout classification') || timeout_rc=$?
+	export GH_PR_LIST_FAIL_RC=75
+	cooldown_output=$("$HELPER_SCRIPT" has-open-pr 18788 marcusquinn/aidevops 'cooldown classification') || cooldown_rc=$?
+	unset GH_PR_LIST_FAIL GH_PR_LIST_FAIL_RC
+
+	if [[ "$timeout_rc" -eq 0 && "$timeout_output" == *"reason=timeout scope=open_siblings"* &&
+		"$cooldown_rc" -eq 0 && "$cooldown_output" == *"reason=local_budget_or_cooldown scope=open_siblings"* ]]; then
+		print_result "has-open-pr emits sanitized timeout and local-budget diagnostics" 0
+		return 0
+	fi
+
+	print_result "has-open-pr emits sanitized timeout and local-budget diagnostics" 1 \
+		"timeout_rc=${timeout_rc} timeout=${timeout_output} cooldown_rc=${cooldown_rc} cooldown=${cooldown_output}"
 	return 0
 }
 
@@ -976,6 +1028,8 @@ main() {
 	test_has_open_pr_marks_worker_draft_for_stale_routing
 	test_has_open_pr_keeps_protected_draft_unroutable
 	test_has_open_pr_fails_closed_when_sibling_lookup_fails
+	test_has_open_pr_recovers_after_lookup_uncertainty
+	test_has_open_pr_classifies_sanitized_lookup_failures
 	test_has_open_pr_fails_closed_without_response_owned_cost
 	test_has_open_pr_fails_closed_on_partial_sibling_connections
 	test_has_open_pr_ignores_open_body_planning_for_reference

--- a/.agents/scripts/tests/test-pulse-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-issue-reconcile.sh
@@ -1286,6 +1286,53 @@ test_feedback_backfill_uses_label_constants() {
 	return 0
 }
 
+test_pr_lookup_uncertainty_preserves_issue_state() {
+	local tmp_dir=""
+	local dedup_helper=""
+	local mutation_log=""
+	local action_log=""
+	local actions_sh="${SCRIPT_DIR}/../pulse-issue-reconcile-actions.sh"
+	local result=""
+	tmp_dir=$(mktemp -d)
+	dedup_helper="${tmp_dir}/dedup-helper.sh"
+	mutation_log="${tmp_dir}/mutations.log"
+	action_log="${tmp_dir}/actions.log"
+	cat >"$dedup_helper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'PR_LOOKUP_UNCERTAIN: unable to verify PR state for issue #42 (open_siblings; reason=timeout)'
+printf '%s\n' 'PR_LOOKUP_RESULT=uncertain reason=timeout scope=open_siblings'
+exit 0
+EOF
+	chmod +x "$dedup_helper"
+
+	result=$(bash -c '
+		actions_sh="$1"
+		dedup_helper="$2"
+		mutation_log="$3"
+		LOGFILE="$4"
+		# shellcheck source=/dev/null
+		source "$actions_sh"
+		gh() { printf "gh:%s\n" "$*" >>"$mutation_log"; return 0; }
+		set_issue_status() { printf "status:%s\n" "$*" >>"$mutation_log"; return 0; }
+		_pir_pr_merged_at() { return 1; }
+		ciw_rc=0
+		rsd_rc=0
+		_action_ciw_single owner/repo 42 title "$dedup_helper" /nonexistent || ciw_rc=$?
+		_action_rsd_single owner/repo 42 title "$dedup_helper" /nonexistent || rsd_rc=$?
+		printf "ciw_rc=%s rsd_rc=%s\n" "$ciw_rc" "$rsd_rc"
+		[[ ! -s "$mutation_log" ]] && printf "mutations=none\n"
+	' _ "$actions_sh" "$dedup_helper" "$mutation_log" "$action_log" 2>/dev/null)
+	rm -rf "$tmp_dir"
+
+	if [[ "$result" == *"ciw_rc=1 rsd_rc=1"* && "$result" == *"mutations=none"* ]]; then
+		_pass "PR lookup uncertainty preserves issue state in reconcile actions"
+		return 0
+	fi
+
+	_fail "PR lookup uncertainty mutated reconciliation state or returned the wrong status: ${result}"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
@@ -1314,6 +1361,7 @@ test_gh25896_oimp_closes_consolidated_successor
 test_gh27444_recurrent_file_size_debt_current_outcome
 test_available_feedback_worker_issue_not_assigned
 test_feedback_backfill_uses_label_constants
+test_pr_lookup_uncertainty_preserves_issue_state
 
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"

--- a/.agents/scripts/tests/test-pulse-stale-pr-continuation.sh
+++ b/.agents/scripts/tests/test-pulse-stale-pr-continuation.sh
@@ -43,6 +43,30 @@ exit 1
 DEDUP_STUB
 chmod +x "${SCRIPT_DIR}/dispatch-dedup-helper.sh"
 
+export STUB_OPEN_PR_OUTPUT='PR_LOOKUP_RESULT=uncertain reason=timeout scope=open_siblings
+PR_LOOKUP_UNCERTAIN: open_siblings lookup failed; dispatch is blocked'
+export STUB_OPEN_PR_RC=0
+LAYER4_OUTPUT=""
+LAYER4_RC=0
+LAYER4_OUTPUT=$(_dedup_layer4_pr_evidence "123" "owner/repo" "Fixture") || LAYER4_RC=$?
+if [[ "$LAYER4_RC" -eq 0 && "$LAYER4_OUTPUT" == "pr_lookup_uncertain" ]] &&
+	grep -q 'PR_LOOKUP_RESULT=uncertain reason=timeout' "$LOGFILE"; then
+	print_result "Layer 4 preserves PR lookup uncertainty as a distinct block" 0
+else
+	print_result "Layer 4 preserves PR lookup uncertainty as a distinct block" 1
+fi
+
+export STUB_OPEN_PR_OUTPUT=''
+export STUB_OPEN_PR_RC=1
+LAYER4_OUTPUT=""
+LAYER4_RC=0
+LAYER4_OUTPUT=$(_dedup_layer4_pr_evidence "123" "owner/repo" "Fixture") || LAYER4_RC=$?
+if [[ "$LAYER4_RC" -eq 1 && -z "$LAYER4_OUTPUT" ]]; then
+	print_result "Layer 4 allows dispatch after a subsequent valid empty lookup" 0
+else
+	print_result "Layer 4 allows dispatch after a subsequent valid empty lookup" 1
+fi
+
 # Exercise the production router's event parsing/argument fence before replacing
 # it with a counter stub for the Layer 6 return-semantics tests below.
 ROUTE_ARGS_FILE="${TEST_ROOT}/route-args"


### PR DESCRIPTION
## Summary

Implementation for issue #30820.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh, .agents/scripts/dispatch-dedup-pr.sh, .agents/scripts/pulse-dispatch-dedup-layers.sh, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/pulse-issue-reconcile-actions.sh, .agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh, .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh, .agents/scripts/tests/test-pulse-issue-reconcile.sh, .agents/scripts/tests/test-pulse-stale-pr-continuation.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30820


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 5h 49m and 2,953,915 tokens on this with the user in an interactive session.