### PR TITLE
GH#30885: fix(planning): preserve held availability

### DIFF
--- a/.agents/scripts/planning-publication-reconcile.sh
+++ b/.agents/scripts/planning-publication-reconcile.sh
@@ -104,12 +104,12 @@ _publication_status_label() {
 		return 0
 	fi
 	_publication_issue_has_active_status "$issue_json" && return 0
-	if [[ "$fenced" == *",${PUBLICATION_AUTO_LABEL},"* &&
+	if [[ ("$fenced" == *",${PUBLICATION_AUTO_LABEL},"* || "$fenced" == *",no-auto-dispatch,") &&
 		"$fenced" != *",parent-task,"* && "$fenced" != *",meta,"* &&
 		"$fenced" != *",${PUBLICATION_BLOCKED_LABEL},"* && "$fenced" != *",status:queued,"* &&
 		"$fenced" != *",status:claimed,"* && "$fenced" != *",status:in-progress,"* &&
 		"$fenced" != *",status:in-review,"* && "$fenced" != *",status:done,"* &&
-		"$fenced" != *",no-auto-dispatch,"* && "$fenced" != *",hold-for-review,"* ]]; then
+		"$fenced" != *",hold-for-review,"* ]]; then
 		printf '%s\n' "$PUBLICATION_AVAILABLE_LABEL"
 	fi
 	return 0

--- a/.agents/scripts/tests/test-planning-publication-reconcile.sh
+++ b/.agents/scripts/tests/test-planning-publication-reconcile.sh
@@ -29,6 +29,10 @@ issue_json='{"labels":[{"name":"publication:pending"}]}'
 issue_json='{"labels":[{"name":"auto-dispatch"},{"name":"bug"},{"name":"status:available"}]}'
 _publication_issue_has_labels "$issue_json" 'auto-dispatch,bug,status:available'
 [[ -z "$(_publication_desired_labels '- [ ] t9001 Manual task ~1h ref:GH#78 logged:2026-08-11')" ]]
+held_task_line='- [ ] t9003 Held foundation #no-auto-dispatch #bug ~1h ref:GH#80 logged:2026-08-11'
+held_labels=$(_publication_desired_labels "$held_task_line")
+[[ ",${held_labels}," == *",no-auto-dispatch,"* ]]
+[[ "$(_publication_status_label "$held_labels" 0 '{"labels":[{"name":"publication:pending"}]}')" == "status:available" ]]
 blocked_task_line='- [ ] t9002 Blocked publication #auto-dispatch #bug ~1h blocked-by:t9000 ref:GH#79 logged:2026-08-11'
 _publication_task_has_dependency "$blocked_task_line"
 [[ "$(_publication_status_label "$desired_labels" 1 '{"labels":[{"name":"publication:pending"}]}')" == "status:blocked" ]]


### PR DESCRIPTION
## Summary

Projects status:available for unblocked no-auto-dispatch planning children while retaining blocked dependency behavior.

## Files Changed

.agents/scripts/planning-publication-reconcile.sh, .agents/scripts/tests/test-planning-publication-reconcile.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-planning-publication-reconcile.sh; bash .agents/scripts/tests/test-planning-publication-lifecycle.sh; bash .agents/scripts/tests/test-issue-sync-relationship-resume.sh; .agents/scripts/linters-local.sh --changed

Resolves #30885


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.294 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 7m and 88,035 tokens on this as a headless worker.