### PR TITLE
GH#30880: prevent queue shortfall autofile loop

### DIFF
--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -206,7 +206,7 @@ end) as $max_workers |
     if ($queue_scan_complete and $dispatch_alive and $effective_available_slots >= $threshold and $eligible_issues < $threshold) then
       finding(
         "pulse-eligible-queue-under-target";
-        "high";
+        "medium";
         "Dispatch-eligible queue depth is below the bounded capacity target";
         [
           ("available_slots=" + ($effective_available_slots | tostring)),
@@ -221,7 +221,7 @@ end) as $max_workers |
           ("missing_status=" + ($needs_status | tostring))
         ];
         "Run existing task generators and metadata normalisers for already-authorized work; if no eligible issues remain, request maintainer authorization decisions. Do not add auto-dispatch, clear needs-maintainer-review, or infer dispatch consent from status/origin labels.";
-        true
+        false
       )
     else empty end,
     if ($queue_scan_complete and $nmr_inactive > 0) then

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -479,6 +479,8 @@ SHORTFALL_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=shortfall" \
 	"PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-shortfall.sh" "$HELPER" json 2>&1)
 SHORTFALL_IDS=$(printf '%s' "$SHORTFALL_OUT" | jq -r '[.findings[].id] | sort | join(",")')
 assert_eq "active workers do not hide eligible queue shortfall" "auto-dispatch-missing-tier-labels,pulse-eligible-queue-under-target,pulse-inactive-nmr-holds" "$SHORTFALL_IDS"
+assert_eq "queue shortfall remains a maintainer advisory" "medium" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.findings[] | select(.id == "pulse-eligible-queue-under-target") | .severity')"
+assert_eq "queue shortfall does not auto-file a non-actionable issue" "false" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.findings[] | select(.id == "pulse-eligible-queue-under-target") | .autofile')"
 assert_eq "shortfall fixture has one eligible issue" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.eligible_available_unassigned')"
 assert_eq "shortfall fixture distinguishes assigned work" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.assigned_in_flight')"
 assert_eq "shortfall fixture distinguishes held work" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.blocked_explicit_hold')"


### PR DESCRIPTION
## Summary

Downgrade the queue-depth condition to a maintainer advisory and prevent it from filing a self-referential remediation issue.

## Files Changed

.agents/scripts/pulse-check-report.jq, .agents/scripts/tests/test-pulse-check-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-pulse-check-helper.sh; ShellCheck; jq filter compilation; live pulse-check JSON confirms medium non-autofiling advisory.

Resolves #30880


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.294 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra spent 7m and 145,227 tokens on this as a headless worker.