### PR TITLE
t18311: feat: add authenticated Playwriter relay lifecycle

### DIFF
--- a/.agents/plugins/opencode-aidevops/mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-registry.mjs
@@ -7,12 +7,16 @@ import { accessSync, constants } from "fs";
 import { randomUUID } from "node:crypto";
 import { homedir, platform } from "os";
 import { delimiter, isAbsolute, join, relative, resolve } from "path";
+import { fileURLToPath } from "url";
 
 const IS_MACOS = platform() === "darwin";
 const MCP_WORKSPACE_MARKER = ".aidevops-mcp-workspace";
 const PLAYWRIGHT_MCP_PACKAGE = "@playwright/mcp@0.0.79";
 const PLAYWRITER_MCP_PACKAGE = "playwriter@0.5.0";
 const LEGACY_PLAYWRITER_MCP_PACKAGE = "playwriter@latest";
+const PLAYWRITER_AUTHENTICATED_RELAY_LAUNCHER = fileURLToPath(
+  new URL("../../scripts/playwriter-authenticated-relay.mjs", import.meta.url),
+);
 
 /**
  * Build unique per-plugin MCP workspace metadata without creating files.
@@ -410,7 +414,10 @@ function buildMcpConfigEntry(mcp, runtime) {
   }
   const workspace = runtime?.workspaces?.[mcp.name];
   if (!workspace) {
-    return { type: "local", command: mcp.command, enabled: mcp.eager };
+    const command = mcp.name === "playwriter" && authenticatedPlaywriterRelayEnabled()
+      ? authenticatedPlaywriterRelayCommand(mcp.command)
+      : mcp.command;
+    return { type: "local", command, enabled: mcp.eager };
   }
 
   const outputDir = join(workspace.directory, ".playwright-mcp");
@@ -475,6 +482,23 @@ function isLegacyGeneratedPlaywriterCommand(command) {
   return isLegacyNpxPlaywriterCommand(command) || isLegacyBunPlaywriterCommand(command);
 }
 
+function authenticatedPlaywriterRelayEnabled() {
+  return process.env.AIDEVOPS_PLAYWRITER_AUTHENTICATED_RELAY === "1";
+}
+
+function authenticatedPlaywriterRelayCommand(command) {
+  const node = findExecutable("node") || "node";
+  return [node, PLAYWRITER_AUTHENTICATED_RELAY_LAUNCHER, ...command];
+}
+
+function isCurrentGeneratedPlaywriterCommand(command) {
+  if (!Array.isArray(command)) return false;
+  const current = command.map((part) => (
+    part === PLAYWRITER_MCP_PACKAGE ? LEGACY_PLAYWRITER_MCP_PACKAGE : part
+  ));
+  return isLegacyGeneratedPlaywriterCommand(current);
+}
+
 /**
  * Register a single MCP server in the config. Returns true if newly registered.
  * @param {object} mcp - MCP registry entry
@@ -493,6 +517,13 @@ function registerSingleMcp(mcp, config, runtime) {
     && isLegacyGeneratedPlaywriterCommand(config.mcp[mcp.name].command)) {
     const command = config.mcp[mcp.name].command;
     command[command.indexOf(LEGACY_PLAYWRITER_MCP_PACKAGE)] = PLAYWRITER_MCP_PACKAGE;
+  }
+  if (mcp.name === "playwriter"
+    && authenticatedPlaywriterRelayEnabled()
+    && isCurrentGeneratedPlaywriterCommand(config.mcp[mcp.name].command)) {
+    config.mcp[mcp.name].command = authenticatedPlaywriterRelayCommand(
+      config.mcp[mcp.name].command,
+    );
   }
 
   // Runtime-activated MCPs must stay disconnected at startup, including when

--- a/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
@@ -151,6 +151,54 @@ test("pins legacy Playwriter commands while preserving custom commands", () => {
   assert.equal(customLatestWithYesConfig.tools["playwriter_*"], false);
 });
 
+test("opts framework-generated Playwriter commands into the authenticated relay launcher", () => {
+  const previous = process.env.AIDEVOPS_PLAYWRITER_AUTHENTICATED_RELAY;
+  process.env.AIDEVOPS_PLAYWRITER_AUTHENTICATED_RELAY = "1";
+  try {
+    const generated = { mcp: {}, tools: {} };
+    registerMcpServers(generated);
+    assert.match(generated.mcp.playwriter.command[0], /node$/);
+    assert.match(generated.mcp.playwriter.command[1], /playwriter-authenticated-relay\.mjs$/);
+    assert.equal(generated.mcp.playwriter.command.at(-1), "playwriter@0.5.0");
+    assert.ok(!generated.mcp.playwriter.command.some((part) => part.includes("TOKEN")));
+
+    const previousGenerated = {
+      mcp: {
+        playwriter: {
+          type: "local",
+          command: ["npx", "playwriter@0.5.0"],
+          enabled: true,
+        },
+      },
+      tools: {},
+    };
+    registerMcpServers(previousGenerated);
+    assert.match(
+      previousGenerated.mcp.playwriter.command[1],
+      /playwriter-authenticated-relay\.mjs$/,
+    );
+    assert.equal(previousGenerated.mcp.playwriter.enabled, false);
+
+    const custom = {
+      mcp: {
+        playwriter: {
+          type: "local",
+          command: ["playwriter", "serve", "--host", "127.0.0.1"],
+          enabled: true,
+        },
+      },
+      tools: {},
+    };
+    registerMcpServers(custom);
+    assert.deepEqual(custom.mcp.playwriter.command, [
+      "playwriter", "serve", "--host", "127.0.0.1",
+    ]);
+  } finally {
+    if (previous === undefined) delete process.env.AIDEVOPS_PLAYWRITER_AUTHENTICATED_RELAY;
+    else process.env.AIDEVOPS_PLAYWRITER_AUTHENTICATED_RELAY = previous;
+  }
+});
+
 test("migrates browser MCPs to disconnected and globally denied", () => {
   const runtime = createMcpSessionRuntime("/managed/workspace", {
     tempRoot: "/managed/tmp",

--- a/.agents/scripts/playwriter-authenticated-relay.mjs
+++ b/.agents/scripts/playwriter-authenticated-relay.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { spawn } from "node:child_process";
+import {
+  chmodSync,
+  closeSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const PLAYWRITER_PACKAGE = "playwriter@0.5.0";
+const RELAY_HOST = "127.0.0.1";
+const RELAY_PORT = 19988;
+const START_TIMEOUT_MS = 5_000;
+
+function fixedError(message) {
+  return new Error(`Authenticated Playwriter relay: ${message}`);
+}
+
+export function validatePlaywriterCommand(command) {
+  if (!Array.isArray(command) || command.some((part) => typeof part !== "string" || !part)) {
+    throw fixedError("invalid package-runner command");
+  }
+  const runner = basename(command[0]);
+  const args = command.slice(1);
+  const npxShape = runner === "npx"
+    && (args.length === 1 || (args.length === 2 && args[0] === "-y"))
+    && args.at(-1) === PLAYWRITER_PACKAGE;
+  const bunShape = runner === "bun"
+    && args.length === 2
+    && args[0] === "x"
+    && args[1] === PLAYWRITER_PACKAGE;
+  if (!npxShape && !bunShape) {
+    throw fixedError("command is not the reviewed Playwriter package shape");
+  }
+  return [...command];
+}
+
+function requireToken(environment) {
+  const token = environment.PLAYWRITER_TOKEN;
+  if (typeof token !== "string" || token.length < 32) {
+    throw fixedError("PLAYWRITER_TOKEN must be injected through the environment and contain at least 32 characters");
+  }
+  return token;
+}
+
+function privateDirectory(path) {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  const stats = lstatSync(path);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw fixedError("private runtime path is not a regular directory");
+  }
+  chmodSync(path, 0o700);
+}
+
+export function createPrivateRuntime(tempRoot, ownerToken = randomUUID()) {
+  if (!isAbsolute(tempRoot)) throw fixedError("AIDEVOPS_TEMP_DIR must be absolute");
+  privateDirectory(tempRoot);
+  const physicalTempRoot = realpathSync(tempRoot);
+  const parent = resolve(tempRoot, "mcp", "playwriter", "authenticated-relay");
+  privateDirectory(parent);
+  const physicalParent = realpathSync(parent);
+  const relativeParent = relative(physicalTempRoot, physicalParent);
+  if (relativeParent.startsWith("..") || isAbsolute(relativeParent)) {
+    throw fixedError("private runtime path escapes AIDEVOPS_TEMP_DIR");
+  }
+  const directory = join(physicalParent, `session-${process.pid}-${randomUUID()}`);
+  mkdirSync(directory, { mode: 0o700 });
+  const markerPath = join(directory, ".aidevops-owned-relay");
+  writeFileSync(markerPath, ownerToken, { flag: "wx", mode: 0o600 });
+  return {
+    directory,
+    markerPath,
+    ownerToken,
+    logPath: join(directory, "relay.log"),
+    statePath: join(directory, "state.json"),
+  };
+}
+
+export function cleanupPrivateRuntime(runtime) {
+  const stats = lstatSync(runtime.directory);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw fixedError("refusing cleanup of a non-regular runtime directory");
+  }
+  if (readFileSync(runtime.markerPath, "utf8") !== runtime.ownerToken) {
+    throw fixedError("refusing cleanup without matching ownership evidence");
+  }
+  rmSync(runtime.directory, { recursive: true, force: false });
+}
+
+function relayUrl(path, port = RELAY_PORT) {
+  return `http://${RELAY_HOST}:${port}${path}`;
+}
+
+async function boundedFetch(fetchImpl, url, options = {}) {
+  return fetchImpl(url, {
+    ...options,
+    redirect: "error",
+    signal: AbortSignal.timeout(1_000),
+  });
+}
+
+export async function probeAuthenticatedRelay({
+  token,
+  port = RELAY_PORT,
+  fetchImpl = fetch,
+} = {}) {
+  try {
+    const versionResponse = await boundedFetch(fetchImpl, relayUrl("/version", port));
+    if (!versionResponse.ok) return { reachable: true, ready: false };
+    const versionPayload = await versionResponse.json();
+    if (versionPayload?.version !== "0.5.0") return { reachable: true, ready: false };
+
+    const wrongToken = randomUUID();
+    const wrongResponse = await boundedFetch(
+      fetchImpl,
+      relayUrl(`/cdp/aidevops-proof?token=${encodeURIComponent(wrongToken)}`, port),
+    );
+    const rightResponse = await boundedFetch(
+      fetchImpl,
+      relayUrl(`/cdp/aidevops-proof?token=${encodeURIComponent(token)}`, port),
+    );
+    return {
+      reachable: true,
+      ready: wrongResponse.status === 401 && rightResponse.status === 404,
+    };
+  } catch {
+    return { reachable: false, ready: false };
+  }
+}
+
+function spawnRelay(command, environment, runtime) {
+  const logDescriptor = openSync(runtime.logPath, "a", 0o600);
+  chmodSync(runtime.logPath, 0o600);
+  try {
+    const child = spawn(command[0], [...command.slice(1), "serve", "--host", RELAY_HOST], {
+      env: environment,
+      shell: false,
+      stdio: ["ignore", logDescriptor, logDescriptor],
+    });
+    child.spawnFailed = false;
+    child.once("error", () => { child.spawnFailed = true; });
+    return child;
+  } finally {
+    closeSync(logDescriptor);
+  }
+}
+
+async function waitForRelay(token, child) {
+  const deadline = Date.now() + START_TIMEOUT_MS;
+  do {
+    const proof = await probeAuthenticatedRelay({ token });
+    if (proof.ready) return proof;
+    if (proof.reachable || child.spawnFailed || child.exitCode !== null) return proof;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  } while (Date.now() < deadline);
+  return { reachable: false, ready: false };
+}
+
+async function terminateChild(child) {
+  if (!child || child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolvePromise) => child.once("exit", resolvePromise)),
+    new Promise((resolvePromise) => setTimeout(resolvePromise, 2_000)),
+  ]);
+  if (child.exitCode === null) child.kill("SIGKILL");
+}
+
+async function ensureRelay(command, environment, runtime, token) {
+  const existing = await probeAuthenticatedRelay({ token });
+  if (existing.ready) return { child: null, owned: false };
+  if (existing.reachable) {
+    throw fixedError("port 19988 is occupied without matching token and version proof");
+  }
+
+  const child = spawnRelay(command, environment, runtime);
+  const proof = await waitForRelay(token, child);
+  if (!proof.ready) {
+    await terminateChild(child);
+    throw fixedError("could not prove the localhost relay version and token contract");
+  }
+  if (child.exitCode !== null || child.spawnFailed) {
+    return { child: null, owned: false };
+  }
+  return { child, owned: true };
+}
+
+function writeState(runtime, relay) {
+  const state = {
+    schema: "aidevops-playwriter-relay/v1",
+    host: RELAY_HOST,
+    port: RELAY_PORT,
+    version: "0.5.0",
+    supervisorPid: process.pid,
+    relayPid: relay.owned ? relay.child.pid : null,
+    owned: relay.owned,
+  };
+  writeFileSync(runtime.statePath, `${JSON.stringify(state)}\n`, { flag: "wx", mode: 0o600 });
+}
+
+async function supervise(command, environment) {
+  const token = requireToken(environment);
+  const tempRoot = environment.AIDEVOPS_TEMP_DIR
+    || join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+  const runtime = createPrivateRuntime(tempRoot);
+  let relay = null;
+  let mcp = null;
+  let stopping = false;
+  try {
+    relay = await ensureRelay(command, environment, runtime, token);
+    writeState(runtime, relay);
+    mcp = spawn(command[0], command.slice(1), {
+      env: {
+        ...environment,
+        PLAYWRITER_HOST: RELAY_HOST,
+      },
+      shell: false,
+      stdio: "inherit",
+    });
+
+    const forwardSignal = (signal) => {
+      stopping = true;
+      if (mcp.exitCode === null) mcp.kill(signal);
+    };
+    process.once("SIGINT", () => forwardSignal("SIGINT"));
+    process.once("SIGTERM", () => forwardSignal("SIGTERM"));
+    if (relay.owned) {
+      relay.child.once("exit", () => {
+        if (!stopping && mcp?.exitCode === null) mcp.kill("SIGTERM");
+      });
+    }
+
+    const result = await new Promise((resolvePromise) => {
+      mcp.once("error", () => resolvePromise({ code: 1, signal: null }));
+      mcp.once("exit", (code, signal) => resolvePromise({ code, signal }));
+    });
+    stopping = true;
+    return result.code ?? (result.signal ? 1 : 0);
+  } finally {
+    stopping = true;
+    await terminateChild(mcp);
+    if (relay?.owned) await terminateChild(relay.child);
+    cleanupPrivateRuntime(runtime);
+  }
+}
+
+export async function main(argv = process.argv.slice(2), environment = process.env) {
+  if (environment.AIDEVOPS_PLAYWRITER_AUTHENTICATED_RELAY !== "1") {
+    throw fixedError("opt-in environment flag is not enabled");
+  }
+  const command = validatePlaywriterCommand(argv);
+  return supervise(command, environment);
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath && fileURLToPath(import.meta.url) === invokedPath) {
+  main()
+    .then((code) => { process.exitCode = code; })
+    .catch((error) => {
+      process.stderr.write(`${error instanceof Error ? error.message : "Authenticated Playwriter relay failed"}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/.agents/scripts/tests/test-playwriter-authenticated-relay.mjs
+++ b/.agents/scripts/tests/test-playwriter-authenticated-relay.mjs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  cleanupPrivateRuntime,
+  createPrivateRuntime,
+  probeAuthenticatedRelay,
+  validatePlaywriterCommand,
+} from "../playwriter-authenticated-relay.mjs";
+
+test("accepts only reviewed Playwriter package-runner commands", () => {
+  assert.deepEqual(validatePlaywriterCommand(["npx", "playwriter@0.5.0"]), [
+    "npx", "playwriter@0.5.0",
+  ]);
+  assert.deepEqual(validatePlaywriterCommand(["bun", "x", "playwriter@0.5.0"]), [
+    "bun", "x", "playwriter@0.5.0",
+  ]);
+  assert.throws(
+    () => validatePlaywriterCommand(["npx", "playwriter@latest"]),
+    /reviewed Playwriter package shape/,
+  );
+  assert.throws(
+    () => validatePlaywriterCommand(["sh", "-c", "playwriter@0.5.0"]),
+    /reviewed Playwriter package shape/,
+  );
+});
+
+test("proves both relay version and token enforcement", async (t) => {
+  const token = "a".repeat(32);
+  const server = createServer((request, response) => {
+    if (request.url === "/version") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end('{"version":"0.5.0"}');
+      return;
+    }
+    const url = new URL(request.url, "http://127.0.0.1");
+    response.writeHead(url.searchParams.get("token") === token ? 404 : 401);
+    response.end();
+  });
+  await new Promise((resolvePromise) => server.listen(0, "127.0.0.1", resolvePromise));
+  t.after(() => server.close());
+  const address = server.address();
+
+  assert.deepEqual(
+    await probeAuthenticatedRelay({ token, port: address.port }),
+    { reachable: true, ready: true },
+  );
+  assert.deepEqual(
+    await probeAuthenticatedRelay({ token: "b".repeat(32), port: address.port }),
+    { reachable: true, ready: false },
+  );
+});
+
+test("removes only runtime directories with matching ownership evidence", (t) => {
+  const tempRoot = mkdtempSync(join(tmpdir(), "aidevops-playwriter-relay-"));
+  const runtime = createPrivateRuntime(tempRoot, "owned-token");
+  t.after(() => {
+    try { cleanupPrivateRuntime(runtime); } catch {}
+  });
+  assert.equal(readFileSync(runtime.markerPath, "utf8"), "owned-token");
+  writeFileSync(runtime.markerPath, "foreign-token");
+  assert.throws(() => cleanupPrivateRuntime(runtime), /matching ownership evidence/);
+  writeFileSync(runtime.markerPath, "owned-token");
+  cleanupPrivateRuntime(runtime);
+});

--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -91,16 +91,19 @@ mcp:
 
 Use `@playwriter` for browser tasks. The agent connects Playwriter before its first operation, receives `playwriter_*` tools on the next step, and disconnects after the requested browser work. The activation tool accepts only MCP names declared by the plugin registry.
 
-### Authenticated Tab Preflight
+### Authenticated Relay and Tab Preflight
 
 Before requesting authentication, credentials, or any authenticated action:
 
-Pinning to `0.5.0` does not complete the secure authenticated-tab lifecycle.
-Until upstream issue `remorses/playwriter#119` is released in this reviewed pin,
-hardened authenticated-tab use requires a separately tokenized, explicit
-`playwriter serve` relay and a client launched through
-`aidevops secret PLAYWRITER_TOKEN -- ...`. Do not place token values in MCP
-configuration, commands, logs, or prompts.
+OpenCode can opt into the framework-owned authenticated localhost relay by
+starting the app with `AIDEVOPS_PLAYWRITER_AUTHENTICATED_RELAY=1` and injecting
+`PLAYWRITER_TOKEN` through `aidevops secret PLAYWRITER_TOKEN -- opencode`. Store
+the value first with `aidevops secret set PLAYWRITER_TOKEN`; never place it in
+MCP configuration, commands, logs, or prompts. The launcher accepts only the
+reviewed `playwriter@0.5.0` command, requires a 32-character token, verifies the
+relay version and token challenge, records private ownership state, and stops
+only a relay process it started. A conflicting or unverifiable relay fails
+closed without `--replace` or port-owner termination.
 
 1. Connect Playwriter and enumerate the accessible pages with `context.pages()`.
 2. Match only the intended target by its expected URL and title. Confirm that the

--- a/TODO.md
+++ b/TODO.md
@@ -1313,6 +1313,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18310 Pin reviewed Playwriter MCP package policy #bug ref:GH#30867
 
+- [ ] t18311 Add an authenticated Playwriter relay lifecycle #bug ref:GH#30868
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Add an opt-in authenticated relay with exact package validation, private runtime ownership, token challenge, port ownership, bounded shutdown, and owned-only cleanup. Resolves #30851.

## Files Changed

.agents/plugins/opencode-aidevops/mcp-registry.mjs, .agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs, .agents/scripts/playwriter-authenticated-relay.mjs, .agents/scripts/tests/test-playwriter-authenticated-relay.mjs, .agents/tools/browser/playwriter.md, TODO.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — After rebasing onto merged phase 1: relay tests passed 3/3, MCP activation tests passed 24/24, Playwriter pin regression passed, and git diff whitespace checks passed. Earlier live launcher testing completed an owned lifecycle and released port 19988 without exposing credentials.

Resolves #30868


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.293 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-sol spent 14h 40m and 1,832,950 tokens on this with the user in an interactive session.