### PR TITLE
GH#30865: fix: accept stdin body sentinel in platform helper

### DIFF
--- a/.agents/scripts/platform-helper.sh
+++ b/.agents/scripts/platform-helper.sh
@@ -13,14 +13,15 @@
 #
 # Functions:
 #   platform_detect <repo_path>                           — detect platform, prints github|gitea|gitlab|local
-#   platform_create_issue <slug> <title> <body_file> <labels>   — create an issue
+#   platform_create_issue <slug> <title> <body_file|-> <labels> — create an issue
 #   platform_get_issue <slug> <num>                       — view an issue (JSON)
-#   platform_comment_issue <slug> <num> <body_file>       — post a comment
-#   platform_create_pr <slug> <title> <body_file> <base> <head> — create a pull request
+#   platform_comment_issue <slug> <num> <body_file|->      — post a comment
+#   platform_create_pr <slug> <title> <body_file|-> <base> <head> — create a pull request
+#   Exact body path "-" forwards piped stdin to the managed GitHub wrapper.
 #
 # Local platform (no remote):
 #   Operations are logged to ~/.aidevops/logs/platform-local-ops.log and exit 0.
-#   No remote calls are made.
+#   No remote calls are made. Body stdin is consumed once and discarded.
 #
 # Gitea/GitLab platforms:
 #   All operations exit 1 with "P9 task — adapter not implemented".
@@ -72,11 +73,25 @@ _platform_require_gh() {
 	return 0
 }
 
-_platform_require_file() {
+_platform_require_body_input() {
 	local body_file="$1"
+	if [[ "$body_file" == "-" ]]; then
+		return 0
+	fi
 	if [[ ! -f "$body_file" ]]; then
 		print_error "Body file not found: $body_file"
 		return 1
+	fi
+	return 0
+}
+
+_platform_consume_local_stdin_body() {
+	local body_file="$1"
+	if [[ "$body_file" == "-" ]]; then
+		command cat >/dev/null || {
+			print_error "Failed to consume local platform body from stdin"
+			return 1
+		}
 	fi
 	return 0
 }
@@ -157,7 +172,7 @@ platform_detect() {
 
 # ---------------------------------------------------------------------------
 # platform_create_issue: create an issue on the detected platform
-# Args: <slug> <title> <body_file> <labels>
+# Args: <slug> <title> <body_file|-> <labels>
 # labels: comma-separated label list (may be empty)
 # ---------------------------------------------------------------------------
 platform_create_issue() {
@@ -166,7 +181,7 @@ platform_create_issue() {
 	local body_file="$3"
 	local labels="${4:-}"
 
-	_platform_require_file "$body_file" || return 1
+	_platform_require_body_input "$body_file" || return 1
 
 	local platform
 	platform=$(platform_detect "$(pwd)")
@@ -176,9 +191,10 @@ platform_create_issue() {
 		_platform_require_gh || return 1
 		local label_args=()
 		[[ -n "$labels" ]] && label_args=("--label" "$labels")
-		gh issue create --repo "$slug" --title "$title" --body-file "$body_file" "${label_args[@]}" # aidevops-allow: raw-gh-wrapper
+		gh issue create --repo "$slug" --title "$title" --body-file "$body_file" "${label_args[@]}" || return 1 # aidevops-allow: raw-gh-wrapper
 		;;
 	local)
+		_platform_consume_local_stdin_body "$body_file" || return 1
 		_platform_local_log "create_issue" "slug=${slug} title=${title}"
 		;;
 	*)
@@ -219,14 +235,14 @@ platform_get_issue() {
 
 # ---------------------------------------------------------------------------
 # platform_comment_issue: post a comment on an issue
-# Args: <slug> <num> <body_file>
+# Args: <slug> <num> <body_file|->
 # ---------------------------------------------------------------------------
 platform_comment_issue() {
 	local slug="$1"
 	local num="$2"
 	local body_file="$3"
 
-	_platform_require_file "$body_file" || return 1
+	_platform_require_body_input "$body_file" || return 1
 
 	local platform
 	platform=$(platform_detect "$(pwd)")
@@ -234,9 +250,10 @@ platform_comment_issue() {
 	case "$platform" in
 	github)
 		_platform_require_gh || return 1
-		gh issue comment "$num" --repo "$slug" --body-file "$body_file"
+		gh issue comment "$num" --repo "$slug" --body-file "$body_file" || return 1
 		;;
 	local)
+		_platform_consume_local_stdin_body "$body_file" || return 1
 		_platform_local_log "comment_issue" "slug=${slug} num=${num}"
 		;;
 	*)
@@ -249,7 +266,7 @@ platform_comment_issue() {
 
 # ---------------------------------------------------------------------------
 # platform_create_pr: create a pull request
-# Args: <slug> <title> <body_file> <base> <head>
+# Args: <slug> <title> <body_file|-> <base> <head>
 # ---------------------------------------------------------------------------
 platform_create_pr() {
 	local slug="$1"
@@ -258,7 +275,7 @@ platform_create_pr() {
 	local base="$4"
 	local head="$5"
 
-	_platform_require_file "$body_file" || return 1
+	_platform_require_body_input "$body_file" || return 1
 
 	local platform
 	platform=$(platform_detect "$(pwd)")
@@ -266,9 +283,10 @@ platform_create_pr() {
 	case "$platform" in
 	github)
 		_platform_require_gh || return 1
-		gh pr create --repo "$slug" --title "$title" --body-file "$body_file" --base "$base" --head "$head" # aidevops-allow: raw-gh-wrapper
+		gh pr create --repo "$slug" --title "$title" --body-file "$body_file" --base "$base" --head "$head" || return 1 # aidevops-allow: raw-gh-wrapper
 		;;
 	local)
+		_platform_consume_local_stdin_body "$body_file" || return 1
 		_platform_local_log "create_pr" "slug=${slug} title=${title} base=${base} head=${head}"
 		;;
 	*)

--- a/.agents/scripts/tests/test-platform-helper-stdin.sh
+++ b/.agents/scripts/tests/test-platform-helper-stdin.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+HOME="${TEST_ROOT}/home"
+mkdir -p "$HOME"
+
+# shellcheck source=../platform-helper.sh
+source "${SCRIPTS_DIR}/platform-helper.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+GH_CALLS_FILE="${TEST_ROOT}/gh-calls"
+GH_BODY_FILE="${TEST_ROOT}/gh-body"
+printf '0\n' >"$GH_CALLS_FILE"
+
+pass() {
+	local message="$1"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	printf 'FAIL: %s\n' "$message" >&2
+	return 0
+}
+
+assert_success() {
+	local message="$1"
+	shift
+	if "$@"; then
+		pass "$message"
+	else
+		fail "$message"
+	fi
+	return 0
+}
+
+assert_failure() {
+	local message="$1"
+	shift
+	if "$@"; then
+		fail "$message"
+	else
+		pass "$message"
+	fi
+	return 0
+}
+
+platform_detect() {
+	printf '%s\n' "${TEST_PLATFORM:-github}"
+	return 0
+}
+
+gh() {
+	local call_count=0
+	local arg=""
+	local previous=""
+	local stdin_body=""
+	call_count=$(<"$GH_CALLS_FILE")
+	call_count=$((call_count + 1))
+	printf '%s\n' "$call_count" >"$GH_CALLS_FILE"
+	printf '%s\n' "$*" >"${TEST_ROOT}/gh-args-${call_count}"
+	for arg in "$@"; do
+		if [[ "$previous" == "--body-file" && "$arg" == "-" ]]; then
+			command cat >"$GH_BODY_FILE"
+			stdin_body=$(<"$GH_BODY_FILE")
+			if [[ -z "$stdin_body" || "$stdin_body" == "<!-- aidevops:sig -->" ]]; then
+				return 1
+			fi
+		fi
+		previous="$arg"
+	done
+	return 0
+}
+
+run_stdin_create_issue() {
+	printf '%s' 'issue body line one
+issue body line two' | platform_create_issue owner/repo "Issue title" - bug
+	return $?
+}
+
+run_stdin_comment_issue() {
+	printf '%s' 'comment body' | platform_comment_issue owner/repo 123 -
+	return $?
+}
+
+run_stdin_create_pr() {
+	printf '%s' 'pull request body' | platform_create_pr owner/repo "PR title" - main feature
+	return $?
+}
+
+run_empty_stdin_comment() {
+	printf '' | platform_comment_issue owner/repo 123 -
+	return $?
+}
+
+run_signature_only_stdin_comment() {
+	printf '%s\n' '<!-- aidevops:sig -->' | platform_comment_issue owner/repo 123 -
+	return $?
+}
+
+run_local_stdin_comment() {
+	printf '%s' "$LOCAL_SENTINEL" | platform_comment_issue owner/repo 123 -
+	return $?
+}
+
+assert_success "create-issue accepts exact stdin sentinel" run_stdin_create_issue
+[[ "$(<"$GH_BODY_FILE")" == $'issue body line one\nissue body line two' ]] &&
+	pass "create-issue forwards multiline stdin once" ||
+	fail "create-issue did not forward multiline stdin"
+[[ "$(<"${TEST_ROOT}/gh-args-1")" == *"--body-file -"* ]] &&
+	pass "create-issue forwards literal body sentinel" ||
+	fail "create-issue changed the body sentinel"
+
+assert_success "comment-issue accepts exact stdin sentinel" run_stdin_comment_issue
+[[ "$(<"$GH_BODY_FILE")" == "comment body" ]] &&
+	pass "comment-issue forwards stdin once" ||
+	fail "comment-issue did not forward stdin"
+
+assert_success "create-pr accepts exact stdin sentinel" run_stdin_create_pr
+[[ "$(<"$GH_BODY_FILE")" == "pull request body" ]] &&
+	pass "create-pr forwards stdin once" ||
+	fail "create-pr did not forward stdin"
+
+REGULAR_BODY="${TEST_ROOT}/regular-body.md"
+printf '%s\n' 'regular body' >"$REGULAR_BODY"
+assert_success "regular body files remain supported" \
+	platform_create_issue owner/repo "Regular title" "$REGULAR_BODY" ""
+[[ "$(<"${TEST_ROOT}/gh-args-4")" == *"--body-file ${REGULAR_BODY}"* ]] &&
+	pass "regular body path is forwarded unchanged" ||
+	fail "regular body path changed"
+
+calls_before=$(<"$GH_CALLS_FILE")
+assert_failure "missing non-stdin body path remains rejected" \
+	platform_comment_issue owner/repo 123 "${TEST_ROOT}/missing-body.md"
+[[ "$(<"$GH_CALLS_FILE")" == "$calls_before" ]] &&
+	pass "missing body path fails before GitHub transport" ||
+	fail "missing body path reached GitHub transport"
+
+assert_failure "empty stdin rejection from managed transport is preserved" run_empty_stdin_comment
+assert_failure "signature-only stdin rejection from managed transport is preserved" \
+	run_signature_only_stdin_comment
+
+TEST_PLATFORM=local
+LOCAL_SENTINEL='private local body that must not be logged'
+assert_success "local platform consumes and discards stdin body" \
+	run_local_stdin_comment
+if [[ -f "$PLATFORM_LOCAL_LOG" ]] && ! grep -Fq "$LOCAL_SENTINEL" "$PLATFORM_LOCAL_LOG"; then
+	pass "local platform log excludes discarded body content"
+else
+	fail "local platform persisted discarded body content"
+fi
+
+printf '\nTests: %d passed, %d failed\n' "$PASS_COUNT" "$FAIL_COUNT"
+[[ "$FAIL_COUNT" -eq 0 ]]


### PR DESCRIPTION
## Summary

Implementation for issue #30865.

## Files Changed

.agents/scripts/platform-helper.sh, .agents/scripts/tests/test-platform-helper-stdin.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #30865


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.294 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 59m and 766,418 tokens on this with the user in an interactive session.