### PR TITLE
GH#30853: fix: allow .nvmrc in root-file validation

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -783,7 +783,7 @@ _init_root_file_allowlist() {
 		"CHANGELOG.md" "DESIGN.md" "LICENSE" "CODE_OF_CONDUCT.md" "CONTRIBUTING.md"
 		"SECURITY.md" "TERMS.md" "MODELS.md" "VERSION"
 		# Config files (dotfiles)
-		".aidevops.json" ".bandit" ".gitattributes" ".gitignore"
+		".aidevops.json" ".bandit" ".gitattributes" ".gitignore" ".nvmrc"
 		".codacy.yml" ".codefactor.yml" ".coderabbit.yaml"
 		".markdownlint-cli2.jsonc" ".markdownlint.json" ".markdownlintignore"
 		".qlty/qlty.toml" ".qlty.toml" ".qltyignore" ".repomixignore"

--- a/.agents/scripts/tests/test-pre-commit-split.sh
+++ b/.agents/scripts/tests/test-pre-commit-split.sh
@@ -271,8 +271,8 @@ test_eslint_flat_config_root_allowlist() {
 	return 0
 }
 
-# --- Test 14: npm lockfiles pass staged root validation ---
-test_npm_lockfile_root_validation() {
+# --- Test 14: Node package metadata files pass staged root validation ---
+test_node_package_root_validation() {
 	local fixture_dir
 	fixture_dir=$(mktemp -d)
 	local hook_dir="${fixture_dir}/.agents/scripts"
@@ -289,13 +289,14 @@ test_npm_lockfile_root_validation() {
 	git -C "$fixture_dir" init --quiet
 	printf '%s\n' '{"name":"root-allowlist-fixture"}' >"${fixture_dir}/package.json"
 	printf '%s\n' '{"name":"root-allowlist-fixture","lockfileVersion":3,"packages":{}}' >"${fixture_dir}/package-lock.json"
-	git -C "$fixture_dir" add package.json package-lock.json
+	printf '%s\n' '22' >"${fixture_dir}/.nvmrc"
+	git -C "$fixture_dir" add .nvmrc package.json package-lock.json
 
 	hook_output=$(cd "$fixture_dir" && HOOK_MODE=pre-commit bash "$hook_dir/pre-commit-hook.sh" 2>&1) || hook_rc=$?
 	if [[ "$hook_rc" -eq 0 ]]; then
-		print_result "root validation permits package.json with package-lock.json" 0
+		print_result "root validation permits .nvmrc with npm package metadata" 0
 	else
-		print_result "root validation permits package.json with package-lock.json" 1 "$hook_output"
+		print_result "root validation permits .nvmrc with npm package metadata" 1 "$hook_output"
 	fi
 
 	printf '%s\n' 'fixture artifact' >"${fixture_dir}/VERIFY-ROOT-ARTIFACT.md"
@@ -342,7 +343,7 @@ test_status_reports_pre_push
 test_pre_commit_dispatcher_sets_mode
 test_pre_push_dispatcher_sets_mode
 test_eslint_flat_config_root_allowlist
-test_npm_lockfile_root_validation
+test_node_package_root_validation
 test_arbitrary_root_artifact_not_allowlisted
 
 echo ""


### PR DESCRIPTION
## Summary

Add .nvmrc to the repository root allowlist so standard Node version metadata passes pre-commit validation without weakening other root-file checks.

## Files Changed

.agents/scripts/pre-commit-hook.sh, .agents/scripts/tests/test-pre-commit-split.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Focused root validation suite passed 16 tests with 0 failures; ShellCheck and whitespace checks passed.

Resolves #30853


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.293 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 13h 45m and 1,612,172 tokens on this with the user in an interactive session.