### PR TITLE
GH#30866: fix: verify Playwriter chat message authors

### DIFF
--- a/.agents/scripts/tests/test-playwriter-pin.sh
+++ b/.agents/scripts/tests/test-playwriter-pin.sh
@@ -114,3 +114,39 @@ else
 	printf 'FAIL Playwriter updater can restore an unreviewed version\n' >&2
 	exit 1
 fi
+
+python3 - "$REPO_ROOT" <<'PY'
+import pathlib
+import sys
+
+playwriter_doc = (pathlib.Path(sys.argv[1]) / ".agents/tools/browser/playwriter.md").read_text()
+required_contract = (
+    "verify\nthe author of **each newly observed message**",
+    "do not infer its author from timing, bubble order,\nalignment, colour, or a generic chat header",
+    "Treat a message verified as operator-authored as local context",
+    "Treat a message verified as support-authored as eligible",
+    "Ambiguous attribution must never\n   trigger an external reply",
+)
+for requirement in required_contract:
+    assert requirement in playwriter_doc, requirement
+
+
+def reply_disposition(message):
+    """Bounded fixture model for the documented attribution contract."""
+    if message["accessible_sender"] == "Support":
+        return "reply-eligible"
+    if message["accessible_sender"] == "Operator":
+        return "local-context"
+    return "pause"
+
+
+fixture = (
+    {"accessible_sender": "Support", "text": "How can I help?"},
+    {"accessible_sender": "Operator", "text": "I have replied."},
+    {"accessible_sender": None, "text": "Please confirm."},
+)
+assert [reply_disposition(message) for message in fixture] == [
+    "reply-eligible", "local-context", "pause",
+]
+print("PASS Playwriter chat attribution contract recognizes support, operator, and ambiguous messages")
+PY

--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -169,6 +169,31 @@ await page.locator('.chart').screenshot({ path: 'chart.png' })
 await page.pdf({ path: 'page.pdf', format: 'A4' })
 ```
 
+### Two-Sided Messaging and Live Chat
+
+For support chat, social messaging, webmail, and any other two-sided UI, verify
+the author of **each newly observed message** before interpreting it as a reply
+or composing an external response. A new bubble is not evidence of a
+third-party response: do not infer its author from timing, bubble order,
+alignment, colour, or a generic chat header.
+
+1. Use explicit DOM or accessibility evidence: an accessible sender label,
+   stable participant metadata, or a verified mapping between the chat side and
+   a named participant.
+2. Record only the attributed author and the bounded message text needed for
+   the current reply; do not expose unrelated participants or full history.
+3. Treat a message verified as operator-authored as local context, not a reply
+   to answer. Treat a message verified as support-authored as eligible for the
+   already authorized response flow.
+4. If the bubble is unlabeled, its sender evidence conflicts, or the mapping is
+   ambiguous, pause and ask the operator. Ambiguous attribution must never
+   trigger an external reply.
+
+Example classification: an accessible label of “Operator” is local context; a
+verified “Support” label may be answered within the approved scope; an
+unlabeled bubble pauses the workflow. Preserve all existing consent,
+approved-tab, privacy, and mutation boundaries.
+
 ## Security
 
 - **Local WebSocket** on `localhost:19988` — no CORS, only local processes connect


### PR DESCRIPTION
## Summary

Require explicit per-message author evidence before interpreting or replying in two-sided Playwriter interfaces.

## Files Changed

.agents/scripts/tests/test-playwriter-pin.sh, .agents/tools/browser/playwriter.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — bash .agents/scripts/tests/test-playwriter-pin.sh; .agents/scripts/linters-local.sh --changed

Resolves #30866


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.294 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 8m and 76,221 tokens on this as a headless worker.