### PR TITLE
GH#30856: recover external fork PR creation

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -1065,8 +1065,11 @@ gh_create_pr() {
 	fi
 
 	local pr_output rc
-	pr_output=$("${pr_cmd[@]}") # aidevops-allow: raw-gh-wrapper
-	rc=$?
+	if pr_output=$("${pr_cmd[@]}"); then # aidevops-allow: raw-gh-wrapper
+		rc=0
+	else
+		rc=$?
+	fi
 	if [[ $rc -ne 0 ]] && _gh_create_pr_resolve_durable_identity "$pr_output" "$@"; then
 		# Native gh can create the PR and fail during a follow-up mutation. The URL
 		# proves creation; never invoke another create transport for this result.

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -905,6 +905,67 @@ _gh_create_pr_resolve_durable_identity() {
 }
 
 #######################################
+# Extract the exact --head value used for PR creation recovery.
+# Args: PR create argv
+# Output: head ref, or empty when unavailable
+#######################################
+_gh_create_pr_extract_head() {
+	while [[ $# -gt 0 ]]; do
+		local cur="$1"
+		case "$cur" in
+		--head)
+			local head_value="${2:-}"
+			[[ $# -gt 1 && "$head_value" != -* ]] && printf '%s\n' "$head_value"
+			return 0
+			;;
+		--head=*)
+			printf '%s\n' "${cur#--head=}"
+			return 0
+			;;
+		esac
+		shift
+	done
+	return 0
+}
+
+#######################################
+# Recover a PR created before native gh failed a follow-up mutation.
+# Sets the durable identity globals.
+# Args: PR create argv
+# Returns: 0=recovered, 1=no exact durable PR found
+#######################################
+_gh_create_pr_recover_after_mutation_failure() {
+	local repo=""
+	local head_ref=""
+	local recovered_url=""
+	repo=$(_gh_extract_repo_from_args "$@")
+	head_ref=$(_gh_create_pr_extract_head "$@")
+	[[ -n "$repo" && -n "$head_ref" ]] || return 1
+	recovered_url=$(_gh_recover_pr_if_exists "$head_ref" "$repo")
+	[[ -n "$recovered_url" ]] || return 1
+	_gh_create_pr_resolve_durable_identity "$recovered_url" "$@" || return 1
+	return 0
+}
+
+#######################################
+# Complete the wrapper-added draft transition after durable recovery.
+# Args: $1=repo $2=PR number
+# Returns: 0=ready, 1=still draft
+#######################################
+_gh_create_pr_ready_recovered_draft() {
+	local repo="$1"
+	local pr_number="$2"
+	if _gh_with_timeout write gh pr ready "$pr_number" --repo "$repo" >/dev/null 2>&1; then # aidevops-allow: raw-gh-wrapper
+		printf '[aidevops][gh-wrapper][PARTIAL] recovered PR #%s and marked it ready for review\n' \
+			"$pr_number" >&2
+		return 0
+	fi
+	printf '[aidevops][gh-wrapper][PARTIAL] recovered PR #%s remains draft; run gh pr ready %s --repo %s\n' \
+		"$pr_number" "$pr_number" "$repo" >&2
+	return 1
+}
+
+#######################################
 # Verify that a PR has exactly the expected origin label.
 # Args: $1=repo $2=PR number $3=expected origin label
 # Returns: 0=exact postcondition, 1=missing/wrong/dual/unavailable
@@ -1010,7 +1071,19 @@ gh_create_pr() {
 		# Native gh can create the PR and fail during a follow-up mutation. The URL
 		# proves creation; never invoke another create transport for this result.
 		rc="$_GH_PR_CREATE_PARTIAL_RC"
-	elif [[ $rc -ne 0 ]] && _rest_should_fallback_write; then
+	elif [[ $rc -ne 0 ]]; then
+		if _gh_create_pr_recover_after_mutation_failure "$@"; then
+			pr_output="$_GH_CREATE_PR_DURABLE_URL"
+			printf '[aidevops][gh-wrapper][PARTIAL] recovered durable PR #%s after a create-time mutation failure; not retrying creation\n' \
+				"$_GH_CREATE_PR_DURABLE_NUMBER" >&2
+			if [[ ${#_draft_args[@]} -gt 0 ]]; then
+				_gh_create_pr_ready_recovered_draft "$_GH_CREATE_PR_DURABLE_REPO" \
+					"$_GH_CREATE_PR_DURABLE_NUMBER" || true
+			fi
+			rc="$_GH_PR_CREATE_PARTIAL_RC"
+		fi
+	fi
+	if [[ $rc -ne 0 && "$rc" -ne "$_GH_PR_CREATE_PARTIAL_RC" ]] && _rest_should_fallback_write; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr create"
 		if [[ ${#_origin_label_args[@]} -gt 0 || ${#_draft_args[@]} -gt 0 ]]; then
 			pr_output=$(_rest_pr_create "$@" "${_draft_args[@]}" "${_origin_label_args[@]}")

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -79,10 +79,10 @@ case "$1 $2" in
 		printf 'pull request update failed: GraphQL: external contributor cannot update the pull request\n' >&2
 		exit 1
 	fi
-	echo "https://example.invalid/o/r/pull/0"
+	echo "https://github.com/o/r/pull/0"
 	;;
 "issue create")
-	echo "https://example.invalid/o/r/pull/0"
+	echo "https://github.com/o/r/pull/0"
 	;;
 "pr list")
 	printf '%s\n' "${MOCK_RECOVERED_PR_URL:-}"
@@ -421,7 +421,7 @@ fi
 # mutation. The wrapper must not create twice and must print the durable URL.
 reset_recorder
 export MOCK_PR_CREATE_MUTATION_FAILURE=1
-export MOCK_RECOVERED_PR_URL="https://example.invalid/o/r/pull/42"
+export MOCK_RECOVERED_PR_URL="https://github.com/o/r/pull/42"
 export MOCK_PR_READY_RC=0
 export MOCK_ORIGIN_EXACT=0
 partial_output=""
@@ -435,7 +435,7 @@ partial_output_file="${TEST_ROOT}/partial-output.txt"
 ) || partial_rc=$?
 partial_output=$(<"$partial_output_file")
 create_count=$(grep -c '^pr create ' "$GH_RECORD_FILE" || true)
-if [[ "$partial_rc" -eq 78 && "$partial_output" == "https://example.invalid/o/r/pull/42" &&
+if [[ "$partial_rc" -eq 78 && "$partial_output" == "https://github.com/o/r/pull/42" &&
 	"$create_count" -eq 1 ]] && grep -q '^pr ready 42 --repo o/r$' "$GH_RECORD_FILE"; then
 	print_result "B10: durable external-fork PR recovery is idempotent and ready" 0
 else

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -426,8 +426,14 @@ export MOCK_PR_READY_RC=0
 export MOCK_ORIGIN_EXACT=0
 partial_output=""
 partial_rc=0
-partial_output=$(gh_create_pr --repo o/r --head contributor:feature/recovery \
-	--title "GH#30856: recover partial creation" --body "Resolves #30856" 2>/dev/null) || partial_rc=$?
+partial_output_file="${TEST_ROOT}/partial-output.txt"
+(
+	set -e
+	gh_create_pr --repo o/r --head contributor:feature/recovery \
+		--title "GH#30856: recover partial creation" --body "Resolves #30856" \
+		>"$partial_output_file" 2>/dev/null
+) || partial_rc=$?
+partial_output=$(<"$partial_output_file")
 create_count=$(grep -c '^pr create ' "$GH_RECORD_FILE" || true)
 if [[ "$partial_rc" -eq 78 && "$partial_output" == "https://example.invalid/o/r/pull/42" &&
 	"$create_count" -eq 1 ]] && grep -q '^pr ready 42 --repo o/r$' "$GH_RECORD_FILE"; then

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -74,8 +74,21 @@ if [[ -n "${GH_ARGV_RECORD_FILE:-}" ]]; then
 fi
 # pr/issue create paths print a URL on stdout for caller capture
 case "$1 $2" in
-"pr create" | "issue create")
+"pr create")
+	if [[ "${MOCK_PR_CREATE_MUTATION_FAILURE:-0}" == "1" ]]; then
+		printf 'pull request update failed: GraphQL: external contributor cannot update the pull request\n' >&2
+		exit 1
+	fi
 	echo "https://example.invalid/o/r/pull/0"
+	;;
+"issue create")
+	echo "https://example.invalid/o/r/pull/0"
+	;;
+"pr list")
+	printf '%s\n' "${MOCK_RECOVERED_PR_URL:-}"
+	;;
+"pr ready")
+	exit "${MOCK_PR_READY_RC:-0}"
 	;;
 esac
 exit 0
@@ -116,7 +129,12 @@ _gh_validate_edit_args() { return 0; }
 # Privacy/write-policy and durable readback have dedicated suites. This harness
 # inspects only the exact create argv emitted by the wrapper.
 _gh_guard_public_write_args() { return 0; }
-_gh_create_pr_origin_is_exact() { return 0; }
+_gh_create_pr_origin_is_exact() {
+	if [[ "${MOCK_ORIGIN_EXACT:-1}" == "1" ]]; then
+		return 0
+	fi
+	return 1
+}
 _gh_lock_created_auto_dispatch_issue() { return 0; }
 
 # Stub _gh_should_fallback_to_rest (never fall back — REST path adds noise)
@@ -398,6 +416,27 @@ else
 	print_result "B9: gh_create_pr rejects conflicting origins before create" 1 \
 		"rc=${dual_origin_rc}; calls=$(tr '\n' ' ' <"$GH_RECORD_FILE")"
 fi
+
+# B10: recover an external-fork PR after native create fails a follow-up
+# mutation. The wrapper must not create twice and must print the durable URL.
+reset_recorder
+export MOCK_PR_CREATE_MUTATION_FAILURE=1
+export MOCK_RECOVERED_PR_URL="https://example.invalid/o/r/pull/42"
+export MOCK_PR_READY_RC=0
+export MOCK_ORIGIN_EXACT=0
+partial_output=""
+partial_rc=0
+partial_output=$(gh_create_pr --repo o/r --head contributor:feature/recovery \
+	--title "GH#30856: recover partial creation" --body "Resolves #30856" 2>/dev/null) || partial_rc=$?
+create_count=$(grep -c '^pr create ' "$GH_RECORD_FILE" || true)
+if [[ "$partial_rc" -eq 78 && "$partial_output" == "https://example.invalid/o/r/pull/42" &&
+	"$create_count" -eq 1 ]] && grep -q '^pr ready 42 --repo o/r$' "$GH_RECORD_FILE"; then
+	print_result "B10: durable external-fork PR recovery is idempotent and ready" 0
+else
+	print_result "B10: durable external-fork PR recovery is idempotent and ready" 1 \
+		"rc=$partial_rc output=$partial_output creates=$create_count calls=$(cat "$GH_RECORD_FILE")"
+fi
+unset MOCK_PR_CREATE_MUTATION_FAILURE MOCK_RECOVERED_PR_URL MOCK_PR_READY_RC MOCK_ORIGIN_EXACT
 
 # ---------------------------------------------------------------------------
 # Layer B': gh_create_issue defence-in-depth (mirrors PR tests)


### PR DESCRIPTION
## Outcome

- recover an exact durable PR by repository and head ref when native creation fails after a follow-up mutation
- prevent REST or native recreation after durable identity is established
- complete the wrapper-added draft-to-ready transition when contributor permissions allow it
- print the durable PR URL and retain the protected origin-label postcondition as an explicit partial-success state

## Verification

- `bash .agents/scripts/tests/test-origin-label-mutex-create.sh` — 31 passed
- ShellCheck on changed shell files — passed
- `git diff --check` — passed
- Pre-commit and pre-push quality hooks — passed

Resolves #30856

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.293 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 17m and 206,523 tokens on this with the user in an interactive session.