### PR TITLE
GH#30886: fix(pulse): recover disk capacity before dispatch block

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -35,6 +35,8 @@
 #   - _dispatch_run_guarded_worktree_cleanup
 #   - _dispatch_cleanup_worktree_capacity
 #   - _dispatch_worktree_capacity_gate
+#   - _dispatch_run_guarded_disk_cleanup
+#   - _dispatch_cleanup_disk_pressure
 #   - _dispatch_dedup_check_layers  (t1999: extracted from dispatch_with_dedup)
 #   - dispatch_with_dedup           (t1999: thin orchestrator, <80 lines)
 #   - _ensure_issue_body_has_brief
@@ -65,6 +67,9 @@ _PULSE_DISPATCH_FALSE="false"
 _PULSE_DISPATCH_ELIGIBILITY_STAGE="eligibility_gate"
 _PULSE_DISPATCH_NMR_LABEL="needs-maintainer-review"
 _PULSE_DISPATCH_COLLABORATOR_ASSOCIATION="COLLABORATOR"
+# One Pulse invocation sources this module once. This guard therefore bounds
+# synchronous global disk-pressure recovery to one guarded cleanup per cycle.
+AIDEVOPS_DISPATCH_DISK_PRESSURE_CLEANUP_ATTEMPTED=0
 
 # t2863: Module-level variable defaults (set -u guards).
 # Ensures LOGFILE is safe to dereference in all functions when this module
@@ -1409,6 +1414,54 @@ _dispatch_worktree_capacity_gate() {
 	return $?
 }
 
+_dispatch_run_guarded_disk_cleanup() {
+	cleanup_worktrees
+	return $?
+}
+
+# At the global worktree-filesystem capacity gate, synchronously run the
+# existing all-repository guarded cleanup once per Pulse cycle, then recheck
+# both capacity thresholds. The cleanup owns all destructive safety guards.
+_dispatch_cleanup_disk_pressure() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local target_path="$3"
+	local before_reason="$4"
+	local before_kb="$5"
+	local before_percent="$6"
+	local cleanup_timeout="${AIDEVOPS_DISPATCH_DISK_CLEANUP_TIMEOUT:-60}"
+	local cleanup_rc=0
+	local after_rc=0
+
+	if [[ "${AIDEVOPS_DISPATCH_DISK_PRESSURE_CLEANUP_ATTEMPTED:-0}" == "1" ]]; then
+		echo "[dispatch_with_dedup] Disk-pressure cleanup already attempted this Pulse cycle; dispatch remains fail-closed for #${issue_number} in ${repo_slug} (reason=${before_reason}, available=${before_kb}KB/${before_percent}%)" >>"$LOGFILE"
+		return 1
+	fi
+	AIDEVOPS_DISPATCH_DISK_PRESSURE_CLEANUP_ATTEMPTED=1
+	[[ "$cleanup_timeout" =~ ^[0-9]+$ ]] || cleanup_timeout=60
+	[[ "$cleanup_timeout" -ge 1 ]] || cleanup_timeout=1
+	if ! declare -F cleanup_worktrees >/dev/null 2>&1; then
+		echo "[dispatch_with_dedup] Disk-pressure cleanup unavailable for #${issue_number} in ${repo_slug}: guarded all-repository cleanup missing (before reason=${before_reason}, available=${before_kb}KB/${before_percent}%); dispatch remains fail-closed" >>"$LOGFILE"
+		return 1
+	fi
+	if ! declare -F run_stage_with_timeout >/dev/null 2>&1; then
+		echo "[dispatch_with_dedup] Disk-pressure cleanup unavailable for #${issue_number} in ${repo_slug}: bounded stage runner missing (before reason=${before_reason}, available=${before_kb}KB/${before_percent}%); dispatch remains fail-closed" >>"$LOGFILE"
+		return 1
+	fi
+
+	echo "[dispatch_with_dedup] Disk pressure for #${issue_number} in ${repo_slug}: reason=${before_reason}, available=${before_kb}KB/${before_percent}%; attempting guarded all-repository cleanup once this Pulse cycle (timeout ${cleanup_timeout}s)" >>"$LOGFILE"
+	run_stage_with_timeout "dispatch_disk_pressure_cleanup" "$cleanup_timeout" \
+		_dispatch_run_guarded_disk_cleanup || cleanup_rc=$?
+	aidevops_worktree_capacity_check "$target_path" || after_rc=$?
+	if [[ "$after_rc" -eq 0 ]]; then
+		echo "[dispatch_with_dedup] Guarded disk-pressure cleanup recovered dispatch capacity for #${issue_number} in ${repo_slug}: ${before_kb}KB/${before_percent}% -> ${AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB}KB/${AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT}% (cleanup_rc=${cleanup_rc})" >>"$LOGFILE"
+		return 0
+	fi
+
+	echo "[dispatch_with_dedup] Guarded disk-pressure cleanup could not recover dispatch capacity for #${issue_number} in ${repo_slug}: before reason=${before_reason}, available=${before_kb}KB/${before_percent}%; after reason=${AIDEVOPS_DISK_CAPACITY_REASON}, available=${AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB}KB/${AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT}% (cleanup_rc=${cleanup_rc}, capacity_rc=${after_rc}); existing cleanup safety gates preserved remaining worktrees" >>"$LOGFILE"
+	return 1
+}
+
 _dispatch_dedup_check_layers() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -1447,11 +1500,18 @@ _dispatch_dedup_check_layers() {
 	# worktree creation boundary, covering interactive and non-Pulse callers.
 	_dss_t0=$(_ds_now_ns)
 	local _capacity_rc=0
-	aidevops_worktree_capacity_check "${AIDEVOPS_WORKTREE_BASE_DIR:-$HOME}" || _capacity_rc=$?
+	local _capacity_path="${AIDEVOPS_WORKTREE_BASE_DIR:-$HOME}"
+	aidevops_worktree_capacity_check "$_capacity_path" || _capacity_rc=$?
 	if [[ "$_capacity_rc" -ne 0 ]]; then
-		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: disk space critical (reason=${AIDEVOPS_DISK_CAPACITY_REASON}, available=${AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB}KB/${AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT}%, require at least ${AIDEVOPS_MIN_WORKTREE_FREE_KB:-5242880}KB and ${AIDEVOPS_MIN_WORKTREE_FREE_PERCENT:-5}%). Run: worktree-helper.sh clean --auto --force-merged" >>"$LOGFILE"
-		_ds_record "$issue_number" "$repo_slug" "dedup.disk_space" "$_dss_t0"
-		return 1
+		if _dispatch_cleanup_disk_pressure "$issue_number" "$repo_slug" "$_capacity_path" \
+			"${AIDEVOPS_DISK_CAPACITY_REASON}" "${AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB}" \
+			"${AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT}"; then
+			_ds_record "$issue_number" "$repo_slug" "dedup.disk_space" "$_dss_t0"
+		else
+			echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: disk space critical (reason=${AIDEVOPS_DISK_CAPACITY_REASON}, available=${AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB}KB/${AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT}%, require at least ${AIDEVOPS_MIN_WORKTREE_FREE_KB:-5242880}KB and ${AIDEVOPS_MIN_WORKTREE_FREE_PERCENT:-5}%). Run: worktree-helper.sh clean --auto --force-merged" >>"$LOGFILE"
+			_ds_record "$issue_number" "$repo_slug" "dedup.disk_space" "$_dss_t0"
+			return 1
+		fi
 	fi
 	_ds_record "$issue_number" "$repo_slug" "dedup.disk_space" "$_dss_t0"
 

--- a/.agents/scripts/tests/test-pulse-dispatch-worktree-cap-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worktree-cap-cleanup.sh
@@ -24,6 +24,8 @@ COUNT_FAIL=0
 GIT_MODE="valid"
 STAGE_TIMEOUT=""
 STAGE_RC=0
+DISK_MODE="blocked"
+CLEANUP_RUNS=0
 
 print_result() {
 	local name="$1"
@@ -54,6 +56,8 @@ eval "${PRODUCTION_COUNT_HELPER/_dispatch_registered_worktree_count/_production_
 eval "$(extract_helper _dispatch_run_guarded_worktree_cleanup)"
 eval "$(extract_helper _dispatch_cleanup_worktree_capacity)"
 eval "$(extract_helper _dispatch_worktree_capacity_gate)"
+eval "$(extract_helper _dispatch_run_guarded_disk_cleanup)"
+eval "$(extract_helper _dispatch_cleanup_disk_pressure)"
 
 git() {
 	case "$GIT_MODE" in
@@ -78,10 +82,41 @@ run_stage_with_timeout() {
 	local rc=0
 	STAGE_TIMEOUT="$2"
 	shift 2
-	[[ "$stage_name" == "dispatch_worktree_capacity_cleanup" ]] || return 2
+	[[ "$stage_name" == "dispatch_worktree_capacity_cleanup" || "$stage_name" == "dispatch_disk_pressure_cleanup" ]] || return 2
 	[[ "$STAGE_RC" -eq 0 ]] || return "$STAGE_RC"
 	"$@" || rc=$?
 	return "$rc"
+}
+
+cleanup_worktrees() {
+	CLEANUP_RUNS=$((CLEANUP_RUNS + 1))
+	if [[ "$DISK_MODE" == "recover" ]]; then
+		DISK_MODE="available"
+	fi
+	return 0
+}
+
+aidevops_worktree_capacity_check() {
+	case "$DISK_MODE" in
+	available)
+		AIDEVOPS_DISK_CAPACITY_REASON="available"
+		AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB=6291456
+		AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT=6
+		return 0
+		;;
+	unknown)
+		AIDEVOPS_DISK_CAPACITY_REASON="capacity-unknown"
+		AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB=0
+		AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT=0
+		return 2
+		;;
+	*)
+		AIDEVOPS_DISK_CAPACITY_REASON="below-minimum-percent"
+		AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB=4194304
+		AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT=4
+		return 1
+		;;
+	esac
 }
 
 test_cleanup_recovers_capacity() {
@@ -214,6 +249,44 @@ test_missing_bounded_runner_fails_closed() {
 	return 0
 }
 
+test_disk_cleanup_recovers_capacity_once() {
+	AIDEVOPS_DISPATCH_DISK_PRESSURE_CLEANUP_ATTEMPTED=0
+	AIDEVOPS_DISPATCH_DISK_CLEANUP_TIMEOUT=19
+	DISK_MODE="recover"
+	CLEANUP_RUNS=0
+	STAGE_TIMEOUT=""
+	STAGE_RC=0
+	if _dispatch_cleanup_disk_pressure 30886 "owner/repo" "$TEST_ROOT" "below-minimum-percent" 4194304 4 &&
+		[[ "$CLEANUP_RUNS" -eq 1 ]] &&
+		[[ "$STAGE_TIMEOUT" == "19" ]] &&
+		grep -q "recovered dispatch capacity.*4194304KB/4% -> 6291456KB/6%" "$LOGFILE"; then
+		print_result "disk gate invokes one guarded cleanup and proceeds after capacity recheck" 0
+	else
+		print_result "disk gate invokes one guarded cleanup and proceeds after capacity recheck" 1
+	fi
+	return 0
+}
+
+test_disk_cleanup_remains_fail_closed_and_is_cycle_scoped() {
+	AIDEVOPS_DISPATCH_DISK_PRESSURE_CLEANUP_ATTEMPTED=0
+	DISK_MODE="blocked"
+	CLEANUP_RUNS=0
+	STAGE_RC=0
+	if _dispatch_cleanup_disk_pressure 30886 "owner/repo" "$TEST_ROOT" "below-minimum-percent" 4194304 4; then
+		print_result "disk cleanup remains fail-closed when capacity stays blocked" 1
+	elif _dispatch_cleanup_disk_pressure 30887 "owner/repo" "$TEST_ROOT" "below-minimum-percent" 4194304 4; then
+		print_result "disk cleanup runs only once per Pulse cycle" 1
+	elif [[ "$CLEANUP_RUNS" -eq 1 ]] &&
+		grep -q "cleanup_rc=0, capacity_rc=1" "$LOGFILE" &&
+		grep -q "already attempted this Pulse cycle" "$LOGFILE"; then
+		print_result "disk cleanup remains fail-closed and runs only once per Pulse cycle" 0
+	else
+		print_result "disk cleanup remains fail-closed and runs only once per Pulse cycle" 1
+	fi
+	STAGE_RC=0
+	return 0
+}
+
 main() {
 	test_cleanup_recovers_capacity
 	test_cleanup_fails_closed_without_reduction
@@ -222,6 +295,8 @@ main() {
 	test_post_cleanup_recount_failure_remains_fail_closed
 	test_count_probe_failure_remains_fail_closed
 	test_missing_bounded_runner_fails_closed
+	test_disk_cleanup_recovers_capacity_once
+	test_disk_cleanup_remains_fail_closed_and_is_cycle_scoped
 
 	printf 'Ran %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Runs the existing guarded all-repository worktree cleanup once when Pulse first encounters disk pressure, then rechecks both capacity thresholds and preserves fail-closed behavior with before/after evidence.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh, .agents/scripts/tests/test-pulse-dispatch-worktree-cap-cleanup.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-pulse-dispatch-worktree-cap-cleanup.sh; .agents/scripts/tests/test-disk-capacity-lib.sh; shellcheck .agents/scripts/pulse-dispatch-core.sh .agents/scripts/pulse-dispatch-preflight-lib.sh .agents/scripts/pulse-cleanup-worktree-removal.sh .agents/scripts/disk-capacity-lib.sh; git diff --check

Resolves #30886


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.294 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 5m and 87,930 tokens on this as a headless worker.