### PR TITLE
GH#30900: classify Secretlint scanner errors

### DIFF
--- a/.agents/scripts/privacy-filter-helper.sh
+++ b/.agents/scripts/privacy-filter-helper.sh
@@ -173,38 +173,48 @@ get_all_patterns() {
 	return 0
 }
 
-# Run secretlint scan first
+# Run one Secretlint command while preserving its documented exit-status contract.
+run_secretlint_command() {
+	local target="$1"
+	shift
+	local output=""
+	local status=0
+
+	output=$("$@" "$target" 2>&1) || status=$?
+	case "$status" in
+	0)
+		print_success "Secretlint: No secrets detected"
+		return 0
+		;;
+	1)
+		[[ -n "$output" ]] && printf '%s\n' "$output"
+		print_error "Secretlint: Potential secrets found!"
+		return 1
+		;;
+	*)
+		print_warning "Secretlint unavailable: configuration or execution error (exit $status); continuing with privacy-pattern scan"
+		return 0
+		;;
+	esac
+}
+
+# Run secretlint scan first.
 run_secretlint() {
 	local target="${1:-.}"
 
 	print_header "Running Secretlint scan..."
 
 	if command -v secretlint &>/dev/null; then
-		if secretlint "$target" 2>/dev/null; then
-			print_success "Secretlint: No secrets detected"
-			return 0
-		else
-			print_error "Secretlint: Potential secrets found!"
-			return 1
-		fi
+		run_secretlint_command "$target" secretlint
+		return $?
 	elif [[ -f "node_modules/.bin/secretlint" ]]; then
-		if ./node_modules/.bin/secretlint "$target" 2>/dev/null; then
-			print_success "Secretlint: No secrets detected"
-			return 0
-		else
-			print_error "Secretlint: Potential secrets found!"
-			return 1
-		fi
-	else
-		# Try npx
-		if npx --yes secretlint "$target" 2>/dev/null; then
-			print_success "Secretlint: No secrets detected"
-			return 0
-		else
-			print_warning "Secretlint not available, skipping credential scan"
-			return 0
-		fi
+		run_secretlint_command "$target" ./node_modules/.bin/secretlint
+		return $?
 	fi
+
+	# Preserve the existing on-demand fallback while applying the same exit contract.
+	run_secretlint_command "$target" npx --yes secretlint
+	return $?
 }
 
 # Scan for privacy-sensitive content

--- a/.agents/scripts/tests/test-privacy-filter-helper.sh
+++ b/.agents/scripts/tests/test-privacy-filter-helper.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/privacy-filter-helper.sh"
+TEST_ROOT="$(mktemp -d)"
+BIN_DIR="${TEST_ROOT}/bin"
+HOME_DIR="${TEST_ROOT}/home"
+CLEAN_FILE="${TEST_ROOT}/clean.txt"
+MATCH_FILE="${TEST_ROOT}/match.txt"
+TESTS=0
+FAILURES=0
+RUN_OUTPUT=""
+RUN_STATUS=0
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+pass() {
+	local name="$1"
+	TESTS=$((TESTS + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="$2"
+	TESTS=$((TESTS + 1))
+	FAILURES=$((FAILURES + 1))
+	printf 'FAIL %s: %s\n' "$name" "$detail"
+	return 0
+}
+
+run_scan() {
+	local fixture="$1"
+	local target="$2"
+	RUN_OUTPUT=""
+	RUN_STATUS=0
+	RUN_OUTPUT=$(HOME="$HOME_DIR" SECRETLINT_FIXTURE="$fixture" PATH="$BIN_DIR:$PATH" \
+		"$HELPER" scan "$target" 2>&1) || RUN_STATUS=$?
+	return 0
+}
+
+assert_status() {
+	local name="$1"
+	local expected="$2"
+	if [[ "$RUN_STATUS" -eq "$expected" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected status $expected, got $RUN_STATUS; output=${RUN_OUTPUT}"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local expected="$2"
+	if [[ "$RUN_OUTPUT" == *"$expected"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "missing '${expected}'; output=${RUN_OUTPUT}"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local name="$1"
+	local unexpected="$2"
+	if [[ "$RUN_OUTPUT" != *"$unexpected"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "unexpected '${unexpected}'; output=${RUN_OUTPUT}"
+	fi
+	return 0
+}
+
+mkdir -p "$BIN_DIR" "$HOME_DIR"
+printf 'plain fixture content\n' >"$CLEAN_FILE"
+printf 'contact fixture@example.invalid\n' >"$MATCH_FILE"
+
+cat >"${BIN_DIR}/secretlint" <<'EOF'
+#!/usr/bin/env bash
+case "${SECRETLINT_FIXTURE:-clean}" in
+clean)
+	exit 0
+	;;
+finding)
+	printf 'fixture:1:1 secretlint finding\n'
+	exit 1
+	;;
+fatal)
+	printf 'Error: secretlint config is not found\n' >&2
+	exit 2
+	;;
+execution)
+	printf 'scanner could not execute\n' >&2
+	exit 7
+	;;
+*)
+	exit 9
+	;;
+esac
+EOF
+chmod +x "${BIN_DIR}/secretlint"
+
+run_scan clean "$CLEAN_FILE"
+assert_status "clean Secretlint scan succeeds" 0
+assert_contains "clean Secretlint scan reports success" "Secretlint: No secrets detected"
+
+run_scan finding "$CLEAN_FILE"
+assert_status "Secretlint finding remains blocking" 1
+assert_contains "Secretlint finding is classified as content" "Secretlint: Potential secrets found!"
+assert_contains "Secretlint finding increments the privacy total" "Found 1 potential privacy issues"
+
+run_scan fatal "$CLEAN_FILE"
+assert_status "Secretlint fatal error does not synthesize a finding" 0
+assert_contains "Secretlint fatal error is reported explicitly" "configuration or execution error (exit 2)"
+assert_not_contains "Secretlint fatal error is not called a secret" "Potential secrets found"
+assert_contains "built-in scan still completes after fatal error" "No privacy-sensitive content detected"
+
+run_scan execution "$CLEAN_FILE"
+assert_status "Secretlint execution failure does not synthesize a finding" 0
+assert_contains "Secretlint execution failure includes its status" "configuration or execution error (exit 7)"
+assert_not_contains "Secretlint execution failure is not called a secret" "Potential secrets found"
+
+run_scan fatal "$MATCH_FILE"
+assert_status "built-in privacy match remains blocking" 1
+assert_contains "built-in privacy match is reported" "Found 1 potential privacy issues"
+
+printf '%s tests, %s failures\n' "$TESTS" "$FAILURES"
+[[ "$FAILURES" -eq 0 ]]


### PR DESCRIPTION
## Summary

Distinguish confirmed Secretlint findings from configuration and execution failures while preserving the independent privacy-pattern scan.

## Files Changed

.agents/scripts/privacy-filter-helper.sh, .agents/scripts/tests/test-privacy-filter-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — The production helper was run against /dev/null from an unconfigured directory and returned a scanner warning plus a successful built-in scan; the 14-assertion focused suite, Bash syntax, ShellCheck, and changed-file linters also passed.

Resolves #30900


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.295 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 47m and 344,489 tokens on this with the user in an interactive session.