### PR TITLE
GH#30849: preserve bounded MCP failure diagnostics

### DIFF
--- a/.agents/aidevops/mcp-troubleshooting.md
+++ b/.agents/aidevops/mcp-troubleshooting.md
@@ -30,6 +30,10 @@ After the OpenCode connect API succeeds, an on-demand MCP can transiently report
 Direct API errors, authentication requirements, timeouts, and dead-schema errors
 such as `Connection closed` are not reset. Report the activation diagnostic and
 treat the MCP as unavailable for the session when the bounded reset fails.
+The terminal result reports the initial and post-reset phases with only the
+bounded, sanitized SDK error string when OpenCode supplies one. If it reports
+`diagnostic unavailable`, use the secure CLI checks below. Do not retry through
+another child or treat direct CLI initialization as successful OpenCode activation.
 
 ## Errored Servers — Dead Tool Schemas (t1682)
 

--- a/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
@@ -27,9 +27,30 @@ const PLAYWRIGHT_OUTPUT_TOOLS = new Set([
   "playwright_browser_take_screenshot",
 ]);
 
+const MCP_DIAGNOSTIC_MAX_LENGTH = 240;
+
+function sanitizeMcpStatusDiagnostic(statusEntry) {
+  if (!statusEntry || typeof statusEntry.error !== "string" || !statusEntry.error.trim()) {
+    return "diagnostic unavailable; use the documented secure CLI diagnostic path";
+  }
+
+  let detail = statusEntry.error
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/\b([A-Z][A-Z0-9_]{1,63})=(?:"[^"]*"|'[^']*'|[^\s]+)/g, "$1=[redacted]")
+    .replace(/\bAuthorization\s*:\s*Bearer\s+[^\s,;]+/gi, "Authorization: Bearer [redacted]")
+    .replace(/\b(api[_-]?key|authorization|password|secret|token)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi, "$1=[redacted]")
+    .replace(/\bBearer\s+[^\s,;]+/gi, "Bearer [redacted]")
+    .replace(/([?&](?:api[_-]?key|password|secret|token)=)[^&\s]+/gi, "$1[redacted]")
+    .trim();
+  if (detail.length > MCP_DIAGNOSTIC_MAX_LENGTH) {
+    detail = `${detail.slice(0, MCP_DIAGNOSTIC_MAX_LENGTH - 1)}…`;
+  }
+  return `diagnostic: ${detail}`;
+}
+
 class McpFailedStatusError extends Error {
-  constructor(status) {
-    super(`MCP entered ${status} status`);
+  constructor(status, phase, statusEntry) {
+    super(`MCP entered ${status} status during ${phase}; ${sanitizeMcpStatusDiagnostic(statusEntry)}`);
     this.name = "McpFailedStatusError";
   }
 }
@@ -52,7 +73,7 @@ async function callLifecycle(action, name, options) {
   }
 }
 
-async function waitForConnection(name, options) {
+async function waitForConnection(name, options, phase) {
   const statusMethod = options.client?.status;
   if (typeof statusMethod !== "function") return;
 
@@ -68,10 +89,11 @@ async function waitForConnection(name, options) {
       throw new Error(result.error.message || String(result.error));
     }
     const payload = result?.data ?? result;
-    status = payload?.[name]?.status || "unknown";
+    const statusEntry = payload?.[name];
+    status = statusEntry?.status || "unknown";
     if (status === "connected") return;
     if (["error", "failed"].includes(status)) {
-      throw new McpFailedStatusError(status);
+      throw new McpFailedStatusError(status, phase, statusEntry);
     }
     await pause(pollIntervalMs);
   } while (Date.now() < deadline);
@@ -101,10 +123,10 @@ async function recoverFailedConnection(name, options, statusError) {
   }
 
   try {
-    await waitForConnection(name, options);
+    await waitForConnection(name, options, "post-reset activation");
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`${message} after one bounded reset`);
+    throw new Error(`${statusError.message}; ${message} after one bounded reset`);
   }
 }
 
@@ -265,7 +287,7 @@ export function createMcpActivationTool(tool, z, options) {
         await callLifecycle(action, name, options);
         if (action === "connect") {
           try {
-            await waitForConnection(name, options);
+            await waitForConnection(name, options, "initial activation");
           } catch (error) {
             if (!(error instanceof McpFailedStatusError)) throw error;
             await recoverFailedConnection(name, options, error);

--- a/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
@@ -517,7 +517,15 @@ test("limits failed-status recovery to one reset", async () => {
       async disconnect() { calls.push("disconnect"); },
       async status() {
         calls.push("status");
-        return { data: { playwriter: { status: "failed" } } };
+        const phase = calls.filter((call) => call === "status").length;
+        return {
+          data: {
+            playwriter: {
+              status: "failed",
+              error: phase === 1 ? "relay launch failed" : "protocol handshake failed",
+            },
+          },
+        };
       },
     },
     allowedNames: ["playwriter"],
@@ -526,7 +534,7 @@ test("limits failed-status recovery to one reset", async () => {
 
   assert.equal(
     await activation.execute({ action: "connect", name: "playwriter" }),
-    "Error: MCP connect failed for playwriter: MCP entered failed status after one bounded reset",
+    "Error: MCP connect failed for playwriter: MCP entered failed status during initial activation; diagnostic: relay launch failed; MCP entered failed status during post-reset activation; diagnostic: protocol handshake failed after one bounded reset",
   );
   assert.deepEqual(calls, ["connect", "status", "disconnect", "connect", "status"]);
 });
@@ -542,7 +550,7 @@ test("reports when failed-status reset is unavailable", async () => {
 
   assert.equal(
     await activation.execute({ action: "connect", name: "playwriter" }),
-    "Error: MCP connect failed for playwriter: MCP entered error status; bounded reset unavailable because OpenCode does not expose MCP disconnect in this runtime.",
+    "Error: MCP connect failed for playwriter: MCP entered error status during initial activation; diagnostic unavailable; use the documented secure CLI diagnostic path; bounded reset unavailable because OpenCode does not expose MCP disconnect in this runtime.",
   );
 });
 
@@ -565,9 +573,34 @@ test("reports failed-status reset errors without reconnecting", async () => {
 
   assert.equal(
     await activation.execute({ action: "connect", name: "playwriter" }),
-    "Error: MCP connect failed for playwriter: MCP entered failed status; bounded reset disconnect failed: reset unavailable",
+    "Error: MCP connect failed for playwriter: MCP entered failed status during initial activation; diagnostic unavailable; use the documented secure CLI diagnostic path; bounded reset disconnect failed: reset unavailable",
   );
   assert.deepEqual(calls, ["connect", "status", "disconnect"]);
+});
+
+test("bounds and redacts failed-status diagnostics", async () => {
+  const activation = createMcpActivationTool(tool, z, {
+    client: {
+      async connect() {},
+      async status() {
+        return {
+          data: {
+            playwriter: {
+              status: "failed",
+              error: `PLAYWRITER_TOKEN=private-value Authorization: Bearer private-bearer ${"x".repeat(400)}`,
+              token: "must-not-be-serialized",
+            },
+          },
+        };
+      },
+    },
+    allowedNames: ["playwriter"],
+  });
+
+  const result = await activation.execute({ action: "connect", name: "playwriter" });
+  assert.match(result, /PLAYWRITER_TOKEN=\[redacted\]/);
+  assert.doesNotMatch(result, /private-value|private-bearer|must-not-be-serialized/);
+  assert.match(result, /…; bounded reset unavailable/);
 });
 
 test("does not reset status API errors or timeouts", async () => {

--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -171,6 +171,7 @@ await page.pdf({ path: 'page.pdf', format: 'A4' })
 - **Extension not connecting**: Installed and pinned? Click icon on tab (should turn green). Red badge = error. Reload tab.
 - **MCP not finding tabs**: Green icon? Restart MCP client. Verify WebSocket on port 19988.
 - **No approved tab**: Click the Playwriter extension on the intended tab and wait for the icon to turn green; this consent requirement is distinct from missing MCP tools.
+- **Terminal OpenCode activation failure**: After the one bounded reset, treat Playwriter as unavailable for the session and use the documented secure CLI diagnostic path only to isolate the cause. Do not retry through another child or treat direct CLI initialization as successful OpenCode activation.
 - **Automation detection**: Disconnect (click icon → gray) → complete manual action (login, captcha) → reconnect (click → green) → resume.
 
 ## Resources


### PR DESCRIPTION
## Outcome

- preserve both initial and post-reset MCP failure phases after the one bounded reset
- report only the installed OpenCode SDK's bounded `McpStatusFailed.error` field
- redact environment assignments and credential-like values before returning diagnostics
- make missing diagnostics explicit and document the secure, non-retrying CLI fallback

## Verification

- Confirmed OpenCode 1.18.25 is installed and its local SDK exports `McpStatusFailed.error: string`
- `node --test .agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs` — 21 passed
- `git diff --check` — passed
- Pre-commit and pre-push quality hooks — passed

Resolves #30849

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.293 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 17m and 206,523 tokens on this with the user in an interactive session.