### PR TITLE
GH#30821: preserve remediated worker PRs

### DIFF
--- a/.agents/scripts/pulse-merge-feedback-finalizer.sh
+++ b/.agents/scripts/pulse-merge-feedback-finalizer.sh
@@ -866,8 +866,21 @@ _feedback_route_close_and_finish() {
 	local close_rc=0
 	local close_snapshot_rc=0
 	local closed_by_this_call=0
+	local preclose_guard_rc=0
 
 	if [[ "$pr_state" == "$PULSE_FEEDBACK_ROUTE_OPEN_STATE" ]]; then
+		if [[ "$kind" == "review" && "${_PULSE_FEEDBACK_ROUTE_REVIEW_PRECLOSE_GUARD:-0}" == "1" ]]; then
+			if ! declare -F _review_feedback_route_preclose_allows >/dev/null 2>&1; then
+				preclose_guard_rc="${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+			else
+				_review_feedback_route_preclose_allows "$pr_number" "$repo_slug" "$expected_head" || preclose_guard_rc=$?
+			fi
+			if [[ "$preclose_guard_rc" -ne 0 ]]; then
+				_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+					"review readiness changed immediately before close; preserving remediated PR"
+				return $?
+			fi
+		fi
 		_feedback_route_gh_write pr close "$pr_number" --repo "$repo_slug" \
 			--comment "${close_comment}
 

--- a/.agents/scripts/pulse-merge-feedback-finalizer.sh
+++ b/.agents/scripts/pulse-merge-feedback-finalizer.sh
@@ -15,6 +15,7 @@ PULSE_FEEDBACK_ROUTE_NMR_LABEL="needs-maintainer-review"
 PULSE_FEEDBACK_ROUTE_OPEN_STATE="OPEN"
 PULSE_FEEDBACK_ROUTE_AVAILABLE_LABEL="status:available"
 PULSE_FEEDBACK_ROUTE_JSON_ARRAY_TYPE="array"
+PULSE_FEEDBACK_ROUTE_WORKER_TAKEOVER_LABEL="origin:worker-takeover"
 
 _PULSE_FEEDBACK_ROUTE_CONTEXT_KIND=""
 _PULSE_FEEDBACK_ROUTE_CONTEXT_HEAD=""
@@ -49,7 +50,19 @@ _feedback_route_labels_block_routing() {
 		return 0
 	fi
 	if _feedback_route_labels_include "$labels" "origin:interactive" \
-		&& ! _feedback_route_labels_include "$labels" "origin:worker-takeover"; then
+		&& ! _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_WORKER_TAKEOVER_LABEL"; then
+		return 0
+	fi
+	return 1
+}
+
+_feedback_route_labels_allow_worker_route() {
+	local labels="$1"
+	local ignore_hold="${2:-0}"
+
+	_feedback_route_labels_block_routing "$labels" "$ignore_hold" && return 1
+	if _feedback_route_labels_include "$labels" "origin:worker" \
+		|| _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_WORKER_TAKEOVER_LABEL"; then
 		return 0
 	fi
 	return 1
@@ -450,7 +463,7 @@ _feedback_route_issue_is_ready() {
 	_feedback_route_labels_include "$labels" "$source_label" || return 1
 	_feedback_route_labels_include "$labels" "origin:worker" || return 1
 	! _feedback_route_labels_include "$labels" "origin:interactive" || return 1
-	! _feedback_route_labels_include "$labels" "origin:worker-takeover" || return 1
+	! _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_WORKER_TAKEOVER_LABEL" || return 1
 	! _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" || return 1
 	! _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_NMR_LABEL" || return 1
 	[[ -z "$assignees" ]] || return 1
@@ -1000,7 +1013,7 @@ _feedback_route_prepare_finalization_snapshot() {
 			"${kind} route head drifted from ${expected_head} to ${current_head:-unknown}"
 		return $?
 	fi
-	if _feedback_route_labels_block_routing "$labels" 1; then
+	if ! _feedback_route_labels_allow_worker_route "$labels" 1; then
 		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" \
 			"current PR ownership labels prohibit ${kind} finalization"
 		return $?
@@ -1025,7 +1038,7 @@ _feedback_route_prepare_finalization_snapshot() {
 			return $?
 		fi
 	fi
-	if _feedback_route_labels_block_routing "$labels"; then
+	if ! _feedback_route_labels_allow_worker_route "$labels"; then
 		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" \
 			"current PR ownership labels prohibit ${kind} finalization"
 		return $?
@@ -1116,7 +1129,7 @@ _finalize_feedback_route() {
 			"${kind} route head changed after issue transition (${expected_head} to ${current_head:-unknown})"
 		return $?
 	fi
-	if _feedback_route_labels_block_routing "$labels"; then
+	if ! _feedback_route_labels_allow_worker_route "$labels"; then
 		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
 			"PR ownership labels changed during ${kind} finalization"
 		return $?

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -27,6 +27,7 @@
 # Functions in this module (in source order):
 #   - _build_review_feedback_section      (t2093)
 #   - _review_feedback_has_trusted_body_change_request (GH#30703)
+#   - _review_feedback_preserve_ready_pr  (GH#30821)
 #   - _append_feedback_to_issue           (GH#20057, shared helper)
 #   - _transition_issue_for_redispatch    (GH#20057, shared helper)
 #   - _finalize_feedback_route            (GH#29288, sourced state machine)
@@ -52,6 +53,7 @@ _PULSE_MERGE_FEEDBACK_LOADED=1
 : "${PULSE_REVIEW_FEEDBACK_ITEM_LIMIT:=4000}"
 : "${PULSE_REVIEW_FEEDBACK_SECTION_LIMIT:=12000}"
 PULSE_REVIEW_REPAIR_SOURCE_LABEL="source:review-repair"
+PULSE_FEEDBACK_JSON_STRING_TYPE="string"
 
 _CI_REPAIR_OUTCOME_SUMMARY=""
 
@@ -264,6 +266,157 @@ _review_feedback_has_trusted_body_change_request() {
 			)
 		end
 	' >/dev/null 2>&1 || return 1
+	return 0
+}
+
+_review_feedback_ready_reviewer_evidence() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local reviews_pages=""
+	local changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
+
+	reviews_pages=$(_pmf_gh_read gh api \
+		"repos/${repo_slug}/pulls/${pr_number}/reviews?per_page=100" --paginate 2>/dev/null) || return 1
+	#aidevops:trust-boundary — only a trusted human's latest substantive change request can preserve a worker PR.
+	printf '%s\n' "$reviews_pages" | jq -cse \
+		--arg string_type "$PULSE_FEEDBACK_JSON_STRING_TYPE" \
+		--arg changes_requested "$changes_requested" '
+		if all(.[]; type == ([] | type)) then [ .[][] ]
+		else error("review evidence page must be an array") end
+		| map(select(.state == "APPROVED" or .state == $changes_requested or .state == "DISMISSED"))
+		| if any(.[];
+			(.id | type) != "number"
+			or (.submitted_at | type) != $string_type or (.submitted_at | length) == 0
+			or (.user | type) != "object"
+			or (.user.login | type) != $string_type or (.user.login | length) == 0
+			or (.user.type | type) != $string_type
+			or (.author_association | type) != $string_type
+			or (.body | type) != $string_type
+			or (.commit_id | type) != $string_type)
+		then error("malformed state-changing review evidence")
+		else . end
+		| group_by(.user.login)
+		| map(max_by([.submitted_at, .id]))
+		| map(select(
+			.state == $changes_requested
+			and .user.type == "User"
+			and (.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")
+			and ((.body | gsub("\\s"; "")) | length) > 0))
+		| if any(.[]; (.commit_id | test("^[0-9a-fA-F]{40}$")) == false)
+		then error("trusted change request has invalid head identity")
+		else {reviewers: (map(.user.login) | unique), reviewed_heads: (map(.commit_id) | unique)} end
+	' 2>/dev/null
+	return $?
+}
+
+_review_feedback_head_advances_reviews() {
+	local repo_slug="$1"
+	local current_head="$2"
+	local reviewed_heads_json="$3"
+	local reviewed_head=""
+	local compare_status=""
+	local count=0
+
+	count=$(printf '%s' "$reviewed_heads_json" | jq 'length' 2>/dev/null) || return 75
+	[[ "$count" =~ ^[1-9][0-9]*$ ]] || return 1
+	while IFS= read -r reviewed_head; do
+		[[ "$reviewed_head" =~ ^[0-9a-fA-F]{40}$ && "$reviewed_head" != "$current_head" ]] || return 1
+		compare_status=$(_pmf_gh_read gh api \
+			"repos/${repo_slug}/compare/${reviewed_head}...${current_head}" --jq '.status // ""' 2>/dev/null) || return 75
+		[[ "$compare_status" == "ahead" ]] || return 1
+	done < <(printf '%s' "$reviewed_heads_json" | jq -r '.[]' 2>/dev/null)
+	return 0
+}
+
+_review_feedback_threads_converged() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local scanner="${PULSE_REVIEW_FEEDBACK_SCANNER:-${BASH_SOURCE[0]%/*}/pr-review-thread-response-scanner.sh}"
+	local scan_output=""
+
+	[[ -x "$scanner" ]] || return 75
+	scan_output=$(PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true \
+		"$scanner" scan-pr "$repo_slug" "$pr_number" 2>>"$LOGFILE") || return 75
+	[[ -z "$scan_output" ]] || return 1
+	return 0
+}
+
+_review_feedback_required_checks_green() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local checks_json=""
+	local checks_rc=0
+
+	declare -F gh_pr_checks_exact_json >/dev/null 2>&1 || return 75
+	checks_json=$(gh_pr_checks_exact_json "$repo_slug" "$pr_number" required 2>/dev/null) || checks_rc=$?
+	case "$checks_rc" in
+	0 | 1 | 8) ;;
+	*) return 75 ;;
+	esac
+	[[ -n "$checks_json" ]] || checks_json="[]"
+	printf '%s' "$checks_json" | jq -e 'type == ([] | type)' >/dev/null 2>&1 || return 75
+	printf '%s' "$checks_json" | jq -e 'any(.[]?; .bucket == "fail" or .bucket == "cancel")' >/dev/null 2>&1 && return 1
+	[[ "$checks_rc" -eq 0 ]] || return 75
+	printf '%s' "$checks_json" | jq -e 'any(.[]?; .bucket == "pending")' >/dev/null 2>&1 && return 75
+	return 0
+}
+
+_review_feedback_pending_reviewers() {
+	local reviewers_json="$1"
+	local requested_reviewers_csv="$2"
+
+	jq -nr --argjson reviewers "$reviewers_json" --arg requested "$requested_reviewers_csv" '
+		($requested | split("|") | map(select(length > 0))) as $already
+		| [$reviewers[] | select(($already | index(.)) == null)] | unique | join(",")
+	' 2>/dev/null
+	return $?
+}
+
+_review_feedback_preserve_ready_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head="$3"
+	local evidence=""
+	local reviewers_json="[]"
+	local reviewed_heads_json="[]"
+	local snapshot=""
+	local pr_state="" is_draft="" current_head="" requested_reviewers=""
+	local pending_reviewers=""
+	local readiness_rc=0
+
+	evidence=$(_review_feedback_ready_reviewer_evidence "$pr_number" "$repo_slug") || return 75
+	reviewers_json=$(printf '%s' "$evidence" | jq -c '.reviewers' 2>/dev/null) || return 75
+	reviewed_heads_json=$(printf '%s' "$evidence" | jq -c '.reviewed_heads' 2>/dev/null) || return 75
+	[[ "$(printf '%s' "$reviewers_json" | jq 'length' 2>/dev/null)" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ "$expected_head" =~ ^[0-9a-fA-F]{40}$ ]] || return 75
+	snapshot=$(_pmf_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}" --jq \
+		'[
+			(if .merged_at != null then "MERGED" else ((.state // "") | ascii_upcase) end),
+			(.draft | tostring),
+			(.head.sha // ""),
+			([.requested_reviewers[].login] | join("|"))
+		] | @tsv' 2>/dev/null) || return 75
+	IFS=$'\t' read -r pr_state is_draft current_head requested_reviewers <<<"$snapshot"
+	[[ "$pr_state" == "OPEN" && "$is_draft" == "false" && "$current_head" == "$expected_head" ]] || return 75
+
+	_review_feedback_head_advances_reviews "$repo_slug" "$current_head" "$reviewed_heads_json" || readiness_rc=$?
+	[[ "$readiness_rc" -eq 0 ]] || return "$readiness_rc"
+	_review_feedback_threads_converged "$pr_number" "$repo_slug" || readiness_rc=$?
+	[[ "$readiness_rc" -eq 0 ]] || return "$readiness_rc"
+	_review_feedback_required_checks_green "$pr_number" "$repo_slug" || readiness_rc=$?
+	[[ "$readiness_rc" -eq 0 ]] || return "$readiness_rc"
+	pending_reviewers=$(_review_feedback_pending_reviewers "$reviewers_json" "$requested_reviewers") || return 75
+	if [[ -n "$pending_reviewers" ]]; then
+		if ! declare -F _feedback_route_gh_write >/dev/null 2>&1 ||
+			! _feedback_route_gh_write pr edit "$pr_number" --repo "$repo_slug" \
+				--add-reviewer "$pending_reviewers" >/dev/null 2>&1; then
+			echo "[pulse-wrapper] review feedback: ready PR #${pr_number} in ${repo_slug} could not re-request trusted reviewer(s); preserving PR for retry" >>"$LOGFILE"
+			return 0
+		fi
+		echo "[pulse-wrapper] review feedback: ready PR #${pr_number} in ${repo_slug} re-requested trusted reviewer(s) for changed head ${current_head}; preserving PR" >>"$LOGFILE"
+	else
+		echo "[pulse-wrapper] review feedback: ready PR #${pr_number} in ${repo_slug} already awaits its trusted reviewer(s) on changed head ${current_head}; preserving PR" >>"$LOGFILE"
+	fi
 	return 0
 }
 
@@ -2480,6 +2633,15 @@ _dispatch_pr_fix_worker() {
 	fi
 	local reviews_json="$_PULSE_REVIEW_FEEDBACK_REVIEWS_JSON"
 	local inline_json="$_PULSE_REVIEW_FEEDBACK_INLINE_JSON"
+	local readiness_rc=0
+	_review_feedback_preserve_ready_pr "$pr_number" "$repo_slug" "$expected_head" || readiness_rc=$?
+	if [[ "$readiness_rc" -eq 0 ]]; then
+		return 0
+	fi
+	if [[ "$readiness_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ]]; then
+		echo "[pulse-wrapper] _dispatch_pr_fix_worker: ready-review evidence unavailable for PR #${pr_number} in ${repo_slug} — deferring without destructive routing" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
 
 	# --- Build the Review Feedback markdown section ---
 	local feedback_section=""

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -356,6 +356,9 @@ _review_feedback_required_checks_green() {
 	esac
 	[[ -n "$checks_json" ]] || checks_json="[]"
 	printf '%s' "$checks_json" | jq -e 'type == ([] | type)' >/dev/null 2>&1 || return 75
+	if [[ "$checks_rc" -eq 1 && "$checks_json" == "[]" ]]; then
+		return 0
+	fi
 	printf '%s' "$checks_json" | jq -e 'any(.[]?; .bucket == "fail")' >/dev/null 2>&1 && return 1
 	printf '%s' "$checks_json" | jq -e 'any(.[]?; .bucket == "cancel")' >/dev/null 2>&1 && return 75
 	[[ "$checks_rc" -eq 0 ]] || return 75
@@ -385,7 +388,7 @@ _review_feedback_ready_snapshot() {
 			(.draft | tostring),
 			(.head.sha // ""),
 			([.requested_reviewers[].login] | join("|")),
-			([.labels[].name] | join("|"))
+			([.labels[].name] | join(","))
 		] | join("\u001f")
 	' 2>/dev/null
 	return $?
@@ -399,8 +402,8 @@ _review_feedback_ready_snapshot_matches() {
 
 	IFS=$'\x1f' read -r pr_state is_draft current_head observed_reviewers labels <<<"$snapshot"
 	[[ "$pr_state" == "OPEN" && "$is_draft" == "false" && "$current_head" == "$expected_head" ]] || return 1
-	declare -F _feedback_route_labels_block_routing >/dev/null 2>&1 || return 1
-	_feedback_route_labels_block_routing "$labels" && return 1
+	declare -F _feedback_route_labels_allow_worker_route >/dev/null 2>&1 || return 1
+	_feedback_route_labels_allow_worker_route "$labels" || return 1
 	printf -v "$requested_var" '%s' "$observed_reviewers"
 	return 0
 }
@@ -448,6 +451,8 @@ _review_feedback_preserve_ready_pr() {
 	fi
 	snapshot=$(_review_feedback_ready_snapshot "$pr_number" "$repo_slug") || return 75
 	_review_feedback_ready_snapshot_matches "$snapshot" "$expected_head" requested_reviewers || return 75
+	pending_reviewers=$(_review_feedback_pending_reviewers "$reviewers_json" "$requested_reviewers") || return 75
+	[[ -z "$pending_reviewers" ]] || return 75
 	return 0
 }
 

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -54,6 +54,7 @@ _PULSE_MERGE_FEEDBACK_LOADED=1
 : "${PULSE_REVIEW_FEEDBACK_SECTION_LIMIT:=12000}"
 PULSE_REVIEW_REPAIR_SOURCE_LABEL="source:review-repair"
 PULSE_FEEDBACK_JSON_STRING_TYPE="string"
+PULSE_REVIEW_FEEDBACK_NO_TRUSTED_REVIEW_RC=2
 
 _CI_REPAIR_OUTCOME_SUMMARY=""
 
@@ -355,7 +356,8 @@ _review_feedback_required_checks_green() {
 	esac
 	[[ -n "$checks_json" ]] || checks_json="[]"
 	printf '%s' "$checks_json" | jq -e 'type == ([] | type)' >/dev/null 2>&1 || return 75
-	printf '%s' "$checks_json" | jq -e 'any(.[]?; .bucket == "fail" or .bucket == "cancel")' >/dev/null 2>&1 && return 1
+	printf '%s' "$checks_json" | jq -e 'any(.[]?; .bucket == "fail")' >/dev/null 2>&1 && return 1
+	printf '%s' "$checks_json" | jq -e 'any(.[]?; .bucket == "cancel")' >/dev/null 2>&1 && return 75
 	[[ "$checks_rc" -eq 0 ]] || return 75
 	printf '%s' "$checks_json" | jq -e 'any(.[]?; .bucket == "pending")' >/dev/null 2>&1 && return 75
 	return 0
@@ -367,9 +369,40 @@ _review_feedback_pending_reviewers() {
 
 	jq -nr --argjson reviewers "$reviewers_json" --arg requested "$requested_reviewers_csv" '
 		($requested | split("|") | map(select(length > 0))) as $already
-		| [$reviewers[] | select(($already | index(.)) == null)] | unique | join(",")
+		| [$reviewers[] as $reviewer | select(($already | index($reviewer)) == null) | $reviewer]
+		| unique | join(",")
 	' 2>/dev/null
 	return $?
+}
+
+_review_feedback_ready_snapshot() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	_pmf_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}" --jq '
+		[
+			(if .merged_at != null then "MERGED" else ((.state // "") | ascii_upcase) end),
+			(.draft | tostring),
+			(.head.sha // ""),
+			([.requested_reviewers[].login] | join("|")),
+			([.labels[].name] | join("|"))
+		] | join("\u001f")
+	' 2>/dev/null
+	return $?
+}
+
+_review_feedback_ready_snapshot_matches() {
+	local snapshot="$1"
+	local expected_head="$2"
+	local requested_var="$3"
+	local pr_state="" is_draft="" current_head="" observed_reviewers="" labels=""
+
+	IFS=$'\x1f' read -r pr_state is_draft current_head observed_reviewers labels <<<"$snapshot"
+	[[ "$pr_state" == "OPEN" && "$is_draft" == "false" && "$current_head" == "$expected_head" ]] || return 1
+	declare -F _feedback_route_labels_block_routing >/dev/null 2>&1 || return 1
+	_feedback_route_labels_block_routing "$labels" && return 1
+	printf -v "$requested_var" '%s' "$observed_reviewers"
+	return 0
 }
 
 _review_feedback_preserve_ready_pr() {
@@ -380,24 +413,18 @@ _review_feedback_preserve_ready_pr() {
 	local reviewers_json="[]"
 	local reviewed_heads_json="[]"
 	local snapshot=""
-	local pr_state="" is_draft="" current_head="" requested_reviewers=""
+	local current_head="" requested_reviewers=""
 	local pending_reviewers=""
 	local readiness_rc=0
 
 	evidence=$(_review_feedback_ready_reviewer_evidence "$pr_number" "$repo_slug") || return 75
 	reviewers_json=$(printf '%s' "$evidence" | jq -c '.reviewers' 2>/dev/null) || return 75
 	reviewed_heads_json=$(printf '%s' "$evidence" | jq -c '.reviewed_heads' 2>/dev/null) || return 75
-	[[ "$(printf '%s' "$reviewers_json" | jq 'length' 2>/dev/null)" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ "$(printf '%s' "$reviewers_json" | jq 'length' 2>/dev/null)" =~ ^[1-9][0-9]*$ ]] || return "$PULSE_REVIEW_FEEDBACK_NO_TRUSTED_REVIEW_RC"
 	[[ "$expected_head" =~ ^[0-9a-fA-F]{40}$ ]] || return 75
-	snapshot=$(_pmf_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}" --jq \
-		'[
-			(if .merged_at != null then "MERGED" else ((.state // "") | ascii_upcase) end),
-			(.draft | tostring),
-			(.head.sha // ""),
-			([.requested_reviewers[].login] | join("|"))
-		] | @tsv' 2>/dev/null) || return 75
-	IFS=$'\t' read -r pr_state is_draft current_head requested_reviewers <<<"$snapshot"
-	[[ "$pr_state" == "OPEN" && "$is_draft" == "false" && "$current_head" == "$expected_head" ]] || return 75
+	snapshot=$(_review_feedback_ready_snapshot "$pr_number" "$repo_slug") || return 75
+	_review_feedback_ready_snapshot_matches "$snapshot" "$expected_head" requested_reviewers || return 75
+	current_head="$expected_head"
 
 	_review_feedback_head_advances_reviews "$repo_slug" "$current_head" "$reviewed_heads_json" || readiness_rc=$?
 	[[ "$readiness_rc" -eq 0 ]] || return "$readiness_rc"
@@ -405,6 +432,8 @@ _review_feedback_preserve_ready_pr() {
 	[[ "$readiness_rc" -eq 0 ]] || return "$readiness_rc"
 	_review_feedback_required_checks_green "$pr_number" "$repo_slug" || readiness_rc=$?
 	[[ "$readiness_rc" -eq 0 ]] || return "$readiness_rc"
+	snapshot=$(_review_feedback_ready_snapshot "$pr_number" "$repo_slug") || return 75
+	_review_feedback_ready_snapshot_matches "$snapshot" "$expected_head" requested_reviewers || return 75
 	pending_reviewers=$(_review_feedback_pending_reviewers "$reviewers_json" "$requested_reviewers") || return 75
 	if [[ -n "$pending_reviewers" ]]; then
 		if ! declare -F _feedback_route_gh_write >/dev/null 2>&1 ||
@@ -417,7 +446,48 @@ _review_feedback_preserve_ready_pr() {
 	else
 		echo "[pulse-wrapper] review feedback: ready PR #${pr_number} in ${repo_slug} already awaits its trusted reviewer(s) on changed head ${current_head}; preserving PR" >>"$LOGFILE"
 	fi
+	snapshot=$(_review_feedback_ready_snapshot "$pr_number" "$repo_slug") || return 75
+	_review_feedback_ready_snapshot_matches "$snapshot" "$expected_head" requested_reviewers || return 75
 	return 0
+}
+
+_review_feedback_route_preclose_allows() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head="$3"
+	local readiness_rc=0
+
+	_review_feedback_preserve_ready_pr "$pr_number" "$repo_slug" "$expected_head" || readiness_rc=$?
+	[[ "$readiness_rc" -eq 1 ]] || return 75
+	return 0
+}
+
+_review_feedback_route_initial_gate() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head="$3"
+	local readiness_rc=0
+
+	_PULSE_FEEDBACK_ROUTE_REVIEW_PRECLOSE_GUARD=0
+	_review_feedback_preserve_ready_pr "$pr_number" "$repo_slug" "$expected_head" || readiness_rc=$?
+	[[ "$readiness_rc" -ne 0 ]] || return 0
+	if [[ "$readiness_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ]]; then
+		echo "[pulse-wrapper] _dispatch_pr_fix_worker: ready-review evidence unavailable for PR #${pr_number} in ${repo_slug} — deferring without destructive routing" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
+	[[ "$readiness_rc" -eq "$PULSE_REVIEW_FEEDBACK_NO_TRUSTED_REVIEW_RC" ]] || _PULSE_FEEDBACK_ROUTE_REVIEW_PRECLOSE_GUARD=1
+	return 1
+}
+
+_review_feedback_route_before_finalization() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head="$3"
+
+	[[ "${_PULSE_FEEDBACK_ROUTE_REVIEW_PRECLOSE_GUARD:-0}" == "1" ]] || return 0
+	_review_feedback_route_preclose_allows "$pr_number" "$repo_slug" "$expected_head" && return 0
+	echo "[pulse-wrapper] _dispatch_pr_fix_worker: review readiness changed before finalization for PR #${pr_number} in ${repo_slug} — deferring without destructive routing" >>"$LOGFILE"
+	return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
 }
 
 _PULSE_REVIEW_FEEDBACK_REVIEWS_JSON="[]"
@@ -2634,14 +2704,11 @@ _dispatch_pr_fix_worker() {
 	local reviews_json="$_PULSE_REVIEW_FEEDBACK_REVIEWS_JSON"
 	local inline_json="$_PULSE_REVIEW_FEEDBACK_INLINE_JSON"
 	local readiness_rc=0
-	_review_feedback_preserve_ready_pr "$pr_number" "$repo_slug" "$expected_head" || readiness_rc=$?
+	_review_feedback_route_initial_gate "$pr_number" "$repo_slug" "$expected_head" || readiness_rc=$?
 	if [[ "$readiness_rc" -eq 0 ]]; then
 		return 0
 	fi
-	if [[ "$readiness_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ]]; then
-		echo "[pulse-wrapper] _dispatch_pr_fix_worker: ready-review evidence unavailable for PR #${pr_number} in ${repo_slug} — deferring without destructive routing" >>"$LOGFILE"
-		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
-	fi
+	[[ "$readiness_rc" -eq 1 ]] || return "$readiness_rc"
 
 	# --- Build the Review Feedback markdown section ---
 	local feedback_section=""
@@ -2678,10 +2745,12 @@ open a fresh PR against issue #${linked_issue}.
 
 _Closed by deterministic merge pass (pulse-merge.sh, t2093)._"
 	local finalize_rc=0
+	_review_feedback_route_before_finalization "$pr_number" "$repo_slug" "$expected_head" || return $?
 	_finalize_feedback_route "review" "$pr_number" "$repo_slug" "$linked_issue" "$expected_head" \
 		"$PULSE_REVIEW_REPAIR_SOURCE_LABEL" "review-routed-to-issue" "$marker" "$feedback_section" \
 		"_dispatch_pr_fix_worker" "$close_comment" "$legacy_match" "$evidence_fingerprint" \
 		"source:review-feedback" || finalize_rc=$?
+	_PULSE_FEEDBACK_ROUTE_REVIEW_PRECLOSE_GUARD=0
 	if [[ "$finalize_rc" -eq 0 ]]; then
 		echo "[pulse-wrapper] _dispatch_pr_fix_worker: routed review feedback from PR #${pr_number} to issue #${linked_issue} in ${repo_slug} (t2093)" >>"$LOGFILE"
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -63,7 +63,8 @@ reset_mock_state() {
 		TEST_ADD_NMR_DURING_TRANSITION TEST_ADD_PR_PROTECTION_DURING_TRANSITION \
 		TEST_READD_HOLD_DURING_TRANSITION TEST_HOLD_EVENT_ACTOR TEST_AUTHENTICATED_ACTOR \
 		TEST_HUMAN_PR_HOLD_EVENT_DURING_REMOVAL TEST_SCANNER_RC TEST_SCANNER_OUTPUT \
-		TEST_COMPARE_STATUS TEST_REQUIRED_CHECKS_JSON TEST_REQUIRED_CHECKS_RC TEST_FAIL_REREVIEW
+		TEST_COMPARE_STATUS TEST_REQUIRED_CHECKS_JSON TEST_REQUIRED_CHECKS_RC TEST_FAIL_REREVIEW \
+		TEST_SCANNER_UNRESOLVED_CALLS TEST_SCANNER_DRIFT_HEAD
 	rm -f "${TEST_ROOT}/pr-close-observed" "${TEST_ROOT}/pr-snapshot-failure-consumed"
 	printf '1000\n' >"${TEST_ROOT}/pr-hold-event-id.txt"
 	printf '2000\n' >"${TEST_ROOT}/issue-hold-event-id.txt"
@@ -108,7 +109,16 @@ setup_test_paths() {
 	cat >"$PULSE_REVIEW_FEEDBACK_SCANNER" <<'SCANNER_STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"${SCANNER_LOG}"
-[[ -z "${TEST_SCANNER_OUTPUT:-}" ]] || printf '%s\n' "$TEST_SCANNER_OUTPUT"
+if [[ -n "${TEST_SCANNER_DRIFT_HEAD:-}" ]]; then
+	printf '%s\n' "$TEST_SCANNER_DRIFT_HEAD" >"${TEST_ROOT}/pr-head.txt"
+fi
+_scanner_call_count=$(wc -l <"${SCANNER_LOG}")
+_scanner_call_count=${_scanner_call_count//[^0-9]/}
+if [[ -n "${TEST_SCANNER_OUTPUT:-}" \
+	&& (-z "${TEST_SCANNER_UNRESOLVED_CALLS:-}" \
+		|| "$_scanner_call_count" -le "$TEST_SCANNER_UNRESOLVED_CALLS") ]]; then
+	printf '%s\n' "$TEST_SCANNER_OUTPUT"
+fi
 exit "${TEST_SCANNER_RC:-0}"
 SCANNER_STUB
 	chmod +x "$PULSE_REVIEW_FEEDBACK_SCANNER"
@@ -416,8 +426,9 @@ if [[ "${1:-}" == "api" ]]; then
 			exit 1
 		fi
 		if [[ "$_jq_filter" == *"requested_reviewers"* ]]; then
-			printf '%s\tfalse\t%s\t%s\n' "$(<"${TEST_ROOT}/pr-state.txt")" \
-				"$(<"${TEST_ROOT}/pr-head.txt")" "$(<"${TEST_ROOT}/requested-reviewers.txt")"
+			printf '%s\037false\037%s\037%s\037%s\n' "$(<"${TEST_ROOT}/pr-state.txt")" \
+				"$(<"${TEST_ROOT}/pr-head.txt")" "$(<"${TEST_ROOT}/requested-reviewers.txt")" \
+				"$(<"${TEST_ROOT}/pr-labels.txt")"
 		else
 			printf '%s\t%s\t%s\n' "$(<"${TEST_ROOT}/pr-state.txt")" \
 				"$(<"${TEST_ROOT}/pr-head.txt")" "$(<"${TEST_ROOT}/pr-labels.txt")"
@@ -688,6 +699,90 @@ test_dispatch_defers_while_required_checks_are_pending() {
 		return 0
 	fi
 	print_result "pending required checks defer without destructive routing" 0
+	return 0
+}
+
+test_dispatch_defers_when_required_checks_are_cancelled() {
+	reset_mock_state
+	prepare_ready_review_state
+	export TEST_REQUIRED_CHECKS_JSON='[{"name":"Lint","bucket":"cancel","state":"CANCELLED","link":"https://github.com/owner/repo/actions/runs/456/job/789"}]'
+	export TEST_REQUIRED_CHECKS_RC=1
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ||
+		"$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" ||
+		$(grep -cF 'gh pr close 100' "$GH_LOG" 2>/dev/null || true) -ne 0 ]]; then
+		print_result "cancelled required checks defer without destructive routing" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "cancelled required checks defer without destructive routing" 0
+	return 0
+}
+
+test_dispatch_requests_only_missing_trusted_reviewers() {
+	reset_mock_state
+	prepare_ready_review_state
+	cat >"${TEST_ROOT}/reviews.json" <<EOF
+[{"id":2001,"user":{"login":"trusted-maintainer","type":"User"},"author_association":"MEMBER","state":"CHANGES_REQUESTED","body":"Please correct the worker path before merge.","submitted_at":"2026-08-27T10:00:00Z","commit_id":"${TEST_REVIEWED_SHA}"},{"id":2002,"user":{"login":"second-maintainer","type":"User"},"author_association":"COLLABORATOR","state":"CHANGES_REQUESTED","body":"Please add the missing guard.","submitted_at":"2026-08-27T10:01:00Z","commit_id":"${TEST_REVIEWED_SHA}"}]
+EOF
+	printf '%s\n' "trusted-maintainer" >"${TEST_ROOT}/requested-reviewers.txt"
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne 0 ||
+		$(grep -cF -- '--add-reviewer second-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 1 ||
+		$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 0 ||
+		"$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" ]]; then
+		print_result "ready PR re-requests only missing trusted reviewers" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "ready PR re-requests only missing trusted reviewers" 0
+	return 0
+}
+
+test_dispatch_defers_head_drift_before_reviewer_mutation() {
+	reset_mock_state
+	prepare_ready_review_state
+	export TEST_SCANNER_DRIFT_HEAD="3333333333333333333333333333333333333333"
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ||
+		$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 0 ||
+		$(grep -cF 'gh pr close 100' "$GH_LOG" 2>/dev/null || true) -ne 0 ]]; then
+		print_result "head drift before reviewer mutation defers safely" 1 \
+			"rc=${dispatch_rc}; head=$(<"${TEST_ROOT}/pr-head.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "head drift before reviewer mutation defers safely" 0
+	return 0
+}
+
+test_dispatch_preserves_when_threads_converge_at_preclose() {
+	reset_mock_state
+	prepare_ready_review_state
+	export TEST_SCANNER_OUTPUT=$'RVW_2001\ttrusted-maintainer\tPlease correct the worker path before merge.'
+	export TEST_SCANNER_UNRESOLVED_CALLS=2
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ||
+		"$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" ||
+		$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 1 ||
+		$(grep -cF 'gh pr close 100' "$GH_LOG" 2>/dev/null || true) -ne 0 ||
+		",$(<"${TEST_ROOT}/pr-labels.txt")," != *",hold-for-review,"* ]]; then
+		print_result "late thread convergence preserves PR at pre-close boundary" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); labels=$(<"${TEST_ROOT}/pr-labels.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "late thread convergence preserves PR at pre-close boundary" 0
 	return 0
 }
 
@@ -1707,6 +1802,10 @@ main() {
 	test_dispatch_routes_when_review_threads_remain_unresolved
 	test_dispatch_routes_when_required_checks_fail
 	test_dispatch_defers_while_required_checks_are_pending
+	test_dispatch_defers_when_required_checks_are_cancelled
+	test_dispatch_requests_only_missing_trusted_reviewers
+	test_dispatch_defers_head_drift_before_reviewer_mutation
+	test_dispatch_preserves_when_threads_converge_at_preclose
 	test_dispatch_appends_to_issue_body_and_closes_pr
 	test_dispatch_wraps_paginated_feedback_reads
 	test_paginated_feedback_pages_are_merged

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -28,6 +28,9 @@ TEST_ROOT=""
 GH_LOG=""
 TIMEOUT_CALL_LOG=""
 EVENT_LOG=""
+SCANNER_LOG=""
+readonly TEST_REVIEWED_SHA="1111111111111111111111111111111111111111"
+readonly TEST_READY_SHA="2222222222222222222222222222222222222222"
 
 print_result() {
 	local test_name="$1"
@@ -53,12 +56,14 @@ reset_mock_state() {
 	: >"$GH_LOG"
 	: >"$TIMEOUT_CALL_LOG"
 	: >"$EVENT_LOG"
+	: >"$SCANNER_LOG"
 	unset DRY_RUN TEST_TIMEOUT_FAIL_PATTERN TEST_FAIL_TRANSITION TEST_FAIL_CLOSE \
 		TEST_FAIL_REOPEN TEST_FAIL_BODY_PHASE TEST_FAIL_TERMINAL_LABEL \
 		TEST_DRIFT_AFTER_TRANSITION_HEAD TEST_FAIL_PR_SNAPSHOT_AFTER_CLOSE \
 		TEST_ADD_NMR_DURING_TRANSITION TEST_ADD_PR_PROTECTION_DURING_TRANSITION \
 		TEST_READD_HOLD_DURING_TRANSITION TEST_HOLD_EVENT_ACTOR TEST_AUTHENTICATED_ACTOR \
-		TEST_HUMAN_PR_HOLD_EVENT_DURING_REMOVAL
+		TEST_HUMAN_PR_HOLD_EVENT_DURING_REMOVAL TEST_SCANNER_RC TEST_SCANNER_OUTPUT \
+		TEST_COMPARE_STATUS TEST_REQUIRED_CHECKS_JSON TEST_REQUIRED_CHECKS_RC TEST_FAIL_REREVIEW
 	rm -f "${TEST_ROOT}/pr-close-observed" "${TEST_ROOT}/pr-snapshot-failure-consumed"
 	printf '1000\n' >"${TEST_ROOT}/pr-hold-event-id.txt"
 	printf '2000\n' >"${TEST_ROOT}/issue-hold-event-id.txt"
@@ -71,11 +76,12 @@ reset_mock_state() {
 	printf 'OPEN\n' >"${TEST_ROOT}/pr-state.txt"
 	printf 'abc123repairsha\n' >"${TEST_ROOT}/pr-head.txt"
 	printf 'origin:worker,auto-dispatch\n' >"${TEST_ROOT}/pr-labels.txt"
+	: >"${TEST_ROOT}/requested-reviewers.txt"
 	printf 'status:in-review,origin:interactive\n' >"${TEST_ROOT}/issue-labels.txt"
 	printf 'stale-owner\n' >"${TEST_ROOT}/issue-assignees.txt"
 	# Defaults: populated reviews + comments, empty issue body.
 	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
-[{"id":1001,"user":{"login":"coderabbitai[bot]"},"state":"CHANGES_REQUESTED","body":"## Senior review\n\nBLOCK: missing import.\nFix the worker entry point before merge.","html_url":"https://github.com/owner/repo/pull/100#pullrequestreview-1","submitted_at":"2026-08-03T10:00:00Z","commit_id":"abc123repairsha"}]
+	[{"id":1001,"user":{"login":"coderabbitai[bot]","type":"Bot"},"author_association":"NONE","state":"CHANGES_REQUESTED","body":"## Senior review\n\nBLOCK: missing import.\nFix the worker entry point before merge.","html_url":"https://github.com/owner/repo/pull/100#pullrequestreview-1","submitted_at":"2026-08-03T10:00:00Z","commit_id":"abc123repairsha"}]
 EOF
 	cat >"${TEST_ROOT}/comments.json" <<'EOF'
 [{"id":2001,"user":{"login":"coderabbitai[bot]"},"path":".agents/scripts/pulse-merge.sh","line":650,"original_line":650,"body":"This check has an off-by-one.\nSecond actionable line.","html_url":"https://github.com/owner/repo/pull/100#discussion_r1","updated_at":"2026-08-03T10:01:00Z","commit_id":"abc123repairsha"}]
@@ -88,14 +94,24 @@ setup_test_paths() {
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export PULSE_REVIEW_FEEDBACK_SCANNER="${TEST_ROOT}/scanner.sh"
 	: >"$LOGFILE"
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
 	TIMEOUT_CALL_LOG="${TEST_ROOT}/timeout-calls.log"
 	EVENT_LOG="${TEST_ROOT}/route-events.log"
+	SCANNER_LOG="${TEST_ROOT}/scanner.log"
 	: >"$GH_LOG"
 	: >"$TIMEOUT_CALL_LOG"
 	: >"$EVENT_LOG"
-	export TEST_ROOT GH_LOG TIMEOUT_CALL_LOG EVENT_LOG
+	: >"$SCANNER_LOG"
+	export TEST_ROOT GH_LOG TIMEOUT_CALL_LOG EVENT_LOG SCANNER_LOG
+	cat >"$PULSE_REVIEW_FEEDBACK_SCANNER" <<'SCANNER_STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${SCANNER_LOG}"
+[[ -z "${TEST_SCANNER_OUTPUT:-}" ]] || printf '%s\n' "$TEST_SCANNER_OUTPUT"
+exit "${TEST_SCANNER_RC:-0}"
+SCANNER_STUB
+	chmod +x "$PULSE_REVIEW_FEEDBACK_SCANNER"
 	return 0
 }
 
@@ -194,6 +210,16 @@ GHEOF
 append_gh_mock_pr_edit_cases() {
 	cat >>"${TEST_ROOT}/bin/gh" <<'GHEOF'
 "pr edit")
+	if [[ "$*" == *"--add-reviewer"* ]]; then
+		[[ "${TEST_FAIL_REREVIEW:-0}" == "1" ]] && exit 1
+		for _i in "${!_all_args[@]}"; do
+			if [[ "${_all_args[$_i]}" == "--add-reviewer" ]]; then
+				printf '%s\n' "${_all_args[$((_i + 1))]:-}" >"${TEST_ROOT}/requested-reviewers.txt"
+				break
+			fi
+		done
+		exit 0
+	fi
 	if [[ "$*" == *"--add-label review-routed-to-issue"* \
 		|| "$*" == *"--add-label conflict-feedback-routed"* \
 		|| "$*" == *"--add-label ci-feedback-routed"* ]]; then
@@ -378,6 +404,10 @@ if [[ "${1:-}" == "api" ]]; then
 		fi
 		exit 0
 	fi
+	if [[ "${2:-}" == repos/owner/repo/compare/* ]]; then
+		printf '%s\n' "${TEST_COMPARE_STATUS:-behind}"
+		exit 0
+	fi
 	if [[ "${2:-}" == "repos/owner/repo/pulls/100" ]]; then
 		if [[ "${TEST_FAIL_PR_SNAPSHOT_AFTER_CLOSE:-0}" == "1" \
 			&& -f "${TEST_ROOT}/pr-close-observed" \
@@ -385,8 +415,13 @@ if [[ "${1:-}" == "api" ]]; then
 			: >"${TEST_ROOT}/pr-snapshot-failure-consumed"
 			exit 1
 		fi
-		printf '%s\t%s\t%s\n' "$(<"${TEST_ROOT}/pr-state.txt")" \
-			"$(<"${TEST_ROOT}/pr-head.txt")" "$(<"${TEST_ROOT}/pr-labels.txt")"
+		if [[ "$_jq_filter" == *"requested_reviewers"* ]]; then
+			printf '%s\tfalse\t%s\t%s\n' "$(<"${TEST_ROOT}/pr-state.txt")" \
+				"$(<"${TEST_ROOT}/pr-head.txt")" "$(<"${TEST_ROOT}/requested-reviewers.txt")"
+		else
+			printf '%s\t%s\t%s\n' "$(<"${TEST_ROOT}/pr-state.txt")" \
+				"$(<"${TEST_ROOT}/pr-head.txt")" "$(<"${TEST_ROOT}/pr-labels.txt")"
+		fi
 		exit 0
 	fi
 	if [[ "${2:-}" == "repos/owner/repo/issues/100/timeline?per_page=100" ]]; then
@@ -464,8 +499,12 @@ define_helpers_under_test() {
 		local pr_number="$2"
 		local selection_mode="$3"
 		printf 'exact-checks %s %s %s\n' "$repo_slug" "$pr_number" "$selection_mode" >>"$GH_LOG"
-		printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
-		return 1
+		if [[ -n "${TEST_REQUIRED_CHECKS_JSON:-}" ]]; then
+			printf '%s\n' "$TEST_REQUIRED_CHECKS_JSON"
+		else
+			printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
+		fi
+		return "${TEST_REQUIRED_CHECKS_RC:-1}"
 	}
 	unset _PULSE_MERGE_FEEDBACK_LOADED _PULSE_MERGE_FEEDBACK_FINALIZER_LOADED
 	# shellcheck disable=SC1090
@@ -550,6 +589,105 @@ test_build_section_empty_when_no_content() {
 		return 0
 	fi
 	print_result "build section returns empty when no reviews or comments" 0
+	return 0
+}
+
+prepare_ready_review_state() {
+	printf '%s\n' "$TEST_READY_SHA" >"${TEST_ROOT}/pr-head.txt"
+	cat >"${TEST_ROOT}/reviews.json" <<EOF
+[{"id":2001,"user":{"login":"trusted-maintainer","type":"User"},"author_association":"MEMBER","state":"CHANGES_REQUESTED","body":"Please correct the worker path before merge.","html_url":"https://github.com/owner/repo/pull/100#pullrequestreview-2","submitted_at":"2026-08-27T10:00:00Z","commit_id":"${TEST_REVIEWED_SHA}"}]
+EOF
+	export TEST_COMPARE_STATUS="ahead"
+	export TEST_REQUIRED_CHECKS_JSON='[{"name":"Lint","bucket":"pass","state":"SUCCESS","link":"https://github.com/owner/repo/actions/runs/456/job/789"}]'
+	export TEST_REQUIRED_CHECKS_RC=0
+	return 0
+}
+
+test_dispatch_preserves_ready_changed_head_and_rerequests_reviewer() {
+	reset_mock_state
+	prepare_ready_review_state
+	local first_rc=0
+	local second_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || first_rc=$?
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || second_rc=$?
+
+	local rerequest_count=0
+	rerequest_count=$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true)
+	if [[ "$first_rc" -ne 0 || "$second_rc" -ne 0 ||
+		"$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" ||
+		"$(<"${TEST_ROOT}/issue-body.txt")" != "Original issue body." ||
+		"$rerequest_count" -ne 1 ||
+		"$(<"${TEST_ROOT}/requested-reviewers.txt")" != "trusted-maintainer" ||
+		"$(grep -cF 'scan-pr owner/repo 100' "$SCANNER_LOG" 2>/dev/null || true)" -ne 2 ||
+		$(grep -cF 'gh pr close 100' "$GH_LOG" 2>/dev/null || true) -ne 0 ]]; then
+		print_result "ready changed-head PR is preserved and trusted review is re-requested once" 1 \
+			"first_rc=${first_rc}; second_rc=${second_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); rerequests=${rerequest_count}; gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "ready changed-head PR is preserved and trusted review is re-requested once" 0
+	return 0
+}
+
+test_dispatch_routes_when_review_threads_remain_unresolved() {
+	reset_mock_state
+	prepare_ready_review_state
+	export TEST_SCANNER_OUTPUT=$'RVW_2001\ttrusted-maintainer\tPlease correct the worker path before merge.'
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne 0 ||
+		"$(<"${TEST_ROOT}/pr-state.txt")" != "CLOSED" ||
+		"$(<"${TEST_ROOT}/issue-body.txt")" != *"t2093:review-feedback:PR100"* ||
+		$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 0 ]]; then
+		print_result "unresolved review threads retain destructive reroute behavior" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "unresolved review threads retain destructive reroute behavior" 0
+	return 0
+}
+
+test_dispatch_routes_when_required_checks_fail() {
+	reset_mock_state
+	prepare_ready_review_state
+	export TEST_REQUIRED_CHECKS_JSON='[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/456/job/789"}]'
+	export TEST_REQUIRED_CHECKS_RC=1
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne 0 ||
+		"$(<"${TEST_ROOT}/pr-state.txt")" != "CLOSED" ||
+		$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 0 ]]; then
+		print_result "failed required checks retain destructive reroute behavior" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "failed required checks retain destructive reroute behavior" 0
+	return 0
+}
+
+test_dispatch_defers_while_required_checks_are_pending() {
+	reset_mock_state
+	prepare_ready_review_state
+	export TEST_REQUIRED_CHECKS_JSON='[{"name":"Lint","bucket":"pending","state":"IN_PROGRESS","link":"https://github.com/owner/repo/actions/runs/456/job/789"}]'
+	export TEST_REQUIRED_CHECKS_RC=8
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ||
+		"$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" ||
+		"$(<"${TEST_ROOT}/issue-body.txt")" != "Original issue body." ||
+		$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 0 ||
+		$(grep -cF 'gh pr close 100' "$GH_LOG" 2>/dev/null || true) -ne 0 ]]; then
+		print_result "pending required checks defer without destructive routing" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "pending required checks defer without destructive routing" 0
 	return 0
 }
 
@@ -1565,6 +1703,10 @@ main() {
 	test_build_section_includes_marker_and_citations
 	test_build_section_bounds_total_output
 	test_build_section_empty_when_no_content
+	test_dispatch_preserves_ready_changed_head_and_rerequests_reviewer
+	test_dispatch_routes_when_review_threads_remain_unresolved
+	test_dispatch_routes_when_required_checks_fail
+	test_dispatch_defers_while_required_checks_are_pending
 	test_dispatch_appends_to_issue_body_and_closes_pr
 	test_dispatch_wraps_paginated_feedback_reads
 	test_paginated_feedback_pages_are_merged

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -64,7 +64,8 @@ reset_mock_state() {
 		TEST_READD_HOLD_DURING_TRANSITION TEST_HOLD_EVENT_ACTOR TEST_AUTHENTICATED_ACTOR \
 		TEST_HUMAN_PR_HOLD_EVENT_DURING_REMOVAL TEST_SCANNER_RC TEST_SCANNER_OUTPUT \
 		TEST_COMPARE_STATUS TEST_REQUIRED_CHECKS_JSON TEST_REQUIRED_CHECKS_RC TEST_FAIL_REREVIEW \
-		TEST_SCANNER_UNRESOLVED_CALLS TEST_SCANNER_DRIFT_HEAD
+		TEST_SCANNER_UNRESOLVED_CALLS TEST_SCANNER_DRIFT_HEAD TEST_SCANNER_PR_LABELS \
+		TEST_REQUIRED_CHECKS_EMPTY TEST_REREVIEW_NOOP
 	rm -f "${TEST_ROOT}/pr-close-observed" "${TEST_ROOT}/pr-snapshot-failure-consumed"
 	printf '1000\n' >"${TEST_ROOT}/pr-hold-event-id.txt"
 	printf '2000\n' >"${TEST_ROOT}/issue-hold-event-id.txt"
@@ -111,6 +112,9 @@ setup_test_paths() {
 printf '%s\n' "$*" >>"${SCANNER_LOG}"
 if [[ -n "${TEST_SCANNER_DRIFT_HEAD:-}" ]]; then
 	printf '%s\n' "$TEST_SCANNER_DRIFT_HEAD" >"${TEST_ROOT}/pr-head.txt"
+fi
+if [[ -n "${TEST_SCANNER_PR_LABELS:-}" ]]; then
+	printf '%s\n' "$TEST_SCANNER_PR_LABELS" >"${TEST_ROOT}/pr-labels.txt"
 fi
 _scanner_call_count=$(wc -l <"${SCANNER_LOG}")
 _scanner_call_count=${_scanner_call_count//[^0-9]/}
@@ -222,9 +226,16 @@ append_gh_mock_pr_edit_cases() {
 "pr edit")
 	if [[ "$*" == *"--add-reviewer"* ]]; then
 		[[ "${TEST_FAIL_REREVIEW:-0}" == "1" ]] && exit 1
+		[[ "${TEST_REREVIEW_NOOP:-0}" == "1" ]] && exit 0
 		for _i in "${!_all_args[@]}"; do
 			if [[ "${_all_args[$_i]}" == "--add-reviewer" ]]; then
-				printf '%s\n' "${_all_args[$((_i + 1))]:-}" >"${TEST_ROOT}/requested-reviewers.txt"
+				_new_reviewers="${_all_args[$((_i + 1))]:-}"
+				_existing_reviewers=$(<"${TEST_ROOT}/requested-reviewers.txt")
+				if [[ -n "$_existing_reviewers" ]]; then
+					printf '%s|%s\n' "$_existing_reviewers" "$_new_reviewers" >"${TEST_ROOT}/requested-reviewers.txt"
+				else
+					printf '%s\n' "$_new_reviewers" >"${TEST_ROOT}/requested-reviewers.txt"
+				fi
 				break
 			fi
 		done
@@ -510,7 +521,9 @@ define_helpers_under_test() {
 		local pr_number="$2"
 		local selection_mode="$3"
 		printf 'exact-checks %s %s %s\n' "$repo_slug" "$pr_number" "$selection_mode" >>"$GH_LOG"
-		if [[ -n "${TEST_REQUIRED_CHECKS_JSON:-}" ]]; then
+		if [[ "${TEST_REQUIRED_CHECKS_EMPTY:-0}" == "1" ]]; then
+			:
+		elif [[ -n "${TEST_REQUIRED_CHECKS_JSON:-}" ]]; then
 			printf '%s\n' "$TEST_REQUIRED_CHECKS_JSON"
 		else
 			printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
@@ -783,6 +796,85 @@ test_dispatch_preserves_when_threads_converge_at_preclose() {
 		return 0
 	fi
 	print_result "late thread convergence preserves PR at pre-close boundary" 0
+	return 0
+}
+
+test_dispatch_preserves_ready_pr_without_required_checks() {
+	reset_mock_state
+	prepare_ready_review_state
+	export TEST_REQUIRED_CHECKS_EMPTY=1
+	export TEST_REQUIRED_CHECKS_RC=1
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne 0 ||
+		"$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" ||
+		$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 1 ||
+		$(grep -cF 'gh pr close 100' "$GH_LOG" 2>/dev/null || true) -ne 0 ]]; then
+		print_result "empty required-check set preserves ready PR" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "empty required-check set preserves ready PR" 0
+	return 0
+}
+
+test_dispatch_defers_unverified_reviewer_mutation() {
+	reset_mock_state
+	prepare_ready_review_state
+	export TEST_REREVIEW_NOOP=1
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ||
+		"$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" ||
+		$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 1 ||
+		$(grep -cF 'gh pr close 100' "$GH_LOG" 2>/dev/null || true) -ne 0 ]]; then
+		print_result "successful reviewer no-op defers after postcondition failure" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "successful reviewer no-op defers after postcondition failure" 0
+	return 0
+}
+
+test_dispatch_defers_multilabel_ownership_blocker() {
+	reset_mock_state
+	prepare_ready_review_state
+	printf '%s\n' "origin:worker,auto-dispatch,no-takeover" >"${TEST_ROOT}/pr-labels.txt"
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ||
+		$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 0 ||
+		$(grep -cF 'gh pr close 100' "$GH_LOG" 2>/dev/null || true) -ne 0 ]]; then
+		print_result "comma-delimited ownership blocker prevents reviewer mutation" 1 \
+			"rc=${dispatch_rc}; labels=$(<"${TEST_ROOT}/pr-labels.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "comma-delimited ownership blocker prevents reviewer mutation" 0
+	return 0
+}
+
+test_dispatch_defers_when_worker_origin_disappears() {
+	reset_mock_state
+	prepare_ready_review_state
+	export TEST_SCANNER_PR_LABELS="auto-dispatch"
+	local dispatch_rc=0
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ||
+		$(grep -cF -- '--add-reviewer trusted-maintainer' "$GH_LOG" 2>/dev/null || true) -ne 0 ||
+		$(grep -cF 'gh pr close 100' "$GH_LOG" 2>/dev/null || true) -ne 0 ]]; then
+		print_result "lost worker origin defers before reviewer mutation" 1 \
+			"rc=${dispatch_rc}; labels=$(<"${TEST_ROOT}/pr-labels.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "lost worker origin defers before reviewer mutation" 0
 	return 0
 }
 
@@ -1668,7 +1760,7 @@ if [[ "${1:-}" == "api" ]]; then
 		fi
 	done
 	if [[ "$*" == *"/pulls/100"* && "$*" != *"/reviews"* && "$*" != *"/comments"* ]]; then
-		printf 'OPEN\tabc123head\t\n'
+		printf 'OPEN\tabc123head\torigin:worker\n'
 		exit 0
 	fi
 	if [[ "$*" == *"/pulls/"*"/reviews"* ]]; then
@@ -1806,6 +1898,10 @@ main() {
 	test_dispatch_requests_only_missing_trusted_reviewers
 	test_dispatch_defers_head_drift_before_reviewer_mutation
 	test_dispatch_preserves_when_threads_converge_at_preclose
+	test_dispatch_preserves_ready_pr_without_required_checks
+	test_dispatch_defers_unverified_reviewer_mutation
+	test_dispatch_defers_multilabel_ownership_blocker
+	test_dispatch_defers_when_worker_origin_disappears
 	test_dispatch_appends_to_issue_body_and_closes_pr
 	test_dispatch_wraps_paginated_feedback_reads
 	test_paginated_feedback_pages_are_merged


### PR DESCRIPTION
## Summary

Preserve ready worker PRs after trusted review remediation, re-request missing trusted reviewers, and retain fail-closed rerouting for unresolved feedback.

## Files Changed

.agents/scripts/pulse-merge-feedback-finalizer.sh, .agents/scripts/pulse-merge-feedback.sh, .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 49 focused feedback-routing tests and 27 review-thread remediation tests pass; ShellCheck, bash syntax, git diff checks, local quality gates, and independent high-risk closeout review pass.

Resolves #30821


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.293 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 3h 23m and 1,008,992 tokens on this with the user in an interactive session.