### PR TITLE
GH#30888: fix: keep inactive NMR holds report-only

### DIFF
--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -237,7 +237,7 @@ end) as $max_workers |
           "nmr_inactivity_basis=issue_updatedAt_not_label_application_time"
         ];
         "Request authority-aware maintainer review of inactive NMR holds without removing needs-maintainer-review, adding auto-dispatch, posting approval markers, or commenting on individual held issues.";
-        true
+        false
       )
     else empty end,
     if ($dispatch_alive and ($spawned - ([($recent_total), ($current_terminal_events)] | max) - $launch_validation_failed) >= 3 and $active_workers == 0) then

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -485,6 +485,9 @@ assert_eq "shortfall fixture has one eligible issue" "1" "$(printf '%s' "$SHORTF
 assert_eq "shortfall fixture distinguishes assigned work" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.assigned_in_flight')"
 assert_eq "shortfall fixture distinguishes held work" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.blocked_explicit_hold')"
 assert_contains "NMR advisory names updatedAt inactivity basis" "issue_updatedAt_not_label_application_time" "$SHORTFALL_OUT"
+assert_eq "inactive NMR holds remain visible" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '[.findings[] | select(.id == "pulse-inactive-nmr-holds")] | length')"
+assert_eq "inactive NMR holds remain medium severity" "medium" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.findings[] | select(.id == "pulse-inactive-nmr-holds") | .severity')"
+assert_eq "inactive NMR holds do not auto-file" "false" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.findings[] | select(.id == "pulse-inactive-nmr-holds") | .autofile')"
 assert_not_contains "shortfall JSON omits private issue title" "private nmr" "$SHORTFALL_OUT"
 
 IDLE_SHORTFALL_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=shortfall" \


### PR DESCRIPTION
## Summary

Changed pulse-inactive-nmr-holds to remain visible while disabling automatic issue creation, with focused JSON assertions for visibility, severity, and autofile policy.

## Files Changed

.agents/scripts/pulse-check-report.jq, .agents/scripts/tests/test-pulse-check-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-check-helper.sh; jq -n --argjson current '{}' --argjson summary '{}' --argjson recent_summary '{}' --argjson providers '{}' --argjson runner '{}' --argjson api '{}' --argjson queue '{}' --argjson threshold 3 --argjson failure_threshold 3 --arg window current --arg since historical --arg recent recent -f .agents/scripts/pulse-check-report.jq; .agents/scripts/linters-local.sh --changed --no-cache

Resolves #30888


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.294 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-luna spent 2m and 49,243 tokens on this as a headless worker.