### PR TITLE
GH#30823: fix(issue-sync): bound dependency traversal

### DIFF
--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -707,7 +707,7 @@ _relationship_declared_edges() {
 _relationship_edges_for_file() {
 	local todo_file="$1"
 	if [[ "$_RELATIONSHIP_EDGE_CACHE_FILE" != "$todo_file" ]]; then
-		_RELATIONSHIP_EDGE_CACHE=$(_relationship_declared_edges "$todo_file")
+		_RELATIONSHIP_EDGE_CACHE=$(_relationship_declared_edges "$todo_file" | LC_ALL=C sort -u)
 		_RELATIONSHIP_EDGE_CACHE_FILE="$todo_file"
 	fi
 	printf '%s\n' "$_RELATIONSHIP_EDGE_CACHE"
@@ -719,14 +719,56 @@ _declared_dependency_path_exists() {
 	local target_task="$2"
 	local edges="$3"
 	local seen_tasks="$4"
-	local edge_from="" edge_to=""
-	[[ "$current_task" == "$target_task" ]] && return 0
-	printf '%s\n' "$seen_tasks" | grep -Fxq -- "$current_task" && return 1
-	seen_tasks="${seen_tasks}${current_task}"$'\n'
-	while IFS='|' read -r edge_from edge_to; do
-		[[ "$edge_from" == "$current_task" && -n "$edge_to" ]] || continue
-		_declared_dependency_path_exists "$edge_to" "$target_task" "$edges" "$seen_tasks" && return 0
-	done <<<"$edges"
+	local metrics_file="${5:-}"
+	local seen_csv="${seen_tasks//$'\n'/,}"
+	# Build a deduplicated adjacency table once, then traverse iteratively. The
+	# legacy seen_tasks argument remains accepted for source-compatible callers.
+	if printf '%s\n' "$edges" | awk -F'|' \
+		-v start="$current_task" -v target="$target_task" \
+		-v initial_seen="$seen_csv" -v metrics_file="$metrics_file" '
+		function mark_initial_seen(raw, parts, count, idx) {
+			count = split(raw, parts, ",")
+			for (idx = 1; idx <= count; idx++) {
+				if (parts[idx] != "") visited[parts[idx]] = 1
+			}
+		}
+		NF == 2 && $1 != "" && $2 != "" {
+			edge_key = $1 SUBSEP $2
+			if (!(edge_key in unique_edge)) {
+				unique_edge[edge_key] = 1
+				degree[$1]++
+				adjacent[$1, degree[$1]] = $2
+				edge_count++
+			}
+		}
+		END {
+			mark_initial_seen(initial_seen)
+			found = (start == target)
+			stack[++stack_size] = start
+			while (!found && stack_size > 0) {
+				current = stack[stack_size--]
+				if (current in visited) continue
+				visited[current] = 1
+				visited_count++
+				for (idx = 1; idx <= degree[current]; idx++) {
+					next_task = adjacent[current, idx]
+					traversed_count++
+					if (next_task == target) {
+						found = 1
+						break
+					}
+					if (!(next_task in visited)) stack[++stack_size] = next_task
+				}
+			}
+			if (metrics_file != "") {
+				printf "nodes=%d edges=%d traversed=%d\n", visited_count, edge_count, traversed_count > metrics_file
+				close(metrics_file)
+			}
+			exit(found ? 0 : 1)
+		}'
+	then
+		return 0
+	fi
 	return 1
 }
 
@@ -1206,7 +1248,7 @@ _relationship_prepare_workset() {
 	# Broad reconciliation only needs active work. Explicit single-task sync still
 	# repairs completed tasks after publication, but unchanged historical rows do
 	# not consume every hosted default-branch pass.
-	local todo_line_re='^[[:space:]]*-[[:space:]]+\[[[:space:]>-]\][[:space:]]+(t[0-9]+(\.[0-9]+)*)[[:space:]]'
+	local todo_line_re='^[[:space:]]*-[[:space:]]+\[[[:space:]>]\][[:space:]]+(t[0-9]+(\.[0-9]+)*)[[:space:]]'
 	local tasks=() unique_tasks=()
 	_RELATIONSHIP_WORK_TASKS=()
 	_RELATIONSHIP_CANDIDATE_TOTAL=0

--- a/.agents/scripts/tests/benchmark-issue-sync-relationships.sh
+++ b/.agents/scripts/tests/benchmark-issue-sync-relationships.sh
@@ -9,6 +9,9 @@ TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
 mkdir -p "$TEMP_PARENT"
 BENCHMARK_DIR=$(mktemp -d "${TEMP_PARENT}/relationship-benchmark.XXXXXX")
 
+# shellcheck source=../issue-sync-helper.sh
+source "${TEST_DIR}/../issue-sync-helper.sh"
+
 cleanup() {
 	rm -rf "$BENCHMARK_DIR"
 	return 0
@@ -49,4 +52,36 @@ grep -m1 '^Edges:' "$stdout_file"
 grep -m1 '^Tasks:' "$stdout_file"
 grep -m1 '^Workset:' "$stdout_file"
 grep -m1 '^Timing:' "$stdout_file"
+
+graph_edges=""
+for ((node = 1; node <= 18; node++)); do
+	graph_edges="${graph_edges}t${node}|t$((node + 1))"$'\n'
+	graph_edges="${graph_edges}t${node}|t$((node + 1))"$'\n'
+done
+for ((node = 1; node <= 9; node++)); do
+	graph_edges="${graph_edges}t${node}|t$((node + 10))"$'\n'
+done
+metrics_file="${BENCHMARK_DIR}/traversal-metrics.log"
+if _declared_dependency_path_exists "t1" "t999" "$graph_edges" "" "$metrics_file"; then
+	printf 'FAIL: unreachable branching-graph target was reported reachable\n' >&2
+	exit 1
+fi
+traversal_metrics=$(<"$metrics_file")
+[[ "$traversal_metrics" == "nodes=19 edges=27 traversed=27" ]] || {
+	printf 'FAIL: branching traversal was not bounded to unique graph elements: %s\n' "$traversal_metrics" >&2
+	exit 1
+}
+if _declared_dependency_path_exists "t1" "t999" "$graph_edges" $'t1\n'; then
+	printf 'FAIL: a pre-seen traversal start was revisited\n' >&2
+	exit 1
+fi
+if ! _declared_dependency_path_exists "t1" "t19" "$graph_edges" $'t19\n'; then
+	printf 'FAIL: a reachable pre-seen target lost target-before-seen semantics\n' >&2
+	exit 1
+fi
+if ! _declared_dependency_path_exists "t5" "t5" "$graph_edges" $'t5\n'; then
+	printf 'FAIL: identical start and target lost target-before-seen semantics\n' >&2
+	exit 1
+fi
+printf 'Traversal: %s\n' "$traversal_metrics"
 printf 'PASS: 800-task relationship benchmark captured resources and progress\n'

--- a/.agents/scripts/tests/test-issue-sync-relationship-resume.sh
+++ b/.agents/scripts/tests/test-issue-sync-relationship-resume.sh
@@ -16,6 +16,10 @@ trap cleanup EXIT
 
 HOSTED_ARTIFACT_DIR="${TMP_DIR}/hosted-artifact"
 export AIDEVOPS_RELATIONSHIP_STATE_DIR="${TMP_DIR}/hosted-runner-one/state"
+export AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="${TMP_DIR}/gh-secondary-cooldown.json"
+export AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE="${TMP_DIR}/gh-cooldown-events.jsonl"
+export AIDEVOPS_GH_READ_RAMP_STATE_FILE="${TMP_DIR}/gh-read-ramp-state.tsv"
+export AIDEVOPS_GH_READ_RAMP_ENABLED=0
 TODO_FILE="${TMP_DIR}/TODO.md"
 ATTEMPT_LOG="${TMP_DIR}/attempts.log"
 DEADLINE_FLAG="${TMP_DIR}/deadline"
@@ -95,6 +99,14 @@ for ((task_number = 1001; task_number <= 1141; task_number++)); do
 	printf -- '- [x] t%d Completed task %d blocked-by:t900 ref:GH#%d\n' \
 		"$task_number" "$task_number" "$task_number" >>"$TODO_FILE"
 done
+# Cancelled rows are terminal too. Broad reconciliation excludes them, while an
+# explicit repair request still accepts their task ID.
+for ((task_number = 1201; task_number <= 1225; task_number++)); do
+	printf -- '- [-] t%d Cancelled task %d blocked-by:t900 ref:GH#%d\n' \
+		"$task_number" "$task_number" "$task_number" >>"$TODO_FILE"
+done
+_relationship_prepare_workset "t1201" "$TODO_FILE" "example/repo" || fail "explicit cancelled-task repair was rejected"
+[[ "${_RELATIONSHIP_WORK_TASKS[*]}" == "t1201" ]] || fail "explicit cancelled-task repair changed its target"
 : >"$ATTEMPT_LOG"
 
 first_rc=0
@@ -110,6 +122,8 @@ if [[ "${AIDEVOPS_BENCHMARK_OUTPUT:-0}" == "1" ]]; then
 	printf '%s\n' "$first_output"
 fi
 pass "800 active-task reconciliation persists bounded first-pass progress"
+[[ "$first_output" != *"t1201"* ]] || fail "broad reconciliation included a cancelled task"
+pass "broad reconciliation excludes cancelled relationship rows"
 
 # Hosted runners are ephemeral. Simulate the workflow handoff by copying only
 # the persisted state into a fresh runner state directory before the next pass.


### PR DESCRIPTION
## Summary

Deduplicate declared dependency edges, traverse each unique graph element iteratively, and exclude cancelled rows from broad relationship reconciliation.

## Files Changed

.agents/scripts/issue-sync-relationships.sh, .agents/scripts/tests/benchmark-issue-sync-relationships.sh, .agents/scripts/tests/test-issue-sync-relationship-resume.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified with the 800-candidate resume and benchmark fixtures: bounded traversal visited 19 nodes and 27 unique edges exactly once; resume, deadline, 47 cycle-normalization tests, Bash syntax, ShellCheck, and local linters passed

Resolves #30823


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.292 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 7h 24m and 3,438,463 tokens on this with the user in an interactive session.