### PR TITLE
GH#30855: support -R in GitHub create wrappers

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -59,7 +59,10 @@ _gh_guard_public_write_args() {
 	for arg in "$@"; do
 		if [[ -n "$expect" ]]; then
 			case "$expect" in
-			repo) repo="$arg" ;;
+			repo)
+				[[ "$arg" != -* ]] || return 1
+				repo="$arg"
+				;;
 			text) text+=$'\n'"$arg" ;;
 			body-file)
 				body_file="$arg"
@@ -71,7 +74,7 @@ _gh_guard_public_write_args() {
 			continue
 		fi
 		case "$arg" in
-		--repo) expect="repo" ;;
+		--repo | -R) expect="repo" ;;
 		--repo=*) repo="${arg#--repo=}" ;;
 		--title | --body | --comment | -c) expect="text" ;;
 		--title=* | --body=* | --comment=* | -c=*) text+=$'\n'"${arg#*=}" ;;
@@ -83,6 +86,7 @@ _gh_guard_public_write_args() {
 			;;
 		esac
 	done
+	[[ "$expect" != "repo" ]] || return 1
 	privacy_guard_public_write "$repo" "$text"
 	return $?
 }
@@ -717,7 +721,7 @@ _gh_auto_link_sub_issue() {
 		--title=*)
 			title="${_a#--title=}"; shift
 			;;
-		--repo)
+		--repo | -R)
 			if [[ $# -gt 1 ]]; then repo="$_v"; shift 2; else shift; fi
 			;;
 		--repo=*)

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -126,8 +126,12 @@ _gh_extract_repo_from_args() {
 	local -a args=("$@")
 	while [[ $i -lt ${#args[@]} ]]; do
 		case "${args[i]}" in
-		--repo)
-			echo "${args[i + 1]:-}"
+		--repo | -R)
+			if [[ -n "${args[i + 1]:-}" && "${args[i + 1]}" != -* ]]; then
+				echo "${args[i + 1]}"
+			else
+				echo ""
+			fi
 			return 0
 			;;
 		--repo=*)

--- a/.agents/scripts/tests/test-gh-auto-link-parent-line.sh
+++ b/.agents/scripts/tests/test-gh-auto-link-parent-line.sh
@@ -25,6 +25,7 @@
 #   6. `--body-file <path>` with `Parent: #502` inside fires method 2.
 #   7. No dot-notation and no `Parent:` line → no addSubIssue mutation.
 #   8. Dot-notation in title AND `Parent:` in body → method 1 wins.
+#   9. Native `gh -R owner/repo` repo selection reaches parent linking.
 #
 # Strategy mirrors test-backfill-sub-issues.sh: stub `gh` on PATH, record all
 # `gh api graphql` calls to a log file, inspect the log after each scenario
@@ -207,6 +208,21 @@ if saw_addsubissue; then
 	pass "dot-notation title fires addSubIssue (method 1, regression)"
 else
 	fail "dot-notation title fires addSubIssue (method 1, regression)" \
+		"no ADDSUBISSUE entry in gh log"
+fi
+
+# =============================================================================
+# Test 9 — native -R repo alias reaches parent linking
+# =============================================================================
+reset_log
+_gh_auto_link_sub_issue "https://github.com/owner/repo/issues/308" \
+	-R "owner/repo" \
+	--title "plain title" \
+	--body "Parent: #503"
+if saw_addsubissue; then
+	pass "-R repo alias reaches addSubIssue"
+else
+	fail "-R repo alias reaches addSubIssue" \
 		"no ADDSUBISSUE entry in gh log"
 fi
 

--- a/.agents/scripts/tests/test-gh-wrapper-repo-alias.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-repo-alias.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+CALLS_FILE="$(mktemp -t gh-wrapper-repo-alias.XXXXXX)"
+trap 'rm -f "$CALLS_FILE"' EXIT
+
+# shellcheck source=../shared-constants.sh
+source "${SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=../shared-gh-wrappers.sh
+source "${SCRIPTS_DIR}/shared-gh-wrappers.sh"
+
+privacy_guard_public_write() {
+	local repo="$1"
+	local text="$2"
+	printf '<%s> <%s>\n' "$repo" "$text" >>"$CALLS_FILE"
+	if [[ -n "$repo" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+failures=0
+
+if [[ "$(_gh_extract_repo_from_args -R owner/repo --title example)" == "owner/repo" ]]; then
+	printf 'PASS: safe-edit extraction accepts -R\n'
+else
+	printf 'FAIL: safe-edit extraction accepts -R\n'
+	failures=$((failures + 1))
+fi
+
+: >"$CALLS_FILE"
+if _gh_guard_public_write_args -R public/repo --title "Public title" &&
+	grep -Fq '<public/repo>' "$CALLS_FILE"; then
+	printf 'PASS: privacy guard receives -R repository\n'
+else
+	printf 'FAIL: privacy guard receives -R repository\n'
+	failures=$((failures + 1))
+fi
+
+: >"$CALLS_FILE"
+if _gh_guard_public_write_args -R --title "Missing repository"; then
+	printf 'FAIL: missing -R value fails closed\n'
+	failures=$((failures + 1))
+else
+	printf 'PASS: missing -R value fails closed\n'
+fi
+
+exit "$failures"


### PR DESCRIPTION
## Outcome

- accept native `gh -R owner/repo` repository selection in create-path privacy scanning
- normalize `-R` in shared repository extraction and sub-issue linking
- keep missing repository values fail-closed

## Verification

- `bash .agents/scripts/tests/test-gh-wrapper-repo-alias.sh` — 3 passed
- `bash .agents/scripts/tests/test-gh-auto-link-parent-line.sh` — 9 passed
- ShellCheck on all changed shell files — passed
- `git diff --check` — passed
- Pre-commit and pre-push quality hooks — passed

Resolves #30855

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.293 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 17m and 206,523 tokens on this with the user in an interactive session.