### PR TITLE
GH#30878: fix merged receipt adoption query

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -1452,17 +1452,16 @@ _merge_fresh_adopted_worktree_cleanup_target() {
 	local current_repo=""
 
 	pr_json=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh pr view "$pr_number" --repo "$repo" \
-		--json state,mergedAt,mergeCommit,baseRepository,headRefName,headRefOid,headRepository,isCrossRepository 2>/dev/null) || return 1
-	printf '%s' "$pr_json" | jq -e --arg repo "$repo" '
+		--json state,mergedAt,mergeCommit,headRefName,headRefOid,headRepository,isCrossRepository 2>/dev/null) || return 2
+	printf '%s' "$pr_json" | jq -e '
 		.state == "MERGED"
 		and (.mergedAt | strings | length > 0)
 		and (.mergeCommit.oid | strings | length > 0)
 		and (.headRefName | strings | length > 0)
 		and (.headRefOid | strings | length > 0)
-		and .baseRepository.nameWithOwner == $repo
 		and (.headRepository.nameWithOwner | strings | length > 0)
 		and (.isCrossRepository == true or .isCrossRepository == false)
-	' >/dev/null 2>&1 || return 1
+	' >/dev/null 2>&1 || return 3
 	IFS=$'\t' read -r pr_head_ref pr_head_oid pr_head_repo < <(
 		printf '%s' "$pr_json" | jq -r '[.headRefName, .headRefOid, .headRepository.nameWithOwner] | @tsv'
 	)
@@ -1630,6 +1629,7 @@ cmd_adopt_merged_receipt() {
 	local pr_number="${1:-}"
 	local repo=""
 	local cleanup_target=""
+	local cleanup_target_rc=0
 	local release_status=""
 
 	if [[ $# -lt 1 || $# -gt 2 || ! "$pr_number" =~ ^[0-9]+$ ]]; then
@@ -1640,10 +1640,22 @@ cmd_adopt_merged_receipt() {
 		print_error "Adoption blocked: repository identity is unavailable"
 		return 1
 	}
-	cleanup_target=$(_merge_fresh_adopted_worktree_cleanup_target "$pr_number" "$repo") || {
+	cleanup_target=$(_merge_fresh_adopted_worktree_cleanup_target "$pr_number" "$repo") || cleanup_target_rc=$?
+	case "$cleanup_target_rc" in
+	0) ;;
+	2)
+		print_error "Adoption blocked: unable to query merged PR metadata with the supported GitHub CLI field set"
+		return 1
+		;;
+	3)
+		print_error "Adoption blocked: merged PR metadata is incomplete or invalid"
+		return 1
+		;;
+	*)
 		print_error "Adoption blocked: merged PR head does not match this registered linked worktree and repository"
 		return 1
-	}
+		;;
+	esac
 	if ! declare -F _full_loop_terminal_release_status >/dev/null 2>&1; then
 		print_error "Adoption blocked: terminal release verifier is unavailable"
 		return 1

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -14,6 +14,7 @@ GH_PR_HEAD_OID=""
 GH_PR_HEAD_REPO=""
 GH_PR_BASE_REPO=""
 GH_PR_IS_CROSS_REPOSITORY="false"
+GH_PR_VIEW_FAIL="false"
 GH_RELEASE_STATUS="not-requested"
 GH_RELEASE_TAG_MODE=""
 GH_RELEASE_TAG_COMMIT="1111111111111111111111111111111111111111"
@@ -99,12 +100,13 @@ gh() {
 		esac
 	fi
 	if [[ "$command" == "pr" && "$subcommand" == "view" ]]; then
-		if [[ "$args" == *"state,mergedAt,mergeCommit,baseRepository,headRefName,headRefOid,headRepository,isCrossRepository"* ]]; then
+		if [[ "$args" == *"state,mergedAt,mergeCommit,headRefName,headRefOid,headRepository,isCrossRepository"* ]]; then
+			[[ "$GH_PR_VIEW_FAIL" == "false" ]] || return 1
 			jq -cn --arg head_ref "$GH_PR_HEAD_REF" --arg head_oid "$GH_PR_HEAD_OID" \
-				--arg head_repo "$GH_PR_HEAD_REPO" --arg base_repo "$GH_PR_BASE_REPO" \
+				--arg head_repo "$GH_PR_HEAD_REPO" \
 				--arg is_cross_repository "$GH_PR_IS_CROSS_REPOSITORY" \
 				'{state:"MERGED",mergedAt:"2026-07-11T00:00:00Z",mergeCommit:{oid:"merge123"},
-				  baseRepository:{nameWithOwner:$base_repo},headRefName:$head_ref,headRefOid:$head_oid,
+				  headRefName:$head_ref,headRefOid:$head_oid,
 				  headRepository:{nameWithOwner:$head_repo},isCrossRepository:($is_cross_repository == "true")}'
 			return 0
 		fi
@@ -305,6 +307,7 @@ TRASH
 	GH_PR_HEAD_REPO="example/repo"
 	GH_PR_BASE_REPO="example/repo"
 	GH_PR_IS_CROSS_REPOSITORY="false"
+	GH_PR_VIEW_FAIL="false"
 	GH_RELEASE_STATUS="not-requested"
 	git -C "$canonical_repo" checkout -q -b feature/active
 	git clone -q "$origin_repo" "$updater_repo"
@@ -486,6 +489,23 @@ test_cmd_adopt_merged_receipt_accepts_verified_fork_head() {
 		and .cleanup_lease.state == "pending"
 	' "$receipt_path" >/dev/null || rc=1
 	print_result "externally merged fork head adopts an exact managed worktree" "$rc"
+	return 0
+}
+
+test_cmd_adopt_merged_receipt_reports_query_failure() {
+	setup_subject
+	configure_managed_repo_identity
+	local stderr_file="${TEST_ROOT}/adopt-query.stderr"
+	local rc=0
+	GH_PR_VIEW_FAIL="true"
+
+	if cmd_adopt_merged_receipt "123" "example/repo" 2>"$stderr_file"; then
+		rc=1
+	fi
+	grep -q "unable to query merged PR metadata with the supported GitHub CLI field set" \
+		"$stderr_file" || rc=1
+	grep -q "merged PR head does not match" "$stderr_file" && rc=1
+	print_result "merged-receipt adoption distinguishes PR query failures from head mismatches" "$rc"
 	return 0
 }
 
@@ -775,6 +795,7 @@ main() {
 	test_cmd_merge_defers_exact_head_alias_worktree
 	test_cmd_adopt_merged_receipt_is_idempotent
 	test_cmd_adopt_merged_receipt_accepts_verified_fork_head
+	test_cmd_adopt_merged_receipt_reports_query_failure
 	test_cmd_adopt_merged_receipt_rejects_unsafe_evidence
 	test_cmd_adopt_merged_receipt_rejects_receipt_conflicts
 	test_cleanup_plan_rejects_head_drift


### PR DESCRIPTION
## Summary

Use only supported gh pr view fields for merged-receipt adoption while retaining exact head, repository, branch, and release evidence checks; distinguish query and response-shape failures from true worktree mismatches.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh, .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 18 focused merge/worktree cleanup tests passed; ShellCheck, changed-file linters, and git diff --check passed.

Resolves #30878


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.294 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 38m and 240,800 tokens on this with the user in an interactive session.