### PR TITLE
GH#30901: fix: block direct pull request merges

### DIFF
--- a/.agents/configs/command-policy.json
+++ b/.agents/configs/command-policy.json
@@ -101,6 +101,12 @@
       "matcher": "git_stash_delete",
       "decision": "forbid",
       "reason": "Permanent deletion of stashed changes is forbidden"
+    },
+    {
+      "id": "github.pr-merge-lifecycle",
+      "matcher": "gh_pr_merge",
+      "decision": "forbid",
+      "reason": "Direct GitHub pull request merges bypass lifecycle receipts; use full-loop-helper.sh merge <PR> <REPO> instead"
     }
   ],
   "fixtures": [
@@ -235,6 +241,18 @@
       "command": "printf '%s' 'rm -rf ./generated' | xargs sh -c",
       "decision": "forbid",
       "rule_id": "command.parse-error"
+    },
+    {
+      "name": "direct pull request merge requires lifecycle helper",
+      "command": "gh pr merge 123 --repo owner/repo --squash",
+      "decision": "forbid",
+      "rule_id": "github.pr-merge-lifecycle"
+    },
+    {
+      "name": "lifecycle helper merge remains allowed",
+      "command": "full-loop-helper.sh merge 123 owner/repo --squash",
+      "decision": "allow",
+      "rule_id": "command.default-allow"
     }
   ]
 }

--- a/.agents/scripts/command_policy_config.py
+++ b/.agents/scripts/command_policy_config.py
@@ -20,6 +20,7 @@ KNOWN_MATCHERS = {
     "git_push_force",
     "git_branch_force_delete",
     "git_stash_delete",
+    "gh_pr_merge",
 }
 
 

--- a/.agents/scripts/command_policy_matchers.py
+++ b/.agents/scripts/command_policy_matchers.py
@@ -23,6 +23,7 @@ __all__ = [
     "_is_temp_operand",
     "_matches",
     "_matches_gh_command_path",
+    "_matches_gh_pr_merge",
     "_matches_git",
     "_matches_rm",
     "_rm_operands",
@@ -34,6 +35,36 @@ def _matches_gh_command_path(argv: list[str], command_paths: list[list[str]]) ->
     if len(argv) < 3 or os.path.basename(argv[0]) != "gh":
         return False
     return argv[1:3] in command_paths
+
+
+def _matches_gh_pr_merge(argv: list[str]) -> bool:
+    if len(argv) < 3 or os.path.basename(argv[0]) != "gh":
+        return False
+    command_index = _gh_command_index(argv[1:])
+    if command_index is None or argv[command_index : command_index + 2] != ["pr", "merge"]:
+        return False
+    merge_args = argv[command_index + 2 :]
+    return not (len(merge_args) == 1 and merge_args[0] in {"--help", "-h"})
+
+
+def _gh_command_index(args: list[str]) -> int | None:
+    index = 1
+    while index < len(args):
+        arg = args[index - 1]
+        if arg in {"--help", "-h", "--version"}:
+            return None
+        if arg == "--hostname":
+            index += 1
+            if index > len(args):
+                return None
+        elif arg.startswith("--hostname="):
+            pass
+        elif arg.startswith("-"):
+            return None
+        else:
+            return index
+        index += 1
+    return None
 
 
 def _rm_operands(args: list[str]) -> list[str]:
@@ -89,6 +120,8 @@ def _is_root_or_home_operand(path: str, cwd: str) -> bool:
 def _matches(matcher: str, argv: list[str], cwd: str) -> bool:
     if matcher in {"rm_recursive_force_root", "rm_recursive_force"}:
         return _matches_rm(matcher, argv, cwd)
+    if matcher == "gh_pr_merge":
+        return _matches_gh_pr_merge(argv)
     subcommand, git_args = _git_parts(argv)
     if not subcommand:
         return False

--- a/.agents/scripts/tests/test-command-policy-helper.sh
+++ b/.agents/scripts/tests/test-command-policy-helper.sh
@@ -464,6 +464,16 @@ PY
 
 test_static_decisions() {
 	assert_decision "allows unmatched command" "printf safe" allow command.default-allow 0
+	assert_decision "forbids direct pull request merge" "gh pr merge 123 --repo owner/repo --squash" forbid github.pr-merge-lifecycle 20 "/work"
+	assert_decision "forbids absolute-path pull request merge" "/usr/local/bin/gh pr merge 123 --repo owner/repo --squash" forbid github.pr-merge-lifecycle 20 "/work"
+	assert_decision "forbids environment-wrapped pull request merge" "env GH_PAGER=cat gh pr merge 123 --repo owner/repo --squash" forbid github.pr-merge-lifecycle 20 "/work"
+	assert_decision "forbids shell-launched pull request merge" "bash -lc 'gh pr merge 123 --repo owner/repo --squash'" forbid github.pr-merge-lifecycle 20 "/work"
+	assert_decision "forbids chained pull request merge" "printf safe && gh pr merge 123 --repo owner/repo --squash" forbid github.pr-merge-lifecycle 20 "/work"
+	assert_decision "forbids disabling pull request auto-merge directly" "gh pr merge 123 --repo owner/repo --disable-auto" forbid github.pr-merge-lifecycle 20 "/work"
+	assert_decision "allows lifecycle helper merge" "full-loop-helper.sh merge 123 owner/repo --squash" allow command.default-allow 0 "/work"
+	assert_decision "allows read-only pull request view" "gh pr view 123 --repo owner/repo" allow command.default-allow 0 "/work"
+	assert_decision "allows quoted merge prose" "printf '%s' 'gh pr merge 123'" allow command.default-allow 0 "/work"
+	assert_decision "allows pull request merge help" "gh pr merge --help" allow command.default-allow 0 "/work"
 	assert_decision "forbids recursive forced removal" "rm -rf ./build-output" forbid filesystem.rm-recursive-force 20 "/work"
 	assert_decision "forbids recursive root removal" "rm --recursive --force /" forbid filesystem.rm-recursive-force-root 20
 	assert_decision "allows temporary cleanup" "rm -rf /tmp/aidevops-example" allow command.default-allow 0


### PR DESCRIPTION
## Summary

Reject direct gh pr merge command shapes through the runtime-neutral command policy while preserving lifecycle helper access.

## Files Changed

.agents/configs/command-policy.json, .agents/scripts/command_policy_config.py, .agents/scripts/command_policy_matchers.py, .agents/scripts/tests/test-command-policy-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-command-policy-helper.sh; node --test .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs; python3 .agents/scripts/command-policy-helper.py validate; .agents/scripts/linters-local.sh

Resolves #30901


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.295 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 6m and 69,142 tokens on this as a headless worker.