### PR TITLE
GH#30887: fix(pulse-check): require write authority for remediation

### DIFF
--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -642,6 +642,13 @@ _apply_findings() {
 		print_warning "pulse-check: skipping issue writes while GitHub API cooldown or dispatch API block is active"
 		return 0
 	fi
+	_load_gh_wrappers || return 1
+	#aidevops:trust-boundary — public issue creation can succeed for read actors;
+	# require a fresh collaborator-permission lookup before every apply write path.
+	if ! _gh_current_user_allows_repo_write "$slug"; then
+		print_warning "pulse-check: generated report but skipped issue writes; GitHub actor lacks repository write authority (${AIDEVOPS_GH_WRITE_PERMISSION_REASON:-unknown})"
+		return 0
+	fi
 	_repo_owns_framework_write_surface "$slug" || return 1
 
 	local applied_count=0

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -186,6 +186,22 @@ if [[ " $* " == *" repo view "* ]]; then
   printf 'owner/aidevops\n'
   exit 0
 fi
+if [[ " $* " == *" api user "* ]]; then
+  if [[ "${PULSE_CHECK_PERMISSION_FIXTURE:-write}" == "unknown-user" ]]; then
+    printf '\n'
+  else
+    printf 'fixture-user\n'
+  fi
+  exit 0
+fi
+if [[ " $* " == *" api -i /repos/"*"/collaborators/fixture-user/permission "* || " $* " == *" api -i repos/"*"/collaborators/fixture-user/permission "* ]]; then
+  if [[ "${PULSE_CHECK_PERMISSION_FIXTURE:-write}" == "lookup-failure" ]]; then
+    printf 'simulated permission lookup failure\n' >&2
+    exit 1
+  fi
+  printf 'HTTP/2 200\n\n{"permission":"%s"}\n' "${PULSE_CHECK_PERMISSION_FIXTURE:-write}"
+  exit 0
+fi
 if [[ " $* " == *" api graphql "* ]]; then
   if [[ "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "dependency-scan-error" ]]; then
     printf 'simulated dependency lookup failure\n' >&2
@@ -552,6 +568,30 @@ assert_contains "apply body carries marker" "aidevops:generator=pulse-check find
 assert_contains "apply body carries verification" ".agents/scripts/tests/test-pulse-check-helper.sh" "$BODY"
 assert_not_contains "apply body omits private slug" "private/repo-one" "$BODY"
 assert_not_contains "apply body omits issue title" "secret one" "$BODY"
+
+rm -f "${TEST_ROOT}/capture.txt" "${TEST_ROOT}/capture.txt.body"
+READ_APPLY_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_PERMISSION_FIXTURE=read" "$HELPER" apply --repo owner/aidevops 2>&1)
+READ_CAPTURE=""
+[[ -f "${TEST_ROOT}/capture.txt" ]] && READ_CAPTURE=$(<"${TEST_ROOT}/capture.txt")
+assert_contains "read actor receives bounded authority warning" "insufficient-permission:read" "$READ_APPLY_OUT"
+assert_contains "read actor still receives report" "Pulse Check" "$READ_APPLY_OUT"
+assert_eq "read actor creates no GitHub writes" "" "$READ_CAPTURE"
+
+rm -f "${TEST_ROOT}/capture.txt" "${TEST_ROOT}/capture.txt.body"
+UNKNOWN_APPLY_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_PERMISSION_FIXTURE=unknown-user" "$HELPER" apply --repo owner/aidevops 2>&1)
+UNKNOWN_CAPTURE=""
+[[ -f "${TEST_ROOT}/capture.txt" ]] && UNKNOWN_CAPTURE=$(<"${TEST_ROOT}/capture.txt")
+assert_contains "unknown actor fails closed" "current-user-lookup-failed" "$UNKNOWN_APPLY_OUT"
+assert_contains "unknown actor still receives report" "Pulse Check" "$UNKNOWN_APPLY_OUT"
+assert_eq "unknown actor creates no GitHub writes" "" "$UNKNOWN_CAPTURE"
+
+rm -f "${TEST_ROOT}/capture.txt" "${TEST_ROOT}/capture.txt.body"
+LOOKUP_FAILURE_APPLY_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_PERMISSION_FIXTURE=lookup-failure" "$HELPER" apply --repo owner/aidevops 2>&1)
+LOOKUP_FAILURE_CAPTURE=""
+[[ -f "${TEST_ROOT}/capture.txt" ]] && LOOKUP_FAILURE_CAPTURE=$(<"${TEST_ROOT}/capture.txt")
+assert_contains "permission lookup failure fails closed" "permission-lookup-failed:api-failure" "$LOOKUP_FAILURE_APPLY_OUT"
+assert_contains "permission lookup failure still receives report" "Pulse Check" "$LOOKUP_FAILURE_APPLY_OUT"
+assert_eq "permission lookup failure creates no GitHub writes" "" "$LOOKUP_FAILURE_CAPTURE"
 
 rm -f "${TEST_ROOT}/capture.txt" "${TEST_ROOT}/capture.txt.body"
 CONFIGURED_OUT=$(env "${COMMON_ENV[@]}" "AIDEVOPS_FRAMEWORK_REPO=${FRAMEWORK_REPO}" "$HELPER" apply 2>&1)


### PR DESCRIPTION
## Summary

Gate pulse apply remediation writes on a fresh verified GitHub write permission and cover authorized, read-only, unknown, and lookup-failure actors.

## Files Changed

.agents/scripts/pulse-check-helper.sh, .agents/scripts/tests/test-pulse-check-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-check-helper.sh; shellcheck .agents/scripts/pulse-check-helper.sh .agents/scripts/tests/test-pulse-check-helper.sh; .agents/scripts/linters-local.sh --changed --no-cache

Resolves #30887


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.294 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 5m and 92,602 tokens on this as a headless worker.