### PR TITLE
GH#30816: preserve and recover dirty PR review worktrees

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -38,6 +38,7 @@ LOGFILE="${LOGFILE:-${HOME}/.aidevops/logs/pr-review-thread-response-scanner.log
 STATE_DIR="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR:-${HOME}/.aidevops/.agent-workspace/pr-review-thread-response}"
 HEADLESS_RUNTIME_HELPER="${HEADLESS_RUNTIME_HELPER:-${SCRIPT_DIR}/headless-runtime-helper.sh}"
 PR_REVIEW_THREAD_RESPONSE_WORKTREE_HELPER="${PR_REVIEW_THREAD_RESPONSE_WORKTREE_HELPER:-${SCRIPT_DIR}/worktree-helper.sh}"
+PR_REVIEW_THREAD_RESPONSE_DIRTY_BACKUP_HELPER="${PR_REVIEW_THREAD_RESPONSE_DIRTY_BACKUP_HELPER:-${SCRIPT_DIR}/dirty-worktree-backup-helper.sh}"
 PR_REVIEW_THREAD_RESPONSE_WORKTREE_BASE_DIR="${PR_REVIEW_THREAD_RESPONSE_WORKTREE_BASE_DIR:-${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}}"
 
 PR_REVIEW_THREAD_RESPONSE_PR_LIMIT="${PR_REVIEW_THREAD_RESPONSE_PR_LIMIT:-50}"
@@ -2309,6 +2310,72 @@ _prrts_claim_existing_worktree_for_reconcile() {
 	return 0
 }
 
+_prrts_preserve_dirty_existing_worktree() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local worktree_path="$3"
+	local initial_head="$4"
+	local worker_task=""
+	local backup_output=""
+	local backup_id=""
+	local backup_dir=""
+	local status_output=""
+	local operation_id="pr-review-reconcile-${pr_number}-${initial_head:-unknown}"
+
+	if [[ ! -x "$PR_REVIEW_THREAD_RESPONSE_DIRTY_BACKUP_HELPER" ]]; then
+		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_backup_helper_unavailable"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — dirty-worktree backup helper is unavailable"
+		return 1
+	fi
+	worker_task=$(_prrts_worker_task_id "$pr_number") || worker_task=""
+	[[ -n "$worker_task" ]] || return 1
+	if ! backup_output=$("$PR_REVIEW_THREAD_RESPONSE_DIRTY_BACKUP_HELPER" backup \
+		--repo "$worktree_path" \
+		--reason "preserve dirty PR review worktree before head reconciliation" \
+		--pr "$pr_number" --task "$worker_task" \
+		--operation-id "$operation_id" --machine 2>>"$LOGFILE"); then
+		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_backup_failed"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — dirty review worktree backup failed"
+		return 1
+	fi
+	IFS='|' read -r backup_id backup_dir <<<"$backup_output"
+	if [[ ! "$backup_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ || -z "$backup_dir" ]]; then
+		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_backup_output_invalid"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — dirty review worktree backup returned invalid evidence"
+		return 1
+	fi
+	if ! "$PR_REVIEW_THREAD_RESPONSE_DIRTY_BACKUP_HELPER" verify \
+		--repo "$worktree_path" --backup "$backup_id" >>"$LOGFILE" 2>&1; then
+		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_backup_unverified"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — dirty review worktree backup could not be verified (backup=${backup_id})"
+		return 1
+	fi
+	if ! "$PR_REVIEW_THREAD_RESPONSE_DIRTY_BACKUP_HELPER" matches \
+		--repo "$worktree_path" --backup "$backup_id" >>"$LOGFILE" 2>&1; then
+		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_backup_mismatch"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — dirty review worktree changed after backup (backup=${backup_id})"
+		return 1
+	fi
+	if ! "$PR_REVIEW_THREAD_RESPONSE_DIRTY_BACKUP_HELPER" clean \
+		--repo "$worktree_path" --backup "$backup_id" \
+		--confirm CLEAN_VERIFIED_DIRTY_WORKTREE_BACKUP >>"$LOGFILE" 2>&1; then
+		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_clean_failed"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — verified dirty review worktree cleanup failed (backup=${backup_id})"
+		return 1
+	fi
+	status_output=$(git -C "$worktree_path" status --porcelain 2>/dev/null) || {
+		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_clean_unverified"
+		return 1
+	}
+	if [[ -n "$status_output" ]]; then
+		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_clean_unverified"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — preserved review worktree is still dirty after guarded cleanup (backup=${backup_id})"
+		return 1
+	fi
+	_prrts_log "dispatch: ${repo_slug}#${pr_number} preserved and cleaned exclusively claimed dirty review worktree (backup=${backup_id})"
+	return 0
+}
+
 _prrts_reconcile_existing_worktree_head() {
 	local repo_slug="$1"
 	local repo_path="$2"
@@ -2331,12 +2398,10 @@ _prrts_reconcile_existing_worktree_head() {
 		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_status_unavailable"
 		return 1
 	}
-	if [[ -n "$status_output" ]]; then
-		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_dirty"
-		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — existing review worktree head mismatch is dirty"
-		return 1
-	fi
 	_prrts_claim_existing_worktree_for_reconcile "$repo_slug" "$pr_number" "$worktree_path" "$head_ref" || return 1
+	if [[ -n "$status_output" ]]; then
+		_prrts_preserve_dirty_existing_worktree "$repo_slug" "$pr_number" "$worktree_path" "$initial_head" || return 1
+	fi
 	_prrts_fetch_exact_worker_head "$repo_slug" "$repo_path" "$pr_number" "$head_ref" "$head_oid" || return 1
 
 	status_output=$(git -C "$worktree_path" status --porcelain 2>/dev/null) || {
@@ -2363,7 +2428,7 @@ _prrts_reconcile_existing_worktree_head() {
 		PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_fast_forward_unverified"
 		return 1
 	fi
-	_prrts_log "dispatch: ${repo_slug}#${pr_number} fast-forwarded clean exclusively claimed review worktree from ${initial_head} to verified PR head ${head_oid}"
+	_prrts_log "dispatch: ${repo_slug}#${pr_number} fast-forwarded exclusively claimed review worktree from ${initial_head} to verified PR head ${head_oid}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -262,7 +262,7 @@ if [[ "${1:-}" == "-C" && "${3:-}" == "symbolic-ref" && "$*" == *"--short HEAD"*
 	exit 1
 fi
 if [[ "${1:-}" == "-C" && "${3:-}" == "status" && "${4:-}" == "--porcelain" ]]; then
-	if [[ "${STUB_GIT_WORKTREE_DIRTY:-false}" == "true" ]]; then
+	if [[ "${STUB_GIT_WORKTREE_DIRTY:-false}" == "true" && ! -f "${DIRTY_BACKUP_CLEANED:-/nonexistent}" ]]; then
 		printf ' M diagnostic.txt\n'
 	fi
 	exit 0
@@ -433,6 +433,44 @@ WORKTREE_STUB
 	return 0
 }
 
+write_fake_dirty_backup_stub() {
+	cat >"${TEST_ROOT}/dirty-worktree-backup-helper.sh" <<'DIRTY_BACKUP_STUB'
+#!/usr/bin/env bash
+command_name="${1:-}"
+shift || true
+printf '%s %s\n' "$command_name" "$*" >>"${DIRTY_BACKUP_LOG}"
+case "$command_name" in
+backup)
+	[[ "${STUB_DIRTY_BACKUP_FAIL:-false}" == "true" ]] && exit 1
+	owner_snapshot=$(bash -c 'source "$1"; check_worktree_owner "$2"' _ "${SHARED_CONSTANTS_PATH}" "${STUB_DIRTY_BACKUP_REPO}") || exit 1
+	IFS='|' read -r owner_pid owner_session owner_batch owner_task owner_created_at owner_process_start <<EOF
+${owner_snapshot}
+EOF
+	printf 'OWNER_PID=%s\nOWNER_SESSION=%s\nOWNER_TASK=%s\n' "$owner_pid" "$owner_session" "$owner_task" >>"${DIRTY_BACKUP_OWNER_LOG}"
+	[[ "$owner_pid" =~ ^[0-9]+$ && "$owner_task" == "1" && "$owner_session" == "dispatch-precreate-1" && -n "$owner_created_at" ]] || exit 1
+	printf 'test-dirty-backup|%s/backups/test-dirty-backup\n' "${TEST_ROOT}"
+	;;
+verify)
+	[[ "${STUB_DIRTY_BACKUP_VERIFY_FAIL:-false}" == "true" ]] && exit 1
+	printf 'VERIFIED_BACKUP_ID=test-dirty-backup\n'
+	;;
+matches)
+	[[ "${STUB_DIRTY_BACKUP_MATCH_FAIL:-false}" == "true" ]] && exit 1
+	printf 'BACKUP_MATCH=true\n'
+	;;
+clean)
+	[[ "${STUB_DIRTY_BACKUP_CLEAN_FAIL:-false}" == "true" ]] && exit 1
+	: >"${DIRTY_BACKUP_CLEANED}"
+	printf 'CLEANED_BACKUP_ID=test-dirty-backup\n'
+	;;
+*) exit 1 ;;
+esac
+exit 0
+DIRTY_BACKUP_STUB
+	chmod +x "${TEST_ROOT}/dirty-worktree-backup-helper.sh"
+	return 0
+}
+
 setup_test_env() {
 	unset STUB_PR_LIST STUB_PR_VIEW STUB_THREADS_MODE STUB_HANG_SECONDS STUB_GRAPHQL_COST_MODE STUB_PR_REPOSITORY_MODE STUB_REMOTE_HEAD STUB_GH_LOGIN
 	unset STUB_GH_REST_FAIL STUB_GH_GRAPHQL_FAIL STUB_GH_GRAPHQL_LOGIN
@@ -440,6 +478,7 @@ setup_test_env() {
 	unset STUB_GIT_INVALID_BRANCH STUB_GIT_FETCH_FAIL STUB_GIT_CANONICAL_FETCH_FAIL
 	unset STUB_REMOTE_HEAD_INITIAL STUB_REMOTE_HEAD_AFTER_FETCH STUB_WORKTREE_ACTUAL_HEAD STUB_WORKTREE_HELPER_FAIL
 	unset STUB_GIT_WORKTREE_DIRTY STUB_GIT_DIVERGED STUB_GIT_FAST_FORWARD_FAIL
+	unset STUB_DIRTY_BACKUP_FAIL STUB_DIRTY_BACKUP_VERIFY_FAIL STUB_DIRTY_BACKUP_MATCH_FAIL STUB_DIRTY_BACKUP_CLEAN_FAIL
 	unset STUB_WORKTREE_REGISTER_OWNER STUB_WORKTREE_OWNER_PID STUB_WORKTREE_OWNER_SESSION
 	unset STUB_ACTIVE_RESPONSE_WORKER
 	unset STUB_HEADLESS_MARK_COMPLETE
@@ -459,6 +498,9 @@ setup_test_env() {
 	export DETACH_LAUNCH_LOG="${TEST_ROOT}/detach-launch.log"
 	export WORKTREE_HELPER_LOG="${TEST_ROOT}/worktree-helper.log"
 	export WORKTREE_CREATED_OWNER_CAPTURE="${TEST_ROOT}/worktree-created-owner.txt"
+	export DIRTY_BACKUP_LOG="${TEST_ROOT}/dirty-backup.log"
+	export DIRTY_BACKUP_OWNER_LOG="${TEST_ROOT}/dirty-backup-owner.log"
+	export DIRTY_BACKUP_CLEANED="${TEST_ROOT}/dirty-backup-cleaned"
 	export GIT_WORKTREE_REGISTRY="${TEST_ROOT}/git-worktrees.tsv"
 	export GIT_FETCH_CWD_LOG="${TEST_ROOT}/git-fetch-cwd.log"
 	export GIT_FETCHED_HEAD_STATE="${TEST_ROOT}/git-fetched-head.state"
@@ -475,9 +517,11 @@ setup_test_env() {
 	write_fake_headless_stub
 	write_fake_detach_stubs
 	write_fake_worktree_stub
+	write_fake_dirty_backup_stub
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export HEADLESS_RUNTIME_HELPER="${TEST_ROOT}/headless-runtime-helper.sh"
 	export PR_REVIEW_THREAD_RESPONSE_WORKTREE_HELPER="${TEST_ROOT}/worktree-helper.sh"
+	export PR_REVIEW_THREAD_RESPONSE_DIRTY_BACKUP_HELPER="${TEST_ROOT}/dirty-worktree-backup-helper.sh"
 	export PR_REVIEW_THREAD_RESPONSE_WORKTREE_BASE_DIR="${TEST_ROOT}/worktrees"
 	export GRAPHQL_MUTATIONS_LOG="${TEST_ROOT}/graphql-mutations.log"
 	export GRAPHQL_BODY_CAPTURE="${TEST_ROOT}/graphql-body.txt"
@@ -494,7 +538,10 @@ setup_test_env() {
 	: >"$HEADLESS_COMPLETE_LOG"
 	: >"$DETACH_LAUNCH_LOG"
 	: >"$GIT_FETCH_CWD_LOG"
+	: >"$DIRTY_BACKUP_LOG"
+	: >"$DIRTY_BACKUP_OWNER_LOG"
 	rm -f "$GIT_FETCHED_HEAD_STATE"
+	rm -f "$DIRTY_BACKUP_CLEANED"
 	return 0
 }
 
@@ -797,7 +844,7 @@ test_dispatch_fast_forwards_clean_behind_existing_worktree() {
 	local reconciled_head=""
 	reconciled_head=$(while IFS=$'\t' read -r path branch oid; do [[ "$path" == "$existing_path" ]] && printf '%s' "$oid"; done <"$GIT_WORKTREE_REGISTRY")
 	if [[ -s "$HEADLESS_LOG" && "$reconciled_head" == "$TEST_HEAD_OID_1" ]] &&
-		grep -Fq "fast-forwarded clean exclusively claimed review worktree from ${TEST_HEAD_OID_2} to verified PR head ${TEST_HEAD_OID_1}" "$LOGFILE" 2>/dev/null; then
+		grep -Fq "fast-forwarded exclusively claimed review worktree from ${TEST_HEAD_OID_2} to verified PR head ${TEST_HEAD_OID_1}" "$LOGFILE" 2>/dev/null; then
 		print_result "dispatch fast-forwards a clean behind existing review worktree" 0
 	else
 		print_result "dispatch fast-forwards a clean behind existing review worktree" 1 \
@@ -807,67 +854,60 @@ test_dispatch_fast_forwards_clean_behind_existing_worktree() {
 	return 0
 }
 
-test_dispatch_rejects_dirty_existing_worktree_reconcile() {
+test_dispatch_preserves_and_recovers_dirty_existing_worktree_reconcile() {
 	setup_test_env
 	export STUB_GIT_WORKTREE_DIRTY=true
 	local existing_path="${TEST_ROOT}/existing-review-worktree-dirty"
+	export STUB_DIRTY_BACKUP_REPO="$existing_path"
 	mkdir -p "$existing_path"
 	printf '%s\t%s\t%s\n' "$existing_path" 'feature/review' "$TEST_HEAD_OID_2" >"$GIT_WORKTREE_REGISTRY"
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
-	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
-	local outcome_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.outcome"
-	local outcome_id="" outcome_reason="" retry_class=""
-	outcome_id=$(read_state_value "$state_file" outcome_id)
-	outcome_reason=$(awk -F= '$1 == "reason" { print $2 }' "$outcome_file" 2>/dev/null || true)
-	retry_class=$(awk -F= '$1 == "retry_class" { print $2 }' "$outcome_file" 2>/dev/null || true)
-	if [[ ! -s "$HEADLESS_LOG" ]] &&
-		grep -q '^blocker_reason=existing_review_worktree_dirty$' "$state_file" 2>/dev/null &&
-		[[ -n "$outcome_id" ]] &&
-		grep -Fxq "outcome_id=${outcome_id}" "$outcome_file" 2>/dev/null &&
-		[[ "$outcome_reason" == "existing_review_worktree_dirty" && "$retry_class" == "retryable_infrastructure" ]]; then
-		print_result "dirty worktree preparation emits an exact typed infrastructure outcome" 0
+	wait_for_headless_log || true
+	local reconciled_head=""
+	reconciled_head=$(while IFS=$'\t' read -r path branch oid; do [[ "$path" == "$existing_path" ]] && printf '%s' "$oid"; done <"$GIT_WORKTREE_REGISTRY")
+	if [[ -s "$HEADLESS_LOG" && "$reconciled_head" == "$TEST_HEAD_OID_1" && -f "$DIRTY_BACKUP_CLEANED" ]] &&
+		grep -q '^OWNER_TASK=1$' "$DIRTY_BACKUP_OWNER_LOG" 2>/dev/null &&
+		grep -q '^OWNER_SESSION=dispatch-precreate-1$' "$DIRTY_BACKUP_OWNER_LOG" 2>/dev/null &&
+		grep -q '^backup .*--machine$' "$DIRTY_BACKUP_LOG" 2>/dev/null &&
+		grep -q '^verify ' "$DIRTY_BACKUP_LOG" 2>/dev/null &&
+		grep -q '^matches ' "$DIRTY_BACKUP_LOG" 2>/dev/null &&
+		grep -q '^clean .*--confirm CLEAN_VERIFIED_DIRTY_WORKTREE_BACKUP$' "$DIRTY_BACKUP_LOG" 2>/dev/null &&
+		grep -q 'preserved and cleaned exclusively claimed dirty review worktree (backup=test-dirty-backup)' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch preserves and recovers an exclusively claimed dirty review worktree" 0
 	else
-		print_result "dirty worktree preparation emits an exact typed infrastructure outcome" 1 \
-			"state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf ''), outcome=$(tr '\n' ';' <"$outcome_file" 2>/dev/null || printf '')"
+		print_result "dispatch preserves and recovers an exclusively claimed dirty review worktree" 1 \
+			"head=${reconciled_head:-<empty>} backup=$(tr '\n' ';' <"$DIRTY_BACKUP_LOG" 2>/dev/null || printf '') owner=$(tr '\n' ';' <"$DIRTY_BACKUP_OWNER_LOG" 2>/dev/null || printf '')"
 	fi
 	teardown_test_env
 	return 0
 }
 
-test_dispatch_retries_dirty_worktree_failure_after_short_cooldown() {
+test_dispatch_fails_closed_when_dirty_backup_no_longer_matches() {
 	setup_test_env
 	export STUB_GIT_WORKTREE_DIRTY=true
-	local existing_path="${TEST_ROOT}/existing-review-worktree-dirty-retry"
+	export STUB_DIRTY_BACKUP_MATCH_FAIL=true
+	local existing_path="${TEST_ROOT}/existing-review-worktree-dirty-mismatch"
+	export STUB_DIRTY_BACKUP_REPO="$existing_path"
 	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
 	local outcome_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.outcome"
-	local old_epoch="" first_outcome_id="" second_outcome_id=""
+	local outcome_id="" outcome_reason="" retry_class=""
 	mkdir -p "$existing_path"
 	printf '%s\t%s\t%s\n' "$existing_path" 'feature/review' "$TEST_HEAD_OID_2" >"$GIT_WORKTREE_REGISTRY"
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
-	first_outcome_id=$(read_state_value "$state_file" outcome_id)
-	: >"$LOGFILE"
-	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
-	local short_cooldown_observed=0
-	grep -q 'infrastructure-failure short cooldown active' "$LOGFILE" 2>/dev/null || short_cooldown_observed=1
-
-	old_epoch="$(($(date +%s) - 120))"
-	expire_state_dispatch_time "$state_file" "$old_epoch"
-	awk -F= -v finished_at="$((old_epoch + 1))" \
-		'{ if ($1 == "finished_at") print "finished_at=" finished_at; else print }' \
-		"$outcome_file" >"${outcome_file}.tmp"
-	mv "${outcome_file}.tmp" "$outcome_file"
-	: >"$LOGFILE"
-	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
-	second_outcome_id=$(read_state_value "$state_file" outcome_id)
-
-	local result=0
-	[[ "$short_cooldown_observed" -eq 0 ]] || result=1
-	[[ -n "$first_outcome_id" && -n "$second_outcome_id" && "$second_outcome_id" != "$first_outcome_id" ]] || result=1
-	grep -q '^attempt_count=1$' "$state_file" 2>/dev/null || result=1
-	grep -q '^infrastructure_failure_count=1$' "$state_file" 2>/dev/null || result=1
-	grep -q 'retrying after infrastructure-failure short cooldown' "$LOGFILE" 2>/dev/null || result=1
-	print_result "dirty worktree infrastructure failure retries once after the short cooldown" "$result" \
-		"first=${first_outcome_id}, second=${second_outcome_id}, state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf '')"
+	outcome_id=$(read_state_value "$state_file" outcome_id)
+	outcome_reason=$(awk -F= '$1 == "reason" { print $2 }' "$outcome_file" 2>/dev/null || true)
+	retry_class=$(awk -F= '$1 == "retry_class" { print $2 }' "$outcome_file" 2>/dev/null || true)
+	if [[ ! -s "$HEADLESS_LOG" && ! -f "$DIRTY_BACKUP_CLEANED" ]] &&
+		grep -q '^blocker_reason=existing_review_worktree_backup_mismatch$' "$state_file" 2>/dev/null &&
+		[[ -n "$outcome_id" ]] &&
+		grep -Fxq "outcome_id=${outcome_id}" "$outcome_file" 2>/dev/null &&
+		[[ "$outcome_reason" == "existing_review_worktree_backup_mismatch" && "$retry_class" == "retryable_infrastructure" ]] &&
+		! grep -q '^clean ' "$DIRTY_BACKUP_LOG" 2>/dev/null; then
+		print_result "dispatch fails closed when preserved dirty state no longer matches" 0
+	else
+		print_result "dispatch fails closed when preserved dirty state no longer matches" 1 \
+			"state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf ''), outcome=$(tr '\n' ';' <"$outcome_file" 2>/dev/null || printf ''), backup=$(tr '\n' ';' <"$DIRTY_BACKUP_LOG" 2>/dev/null || printf '')"
+	fi
 	teardown_test_env
 	return 0
 }
@@ -2809,8 +2849,8 @@ main() {
 	test_dispatch_blocks_cross_repository_head
 	test_dispatch_blocks_remote_head_drift
 	test_dispatch_fast_forwards_clean_behind_existing_worktree
-	test_dispatch_rejects_dirty_existing_worktree_reconcile
-	test_dispatch_retries_dirty_worktree_failure_after_short_cooldown
+	test_dispatch_preserves_and_recovers_dirty_existing_worktree_reconcile
+	test_dispatch_fails_closed_when_dirty_backup_no_longer_matches
 	test_dispatch_rejects_diverged_existing_worktree_reconcile
 	test_dispatch_rejects_live_owned_existing_worktree_reconcile
 	test_dispatch_cleans_up_failed_exact_head_worktree


### PR DESCRIPTION
## Summary

Claim mismatched review worktrees before mutation, preserve dirty tracked/staged/untracked state with audited backup evidence, verify an exact match, clean transactionally, and continue exact-head reconciliation.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Scanner regression suite: 98 passed; ShellCheck passed; local linters passed; git diff --check passed.

Resolves #30816


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.293 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 1h 14m and 456,076 tokens on this with the user in an interactive session.