### PR TITLE
GH#30881: refactor: simplify deployment copy helper

### DIFF
--- a/.agents/scripts/deployment-copy-helper.py
+++ b/.agents/scripts/deployment-copy-helper.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-from typing import Any
+from typing import Any, NamedTuple
 
 
 SCHEMA = "aidevops.deployment-copy/v1"
@@ -38,6 +38,39 @@ class DeploymentError(RuntimeError):
     def __init__(self, message: str, operation_id_value: str | None = None) -> None:
         super().__init__(message)
         self.operation_id = operation_id_value
+
+
+class PreparedDeployment(NamedTuple):
+    """Validated inputs shared by deployment phases."""
+
+    state_root: Path
+    source_context: dict[str, Any]
+    destination: Path
+    source_tree: dict[str, Any]
+    destination_tree: dict[str, Any] | None
+
+
+class DeploymentOperation(NamedTuple):
+    """Mutable state for one deployment attempt."""
+
+    identifier: str
+    prepared: PreparedDeployment
+    rollback_path: Path
+    displaced_path: Path
+    receipt_path: Path
+    receipt: dict[str, Any]
+    progress: dict[str, Any]
+
+
+class RecoveryOperation(NamedTuple):
+    """Validated paths and receipt state shared by recovery phases."""
+
+    identifier: str
+    destination: Path
+    rollback_path: Path
+    stage_path: Path | None
+    receipt_path: Path
+    receipt: dict[str, Any]
 
 
 def utc_now() -> str:
@@ -67,6 +100,12 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def require(condition: bool, message: str) -> None:
+    """Raise a user-facing refusal when a required invariant is false."""
+    if not condition:
+        raise DeploymentError(message)
+
+
 def run_git(git_bin: str, cwd: Path, *args: str) -> str:
     result = subprocess.run(  # nosec B603 -- argv array; Git data is validated separately
         [git_bin, "-C", str(cwd), *args],
@@ -75,8 +114,7 @@ def run_git(git_bin: str, cwd: Path, *args: str) -> str:
         stderr=subprocess.PIPE,
         text=True,
     )
-    if result.returncode != 0:
-        raise DeploymentError("Git provenance could not be verified")
+    require(result.returncode == 0, "Git provenance could not be verified")
     return result.stdout.strip()
 
 
@@ -116,30 +154,27 @@ def assert_existing_components_not_symlinks(path: Path) -> None:
 
 def canonical_existing_directory(raw_path: str, purpose: str) -> Path:
     candidate = Path(raw_path)
-    if not candidate.is_absolute():
-        raise DeploymentError(f"{purpose} must be an absolute path")
+    require(candidate.is_absolute(), f"{purpose} must be an absolute path")
     assert_no_symlink_components(candidate)
-    if not candidate.is_dir():
-        raise DeploymentError(f"{purpose} must be an existing directory")
+    require(candidate.is_dir(), f"{purpose} must be an existing directory")
     resolved = candidate.resolve(strict=True)
-    if stat.S_ISLNK(os.lstat(candidate).st_mode):
-        raise DeploymentError("Symlinked paths are not accepted")
+    require(
+        not stat.S_ISLNK(os.lstat(candidate).st_mode),
+        "Symlinked paths are not accepted",
+    )
     return resolved
 
 
 def canonical_destination(raw_path: str) -> Path:
     candidate = Path(raw_path)
-    if not candidate.is_absolute():
-        raise DeploymentError("Destination must be an absolute path")
+    require(candidate.is_absolute(), "Destination must be an absolute path")
     normalized = Path(os.path.normpath(str(candidate)))
     parent = normalized.parent
     assert_no_symlink_components(parent)
-    if not parent.is_dir():
-        raise DeploymentError("Destination parent must be an existing directory")
+    require(parent.is_dir(), "Destination parent must be an existing directory")
     if os.path.lexists(normalized):
         assert_no_symlink_components(normalized)
-        if not normalized.is_dir():
-            raise DeploymentError("Destination must be a directory or absent")
+        require(normalized.is_dir(), "Destination must be a directory or absent")
         return normalized.resolve(strict=True)
     assert_no_symlink_components(normalized, require_leaf=False)
     return parent.resolve(strict=True) / normalized.name
@@ -151,8 +186,7 @@ def secure_state_root() -> Path:
         str(Path.home() / ".aidevops" / ".agent-workspace" / "deployment-copy"),
     )
     root = Path(configured)
-    if not root.is_absolute():
-        raise DeploymentError("Deployment-copy state root must be absolute")
+    require(root.is_absolute(), "Deployment-copy state root must be absolute")
     normalized = Path(os.path.normpath(str(root)))
     if normalized == Path(normalized.anchor) or normalized == Path.home().resolve(strict=True):
         raise DeploymentError("Root and home directories cannot store deployment-copy state")
@@ -162,8 +196,10 @@ def secure_state_root() -> Path:
     assert_no_symlink_components(root)
     resolved = root.resolve(strict=True)
     current = resolved.stat()
-    if current.st_uid != os.getuid():
-        raise DeploymentError("Deployment-copy state root has an unsafe owner")
+    require(
+        current.st_uid == os.getuid(),
+        "Deployment-copy state root has an unsafe owner",
+    )
     if root_existed and stat.S_IMODE(current.st_mode) & 0o077:
         raise DeploymentError("Deployment-copy state root permissions are unsafe")
     if not root_existed:
@@ -172,8 +208,10 @@ def secure_state_root() -> Path:
         child_path = resolved / child
         child_existed = os.path.lexists(child_path)
         child_path.mkdir(mode=0o700, exist_ok=True)
-        if child_path.is_symlink() or child_path.stat().st_uid != os.getuid():
-            raise DeploymentError("Deployment-copy state storage is unsafe")
+        require(
+            not child_path.is_symlink() and child_path.stat().st_uid == os.getuid(),
+            "Deployment-copy state storage is unsafe",
+        )
         if child_existed and stat.S_IMODE(child_path.stat().st_mode) & 0o077:
             raise DeploymentError("Deployment-copy state storage permissions are unsafe")
         if not child_existed:
@@ -182,11 +220,15 @@ def secure_state_root() -> Path:
 
 
 def validate_source(raw_source: str, expected_sha: str, git_bin: str) -> dict[str, Any]:
-    if not SHA_RE.fullmatch(expected_sha):
-        raise DeploymentError("Expected source SHA must be a full commit identifier")
+    require(
+        bool(SHA_RE.fullmatch(expected_sha)),
+        "Expected source SHA must be a full commit identifier",
+    )
     source = canonical_existing_directory(raw_source, "Source")
-    if any(part.lower() == ".git" for part in source.parts):
-        raise DeploymentError("Git metadata cannot be deployed")
+    require(
+        not any(part.lower() == ".git" for part in source.parts),
+        "Git metadata cannot be deployed",
+    )
     repo_root = Path(run_git(git_bin, source, "rev-parse", "--show-toplevel")).resolve()
     git_dir = Path(
         run_git(git_bin, source, "rev-parse", "--path-format=absolute", "--git-dir")
@@ -196,21 +238,23 @@ def validate_source(raw_source: str, expected_sha: str, git_bin: str) -> dict[st
             git_bin, source, "rev-parse", "--path-format=absolute", "--git-common-dir"
         )
     ).resolve()
-    if git_dir == common_dir:
-        raise DeploymentError("Source must be inside a registered linked worktree")
-    if not path_is_within(source, repo_root):
-        raise DeploymentError("Source escapes its linked worktree")
+    require(git_dir != common_dir, "Source must be inside a registered linked worktree")
+    require(path_is_within(source, repo_root), "Source escapes its linked worktree")
     registered_worktrees = {
         Path(line.removeprefix("worktree ")).resolve()
         for line in run_git(git_bin, repo_root, "worktree", "list", "--porcelain").splitlines()
         if line.startswith("worktree ")
     }
-    if repo_root not in registered_worktrees:
-        raise DeploymentError("Source worktree is not registered in its Git repository")
+    require(
+        repo_root in registered_worktrees,
+        "Source worktree is not registered in its Git repository",
+    )
     resolved_sha = run_git(git_bin, repo_root, "rev-parse", "--verify", f"{expected_sha}^{{commit}}")
     head_sha = run_git(git_bin, repo_root, "rev-parse", "HEAD")
-    if resolved_sha != expected_sha or head_sha != expected_sha:
-        raise DeploymentError("Source worktree does not match the expected commit")
+    require(
+        resolved_sha == expected_sha and head_sha == expected_sha,
+        "Source worktree does not match the expected commit",
+    )
     source_relative = os.path.relpath(source, repo_root)
     return {
         "source": source,
@@ -223,53 +267,68 @@ def validate_source(raw_source: str, expected_sha: str, git_bin: str) -> dict[st
     }
 
 
-def scan_tree(root: Path, require_files: bool = True) -> dict[str, Any]:
-    if not root.is_dir() or root.is_symlink():
-        raise DeploymentError("Tree root must be a non-symlink directory")
-    entries: list[dict[str, Any]] = []
-
-    def visit(directory: Path, relative: PurePosixPath) -> None:
-        directory_stat = os.lstat(directory)
-        if not stat.S_ISDIR(directory_stat.st_mode):
-            raise DeploymentError("Tree changed while it was being inspected")
-        if stat.S_IMODE(directory_stat.st_mode) & 0o7000:
-            raise DeploymentError("Tree entries must not use special permission bits")
+def visit_tree(
+    directory: Path, relative: PurePosixPath, entries: list[dict[str, Any]]
+) -> None:
+    directory_stat = os.lstat(directory)
+    require(
+        stat.S_ISDIR(directory_stat.st_mode),
+        "Tree changed while it was being inspected",
+    )
+    require(
+        not stat.S_IMODE(directory_stat.st_mode) & 0o7000,
+        "Tree entries must not use special permission bits",
+    )
+    entries.append(
+        {
+            "mode": f"{stat.S_IMODE(directory_stat.st_mode):04o}",
+            "path": str(relative),
+            "type": "directory",
+        }
+    )
+    for item in sorted(os.scandir(directory), key=lambda value: value.name):
+        require(item.name.lower() != ".git", "Git metadata cannot be deployed")
+        item_path = Path(item.path)
+        item_relative = relative / item.name if str(relative) != "." else PurePosixPath(item.name)
+        item_stat = item.stat(follow_symlinks=False)
+        require(
+            not stat.S_ISLNK(item_stat.st_mode),
+            "Source and destination trees must not contain symlinks",
+        )
+        if stat.S_ISDIR(item_stat.st_mode):
+            visit_tree(item_path, item_relative, entries)
+            continue
+        require(
+            stat.S_ISREG(item_stat.st_mode),
+            "Source and destination trees must contain only regular files",
+        )
+        require(
+            not stat.S_IMODE(item_stat.st_mode) & 0o7000,
+            "Tree entries must not use special permission bits",
+        )
         entries.append(
             {
-                "mode": f"{stat.S_IMODE(directory_stat.st_mode):04o}",
-                "path": str(relative),
-                "type": "directory",
+                "mode": f"{stat.S_IMODE(item_stat.st_mode):04o}",
+                "path": str(item_relative),
+                "sha256": sha256_file(item_path),
+                "size": item_stat.st_size,
+                "type": "file",
             }
         )
-        for item in sorted(os.scandir(directory), key=lambda value: value.name):
-            if item.name.lower() == ".git":
-                raise DeploymentError("Git metadata cannot be deployed")
-            item_path = Path(item.path)
-            item_relative = relative / item.name if str(relative) != "." else PurePosixPath(item.name)
-            item_stat = item.stat(follow_symlinks=False)
-            if stat.S_ISLNK(item_stat.st_mode):
-                raise DeploymentError("Source and destination trees must not contain symlinks")
-            if stat.S_ISDIR(item_stat.st_mode):
-                visit(item_path, item_relative)
-                continue
-            if not stat.S_ISREG(item_stat.st_mode):
-                raise DeploymentError("Source and destination trees must contain only regular files")
-            if stat.S_IMODE(item_stat.st_mode) & 0o7000:
-                raise DeploymentError("Tree entries must not use special permission bits")
-            entries.append(
-                {
-                    "mode": f"{stat.S_IMODE(item_stat.st_mode):04o}",
-                    "path": str(item_relative),
-                    "sha256": sha256_file(item_path),
-                    "size": item_stat.st_size,
-                    "type": "file",
-                }
-            )
 
-    visit(root, PurePosixPath("."))
+
+def scan_tree(root: Path, require_files: bool = True) -> dict[str, Any]:
+    require(
+        root.is_dir() and not root.is_symlink(),
+        "Tree root must be a non-symlink directory",
+    )
+    entries: list[dict[str, Any]] = []
+    visit_tree(root, PurePosixPath("."), entries)
     file_count = sum(1 for entry in entries if entry["type"] == "file")
-    if require_files and file_count == 0:
-        raise DeploymentError("Source tree must contain at least one regular file")
+    require(
+        not require_files or file_count > 0,
+        "Source tree must contain at least one regular file",
+    )
     exact_digest = sha256_bytes(canonical_json(entries))
     normalized_entries = []
     for entry in entries:
@@ -294,18 +353,24 @@ def safe_extract_git_archive(archive_path: Path, destination: Path) -> None:
     with tarfile.open(archive_path, "r") as archive:
         for member in archive.getmembers():
             relative = PurePosixPath(member.name)
-            if relative.is_absolute() or ".." in relative.parts:
-                raise DeploymentError("Git archive contains an unsafe path")
+            require(
+                not relative.is_absolute() and ".." not in relative.parts,
+                "Git archive contains an unsafe path",
+            )
             target = destination.joinpath(*relative.parts)
             if member.isdir():
                 target.mkdir(mode=member.mode & 0o777, parents=True, exist_ok=True)
                 continue
-            if not member.isfile():
-                raise DeploymentError("Committed source contains an unsupported file type")
+            require(
+                member.isfile(),
+                "Committed source contains an unsupported file type",
+            )
             target.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
             source_handle = archive.extractfile(member)
-            if source_handle is None:
-                raise DeploymentError("Committed source could not be materialized")
+            require(
+                source_handle is not None,
+                "Committed source could not be materialized",
+            )
             with source_handle, target.open("xb") as target_handle:
                 shutil.copyfileobj(source_handle, target_handle, 1024 * 1024)
             os.chmod(target, member.mode & 0o777)
@@ -331,56 +396,72 @@ def verify_committed_source(context: dict[str, Any], source_tree: dict[str, Any]
         result = subprocess.run(  # nosec B603 -- argv array built from validated Git provenance
             command, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-        if result.returncode != 0:
-            raise DeploymentError("Committed source subtree could not be materialized")
+        require(
+            result.returncode == 0,
+            "Committed source subtree could not be materialized",
+        )
         safe_extract_git_archive(archive_path, proof_root)
         committed_root = (
             proof_root
             if context["source_relative"] == "."
             else proof_root / context["source_relative"]
         )
-        if not committed_root.is_dir():
-            raise DeploymentError("Source subtree is not present in the expected commit")
+        require(
+            committed_root.is_dir(),
+            "Source subtree is not present in the expected commit",
+        )
         committed_tree = scan_tree(committed_root)
-        if committed_tree["normalized_digest"] != source_tree["normalized_digest"]:
-            raise DeploymentError(
-                "Source differs from the expected committed subtree; provide a reviewed tree digest for generated artifacts"
-            )
+        require(
+            committed_tree["normalized_digest"] == source_tree["normalized_digest"],
+            "Source differs from the expected committed subtree; provide a reviewed tree digest for generated artifacts",
+        )
 
 
 def validate_tree_proof(
     context: dict[str, Any], source_tree: dict[str, Any], reviewed_digest: str | None, state_root: Path
 ) -> None:
     if reviewed_digest:
-        if not TREE_SHA_RE.fullmatch(reviewed_digest):
-            raise DeploymentError("Reviewed tree digest must be a SHA-256 value")
-        if source_tree["exact_digest"] != reviewed_digest:
-            raise DeploymentError("Source does not match the reviewed tree digest")
+        require(
+            bool(TREE_SHA_RE.fullmatch(reviewed_digest)),
+            "Reviewed tree digest must be a SHA-256 value",
+        )
+        require(
+            source_tree["exact_digest"] == reviewed_digest,
+            "Source does not match the reviewed tree digest",
+        )
         return
     verify_committed_source(context, source_tree, state_root)
 
 
 def validate_allow_file(allow_file_raw: str, destination: Path, context: dict[str, Any]) -> Path:
     allow_file = Path(allow_file_raw)
-    if not allow_file.is_absolute():
-        raise DeploymentError("Destination allow file must be absolute")
+    require(allow_file.is_absolute(), "Destination allow file must be absolute")
     assert_no_symlink_components(allow_file)
-    if not allow_file.is_file() or allow_file.is_symlink():
-        raise DeploymentError("Destination allow file must be a regular non-symlink file")
+    require(
+        allow_file.is_file() and not allow_file.is_symlink(),
+        "Destination allow file must be a regular non-symlink file",
+    )
     allow_file = allow_file.resolve(strict=True)
     file_stat = allow_file.stat()
-    if file_stat.st_uid != os.getuid() or stat.S_IMODE(file_stat.st_mode) & 0o077:
-        raise DeploymentError("Destination allow file must be owner-controlled with mode 0600 or stricter")
-    if path_is_within(allow_file, context["repo_root"]) or path_is_within(allow_file, destination):
-        raise DeploymentError("Destination authority must be stored outside source and destination trees")
+    require(
+        file_stat.st_uid == os.getuid() and not stat.S_IMODE(file_stat.st_mode) & 0o077,
+        "Destination allow file must be owner-controlled with mode 0600 or stricter",
+    )
+    require(
+        not path_is_within(allow_file, context["repo_root"])
+        and not path_is_within(allow_file, destination),
+        "Destination authority must be stored outside source and destination trees",
+    )
     allowed: set[Path] = set()
     for raw_line in allow_file.read_text(encoding="utf-8").splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
         allowed.add(canonical_destination(line))
-    if destination not in allowed:
-        raise DeploymentError("Destination is not present in the owner-controlled allow file")
+    require(
+        destination in allowed,
+        "Destination is not present in the owner-controlled allow file",
+    )
     return allow_file
 
 
@@ -400,17 +481,29 @@ def validate_destination_safety(
     destination: Path, context: dict[str, Any], state_root: Path, allow_file_raw: str
 ) -> Path:
     home = Path.home().resolve(strict=True)
-    if destination == Path(destination.anchor) or destination == home:
-        raise DeploymentError("Root and home directories cannot be deployment targets")
-    if any(part.lower() == ".git" for part in destination.parts):
-        raise DeploymentError("Git metadata cannot be a deployment target")
+    require(
+        destination != Path(destination.anchor) and destination != home,
+        "Root and home directories cannot be deployment targets",
+    )
+    require(
+        not any(part.lower() == ".git" for part in destination.parts),
+        "Git metadata cannot be a deployment target",
+    )
     repo_root = context["repo_root"]
-    if path_is_within(destination, repo_root) or path_is_within(repo_root, destination):
-        raise DeploymentError("Destination must not overlap the source Git worktree")
-    if path_is_within(destination, state_root) or path_is_within(state_root, destination):
-        raise DeploymentError("Destination must not overlap deployment-copy state storage")
-    if destination_is_in_git(context["git_bin"], destination):
-        raise DeploymentError("Destination must be outside every Git worktree")
+    require(
+        not path_is_within(destination, repo_root)
+        and not path_is_within(repo_root, destination),
+        "Destination must not overlap the source Git worktree",
+    )
+    require(
+        not path_is_within(destination, state_root)
+        and not path_is_within(state_root, destination),
+        "Destination must not overlap deployment-copy state storage",
+    )
+    require(
+        not destination_is_in_git(context["git_bin"], destination),
+        "Destination must be outside every Git worktree",
+    )
     validate_allow_file(allow_file_raw, destination, context)
     return destination
 
@@ -429,8 +522,10 @@ def copy_tree(source: Path, stage: Path, source_tree: dict[str, Any]) -> None:
         source_path = source.joinpath(*relative.parts)
         target_path = stage.joinpath(*relative.parts)
         source_stat = os.lstat(source_path)
-        if not stat.S_ISREG(source_stat.st_mode):
-            raise DeploymentError("Source changed while it was being staged")
+        require(
+            stat.S_ISREG(source_stat.st_mode),
+            "Source changed while it was being staged",
+        )
         descriptor = os.open(source_path, os.O_RDONLY | no_follow)
         try:
             with os.fdopen(descriptor, "rb", closefd=False) as source_handle, target_path.open(
@@ -503,46 +598,63 @@ def update_receipt(receipt_path: Path, receipt: dict[str, Any], status_value: st
 def validate_receipt_identity(receipt: Any, identifier: str) -> dict[str, Any]:
     if not isinstance(receipt, dict):
         raise DeploymentError("Operation receipt is invalid")
-    if receipt.get("schema") != SCHEMA or receipt.get("operation_id") != identifier:
-        raise DeploymentError("Operation receipt is invalid")
+    require(
+        receipt.get("schema") == SCHEMA and receipt.get("operation_id") == identifier,
+        "Operation receipt is invalid",
+    )
     return receipt
 
 
 def validate_receipt_paths_and_flags(receipt: dict[str, Any]) -> None:
     required_strings = ("destination", "displaced_path", "rollback_path", "source_repo")
-    if any(not isinstance(receipt.get(key), str) or not receipt[key] for key in required_strings):
-        raise DeploymentError("Operation receipt is invalid")
-    if receipt.get("stage_path") is not None and not isinstance(receipt["stage_path"], str):
-        raise DeploymentError("Operation receipt is invalid")
-    if not isinstance(receipt.get("previous_present"), bool):
-        raise DeploymentError("Operation receipt is invalid")
-    if not isinstance(receipt.get("status"), str):
-        raise DeploymentError("Operation receipt is invalid")
+    require(
+        all(isinstance(receipt.get(key), str) and bool(receipt[key]) for key in required_strings),
+        "Operation receipt is invalid",
+    )
+    require(
+        receipt.get("stage_path") is None or isinstance(receipt["stage_path"], str),
+        "Operation receipt is invalid",
+    )
+    require(
+        isinstance(receipt.get("previous_present"), bool),
+        "Operation receipt is invalid",
+    )
+    require(isinstance(receipt.get("status"), str), "Operation receipt is invalid")
 
 
 def validate_receipt_digests(receipt: dict[str, Any]) -> None:
-    if not isinstance(receipt.get("tree_sha256"), str) or not TREE_SHA_RE.fullmatch(
-        receipt["tree_sha256"]
-    ):
-        raise DeploymentError("Operation receipt is invalid")
+    require(
+        isinstance(receipt.get("tree_sha256"), str)
+        and bool(TREE_SHA_RE.fullmatch(receipt["tree_sha256"])),
+        "Operation receipt is invalid",
+    )
     previous_digest = receipt.get("previous_tree_sha256")
     if receipt["previous_present"]:
-        if not isinstance(previous_digest, str) or not TREE_SHA_RE.fullmatch(previous_digest):
-            raise DeploymentError("Operation receipt is invalid")
-    elif previous_digest is not None:
-        raise DeploymentError("Operation receipt is invalid")
+        require(
+            isinstance(previous_digest, str)
+            and bool(TREE_SHA_RE.fullmatch(previous_digest)),
+            "Operation receipt is invalid",
+        )
+    else:
+        require(previous_digest is None, "Operation receipt is invalid")
 
 
 def load_receipt(state_root: Path, identifier: str) -> tuple[Path, dict[str, Any]]:
-    if not OPERATION_RE.fullmatch(identifier):
-        raise DeploymentError("Operation identifier is malformed")
+    require(
+        bool(OPERATION_RE.fullmatch(identifier)),
+        "Operation identifier is malformed",
+    )
     receipt_path = state_root / "operations" / f"{identifier}.json"
     assert_no_symlink_components(receipt_path)
     receipt_stat = receipt_path.stat()
-    if not stat.S_ISREG(receipt_stat.st_mode) or receipt_stat.st_uid != os.getuid():
-        raise DeploymentError("Operation receipt is unsafe")
-    if stat.S_IMODE(receipt_stat.st_mode) & 0o077:
-        raise DeploymentError("Operation receipt permissions are unsafe")
+    require(
+        stat.S_ISREG(receipt_stat.st_mode) and receipt_stat.st_uid == os.getuid(),
+        "Operation receipt is unsafe",
+    )
+    require(
+        not stat.S_IMODE(receipt_stat.st_mode) & 0o077,
+        "Operation receipt permissions are unsafe",
+    )
     receipt = validate_receipt_identity(
         json.loads(receipt_path.read_text(encoding="utf-8")), identifier
     )
@@ -559,18 +671,23 @@ def receipt_paths(receipt: dict[str, Any], destination: Path) -> tuple[Path, Pat
     displaced_path = destination.with_name(
         f".{destination.name}.aidevops-displaced-{identifier}"
     )
-    if receipt.get("rollback_path") != str(rollback_path):
-        raise DeploymentError("Operation receipt rollback path is invalid")
-    if receipt.get("displaced_path") != str(displaced_path):
-        raise DeploymentError("Operation receipt displaced path is invalid")
+    require(
+        receipt.get("rollback_path") == str(rollback_path),
+        "Operation receipt rollback path is invalid",
+    )
+    require(
+        receipt.get("displaced_path") == str(displaced_path),
+        "Operation receipt displaced path is invalid",
+    )
     stage_path = None
     if receipt.get("stage_path") is not None:
         stage_path = Path(receipt["stage_path"])
         expected_prefix = f".{destination.name}.aidevops-stage-{identifier}-"
-        if stage_path.parent != destination.parent or not stage_path.name.startswith(
-            expected_prefix
-        ):
-            raise DeploymentError("Operation receipt stage path is invalid")
+        require(
+            stage_path.parent == destination.parent
+            and stage_path.name.startswith(expected_prefix),
+            "Operation receipt stage path is invalid",
+        )
     return rollback_path, displaced_path, stage_path
 
 
@@ -578,17 +695,17 @@ def validate_existing_operation_tree(path: Path, purpose: str) -> None:
     if not os.path.lexists(path):
         return
     assert_no_symlink_components(path)
-    if not path.is_dir():
-        raise DeploymentError(f"{purpose} must be a non-symlink directory")
+    require(path.is_dir(), f"{purpose} must be a non-symlink directory")
 
 
 def verify_operation_tree(path: Path, expected_digest: str, purpose: str) -> None:
     validate_existing_operation_tree(path, purpose)
-    if not path.exists():
-        raise DeploymentError(f"{purpose} is unavailable")
+    require(path.exists(), f"{purpose} is unavailable")
     measured = scan_tree(path, require_files=False)
-    if measured["exact_digest"] != expected_digest:
-        raise DeploymentError(f"{purpose} failed exact verification")
+    require(
+        measured["exact_digest"] == expected_digest,
+        f"{purpose} failed exact verification",
+    )
 
 
 def pid_is_alive(pid: int) -> bool:
@@ -697,7 +814,7 @@ def receipt_context(receipt: dict[str, Any], git_bin: str) -> dict[str, Any]:
     return {"git_bin": git_bin, "repo_root": repo_root}
 
 
-def prepare_deploy(args: argparse.Namespace) -> tuple[Path, dict[str, Any], Path, dict[str, Any], dict[str, Any] | None]:
+def prepare_deploy(args: argparse.Namespace) -> PreparedDeployment:
     state_root = secure_state_root()
     git_bin = os.environ.get("AIDEVOPS_REAL_GIT_BIN", "git")
     context = validate_source(args.source, args.expected_sha, git_bin)
@@ -706,254 +823,220 @@ def prepare_deploy(args: argparse.Namespace) -> tuple[Path, dict[str, Any], Path
     destination = canonical_destination(args.destination)
     validate_destination_safety(destination, context, state_root, args.allow_file)
     destination_tree = scan_tree(destination, require_files=False) if destination.exists() else None
-    return state_root, context, destination, source_tree, destination_tree
+    return PreparedDeployment(state_root, context, destination, source_tree, destination_tree)
 
 
 def build_deploy_receipt(
     identifier: str,
-    context: dict[str, Any],
-    destination: Path,
-    source_tree: dict[str, Any],
-    destination_tree: dict[str, Any] | None,
+    prepared: PreparedDeployment,
     rollback_path: Path,
     displaced_path: Path,
 ) -> dict[str, Any]:
     return {
         "created_at": utc_now(),
-        "destination": str(destination),
+        "destination": str(prepared.destination),
         "displaced_path": str(displaced_path),
-        "expected_sha": context["expected_sha"],
+        "expected_sha": prepared.source_context["expected_sha"],
         "operation_id": identifier,
-        "previous_present": destination_tree is not None,
-        "previous_tree_sha256": destination_tree["exact_digest"] if destination_tree else None,
+        "previous_present": prepared.destination_tree is not None,
+        "previous_tree_sha256": (
+            prepared.destination_tree["exact_digest"] if prepared.destination_tree else None
+        ),
         "rollback_path": str(rollback_path),
         "schema": SCHEMA,
-        "source": str(context["source"]),
-        "source_repo": str(context["repo_root"]),
+        "source": str(prepared.source_context["source"]),
+        "source_repo": str(prepared.source_context["repo_root"]),
         "stage_path": None,
         "status": "preparing",
-        "tree_sha256": source_tree["exact_digest"],
+        "tree_sha256": prepared.source_tree["exact_digest"],
         "updated_at": utc_now(),
     }
 
 
 def validate_locked_deploy(
     args: argparse.Namespace,
-    state_root: Path,
-    context: dict[str, Any],
-    destination: Path,
-    source_tree: dict[str, Any],
+    prepared: PreparedDeployment,
     rollback_path: Path,
     displaced_path: Path,
 ) -> None:
-    current_context = validate_source(args.source, args.expected_sha, context["git_bin"])
+    current_context = validate_source(
+        args.source, args.expected_sha, prepared.source_context["git_bin"]
+    )
     current_source_tree = scan_tree(current_context["source"])
-    if current_source_tree["exact_digest"] != source_tree["exact_digest"]:
+    if current_source_tree["exact_digest"] != prepared.source_tree["exact_digest"]:
         raise DeploymentError("Source changed before staging began")
     validate_tree_proof(
-        current_context, current_source_tree, args.reviewed_tree_sha256, state_root
+        current_context, current_source_tree, args.reviewed_tree_sha256, prepared.state_root
     )
     current_destination = canonical_destination(args.destination)
-    validate_destination_safety(current_destination, context, state_root, args.allow_file)
-    if current_destination != destination:
+    validate_destination_safety(
+        current_destination, prepared.source_context, prepared.state_root, args.allow_file
+    )
+    if current_destination != prepared.destination:
         raise DeploymentError("Destination identity changed before staging")
     if os.path.lexists(rollback_path) or os.path.lexists(displaced_path):
         raise DeploymentError("Operation path collision blocked deployment")
 
 
-def perform_deployment(
-    identifier: str,
-    context: dict[str, Any],
-    destination: Path,
-    source_tree: dict[str, Any],
-    destination_tree: dict[str, Any] | None,
-    rollback_path: Path,
-    receipt_path: Path,
-    receipt: dict[str, Any],
-    progress: dict[str, Any],
-) -> None:
-    prefix = f".{destination.name}.aidevops-stage-{identifier}-"
-    stage = Path(tempfile.mkdtemp(prefix=prefix, dir=destination.parent))
-    progress["stage"] = stage
-    receipt["stage_path"] = str(stage)
-    update_receipt(receipt_path, receipt, "staging")
-    copy_tree(context["source"], stage, source_tree)
-    if scan_tree(stage)["exact_digest"] != source_tree["exact_digest"]:
+def perform_deployment(operation: DeploymentOperation) -> None:
+    prepared = operation.prepared
+    prefix = f".{prepared.destination.name}.aidevops-stage-{operation.identifier}-"
+    stage = Path(tempfile.mkdtemp(prefix=prefix, dir=prepared.destination.parent))
+    operation.progress["stage"] = stage
+    operation.receipt["stage_path"] = str(stage)
+    update_receipt(operation.receipt_path, operation.receipt, "staging")
+    copy_tree(prepared.source_context["source"], stage, prepared.source_tree)
+    if scan_tree(stage)["exact_digest"] != prepared.source_tree["exact_digest"]:
         raise DeploymentError("Staged tree does not match the approved source")
-    if scan_tree(context["source"])["exact_digest"] != source_tree["exact_digest"]:
+    if (
+        scan_tree(prepared.source_context["source"])["exact_digest"]
+        != prepared.source_tree["exact_digest"]
+    ):
         raise DeploymentError("Source changed while staging was in progress")
-    current_tree = scan_tree(destination, require_files=False) if destination.exists() else None
+    current_tree = (
+        scan_tree(prepared.destination, require_files=False)
+        if prepared.destination.exists()
+        else None
+    )
     current_digest = current_tree["exact_digest"] if current_tree else None
-    previous_digest = destination_tree["exact_digest"] if destination_tree else None
+    previous_digest = (
+        prepared.destination_tree["exact_digest"] if prepared.destination_tree else None
+    )
     if current_digest != previous_digest:
         raise DeploymentError("Destination changed while staging was in progress")
-    update_receipt(receipt_path, receipt, "staged")
-    if destination.exists():
-        os.replace(destination, rollback_path)
-        update_receipt(receipt_path, receipt, "previous_moved")
+    update_receipt(operation.receipt_path, operation.receipt, "staged")
+    if prepared.destination.exists():
+        os.replace(prepared.destination, operation.rollback_path)
+        update_receipt(operation.receipt_path, operation.receipt, "previous_moved")
     else:
-        update_receipt(receipt_path, receipt, "activating")
-    os.replace(stage, destination)
-    progress["activated"] = True
-    progress["stage"] = None
-    receipt["stage_path"] = None
-    update_receipt(receipt_path, receipt, "active")
-    if scan_tree(destination)["exact_digest"] != source_tree["exact_digest"]:
+        update_receipt(operation.receipt_path, operation.receipt, "activating")
+    os.replace(stage, prepared.destination)
+    operation.progress["activated"] = True
+    operation.progress["stage"] = None
+    operation.receipt["stage_path"] = None
+    update_receipt(operation.receipt_path, operation.receipt, "active")
+    if scan_tree(prepared.destination)["exact_digest"] != prepared.source_tree["exact_digest"]:
         raise DeploymentError("Activated destination failed exact verification")
-    update_receipt(receipt_path, receipt, "success")
+    update_receipt(operation.receipt_path, operation.receipt, "success")
 
 
 def first_deployment_activation_detected(
     destination: Path, receipt: dict[str, Any], progress: dict[str, Any]
 ) -> bool:
+    if receipt["previous_present"]:
+        return False
+    if progress["activated"]:
+        return True
     stage = progress["stage"]
-    return not receipt["previous_present"] and (
-        progress["activated"]
-        or (
-            receipt["status"] == "activating"
-            and stage is not None
-            and not stage.exists()
-            and destination.exists()
-        )
-    )
+    if receipt["status"] != "activating" or stage is None:
+        return False
+    return not stage.exists() and destination.exists()
 
 
-def rollback_failed_deployment(
-    destination: Path,
-    rollback_path: Path,
-    displaced_path: Path,
-    receipt_path: Path,
-    receipt: dict[str, Any],
-    progress: dict[str, Any],
-) -> None:
-    stage = progress["stage"]
-    if destination.exists() and rollback_path.exists():
-        if displaced_path.exists():
+def rollback_failed_deployment(operation: DeploymentOperation) -> None:
+    destination = operation.prepared.destination
+    stage = operation.progress["stage"]
+    if destination.exists() and operation.rollback_path.exists():
+        if operation.displaced_path.exists():
             raise DeploymentError("Automatic rollback path collision requires recovery")
         verify_operation_tree(
-            rollback_path, receipt["previous_tree_sha256"], "Recorded rollback tree"
+            operation.rollback_path,
+            operation.receipt["previous_tree_sha256"],
+            "Recorded rollback tree",
         )
-        os.replace(destination, displaced_path)
-        os.replace(rollback_path, destination)
+        os.replace(destination, operation.displaced_path)
+        os.replace(operation.rollback_path, destination)
         restored_tree = scan_tree(destination, require_files=False)
-        if restored_tree["exact_digest"] != receipt["previous_tree_sha256"]:
+        if restored_tree["exact_digest"] != operation.receipt["previous_tree_sha256"]:
             raise DeploymentError("Automatic rollback verification failed")
-        update_receipt(receipt_path, receipt, "rolled_back_after_failure")
-    elif not destination.exists() and rollback_path.exists():
+        update_receipt(operation.receipt_path, operation.receipt, "rolled_back_after_failure")
+    elif not destination.exists() and operation.rollback_path.exists():
         verify_operation_tree(
-            rollback_path, receipt["previous_tree_sha256"], "Recorded rollback tree"
+            operation.rollback_path,
+            operation.receipt["previous_tree_sha256"],
+            "Recorded rollback tree",
         )
-        os.replace(rollback_path, destination)
-        update_receipt(receipt_path, receipt, "rolled_back_after_failure")
-    elif first_deployment_activation_detected(destination, receipt, progress):
+        os.replace(operation.rollback_path, destination)
+        update_receipt(operation.receipt_path, operation.receipt, "rolled_back_after_failure")
+    elif first_deployment_activation_detected(destination, operation.receipt, operation.progress):
         if not destination.exists():
             raise DeploymentError("Activated destination disappeared during automatic rollback")
-        os.replace(destination, displaced_path)
-        update_receipt(receipt_path, receipt, "rolled_back_after_failure")
+        os.replace(destination, operation.displaced_path)
+        update_receipt(operation.receipt_path, operation.receipt, "rolled_back_after_failure")
     else:
-        update_receipt(receipt_path, receipt, "failed_before_activation")
+        update_receipt(operation.receipt_path, operation.receipt, "failed_before_activation")
     if stage and stage.exists():
         shutil.rmtree(stage)
 
 
 def raise_deployment_failure(
-    identifier: str,
+    operation: DeploymentOperation,
     error: BaseException,
-    destination: Path,
-    rollback_path: Path,
-    displaced_path: Path,
-    receipt_path: Path,
-    receipt: dict[str, Any],
-    progress: dict[str, Any],
 ) -> None:
     try:
-        rollback_failed_deployment(
-            destination, rollback_path, displaced_path, receipt_path, receipt, progress
-        )
+        rollback_failed_deployment(operation)
     except BaseException as recovery_error:
         try:
-            update_receipt(receipt_path, receipt, "recovery_required")
+            update_receipt(operation.receipt_path, operation.receipt, "recovery_required")
         except BaseException:
             pass
         raise DeploymentError(
             "Deployment failed and automatic recovery requires the recorded operation",
-            identifier,
+            operation.identifier,
         ) from recovery_error
     message = (
         str(error)
         if isinstance(error, DeploymentError)
         else "Deployment was interrupted and safe recovery was recorded"
     )
-    raise DeploymentError(message, identifier) from error
+    raise DeploymentError(message, operation.identifier) from error
 
 
 def deploy(args: argparse.Namespace) -> dict[str, Any]:
-    state_root, context, destination, source_tree, destination_tree = prepare_deploy(args)
-    plan = tree_plan(source_tree, destination_tree)
+    prepared = prepare_deploy(args)
+    plan = tree_plan(prepared.source_tree, prepared.destination_tree)
     if args.dry_run:
         return {
             "command": "deploy",
             "dry_run": True,
             "plan": plan,
             "status": "planned",
-            "tree_sha256": source_tree["exact_digest"],
+            "tree_sha256": prepared.source_tree["exact_digest"],
         }
     identifier = operation_id()
-    receipt_path = state_root / "operations" / f"{identifier}.json"
-    rollback_path = destination.with_name(f".{destination.name}.aidevops-rollback-{identifier}")
-    displaced_path = destination.with_name(f".{destination.name}.aidevops-displaced-{identifier}")
-    receipt = build_deploy_receipt(
+    receipt_path = prepared.state_root / "operations" / f"{identifier}.json"
+    rollback_path = prepared.destination.with_name(
+        f".{prepared.destination.name}.aidevops-rollback-{identifier}"
+    )
+    displaced_path = prepared.destination.with_name(
+        f".{prepared.destination.name}.aidevops-displaced-{identifier}"
+    )
+    receipt = build_deploy_receipt(identifier, prepared, rollback_path, displaced_path)
+    progress: dict[str, Any] = {"activated": False, "stage": None}
+    operation = DeploymentOperation(
         identifier,
-        context,
-        destination,
-        source_tree,
-        destination_tree,
+        prepared,
         rollback_path,
         displaced_path,
+        receipt_path,
+        receipt,
+        progress,
     )
-    progress: dict[str, Any] = {"activated": False, "stage": None}
-    with DestinationLock(destination):
-        validate_locked_deploy(
-            args,
-            state_root,
-            context,
-            destination,
-            source_tree,
-            rollback_path,
-            displaced_path,
-        )
-        atomic_write_json(receipt_path, receipt)
+    with DestinationLock(prepared.destination):
+        validate_locked_deploy(args, prepared, rollback_path, displaced_path)
+        atomic_write_json(operation.receipt_path, operation.receipt)
         try:
-            perform_deployment(
-                identifier,
-                context,
-                destination,
-                source_tree,
-                destination_tree,
-                rollback_path,
-                receipt_path,
-                receipt,
-                progress,
-            )
+            perform_deployment(operation)
         except BaseException as error:
-            raise_deployment_failure(
-                identifier,
-                error,
-                destination,
-                rollback_path,
-                displaced_path,
-                receipt_path,
-                receipt,
-                progress,
-            )
+            raise_deployment_failure(operation, error)
     return {
         "command": "deploy",
         "dry_run": False,
         "operation_id": identifier,
         "plan": plan,
-        "rollback_available": bool(destination_tree),
+        "rollback_available": bool(prepared.destination_tree),
         "status": "success",
-        "tree_sha256": source_tree["exact_digest"],
+        "tree_sha256": prepared.source_tree["exact_digest"],
     }
 
 
@@ -983,51 +1066,41 @@ def remove_recorded_stage(stage_path: Path | None, receipt: dict[str, Any]) -> N
         receipt["stage_path"] = None
 
 
-def recover_existing_destination(
-    identifier: str,
-    destination: Path,
-    rollback_path: Path,
-    stage_path: Path | None,
-    receipt_path: Path,
-    receipt: dict[str, Any],
-) -> dict[str, Any] | None:
-    if not destination.exists():
+def recover_existing_destination(operation: RecoveryOperation) -> dict[str, Any] | None:
+    if not operation.destination.exists():
         return None
-    destination_tree = scan_tree(destination, require_files=False)
-    if destination_tree["exact_digest"] == receipt["tree_sha256"]:
-        remove_recorded_stage(stage_path, receipt)
-        update_receipt(receipt_path, receipt, "success")
-        return recovery_result(identifier, "success", rollback_path.exists())
-    if receipt["previous_present"] and (
-        destination_tree["exact_digest"] == receipt["previous_tree_sha256"]
+    destination_tree = scan_tree(operation.destination, require_files=False)
+    if destination_tree["exact_digest"] == operation.receipt["tree_sha256"]:
+        remove_recorded_stage(operation.stage_path, operation.receipt)
+        update_receipt(operation.receipt_path, operation.receipt, "success")
+        return recovery_result(
+            operation.identifier, "success", operation.rollback_path.exists()
+        )
+    if operation.receipt["previous_present"] and (
+        destination_tree["exact_digest"] == operation.receipt["previous_tree_sha256"]
     ):
-        remove_recorded_stage(stage_path, receipt)
-        update_receipt(receipt_path, receipt, "recovered_previous")
-        return recovery_result(identifier, "recovered_previous")
+        remove_recorded_stage(operation.stage_path, operation.receipt)
+        update_receipt(operation.receipt_path, operation.receipt, "recovered_previous")
+        return recovery_result(operation.identifier, "recovered_previous")
     return None
 
 
-def restore_previous_for_recovery(
-    identifier: str,
-    destination: Path,
-    rollback_path: Path,
-    stage_path: Path | None,
-    receipt_path: Path,
-    receipt: dict[str, Any],
-) -> dict[str, Any] | None:
-    if destination.exists() or not rollback_path.exists():
+def restore_previous_for_recovery(operation: RecoveryOperation) -> dict[str, Any] | None:
+    if operation.destination.exists() or not operation.rollback_path.exists():
         return None
     verify_operation_tree(
-        rollback_path, receipt["previous_tree_sha256"], "Recorded rollback tree"
+        operation.rollback_path,
+        operation.receipt["previous_tree_sha256"],
+        "Recorded rollback tree",
     )
-    os.replace(rollback_path, destination)
-    restored = scan_tree(destination, require_files=False)
-    if restored["exact_digest"] != receipt["previous_tree_sha256"]:
-        update_receipt(receipt_path, receipt, "recovery_required")
+    os.replace(operation.rollback_path, operation.destination)
+    restored = scan_tree(operation.destination, require_files=False)
+    if restored["exact_digest"] != operation.receipt["previous_tree_sha256"]:
+        update_receipt(operation.receipt_path, operation.receipt, "recovery_required")
         raise DeploymentError("Recovered destination failed exact verification")
-    remove_recorded_stage(stage_path, receipt)
-    update_receipt(receipt_path, receipt, "recovered_previous")
-    return recovery_result(identifier, "recovered_previous")
+    remove_recorded_stage(operation.stage_path, operation.receipt)
+    update_receipt(operation.receipt_path, operation.receipt, "recovered_previous")
+    return recovery_result(operation.identifier, "recovered_previous")
 
 
 def recover(args: argparse.Namespace) -> dict[str, Any]:
@@ -1043,7 +1116,7 @@ def recover(args: argparse.Namespace) -> dict[str, Any]:
         validate_existing_operation_tree(displaced_path, "Recorded displaced tree")
         if stage_path is not None:
             validate_existing_operation_tree(stage_path, "Recorded stage tree")
-        existing_result = recover_existing_destination(
+        operation = RecoveryOperation(
             args.operation_id,
             destination,
             rollback_path,
@@ -1051,16 +1124,10 @@ def recover(args: argparse.Namespace) -> dict[str, Any]:
             receipt_path,
             receipt,
         )
+        existing_result = recover_existing_destination(operation)
         if existing_result:
             return existing_result
-        previous_result = restore_previous_for_recovery(
-            args.operation_id,
-            destination,
-            rollback_path,
-            stage_path,
-            receipt_path,
-            receipt,
-        )
+        previous_result = restore_previous_for_recovery(operation)
         if previous_result:
             return previous_result
         if stage_path and stage_path.exists():
@@ -1169,19 +1236,13 @@ def main() -> int:
     args = parser.parse_args()
     machine = bool(getattr(args, "machine", False))
     try:
-        if args.command == "manifest":
-            state_root = secure_state_root()
-            git_bin = os.environ.get("AIDEVOPS_REAL_GIT_BIN", "git")
-            context = validate_source(args.source, args.expected_sha, git_bin)
-            result = manifest_result(scan_tree(context["source"]))
-        elif args.command == "deploy":
-            result = deploy(args)
-        elif args.command == "recover":
-            result = recover(args)
-        elif args.command == "rollback":
-            result = rollback(args)
-        else:
-            raise DeploymentError("Unsupported deployment-copy command")
+        handlers = {
+            "manifest": manifest,
+            "deploy": deploy,
+            "recover": recover,
+            "rollback": rollback,
+        }
+        result = handlers[args.command](args)
         emit_result(result, machine)
         return 0
     except (
@@ -1214,6 +1275,13 @@ def main() -> int:
             if operation_id_value:
                 print(f"OPERATION_ID={operation_id_value}", file=sys.stderr)
         return 1
+
+
+def manifest(args: argparse.Namespace) -> dict[str, Any]:
+    state_root = secure_state_root()
+    git_bin = os.environ.get("AIDEVOPS_REAL_GIT_BIN", "git")
+    context = validate_source(args.source, args.expected_sha, git_bin)
+    return manifest_result(scan_tree(context["source"]))
 
 
 def _interrupt(_signal_number: int, _frame: Any) -> None:


### PR DESCRIPTION
## Summary

Reduced deployment-copy helper complexity by grouping deployment and recovery state, extracting tree traversal and manifest dispatch, and consolidating repeated invariant checks without changing the public CLI.

## Files Changed

.agents/scripts/deployment-copy-helper.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — python3 -m py_compile .agents/scripts/deployment-copy-helper.py; bash .agents/scripts/tests/test-deployment-copy-helper.sh; git diff --check origin/main...HEAD. Qlty CLI is unavailable locally, so the PR Qlty workflow validates smell removal.

Resolves #30881


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.294 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 2m and 74,312 tokens on this as a headless worker.