### PR TITLE
GH#30855: fix: normalize repository routing in GitHub create wrappers

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -1065,8 +1065,11 @@ gh_create_pr() {
 	fi
 
 	local pr_output rc
-	pr_output=$("${pr_cmd[@]}") # aidevops-allow: raw-gh-wrapper
-	rc=$?
+	if pr_output=$("${pr_cmd[@]}"); then # aidevops-allow: raw-gh-wrapper
+		rc=0
+	else
+		rc=$?
+	fi
 	if [[ $rc -ne 0 ]] && _gh_create_pr_resolve_durable_identity "$pr_output" "$@"; then
 		# Native gh can create the PR and fail during a follow-up mutation. The URL
 		# proves creation; never invoke another create transport for this result.

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -905,6 +905,67 @@ _gh_create_pr_resolve_durable_identity() {
 }
 
 #######################################
+# Extract the exact --head value used for PR creation recovery.
+# Args: PR create argv
+# Output: head ref, or empty when unavailable
+#######################################
+_gh_create_pr_extract_head() {
+	while [[ $# -gt 0 ]]; do
+		local cur="$1"
+		case "$cur" in
+		--head)
+			local head_value="${2:-}"
+			[[ $# -gt 1 && "$head_value" != -* ]] && printf '%s\n' "$head_value"
+			return 0
+			;;
+		--head=*)
+			printf '%s\n' "${cur#--head=}"
+			return 0
+			;;
+		esac
+		shift
+	done
+	return 0
+}
+
+#######################################
+# Recover a PR created before native gh failed a follow-up mutation.
+# Sets the durable identity globals.
+# Args: PR create argv
+# Returns: 0=recovered, 1=no exact durable PR found
+#######################################
+_gh_create_pr_recover_after_mutation_failure() {
+	local repo=""
+	local head_ref=""
+	local recovered_url=""
+	repo=$(_gh_extract_repo_from_args "$@")
+	head_ref=$(_gh_create_pr_extract_head "$@")
+	[[ -n "$repo" && -n "$head_ref" ]] || return 1
+	recovered_url=$(_gh_recover_pr_if_exists "$head_ref" "$repo")
+	[[ -n "$recovered_url" ]] || return 1
+	_gh_create_pr_resolve_durable_identity "$recovered_url" "$@" || return 1
+	return 0
+}
+
+#######################################
+# Complete the wrapper-added draft transition after durable recovery.
+# Args: $1=repo $2=PR number
+# Returns: 0=ready, 1=still draft
+#######################################
+_gh_create_pr_ready_recovered_draft() {
+	local repo="$1"
+	local pr_number="$2"
+	if _gh_with_timeout write gh pr ready "$pr_number" --repo "$repo" >/dev/null 2>&1; then # aidevops-allow: raw-gh-wrapper
+		printf '[aidevops][gh-wrapper][PARTIAL] recovered PR #%s and marked it ready for review\n' \
+			"$pr_number" >&2
+		return 0
+	fi
+	printf '[aidevops][gh-wrapper][PARTIAL] recovered PR #%s remains draft; run gh pr ready %s --repo %s\n' \
+		"$pr_number" "$pr_number" "$repo" >&2
+	return 1
+}
+
+#######################################
 # Verify that a PR has exactly the expected origin label.
 # Args: $1=repo $2=PR number $3=expected origin label
 # Returns: 0=exact postcondition, 1=missing/wrong/dual/unavailable
@@ -1010,7 +1071,19 @@ gh_create_pr() {
 		# Native gh can create the PR and fail during a follow-up mutation. The URL
 		# proves creation; never invoke another create transport for this result.
 		rc="$_GH_PR_CREATE_PARTIAL_RC"
-	elif [[ $rc -ne 0 ]] && _rest_should_fallback_write; then
+	elif [[ $rc -ne 0 ]]; then
+		if _gh_create_pr_recover_after_mutation_failure "$@"; then
+			pr_output="$_GH_CREATE_PR_DURABLE_URL"
+			printf '[aidevops][gh-wrapper][PARTIAL] recovered durable PR #%s after a create-time mutation failure; not retrying creation\n' \
+				"$_GH_CREATE_PR_DURABLE_NUMBER" >&2
+			if [[ ${#_draft_args[@]} -gt 0 ]]; then
+				_gh_create_pr_ready_recovered_draft "$_GH_CREATE_PR_DURABLE_REPO" \
+					"$_GH_CREATE_PR_DURABLE_NUMBER" || true
+			fi
+			rc="$_GH_PR_CREATE_PARTIAL_RC"
+		fi
+	fi
+	if [[ $rc -ne 0 && "$rc" -ne "$_GH_PR_CREATE_PARTIAL_RC" ]] && _rest_should_fallback_write; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr create"
 		if [[ ${#_origin_label_args[@]} -gt 0 || ${#_draft_args[@]} -gt 0 ]]; then
 			pr_output=$(_rest_pr_create "$@" "${_draft_args[@]}" "${_origin_label_args[@]}")

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -59,7 +59,10 @@ _gh_guard_public_write_args() {
 	for arg in "$@"; do
 		if [[ -n "$expect" ]]; then
 			case "$expect" in
-			repo) repo="$arg" ;;
+			repo)
+				[[ "$arg" != -* ]] || return 1
+				repo="$arg"
+				;;
 			text) text+=$'\n'"$arg" ;;
 			body-file)
 				body_file="$arg"
@@ -71,7 +74,7 @@ _gh_guard_public_write_args() {
 			continue
 		fi
 		case "$arg" in
-		--repo) expect="repo" ;;
+		--repo | -R) expect="repo" ;;
 		--repo=*) repo="${arg#--repo=}" ;;
 		--title | --body | --comment | -c) expect="text" ;;
 		--title=* | --body=* | --comment=* | -c=*) text+=$'\n'"${arg#*=}" ;;
@@ -83,6 +86,7 @@ _gh_guard_public_write_args() {
 			;;
 		esac
 	done
+	[[ "$expect" != "repo" ]] || return 1
 	privacy_guard_public_write "$repo" "$text"
 	return $?
 }
@@ -717,7 +721,7 @@ _gh_auto_link_sub_issue() {
 		--title=*)
 			title="${_a#--title=}"; shift
 			;;
-		--repo)
+		--repo | -R)
 			if [[ $# -gt 1 ]]; then repo="$_v"; shift 2; else shift; fi
 			;;
 		--repo=*)

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -1204,7 +1204,7 @@ _ensure_origin_labels_for_args() {
 	local repo=""
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
-		--repo)
+		--repo | -R)
 			repo="${2:-}"
 			break
 			;;

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -459,7 +459,7 @@ _rest_issue_create() {
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-		--repo) repo="${2:-}"; shift 2 ;;
+		--repo | -R) [[ $# -ge 2 ]] || return 2; repo="${2:-}"; shift 2 ;;
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
 		--title) title="${2:-}"; shift 2 ;;
 		--title=*) title="${_arg#--title=}"; shift ;;
@@ -538,7 +538,7 @@ _rest_issue_comment() {
 	local has_body=0
 
 	local _first="${1:-}"
-	if [[ $# -gt 0 && "$_first" != --* ]]; then
+	if [[ $# -gt 0 && "$_first" != -* ]]; then
 		num_or_url="$_first"
 		shift
 	fi
@@ -546,7 +546,7 @@ _rest_issue_comment() {
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-		--repo) repo="${2:-}"; shift 2 ;;
+		--repo | -R) [[ $# -ge 2 ]] || return 2; repo="${2:-}"; shift 2 ;;
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
 		--body) body="${2:-}"; has_body=1; shift 2 ;;
 		--body=*) body="${_arg#--body=}"; has_body=1; shift ;;
@@ -749,7 +749,7 @@ _rest_issue_edit_preserving_deltas() {
 		arg="$1"
 		[[ "$arg" == *=* ]] && { value="${arg#*=}"; arg="${arg%%=*}"; shift; } || { value="${2:-}"; shift 2; }
 		case "$arg" in
-		--repo) repo="$value" ;;
+		--repo | -R) repo="$value" ;;
 		--require-label) required_label="$value" ;;
 		--require-assignee) required_assignee="$value" ;;
 		--delta-order)
@@ -895,7 +895,7 @@ _rest_issue_edit() {
 	add_assignees=()
 	rm_assignees=()
 	local _first="${1:-}"
-	if [[ $# -gt 0 && "$_first" != --* ]]; then
+	if [[ $# -gt 0 && "$_first" != -* ]]; then
 		num_or_url="$_first"
 		shift
 	fi
@@ -904,7 +904,7 @@ _rest_issue_edit() {
 		local _arg="$1" _v=""
 		[[ "$_arg" == *=* ]] && { _v="${_arg#*=}"; _arg="${_arg%%=*}"; shift; } || { _v="${2:-}"; shift 2; }
 		case "$_arg" in
-		--repo)            repo="$_v" ;;
+		--repo | -R)       repo="$_v" ;;
 		--title)           title="$_v"; has_title=1 ;;
 		--body)            body="$_v"; has_body=1 ;;
 		--body-file)       body_file="$_v"; has_body=1 ;;
@@ -1135,7 +1135,7 @@ _rest_pr_create() {
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-		--repo) repo="${2:-}"; shift 2 ;;
+		--repo | -R) [[ $# -ge 2 ]] || return 2; repo="${2:-}"; shift 2 ;;
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
 		--title) title="${2:-}"; shift 2 ;;
 		--title=*) title="${_arg#--title=}"; shift ;;
@@ -1232,7 +1232,7 @@ _rest_issue_view() {
 	local json_fields=""
 
 	local _first="${1:-}"
-	if [[ $# -gt 0 && "$_first" != --* ]]; then
+	if [[ $# -gt 0 && "$_first" != -* ]]; then
 		num_or_url="$_first"
 		shift
 	fi
@@ -1334,7 +1334,7 @@ _rest_pr_view() {
 	local json_fields=""
 
 	local _first="${1:-}"
-	if [[ $# -gt 0 && "$_first" != --* ]]; then
+	if [[ $# -gt 0 && "$_first" != -* ]]; then
 		num_or_url="$_first"
 		shift
 	fi

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -126,8 +126,12 @@ _gh_extract_repo_from_args() {
 	local -a args=("$@")
 	while [[ $i -lt ${#args[@]} ]]; do
 		case "${args[i]}" in
-		--repo)
-			echo "${args[i + 1]:-}"
+		--repo | -R)
+			if [[ -n "${args[i + 1]:-}" && "${args[i + 1]}" != -* ]]; then
+				echo "${args[i + 1]}"
+			else
+				echo ""
+			fi
 			return 0
 			;;
 		--repo=*)

--- a/.agents/scripts/tests/test-gh-auto-link-parent-line.sh
+++ b/.agents/scripts/tests/test-gh-auto-link-parent-line.sh
@@ -25,6 +25,7 @@
 #   6. `--body-file <path>` with `Parent: #502` inside fires method 2.
 #   7. No dot-notation and no `Parent:` line → no addSubIssue mutation.
 #   8. Dot-notation in title AND `Parent:` in body → method 1 wins.
+#   9. Native `gh -R owner/repo` repo selection reaches parent linking.
 #
 # Strategy mirrors test-backfill-sub-issues.sh: stub `gh` on PATH, record all
 # `gh api graphql` calls to a log file, inspect the log after each scenario
@@ -207,6 +208,21 @@ if saw_addsubissue; then
 	pass "dot-notation title fires addSubIssue (method 1, regression)"
 else
 	fail "dot-notation title fires addSubIssue (method 1, regression)" \
+		"no ADDSUBISSUE entry in gh log"
+fi
+
+# =============================================================================
+# Test 9 — native -R repo alias reaches parent linking
+# =============================================================================
+reset_log
+_gh_auto_link_sub_issue "https://github.com/owner/repo/issues/308" \
+	-R "owner/repo" \
+	--title "plain title" \
+	--body "Parent: #503"
+if saw_addsubissue; then
+	pass "-R repo alias reaches addSubIssue"
+else
+	fail "-R repo alias reaches addSubIssue" \
 		"no ADDSUBISSUE entry in gh log"
 fi
 

--- a/.agents/scripts/tests/test-gh-wrapper-repo-alias.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-repo-alias.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+CALLS_FILE="$(mktemp -t gh-wrapper-repo-alias.XXXXXX)"
+trap 'rm -f "$CALLS_FILE"' EXIT
+
+# shellcheck source=../shared-constants.sh
+source "${SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=../shared-gh-wrappers.sh
+source "${SCRIPTS_DIR}/shared-gh-wrappers.sh"
+
+privacy_guard_public_write() {
+	local repo="$1"
+	local text="$2"
+	printf '<%s> <%s>\n' "$repo" "$text" >>"$CALLS_FILE"
+	if [[ -n "$repo" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+failures=0
+
+if [[ "$(_gh_extract_repo_from_args -R owner/repo --title example)" == "owner/repo" ]]; then
+	printf 'PASS: safe-edit extraction accepts -R\n'
+else
+	printf 'FAIL: safe-edit extraction accepts -R\n'
+	failures=$((failures + 1))
+fi
+
+: >"$CALLS_FILE"
+if _gh_guard_public_write_args -R public/repo --title "Public title" &&
+	grep -Fq '<public/repo>' "$CALLS_FILE"; then
+	printf 'PASS: privacy guard receives -R repository\n'
+else
+	printf 'FAIL: privacy guard receives -R repository\n'
+	failures=$((failures + 1))
+fi
+
+: >"$CALLS_FILE"
+if _gh_guard_public_write_args -R --title "Missing repository"; then
+	printf 'FAIL: missing -R value fails closed\n'
+	failures=$((failures + 1))
+else
+	printf 'PASS: missing -R value fails closed\n'
+fi
+
+exit "$failures"

--- a/.agents/scripts/tests/test-gh-wrapper-repo-alias.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-repo-alias.sh
@@ -50,4 +50,84 @@ else
 	printf 'PASS: missing -R value fails closed\n'
 fi
 
+ensure_origin_labels_exist() {
+	local repo="$1"
+	printf '<origin-labels> <%s>\n' "$repo" >>"$CALLS_FILE"
+	return 0
+}
+
+: >"$CALLS_FILE"
+_ORIGIN_LABELS_ENSURED=""
+_ensure_origin_labels_for_args -R labels/repo --title example
+if grep -Fq '<origin-labels> <labels/repo>' "$CALLS_FILE"; then
+	printf 'PASS: origin-label provisioning accepts -R\n'
+else
+	printf 'FAIL: origin-label provisioning accepts -R\n'
+	failures=$((failures + 1))
+fi
+
+gh() {
+	printf '<gh> %s\n' "$*" >>"$CALLS_FILE"
+	case "$*" in
+	*'/pulls'*) printf 'https://github.com/rest/repo/pull/7\n' ;;
+	*) printf 'https://github.com/rest/repo/issues/42\n' ;;
+	esac
+	return 0
+}
+
+_rest_api_call() {
+	local request_class="$1"
+	shift
+	printf '<rest:%s> %s\n' "$request_class" "$*" >>"$CALLS_FILE"
+	if [[ "$request_class" == "read" ]]; then
+		printf '{"labels":[],"assignees":[]}\n'
+	fi
+	return 0
+}
+
+: >"$CALLS_FILE"
+if _rest_issue_create -R rest/repo --title "REST issue" >/dev/null &&
+	grep -Fq '/repos/rest/repo/issues' "$CALLS_FILE"; then
+	printf 'PASS: REST issue create accepts -R\n'
+else
+	printf 'FAIL: REST issue create accepts -R\n'
+	failures=$((failures + 1))
+fi
+
+: >"$CALLS_FILE"
+if _rest_issue_comment 42 -R rest/repo --body "REST comment" >/dev/null &&
+	grep -Fq '/repos/rest/repo/issues/42/comments' "$CALLS_FILE"; then
+	printf 'PASS: REST issue comment accepts -R\n'
+else
+	printf 'FAIL: REST issue comment accepts -R\n'
+	failures=$((failures + 1))
+fi
+
+: >"$CALLS_FILE"
+if _rest_issue_edit 42 -R rest/repo --title "REST edit" &&
+	grep -Fq '/repos/rest/repo/issues/42' "$CALLS_FILE"; then
+	printf 'PASS: REST issue edit accepts -R\n'
+else
+	printf 'FAIL: REST issue edit accepts -R\n'
+	failures=$((failures + 1))
+fi
+
+: >"$CALLS_FILE"
+if _rest_issue_edit_preserving_deltas 42 -R rest/repo --add-label status:in-review &&
+	grep -Fq '/repos/rest/repo/issues/42/labels' "$CALLS_FILE"; then
+	printf 'PASS: REST preserving edit accepts -R\n'
+else
+	printf 'FAIL: REST preserving edit accepts -R\n'
+	failures=$((failures + 1))
+fi
+
+: >"$CALLS_FILE"
+if _rest_pr_create -R rest/repo --title "REST PR" --head feature --base main >/dev/null &&
+	grep -Fq '/repos/rest/repo/pulls' "$CALLS_FILE"; then
+	printf 'PASS: REST PR create accepts -R\n'
+else
+	printf 'FAIL: REST PR create accepts -R\n'
+	failures=$((failures + 1))
+fi
+
 exit "$failures"

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -955,6 +955,7 @@ export STUB_RATE_LIMIT_REMAINING=5000
 : >"$GH_INFO_OUTPUT"
 export STUB_PRIMARY_FAIL=1
 export STUB_RATE_LIMIT_REMAINING=0
+export STUB_PR_LIST_FIXTURE='[]'
 
 gh_create_pr \
 	--repo "owner/repo" \
@@ -980,7 +981,7 @@ else
 		"INFO log: $(cat "$GH_INFO_OUTPUT")"
 fi
 
-unset STUB_PRIMARY_FAIL
+unset STUB_PRIMARY_FAIL STUB_PR_LIST_FIXTURE
 export STUB_RATE_LIMIT_REMAINING=5000
 
 # =============================================================================

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -79,10 +79,10 @@ case "$1 $2" in
 		printf 'pull request update failed: GraphQL: external contributor cannot update the pull request\n' >&2
 		exit 1
 	fi
-	echo "https://example.invalid/o/r/pull/0"
+	echo "https://github.com/o/r/pull/0"
 	;;
 "issue create")
-	echo "https://example.invalid/o/r/pull/0"
+	echo "https://github.com/o/r/pull/0"
 	;;
 "pr list")
 	printf '%s\n' "${MOCK_RECOVERED_PR_URL:-}"
@@ -421,7 +421,7 @@ fi
 # mutation. The wrapper must not create twice and must print the durable URL.
 reset_recorder
 export MOCK_PR_CREATE_MUTATION_FAILURE=1
-export MOCK_RECOVERED_PR_URL="https://example.invalid/o/r/pull/42"
+export MOCK_RECOVERED_PR_URL="https://github.com/o/r/pull/42"
 export MOCK_PR_READY_RC=0
 export MOCK_ORIGIN_EXACT=0
 partial_output=""
@@ -435,7 +435,7 @@ partial_output_file="${TEST_ROOT}/partial-output.txt"
 ) || partial_rc=$?
 partial_output=$(<"$partial_output_file")
 create_count=$(grep -c '^pr create ' "$GH_RECORD_FILE" || true)
-if [[ "$partial_rc" -eq 78 && "$partial_output" == "https://example.invalid/o/r/pull/42" &&
+if [[ "$partial_rc" -eq 78 && "$partial_output" == "https://github.com/o/r/pull/42" &&
 	"$create_count" -eq 1 ]] && grep -q '^pr ready 42 --repo o/r$' "$GH_RECORD_FILE"; then
 	print_result "B10: durable external-fork PR recovery is idempotent and ready" 0
 else

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -426,8 +426,14 @@ export MOCK_PR_READY_RC=0
 export MOCK_ORIGIN_EXACT=0
 partial_output=""
 partial_rc=0
-partial_output=$(gh_create_pr --repo o/r --head contributor:feature/recovery \
-	--title "GH#30856: recover partial creation" --body "Resolves #30856" 2>/dev/null) || partial_rc=$?
+partial_output_file="${TEST_ROOT}/partial-output.txt"
+(
+	set -e
+	gh_create_pr --repo o/r --head contributor:feature/recovery \
+		--title "GH#30856: recover partial creation" --body "Resolves #30856" \
+		>"$partial_output_file" 2>/dev/null
+) || partial_rc=$?
+partial_output=$(<"$partial_output_file")
 create_count=$(grep -c '^pr create ' "$GH_RECORD_FILE" || true)
 if [[ "$partial_rc" -eq 78 && "$partial_output" == "https://example.invalid/o/r/pull/42" &&
 	"$create_count" -eq 1 ]] && grep -q '^pr ready 42 --repo o/r$' "$GH_RECORD_FILE"; then

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -74,8 +74,21 @@ if [[ -n "${GH_ARGV_RECORD_FILE:-}" ]]; then
 fi
 # pr/issue create paths print a URL on stdout for caller capture
 case "$1 $2" in
-"pr create" | "issue create")
+"pr create")
+	if [[ "${MOCK_PR_CREATE_MUTATION_FAILURE:-0}" == "1" ]]; then
+		printf 'pull request update failed: GraphQL: external contributor cannot update the pull request\n' >&2
+		exit 1
+	fi
 	echo "https://example.invalid/o/r/pull/0"
+	;;
+"issue create")
+	echo "https://example.invalid/o/r/pull/0"
+	;;
+"pr list")
+	printf '%s\n' "${MOCK_RECOVERED_PR_URL:-}"
+	;;
+"pr ready")
+	exit "${MOCK_PR_READY_RC:-0}"
 	;;
 esac
 exit 0
@@ -116,7 +129,12 @@ _gh_validate_edit_args() { return 0; }
 # Privacy/write-policy and durable readback have dedicated suites. This harness
 # inspects only the exact create argv emitted by the wrapper.
 _gh_guard_public_write_args() { return 0; }
-_gh_create_pr_origin_is_exact() { return 0; }
+_gh_create_pr_origin_is_exact() {
+	if [[ "${MOCK_ORIGIN_EXACT:-1}" == "1" ]]; then
+		return 0
+	fi
+	return 1
+}
 _gh_lock_created_auto_dispatch_issue() { return 0; }
 
 # Stub _gh_should_fallback_to_rest (never fall back — REST path adds noise)
@@ -398,6 +416,27 @@ else
 	print_result "B9: gh_create_pr rejects conflicting origins before create" 1 \
 		"rc=${dual_origin_rc}; calls=$(tr '\n' ' ' <"$GH_RECORD_FILE")"
 fi
+
+# B10: recover an external-fork PR after native create fails a follow-up
+# mutation. The wrapper must not create twice and must print the durable URL.
+reset_recorder
+export MOCK_PR_CREATE_MUTATION_FAILURE=1
+export MOCK_RECOVERED_PR_URL="https://example.invalid/o/r/pull/42"
+export MOCK_PR_READY_RC=0
+export MOCK_ORIGIN_EXACT=0
+partial_output=""
+partial_rc=0
+partial_output=$(gh_create_pr --repo o/r --head contributor:feature/recovery \
+	--title "GH#30856: recover partial creation" --body "Resolves #30856" 2>/dev/null) || partial_rc=$?
+create_count=$(grep -c '^pr create ' "$GH_RECORD_FILE" || true)
+if [[ "$partial_rc" -eq 78 && "$partial_output" == "https://example.invalid/o/r/pull/42" &&
+	"$create_count" -eq 1 ]] && grep -q '^pr ready 42 --repo o/r$' "$GH_RECORD_FILE"; then
+	print_result "B10: durable external-fork PR recovery is idempotent and ready" 0
+else
+	print_result "B10: durable external-fork PR recovery is idempotent and ready" 1 \
+		"rc=$partial_rc output=$partial_output creates=$create_count calls=$(cat "$GH_RECORD_FILE")"
+fi
+unset MOCK_PR_CREATE_MUTATION_FAILURE MOCK_RECOVERED_PR_URL MOCK_PR_READY_RC MOCK_ORIGIN_EXACT
 
 # ---------------------------------------------------------------------------
 # Layer B': gh_create_issue defence-in-depth (mirrors PR tests)


### PR DESCRIPTION
## Summary

Normalize -R/--repo across REST create, edit, comment, read parsing, preserving-delta recovery, and origin-label provisioning. Resolves #30856.

## Files Changed

.agents/scripts/shared-gh-wrappers-create.sh, .agents/scripts/shared-gh-wrappers-rest-fallback.sh, .agents/scripts/shared-gh-wrappers-safe-edit.sh, .agents/scripts/tests/test-gh-auto-link-parent-line.sh, .agents/scripts/tests/test-gh-wrapper-repo-alias.sh, .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh, .agents/scripts/tests/test-origin-label-mutex-create.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — REST fallback suite: 59/59 passed; alias, mutex, zsh, wrapper, ShellCheck, whitespace, and local lint checks passed.

Resolves #30855


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.293 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 13h 42m and 1,606,402 tokens on this with the user in an interactive session.