### PR TITLE
GH#30851: pin reviewed Playwriter MCP version

### DIFF
--- a/.agents/plugins/opencode-aidevops/mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-registry.mjs
@@ -11,6 +11,8 @@ import { delimiter, isAbsolute, join, relative, resolve } from "path";
 const IS_MACOS = platform() === "darwin";
 const MCP_WORKSPACE_MARKER = ".aidevops-mcp-workspace";
 const PLAYWRIGHT_MCP_PACKAGE = "@playwright/mcp@0.0.79";
+const PLAYWRITER_MCP_PACKAGE = "playwriter@0.5.0";
+const LEGACY_PLAYWRITER_MCP_PACKAGE = "playwriter@latest";
 
 /**
  * Build unique per-plugin MCP workspace metadata without creating files.
@@ -123,7 +125,7 @@ function getMcpRegistry() {
     {
       name: "playwriter",
       type: "local",
-      command: [...pkgRunnerParts, "playwriter@latest"],
+      command: [...pkgRunnerParts, PLAYWRITER_MCP_PACKAGE],
       eager: false,
       toolPattern: "playwriter_*",
       globallyEnabled: false,
@@ -445,6 +447,25 @@ function buildMcpConfigEntry(mcp, runtime) {
 }
 
 /**
+ * Identify the only Playwriter commands emitted by previous aidevops generators.
+ * @param {unknown} command
+ * @returns {boolean}
+ */
+function isLegacyGeneratedPlaywriterCommand(command) {
+  if (!Array.isArray(command)) return false;
+  const isNpx = command.length === 2
+    && typeof command[0] === "string"
+    && /(?:^|[\\/])npx$/.test(command[0])
+    && command[1] === LEGACY_PLAYWRITER_MCP_PACKAGE;
+  const isBun = command.length === 3
+    && typeof command[0] === "string"
+    && /(?:^|[\\/])bun$/.test(command[0])
+    && command[1] === "x"
+    && command[2] === LEGACY_PLAYWRITER_MCP_PACKAGE;
+  return isNpx || isBun;
+}
+
+/**
  * Register a single MCP server in the config. Returns true if newly registered.
  * @param {object} mcp - MCP registry entry
  * @param {object} config - OpenCode Config object (mutable)
@@ -452,6 +473,14 @@ function buildMcpConfigEntry(mcp, runtime) {
  */
 function registerSingleMcp(mcp, config, runtime) {
   if (!config.mcp[mcp.name] || mcp.alwaysOverwrite) {
+    config.mcp[mcp.name] = buildMcpConfigEntry(mcp, runtime);
+    return true;
+  }
+
+  // Replace only the package argument emitted by older aidevops generators.
+  // Relay and other custom Playwriter commands remain user-owned.
+  if (mcp.name === "playwriter"
+    && isLegacyGeneratedPlaywriterCommand(config.mcp[mcp.name].command)) {
     config.mcp[mcp.name] = buildMcpConfigEntry(mcp, runtime);
     return true;
   }

--- a/.agents/plugins/opencode-aidevops/mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-registry.mjs
@@ -451,19 +451,28 @@ function buildMcpConfigEntry(mcp, runtime) {
  * @param {unknown} command
  * @returns {boolean}
  */
+function isPackageRunner(runner, name) {
+  if (runner === name) return true;
+  if (typeof runner !== "string" || !isAbsolute(runner)) return false;
+  return new RegExp(`[\\\\/]${name}$`).test(runner);
+}
+
+function isLegacyNpxPlaywriterCommand(command) {
+  if (!isPackageRunner(command[0], "npx")) return false;
+  if (command.length === 2) return command[1] === LEGACY_PLAYWRITER_MCP_PACKAGE;
+  if (command.length !== 3 || command[1] !== "-y") return false;
+  return command[2] === LEGACY_PLAYWRITER_MCP_PACKAGE;
+}
+
+function isLegacyBunPlaywriterCommand(command) {
+  if (command.length !== 3 || !isPackageRunner(command[0], "bun")) return false;
+  if (command[1] !== "x") return false;
+  return command[2] === LEGACY_PLAYWRITER_MCP_PACKAGE;
+}
+
 function isLegacyGeneratedPlaywriterCommand(command) {
   if (!Array.isArray(command)) return false;
-  const isRunner = (runner, name) => runner === name
-    || (typeof runner === "string" && isAbsolute(runner) && new RegExp(`[\\\\/]${name}$`).test(runner));
-  const isNpx = isRunner(command[0], "npx")
-    && ((command.length === 2 && command[1] === LEGACY_PLAYWRITER_MCP_PACKAGE)
-      || (command.length === 3 && command[1] === "-y"
-        && command[2] === LEGACY_PLAYWRITER_MCP_PACKAGE));
-  const isBun = command.length === 3
-    && isRunner(command[0], "bun")
-    && command[1] === "x"
-    && command[2] === LEGACY_PLAYWRITER_MCP_PACKAGE;
-  return isNpx || isBun;
+  return isLegacyNpxPlaywriterCommand(command) || isLegacyBunPlaywriterCommand(command);
 }
 
 /**

--- a/.agents/plugins/opencode-aidevops/mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-registry.mjs
@@ -453,13 +453,14 @@ function buildMcpConfigEntry(mcp, runtime) {
  */
 function isLegacyGeneratedPlaywriterCommand(command) {
   if (!Array.isArray(command)) return false;
-  const isNpx = command.length === 2
-    && typeof command[0] === "string"
-    && /(?:^|[\\/])npx$/.test(command[0])
-    && command[1] === LEGACY_PLAYWRITER_MCP_PACKAGE;
+  const isRunner = (runner, name) => runner === name
+    || (typeof runner === "string" && isAbsolute(runner) && new RegExp(`[\\\\/]${name}$`).test(runner));
+  const isNpx = isRunner(command[0], "npx")
+    && ((command.length === 2 && command[1] === LEGACY_PLAYWRITER_MCP_PACKAGE)
+      || (command.length === 3 && command[1] === "-y"
+        && command[2] === LEGACY_PLAYWRITER_MCP_PACKAGE));
   const isBun = command.length === 3
-    && typeof command[0] === "string"
-    && /(?:^|[\\/])bun$/.test(command[0])
+    && isRunner(command[0], "bun")
     && command[1] === "x"
     && command[2] === LEGACY_PLAYWRITER_MCP_PACKAGE;
   return isNpx || isBun;
@@ -481,8 +482,8 @@ function registerSingleMcp(mcp, config, runtime) {
   // Relay and other custom Playwriter commands remain user-owned.
   if (mcp.name === "playwriter"
     && isLegacyGeneratedPlaywriterCommand(config.mcp[mcp.name].command)) {
-    config.mcp[mcp.name] = buildMcpConfigEntry(mcp, runtime);
-    return true;
+    const command = config.mcp[mcp.name].command;
+    command[command.indexOf(LEGACY_PLAYWRITER_MCP_PACKAGE)] = PLAYWRITER_MCP_PACKAGE;
   }
 
   // Runtime-activated MCPs must stay disconnected at startup, including when

--- a/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
@@ -59,6 +59,64 @@ test("registers only the explicit browser MCP activation profiles", () => {
   assert.match(config.agent.playwright.prompt, /# Playwright MCP/);
 });
 
+test("pins legacy Playwriter commands while preserving custom commands", () => {
+  const config = {
+    mcp: {
+      playwriter: {
+        type: "local",
+        command: ["npx", "playwriter@latest"],
+        enabled: true,
+      },
+    },
+    tools: { "playwriter_*": true },
+  };
+
+  registerMcpServers(config);
+
+  assert.equal(config.mcp.playwriter.command.at(-1), "playwriter@0.5.0");
+  assert.ok(!config.mcp.playwriter.command.includes("playwriter@latest"));
+  assert.equal(config.mcp.playwriter.enabled, false);
+  assert.equal(config.tools["playwriter_*"], false);
+
+  const customConfig = {
+    mcp: {
+      playwriter: {
+        type: "local",
+        command: ["playwriter", "serve", "--port", "19988"],
+        enabled: true,
+      },
+    },
+    tools: { "playwriter_*": true },
+  };
+
+  registerMcpServers(customConfig);
+
+  assert.deepEqual(customConfig.mcp.playwriter.command, [
+    "playwriter", "serve", "--port", "19988",
+  ]);
+  assert.equal(customConfig.mcp.playwriter.enabled, false);
+  assert.equal(customConfig.tools["playwriter_*"], false);
+
+  const customLatestConfig = {
+    mcp: {
+      playwriter: {
+        type: "local",
+        command: ["npx", "playwriter@latest", "serve", "--port", "19988"],
+        enabled: true,
+      },
+    },
+    tools: { "playwriter_*": true },
+  };
+
+  registerMcpServers(customLatestConfig);
+
+  assert.deepEqual(customLatestConfig.mcp.playwriter.command, [
+    "npx", "playwriter@latest", "serve", "--port", "19988",
+  ]);
+  assert.equal(customLatestConfig.mcp.playwriter.enabled, false);
+  assert.equal(customLatestConfig.tools["playwriter_*"], false);
+});
+
 test("migrates browser MCPs to disconnected and globally denied", () => {
   const runtime = createMcpSessionRuntime("/managed/workspace", {
     tempRoot: "/managed/tmp",
@@ -84,6 +142,8 @@ test("migrates browser MCPs to disconnected and globally denied", () => {
   registerMcpServers(config, { runtime });
 
   assert.equal(config.mcp.playwriter.enabled, false);
+  assert.ok(config.mcp.playwriter.command.includes("playwriter@0.5.0"));
+  assert.ok(!config.mcp.playwriter.command.includes("playwriter@latest"));
   assert.equal(config.mcp.playwright.enabled, false);
   assert.equal(config.mcp.playwright.command[0], "/bin/bash");
   assert.ok(config.mcp.playwright.command.includes(runtime.workspaces.playwright.directory));

--- a/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
@@ -60,23 +60,38 @@ test("registers only the explicit browser MCP activation profiles", () => {
 });
 
 test("pins legacy Playwriter commands while preserving custom commands", () => {
-  const config = {
-    mcp: {
-      playwriter: {
-        type: "local",
-        command: ["npx", "playwriter@latest"],
-        enabled: true,
-      },
-    },
-    tools: { "playwriter_*": true },
-  };
+  const legacyCommands = [
+    ["npx", "playwriter@latest"],
+    ["/opt/aidevops/bin/npx", "playwriter@latest"],
+    ["npx", "-y", "playwriter@latest"],
+    ["bun", "x", "playwriter@latest"],
+  ];
 
-  registerMcpServers(config);
+  for (const command of legacyCommands) {
+    const playwriter = {
+      type: "local",
+      command: [...command],
+      enabled: true,
+      environment: { PLAYWRITER_RELAY: "local" },
+      timeout: 5_000,
+      customMetadata: { owner: "user" },
+    };
+    const config = {
+      mcp: { playwriter },
+      tools: { "playwriter_*": true },
+    };
 
-  assert.equal(config.mcp.playwriter.command.at(-1), "playwriter@0.5.0");
-  assert.ok(!config.mcp.playwriter.command.includes("playwriter@latest"));
-  assert.equal(config.mcp.playwriter.enabled, false);
-  assert.equal(config.tools["playwriter_*"], false);
+    registerMcpServers(config);
+
+    assert.strictEqual(config.mcp.playwriter, playwriter);
+    assert.equal(playwriter.command.at(-1), "playwriter@0.5.0");
+    assert.ok(!playwriter.command.includes("playwriter@latest"));
+    assert.equal(playwriter.enabled, false);
+    assert.deepEqual(playwriter.environment, { PLAYWRITER_RELAY: "local" });
+    assert.equal(playwriter.timeout, 5_000);
+    assert.deepEqual(playwriter.customMetadata, { owner: "user" });
+    assert.equal(config.tools["playwriter_*"], false);
+  }
 
   const customConfig = {
     mcp: {
@@ -115,6 +130,25 @@ test("pins legacy Playwriter commands while preserving custom commands", () => {
   ]);
   assert.equal(customLatestConfig.mcp.playwriter.enabled, false);
   assert.equal(customLatestConfig.tools["playwriter_*"], false);
+
+  const customLatestWithYesConfig = {
+    mcp: {
+      playwriter: {
+        type: "local",
+        command: ["npx", "-y", "playwriter@latest", "serve", "--port", "19988"],
+        enabled: true,
+      },
+    },
+    tools: { "playwriter_*": true },
+  };
+
+  registerMcpServers(customLatestWithYesConfig);
+
+  assert.deepEqual(customLatestWithYesConfig.mcp.playwriter.command, [
+    "npx", "-y", "playwriter@latest", "serve", "--port", "19988",
+  ]);
+  assert.equal(customLatestWithYesConfig.mcp.playwriter.enabled, false);
+  assert.equal(customLatestWithYesConfig.tools["playwriter_*"], false);
 });
 
 test("migrates browser MCPs to disconnected and globally denied", () => {

--- a/.agents/scripts/lib/mcp_config.py
+++ b/.agents/scripts/lib/mcp_config.py
@@ -8,6 +8,7 @@ shared by both discovery scripts.
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
+import os
 import platform
 import sys
 
@@ -33,6 +34,25 @@ LAZY_MCPS = {
 OMO_TOOL_PATTERNS = ['grep_app_*', 'websearch_*']
 PLAYWRITER_MCP_PACKAGE = 'playwriter@0.5.0'
 LEGACY_PLAYWRITER_MCP_PACKAGE = 'playwriter@latest'
+
+
+def _is_legacy_generated_playwriter_command(command):
+    """Return whether command is an exact prior generated Playwriter launcher."""
+    if not isinstance(command, list) or not command:
+        return False
+    runner = command[0]
+    is_runner = isinstance(runner, str) and (
+        runner == 'npx' or (os.path.isabs(runner) and os.path.basename(runner) == 'npx')
+    )
+    is_bun = isinstance(runner, str) and (
+        runner == 'bun' or (os.path.isabs(runner) and os.path.basename(runner) == 'bun')
+    )
+    return (
+        is_runner and command[1:] in (
+            [LEGACY_PLAYWRITER_MCP_PACKAGE],
+            ['-y', LEGACY_PLAYWRITER_MCP_PACKAGE],
+        )
+    ) or (is_bun and command[1:] == ['x', LEGACY_PLAYWRITER_MCP_PACKAGE])
 
 
 def apply_mcp_loading_policy(config):
@@ -87,14 +107,13 @@ def _register_playwriter(config, bun_path):
                 "enabled": False
             }
         print("  Added playwriter MCP (on demand - @playwriter only)")
-    elif (isinstance(config['mcp']['playwriter'], dict)
-          and config['mcp']['playwriter'].get('command') in (
-              ['npx', LEGACY_PLAYWRITER_MCP_PACKAGE],
-              ['bun', 'x', LEGACY_PLAYWRITER_MCP_PACKAGE],
-          )):
-        command = config['mcp']['playwriter']['command']
-        config['mcp']['playwriter']['command'] = command[:-1] + [PLAYWRITER_MCP_PACKAGE]
-        print("  Pinned legacy playwriter MCP command to 0.5.0")
+    elif isinstance(config['mcp']['playwriter'], dict):
+        playwriter_config = config['mcp']['playwriter']
+        command = playwriter_config.get('command')
+        if _is_legacy_generated_playwriter_command(command):
+            command[command.index(LEGACY_PLAYWRITER_MCP_PACKAGE)] = PLAYWRITER_MCP_PACKAGE
+            print("  Pinned legacy playwriter MCP command to 0.5.0")
+        playwriter_config['enabled'] = False
     config['tools']['playwriter_*'] = False
 
 

--- a/.agents/scripts/lib/mcp_config.py
+++ b/.agents/scripts/lib/mcp_config.py
@@ -31,6 +31,8 @@ LAZY_MCPS = {
 
 # Oh-My-OpenCode tool patterns to disable globally
 OMO_TOOL_PATTERNS = ['grep_app_*', 'websearch_*']
+PLAYWRITER_MCP_PACKAGE = 'playwriter@0.5.0'
+LEGACY_PLAYWRITER_MCP_PACKAGE = 'playwriter@latest'
 
 
 def apply_mcp_loading_policy(config):
@@ -75,16 +77,24 @@ def _register_playwriter(config, bun_path):
         if bun_path:
             config['mcp']['playwriter'] = {
                 "type": "local",
-                "command": ["bun", "x", "playwriter@latest"],
+                "command": ["bun", "x", PLAYWRITER_MCP_PACKAGE],
                 "enabled": False
             }
         else:
             config['mcp']['playwriter'] = {
                 "type": "local",
-                "command": ["npx", "playwriter@latest"],
+                "command": ["npx", PLAYWRITER_MCP_PACKAGE],
                 "enabled": False
             }
         print("  Added playwriter MCP (on demand - @playwriter only)")
+    elif (isinstance(config['mcp']['playwriter'], dict)
+          and config['mcp']['playwriter'].get('command') in (
+              ['npx', LEGACY_PLAYWRITER_MCP_PACKAGE],
+              ['bun', 'x', LEGACY_PLAYWRITER_MCP_PACKAGE],
+          )):
+        command = config['mcp']['playwriter']['command']
+        config['mcp']['playwriter']['command'] = command[:-1] + [PLAYWRITER_MCP_PACKAGE]
+        print("  Pinned legacy playwriter MCP command to 0.5.0")
     config['tools']['playwriter_*'] = False
 
 

--- a/.agents/scripts/setup/modules/mcp-setup.sh
+++ b/.agents/scripts/setup/modules/mcp-setup.sh
@@ -42,14 +42,16 @@ _install_mcp_packages_node() {
 	command -v bun &>/dev/null && installer="bun"
 	print_info "Using $installer to install/update Node.js MCP packages..."
 
-	# Always install latest (bun install -g is fast and idempotent)
+	# Install reviewed pins where required; keep other MCPs current.
 	local updated=0
 	local failed=0
 	local pkg
 	for pkg in "${node_mcps[@]}"; do
 		_mcp_package_supported_on_platform "$pkg" || continue
 		local short_name="${pkg##*/}" # Strip @scope/ prefix for display
-		if run_with_spinner "Installing $short_name" npm_global_install "${pkg}@latest"; then
+		local package_spec="${pkg}@latest"
+		[[ "$pkg" == "playwriter" ]] && package_spec="playwriter@0.5.0"
+		if run_with_spinner "Installing $short_name" npm_global_install "$package_spec"; then
 			((++updated))
 		else
 			((++failed))
@@ -58,7 +60,7 @@ _install_mcp_packages_node() {
 	done
 
 	if [[ $updated -gt 0 ]]; then
-		print_success "$updated Node.js MCP packages installed/updated to latest via $installer"
+		print_success "$updated Node.js MCP packages installed/updated via $installer"
 	fi
 	if [[ $failed -gt 0 ]]; then
 		print_warning "$failed packages failed (check network or package names)"
@@ -422,7 +424,7 @@ setup_browser_tools() {
 
 	# Playwriter MCP (Node.js based, runs via npx)
 	if [[ "$has_node" == "true" ]]; then
-		print_success "Playwriter MCP available (runs via npx playwriter@latest)"
+		print_success "Playwriter MCP available (runs via npx playwriter@0.5.0)"
 		print_info "Install Chrome extension: https://chromewebstore.google.com/detail/playwriter-mcp/jfeammnjpkecdekppnclgkkffahnhfhe"
 	else
 		print_warning "Node.js not found - Playwriter MCP unavailable"

--- a/.agents/scripts/tests/test-macos-automator-platform-filter.sh
+++ b/.agents/scripts/tests/test-macos-automator-platform-filter.sh
@@ -120,7 +120,7 @@ record_result "Linux setup skips macOS Automator MCP" "0" "$(grep -c 'macos-auto
 record_result "Darwin setup retains macOS Automator MCP" "1" "$(grep -c 'macos-automator-mcp' "$darwin_setup_log" || true)"
 record_result "Linux freshness skips macOS Automator MCP" "0" "$(grep -c 'macos-automator-mcp' "$linux_tool_log" || true)"
 record_result "Darwin freshness retains macOS Automator MCP" "1" "$(grep -c 'macos-automator-mcp' "$darwin_tool_log" || true)"
-record_result "Linux setup retains cross-platform MCPs" "1" "$(grep -c 'playwriter@latest' "$linux_setup_log" || true)"
+record_result "Linux setup retains pinned cross-platform MCPs" "1" "$(grep -c 'playwriter@0.5.0' "$linux_setup_log" || true)"
 record_result "Linux freshness retains cross-platform MCPs" "1" "$(grep -c '|playwriter|' "$linux_tool_log" || true)"
 
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/.agents/scripts/tests/test-playwriter-pin.sh
+++ b/.agents/scripts/tests/test-playwriter-pin.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#30851: generated Playwriter commands stay pinned
+# while custom relay commands remain user-owned.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+
+python3 - "$REPO_ROOT" <<'PY'
+import importlib.util
+import pathlib
+import sys
+
+repo_root = pathlib.Path(sys.argv[1])
+module_path = repo_root / ".agents/scripts/lib/mcp_config.py"
+spec = importlib.util.spec_from_file_location("mcp_config", module_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+legacy_config = {
+    "mcp": {
+        "playwriter": {
+            "type": "local",
+            "command": ["npx", "playwriter@latest"],
+            "enabled": True,
+        },
+    },
+    "tools": {},
+}
+module.register_standard_mcps(legacy_config, None, "npx")
+assert legacy_config["mcp"]["playwriter"]["command"] == ["npx", "playwriter@0.5.0"]
+assert legacy_config["tools"]["playwriter_*"] is False
+
+custom_config = {
+    "mcp": {
+        "playwriter": {
+            "type": "local",
+            "command": ["playwriter", "serve", "--port", "19988"],
+            "enabled": True,
+        },
+    },
+    "tools": {},
+}
+module.register_standard_mcps(custom_config, None, "npx")
+assert custom_config["mcp"]["playwriter"]["command"] == [
+    "playwriter", "serve", "--port", "19988",
+]
+assert custom_config["tools"]["playwriter_*"] is False
+
+custom_latest_config = {
+    "mcp": {
+        "playwriter": {
+            "type": "local",
+            "command": ["npx", "playwriter@latest", "serve", "--port", "19988"],
+            "enabled": True,
+        },
+    },
+    "tools": {},
+}
+module.register_standard_mcps(custom_latest_config, None, "npx")
+assert custom_latest_config["mcp"]["playwriter"]["command"] == [
+    "npx", "playwriter@latest", "serve", "--port", "19988",
+]
+assert custom_latest_config["tools"]["playwriter_*"] is False
+
+generated_config = {"mcp": {}, "tools": {}}
+module.register_standard_mcps(generated_config, None, "npx")
+assert generated_config["mcp"]["playwriter"]["command"] == ["npx", "playwriter@0.5.0"]
+assert generated_config["mcp"]["playwriter"]["enabled"] is False
+print("PASS Playwriter Python generator pins legacy and generated commands")
+PY

--- a/.agents/scripts/tests/test-playwriter-pin.sh
+++ b/.agents/scripts/tests/test-playwriter-pin.sh
@@ -8,6 +8,46 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+PLAYWRITER_MCP_PACKAGE="playwriter@0.5.0"
+
+assert_policy_surface() {
+	local relative_path="$1"
+	local expected_fragment="$2"
+	local target_path="${REPO_ROOT}/${relative_path}"
+	if ! grep -Fq "$expected_fragment" "$target_path"; then
+		printf 'FAIL: %s does not consume reviewed Playwriter policy %s\n' \
+			"$relative_path" "$expected_fragment" >&2
+		return 1
+	fi
+	return 0
+}
+
+# Keep every generated, installed, updated, documented, and templated launcher
+# on the same reviewed package. Legacy @latest literals remain only in the
+# bounded migration matchers and their regression fixtures below.
+assert_policy_surface ".agents/plugins/opencode-aidevops/mcp-registry.mjs" \
+	"const PLAYWRITER_MCP_PACKAGE = \"${PLAYWRITER_MCP_PACKAGE}\";"
+assert_policy_surface ".agents/scripts/lib/mcp_config.py" \
+	"PLAYWRITER_MCP_PACKAGE = '${PLAYWRITER_MCP_PACKAGE}'"
+assert_policy_surface ".agents/scripts/setup/modules/mcp-setup.sh" \
+	"package_spec=\"${PLAYWRITER_MCP_PACKAGE}\""
+assert_policy_surface ".agents/scripts/tool-version-check.sh" \
+	"npm install -g ${PLAYWRITER_MCP_PACKAGE}"
+assert_policy_surface "configs/playwriter-config.json.txt" \
+	"\"command\": [\"npx\", \"${PLAYWRITER_MCP_PACKAGE}\"]"
+assert_policy_surface ".agents/tools/browser/playwriter.md" \
+	"npx ${PLAYWRITER_MCP_PACKAGE}"
+
+for policy_path in \
+	".agents/scripts/setup/modules/mcp-setup.sh" \
+	".agents/scripts/tool-version-check.sh" \
+	"configs/playwriter-config.json.txt" \
+	".agents/tools/browser/playwriter.md"; do
+	if grep -Fq 'playwriter@latest' "${REPO_ROOT}/${policy_path}"; then
+		printf 'FAIL: %s can restore unreviewed playwriter@latest\n' "$policy_path" >&2
+		exit 1
+	fi
+done
 
 python3 - "$REPO_ROOT" <<'PY'
 import importlib.util

--- a/.agents/scripts/tests/test-playwriter-pin.sh
+++ b/.agents/scripts/tests/test-playwriter-pin.sh
@@ -20,19 +20,34 @@ spec = importlib.util.spec_from_file_location("mcp_config", module_path)
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
-legacy_config = {
-    "mcp": {
-        "playwriter": {
-            "type": "local",
-            "command": ["npx", "playwriter@latest"],
-            "enabled": True,
-        },
-    },
-    "tools": {},
-}
-module.register_standard_mcps(legacy_config, None, "npx")
-assert legacy_config["mcp"]["playwriter"]["command"] == ["npx", "playwriter@0.5.0"]
-assert legacy_config["tools"]["playwriter_*"] is False
+legacy_commands = [
+    ["npx", "playwriter@latest"],
+    ["/opt/aidevops/bin/npx", "playwriter@latest"],
+    ["npx", "-y", "playwriter@latest"],
+    ["bun", "x", "playwriter@latest"],
+]
+for command in legacy_commands:
+    playwriter = {
+        "type": "local",
+        "command": command.copy(),
+        "enabled": True,
+        "environment": {"PLAYWRITER_RELAY": "local"},
+        "timeout": 5000,
+        "custom_metadata": {"owner": "user"},
+    }
+    legacy_config = {
+        "mcp": {"playwriter": playwriter},
+        "tools": {},
+    }
+    module.register_standard_mcps(legacy_config, None, "npx")
+    assert legacy_config["mcp"]["playwriter"] is playwriter
+    assert playwriter["command"][-1] == "playwriter@0.5.0"
+    assert "playwriter@latest" not in playwriter["command"]
+    assert playwriter["enabled"] is False
+    assert playwriter["environment"] == {"PLAYWRITER_RELAY": "local"}
+    assert playwriter["timeout"] == 5000
+    assert playwriter["custom_metadata"] == {"owner": "user"}
+    assert legacy_config["tools"]["playwriter_*"] is False
 
 custom_config = {
     "mcp": {
@@ -48,6 +63,7 @@ module.register_standard_mcps(custom_config, None, "npx")
 assert custom_config["mcp"]["playwriter"]["command"] == [
     "playwriter", "serve", "--port", "19988",
 ]
+assert custom_config["mcp"]["playwriter"]["enabled"] is False
 assert custom_config["tools"]["playwriter_*"] is False
 
 custom_latest_config = {
@@ -64,7 +80,25 @@ module.register_standard_mcps(custom_latest_config, None, "npx")
 assert custom_latest_config["mcp"]["playwriter"]["command"] == [
     "npx", "playwriter@latest", "serve", "--port", "19988",
 ]
+assert custom_latest_config["mcp"]["playwriter"]["enabled"] is False
 assert custom_latest_config["tools"]["playwriter_*"] is False
+
+custom_latest_with_yes_config = {
+    "mcp": {
+        "playwriter": {
+            "type": "local",
+            "command": ["npx", "-y", "playwriter@latest", "serve", "--port", "19988"],
+            "enabled": True,
+        },
+    },
+    "tools": {},
+}
+module.register_standard_mcps(custom_latest_with_yes_config, None, "npx")
+assert custom_latest_with_yes_config["mcp"]["playwriter"]["command"] == [
+    "npx", "-y", "playwriter@latest", "serve", "--port", "19988",
+]
+assert custom_latest_with_yes_config["mcp"]["playwriter"]["enabled"] is False
+assert custom_latest_with_yes_config["tools"]["playwriter_*"] is False
 
 generated_config = {"mcp": {}, "tools": {}}
 module.register_standard_mcps(generated_config, None, "npx")

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -128,7 +128,7 @@ NPM_TOOLS=(
 	"npm|BDUI|bdui|--version|bdui|npm install -g bdui@latest"
 	"npm|Chrome DevTools MCP|chrome-devtools-mcp|--version|chrome-devtools-mcp|npm install -g chrome-devtools-mcp@latest"
 	"npm|GSC MCP|mcp-server-gsc|--version|mcp-server-gsc|npm install -g mcp-server-gsc@latest"
-	"npm|Playwriter MCP|playwriter|--version|playwriter|npm install -g playwriter@latest"
+	"npm|Playwriter MCP|playwriter|--version|playwriter|npm install -g playwriter@0.5.0"
 	"npm|macOS Automator MCP|macos-automator-mcp|--version|@steipete/macos-automator-mcp|npm install -g @steipete/macos-automator-mcp@latest"
 	"npm|Claude Code MCP|claude-code-mcp|--version|@steipete/claude-code-mcp|npm install -g @steipete/claude-code-mcp@latest"
 	"npm|Google Workspace CLI|gws|--version|@googleworkspace/cli|npm install -g @googleworkspace/cli@latest"

--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -25,7 +25,7 @@ mcp:
 
 - **Purpose**: Browser automation via Chrome extension — full Playwright API
 - **Extension**: [Chrome Web Store](https://chromewebstore.google.com/detail/playwriter-mcp/jfeammnjpkecdekppnclgkkffahnhfhe) (Chrome, Brave, Edge)
-- **MCP**: `npx playwriter@latest` — single `execute` tool runs Playwright code snippets
+- **MCP**: `npx playwriter@0.5.0` — single `execute` tool runs Playwright code snippets
 - **OpenCode activation**: Invoke `@playwriter`; it connects the disabled MCP on demand through the registry-allowlisted `aidevops_mcp` tool
 - **Icon**: Gray/Black = disconnected · Green = ready · Orange = connecting · Red = error
 - **Performance**: Navigate 2.95s, form fill 2.24s, reliability 1.96s avg. Always headed.
@@ -55,20 +55,20 @@ mcp:
   "mcpServers": {
     "playwriter": {
       "command": "npx",
-      "args": ["-y", "playwriter@latest"]
+      "args": ["-y", "playwriter@0.5.0"]
     }
   }
 }
 ```
 
-**OpenCode**: aidevops generates this entry as disabled and exposes it only through `@playwriter`. Use a full path to `npx` if the app runs with a restricted PATH:
+**OpenCode**: aidevops generates this entry as disabled and exposes it only through `@playwriter`. Ensure `npx` is available in the app's PATH if it is restricted:
 
 ```json
 {
   "mcp": {
     "playwriter": {
       "type": "local",
-      "command": ["/opt/homebrew/bin/npx", "-y", "playwriter@latest"],
+      "command": ["npx", "playwriter@0.5.0"],
       "enabled": false
     }
   }
@@ -94,6 +94,13 @@ Use `@playwriter` for browser tasks. The agent connects Playwriter before its fi
 ### Authenticated Tab Preflight
 
 Before requesting authentication, credentials, or any authenticated action:
+
+Pinning to `0.5.0` does not complete the secure authenticated-tab lifecycle.
+Until upstream issue `remorses/playwriter#119` is released in this reviewed pin,
+hardened authenticated-tab use requires a separately tokenized, explicit
+`playwriter serve` relay and a client launched through
+`aidevops secret PLAYWRITER_TOKEN -- ...`. Do not place token values in MCP
+configuration, commands, logs, or prompts.
 
 1. Connect Playwriter and enumerate the accessible pages with `context.pages()`.
 2. Match only the intended target by its expected URL and title. Confirm that the

--- a/configs/playwriter-config.json.txt
+++ b/configs/playwriter-config.json.txt
@@ -8,8 +8,8 @@
     "_merge_into": "mcp",
     "playwriter": {
       "type": "local",
-      "command": ["npx", "playwriter@latest"],
-      "enabled": true
+      "command": ["npx", "playwriter@0.5.0"],
+      "enabled": false
     }
   },
   
@@ -18,7 +18,7 @@
     "_merge_into": "mcpServers",
     "playwriter": {
       "command": "npx",
-      "args": ["playwriter@latest"]
+      "args": ["playwriter@0.5.0"]
     }
   },
   
@@ -27,7 +27,7 @@
     "_merge_into": "mcpServers",
     "playwriter": {
       "command": "npx",
-      "args": ["playwriter@latest"]
+      "args": ["playwriter@0.5.0"]
     }
   },
 


### PR DESCRIPTION
## Summary

- pin generated Playwriter MCP commands and setup installs to reviewed version `0.5.0`
- migrate only exact legacy aidevops `npx`, `npx -y`, absolute-runner, and Bun command forms
- preserve custom commands and existing MCP metadata while keeping Playwriter disabled at startup
- document that the complete tokenized relay lifecycle remains pending the upstream detached-relay fix

## Verification

- `node --test .agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs` — 21 passed
- `bash .agents/scripts/tests/test-playwriter-pin.sh` — passed
- `bash .agents/scripts/tests/test-macos-automator-platform-filter.sh` — 6 passed
- `python3 -m py_compile .agents/scripts/lib/mcp_config.py` — passed
- ShellCheck on changed shell scripts — passed
- `git diff --check` — passed
- independent review found no remaining blocking defects

## Scope

This is the safe dependency-pinning and migration phase. It intentionally does not claim that authenticated relay lifecycle management is complete. That remaining work depends on the fix tracked upstream as `remorses/playwriter#119` becoming available in a reviewed Playwriter release.

For #30851

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.293 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol
