### PR TITLE
GH#30903: fix: fail closed on malformed related files

### DIFF
--- a/.agents/scripts/issue-sync-helper-enrich.sh
+++ b/.agents/scripts/issue-sync-helper-enrich.sh
@@ -490,6 +490,7 @@ cmd_enrich() {
 	fi
 
 	local enriched=0
+	local failed=0
 	local processed=0
 	local started_at
 	started_at=$(date +%s || echo "0")
@@ -498,16 +499,24 @@ cmd_enrich() {
 			break
 		fi
 		local result
-		result=$(_enrich_process_task "$task_id" "$repo" "$todo_file" "$project_root")
+		if ! result=$(_enrich_process_task "$task_id" "$repo" "$todo_file" "$project_root"); then
+			failed=$((failed + 1))
+			processed=$((processed + 1))
+			continue
+		fi
 		processed=$((processed + 1))
 		[[ "$result" == *"ENRICHED"* ]] && enriched=$((enriched + 1))
 	done
-	print_info "Enrich complete: $enriched updated (${processed}/${#tasks[@]} processed)"
 
 	# Clean up prefetch temp file
 	if [[ "$_prefetch_ok" == "true" && -n "${ENRICH_PREFETCH_FILE:-}" && -f "$ENRICH_PREFETCH_FILE" ]]; then
 		rm -f "$ENRICH_PREFETCH_FILE" 2>/dev/null || true
 		ENRICH_PREFETCH_FILE=""
 	fi
+	if [[ "$failed" -gt 0 ]]; then
+		print_error "Enrich failed: $failed task(s); $enriched updated (${processed}/${#tasks[@]} processed)"
+		return 1
+	fi
+	print_info "Enrich complete: $enriched updated (${processed}/${#tasks[@]} processed)"
 	return 0
 }

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -292,8 +292,15 @@ _push_process_task() {
 		tier_label=$(_validate_tier_checklist "$brief_path" "$tier_label")
 	fi
 
-	local body
-	body=$(compose_issue_body "$task_id" "$project_root")
+	local body=""
+	if ! body=$(compose_issue_body "$task_id" "$project_root"); then
+		print_error "Refusing push for $task_id — issue body composition failed"
+		return 1
+	fi
+	if [[ -z "$body" ]]; then
+		print_error "Refusing push for $task_id — issue body composition returned empty output"
+		return 1
+	fi
 
 	_push_warn_if_task_id_collides "$repo" "$task_id"
 
@@ -406,8 +413,8 @@ _enrich_process_task() {
 	local _compose_rc=0
 	body=$(compose_issue_body "$task_id" "$project_root") || _compose_rc=$?
 	if [[ $_compose_rc -ne 0 || -z "$body" ]]; then
-		print_error "Skipping enrich for $task_id — compose_issue_body failed (rc=$_compose_rc). Task ID is not in TODO.md; fix the TODO entry or remove the brief file (t2377)."
-		return 0
+		print_error "Refusing enrich for $task_id — issue body composition failed (rc=$_compose_rc)"
+		return 1
 	fi
 
 	_enrich_apply_labels "$repo" "$num" "$labels" "$tier_label" "$current_labels_csv"

--- a/.agents/scripts/issue-sync-lib-compose.sh
+++ b/.agents/scripts/issue-sync-lib-compose.sh
@@ -318,13 +318,47 @@ _compose_issue_plan_sections() {
 #   $1 - current body text
 #   $2 - task_id
 #   $3 - project_root
+_COMPOSE_RELATED_FILE_ABS=""
+_COMPOSE_RELATED_FILE_REL=""
+
+_compose_validate_related_file() {
+	local file="$1"
+	local project_root="$2"
+	local tasks_dir="$project_root/todo/tasks"
+	local tasks_root="" file_parent="" file_name="" resolved_parent="" resolved_file=""
+	_COMPOSE_RELATED_FILE_ABS=""
+	_COMPOSE_RELATED_FILE_REL=""
+
+	[[ -n "$file" && "$file" == /* && -f "$file" && ! -L "$file" ]] || return 1
+	[[ "$file" != *$'\n'* && "$file" != *$'\r'* && "$file" != *$'\t'* ]] || return 1
+	[[ "$file" != *"\$'\\n'"* ]] || return 1
+	tasks_root=$(cd "$tasks_dir" 2>/dev/null && pwd -P) || return 1
+	file_parent="${file%/*}"
+	file_name="${file##*/}"
+	[[ -n "$file_parent" && -n "$file_name" && "$file_name" != "." && "$file_name" != ".." ]] || return 1
+	resolved_parent=$(cd "$file_parent" 2>/dev/null && pwd -P) || return 1
+	resolved_file="${resolved_parent}/${file_name}"
+	[[ -f "$resolved_file" && ! -L "$resolved_file" ]] || return 1
+	case "$resolved_file" in
+	"$tasks_root"/*) ;;
+	*) return 1 ;;
+	esac
+
+	_COMPOSE_RELATED_FILE_ABS="$resolved_file"
+	_COMPOSE_RELATED_FILE_REL="todo/tasks/${resolved_file#"$tasks_root"/}"
+	return 0
+}
+
 _compose_issue_related_files() {
 	local body="$1"
 	local task_id="$2"
 	local project_root="$3"
 
-	local related_files
-	related_files=$(find_related_files "$task_id" "$project_root")
+	local related_files="" file="" rel_path="" file_summary=""
+	if ! related_files=$(find_related_files "$task_id" "$project_root"); then
+		print_error "Refusing Related Files for $task_id: related-file discovery failed"
+		return 1
+	fi
 	if [[ -z "$related_files" ]]; then
 		echo "$body"
 		return 0
@@ -333,9 +367,12 @@ _compose_issue_related_files() {
 	body="$body"$'\n\n'"## Related Files"
 	while IFS= read -r file; do
 		if [[ -n "$file" ]]; then
-			local rel_path file_summary
-			rel_path="${file#"$project_root"/}"
-			file_summary=$(extract_file_summary "$file" 30)
+			if ! _compose_validate_related_file "$file" "$project_root"; then
+				print_error "Refusing Related Files for $task_id: a path is not a regular repository-relative todo/tasks file"
+				return 1
+			fi
+			rel_path="$_COMPOSE_RELATED_FILE_REL"
+			file_summary=$(extract_file_summary "$_COMPOSE_RELATED_FILE_ABS" 30)
 			if [[ -n "$file_summary" ]]; then
 				body="$body"$'\n\n'"${ISSUE_SYNC_DETAILS_OPEN}<summary><code>$rel_path</code></summary>"$'\n\n'"$file_summary"$'\n\n'"$ISSUE_SYNC_DETAILS_CLOSE"
 			else
@@ -508,7 +545,7 @@ _compose_issue_sections() {
 		body=$(_compose_issue_plan_sections "$body" "$plan_section")
 	fi
 
-	body=$(_compose_issue_related_files "$body" "$task_id" "$project_root")
+	body=$(_compose_issue_related_files "$body" "$task_id" "$project_root") || return 1
 	body=$(_compose_issue_worker_guidance "$body" "$project_root/todo/tasks/${task_id}-brief.md")
 	body=$(_compose_issue_brief "$body" "$project_root/todo/tasks/${task_id}-brief.md")
 	body=$(_compose_issue_brief_workflow_reference "$body")
@@ -684,7 +721,7 @@ compose_issue_body() {
 		"$assignee" "$logged" "$started" "$completed" "$verified" "$tags")
 
 	# All body sections: description, subtasks, plan, related files, brief
-	body=$(_compose_issue_sections "$body" "$block" "$description" "$blocked_by" "$blocks" "$plan_section" "$task_id" "$project_root")
+	body=$(_compose_issue_sections "$body" "$block" "$description" "$blocked_by" "$blocks" "$plan_section" "$task_id" "$project_root") || return 1
 
 	# HTML implementation notes and footer
 	body=$(_compose_issue_html_notes_and_footer "$body" "$first_line")

--- a/.agents/scripts/issue-sync-lib-parse.sh
+++ b/.agents/scripts/issue-sync-lib-parse.sh
@@ -791,7 +791,7 @@ find_related_files() {
 	local project_root="$2"
 	local tasks_dir="$project_root/todo/tasks"
 	local todo_file="$project_root/TODO.md"
-	local all_files=""
+	local -a all_files=()
 
 	# 1. Follow explicit ref:todo/tasks/ from the task line
 	if [[ -f "$todo_file" ]]; then
@@ -801,7 +801,7 @@ find_related_files() {
 		explicit_refs=$(echo "$task_line" | grep -oE 'ref:todo/tasks/[^ ]+' | sed 's/ref://' || true)
 		while IFS= read -r ref; do
 			if [[ -n "$ref" && -f "$project_root/$ref" ]]; then
-				all_files="${all_files:+$all_files"$'\n'"}$project_root/$ref"
+				all_files+=("$project_root/$ref")
 			fi
 		done <<<"$explicit_refs"
 	fi
@@ -815,13 +815,15 @@ find_related_files() {
 			grep_files=$(grep -rlF -- "$task_id" "$tasks_dir" 2>/dev/null || true)
 		fi
 		if [[ -n "$grep_files" ]]; then
-			all_files="${all_files:+$all_files"$'\n'"}$grep_files"
+			while IFS= read -r file; do
+				[[ -n "$file" ]] && all_files+=("$file")
+			done <<<"$grep_files"
 		fi
 	fi
 
 	# Deduplicate and exclude brief files (handled separately by compose_issue_body)
-	if [[ -n "$all_files" ]]; then
-		echo "$all_files" | sort -u | grep -v -- '-brief\.md$'
+	if [[ ${#all_files[@]} -gt 0 ]]; then
+		printf '%s\n' "${all_files[@]}" | sort -u | grep -v -- '-brief\.md$'
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-brief-inline-classifier.sh
+++ b/.agents/scripts/tests/test-brief-inline-classifier.sh
@@ -279,10 +279,12 @@ else
 fi
 
 # Test A6: composed related-file HTML remains schema-v2 worker-ready
+mkdir -p "$TMP/todo/tasks"
+printf '%s\n' 'Related architecture context remains available to the worker.' >"$TMP/todo/tasks/related-plan.md"
 composed_body=$(
 	(
 		find_related_files() {
-			printf '%s\n' "$TMP/related-plan.md"
+			printf '%s\n' "$TMP/todo/tasks/related-plan.md"
 			return 0
 		}
 		extract_file_summary() {
@@ -294,18 +296,36 @@ composed_body=$(
 )
 readiness_output=$("$READINESS_HELPER" check --body "$composed_body" 2>/dev/null)
 readiness_rc=$?
-if [[ $readiness_rc -eq 0 && "$composed_body" == *"<details><summary><code>related-plan.md</code></summary>"* && "$readiness_output" == *"WORKER_READY=true"* && "$readiness_output" == *"VALIDATION_ERRORS=none"* ]]; then
+if [[ $readiness_rc -eq 0 && "$composed_body" == *"<details><summary><code>todo/tasks/related-plan.md</code></summary>"* && "$readiness_output" == *"WORKER_READY=true"* && "$readiness_output" == *"VALIDATION_ERRORS=none"* ]]; then
 	pass "A6 composed related-file HTML round trip remains worker-ready"
 else
 	fail "A6 composed schema-v2 readiness round trip" "exit=$readiness_rc output=$readiness_output"
 fi
 
-# Test A7: no brief file → returns input unchanged
+# Test A7: related files outside todo/tasks fail closed before body rendering
+printf '%s\n' 'Outside context must not be rendered.' >"$TMP/outside-related.md"
+invalid_related_status=0
+invalid_related_output=$(
+	(
+		find_related_files() {
+			printf '%s\n' "$TMP/outside-related.md"
+			return 0
+		}
+		_compose_issue_related_files "base body" "t9005" "$TMP"
+	) 2>/dev/null
+) || invalid_related_status=$?
+if [[ $invalid_related_status -ne 0 && -z "$invalid_related_output" ]]; then
+	pass "A7 out-of-bound related file fails closed without rendering a body"
+else
+	fail "A7 related-file boundary" "expected non-zero with empty output, got exit=$invalid_related_status output=$invalid_related_output"
+fi
+
+# Test A8: no brief file → returns input unchanged
 result=$(_compose_issue_worker_guidance "base body" "$TMP/nonexistent.md")
 if [[ "$result" == "base body" ]]; then
-	pass "A7 no brief file returns input body unchanged"
+	pass "A8 no brief file returns input body unchanged"
 else
-	fail "A7 no brief file" "expected 'base body', got '$result'"
+	fail "A8 no brief file" "expected 'base body', got '$result'"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-enrich-no-data-loss.sh
+++ b/.agents/scripts/tests/test-enrich-no-data-loss.sh
@@ -303,11 +303,13 @@ fi
 # ----------------------------------------------------------------------------
 section "Layer 1: _enrich_process_task compose_issue_body exit code"
 
-# Structural check — the exit-code handling pattern should be present.
-if grep -qE "compose_issue_body .*\\|\\| _compose_rc" "$HELPER" && grep -q "Skipping enrich.*compose_issue_body failed" "$HELPER"; then
-	pass "_enrich_process_task checks compose_issue_body exit code"
+# Structural check — composition failure must propagate instead of reporting a
+# successful skip after refusing the write.
+if grep -qE "compose_issue_body .*\\|\\| _compose_rc" "$HELPER" &&
+	grep -q "Refusing enrich.*issue body composition failed" "$HELPER"; then
+	pass "_enrich_process_task fails closed on compose_issue_body errors"
 else
-	fail "_enrich_process_task missing compose_issue_body exit-code check"
+	fail "_enrich_process_task missing fail-closed compose_issue_body handling"
 fi
 
 # ----------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-issue-sync-enrich-bounds.sh
+++ b/.agents/scripts/tests/test-issue-sync-enrich-bounds.sh
@@ -11,6 +11,7 @@ WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/issue-sync-reusable.yml"
 
 TESTS_RUN=0
 TESTS_FAILED=0
+ENRICH_TEST_FAIL_TASK=""
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP:-}"' EXIT
 
@@ -51,6 +52,9 @@ _init_cmd() {
 _enrich_process_task() {
 	local task_id="$1" repo="$2" todo_file="$3" project_root="$4"
 	: "$repo" "$todo_file" "$project_root"
+	if [[ -n "$ENRICH_TEST_FAIL_TASK" && "$task_id" == "$ENRICH_TEST_FAIL_TASK" ]]; then
+		return 1
+	fi
 	printf '%s\n' "$task_id" >>"$TMP/processed.log"
 	printf 'ENRICHED\n'
 	return 0
@@ -179,6 +183,25 @@ test_elapsed_bound_tolerates_date_failure() {
 	return 0
 }
 
+test_task_failure_propagates() {
+	write_todo_fixture
+	: >"$TMP/processed.log"
+	ENRICH_TEST_FAIL_TASK="t9002"
+	local output status=0
+	set +e
+	output=$(AIDEVOPS_ENRICH_MAX_ISSUES=0 AIDEVOPS_ENRICH_MAX_SECONDS=0 cmd_enrich t9002 2>&1)
+	status=$?
+	set -e
+	ENRICH_TEST_FAIL_TASK=""
+	if [[ "$status" -eq 1 && "$output" == *"Enrich failed: 1 task(s)"* && ! -s "$TMP/processed.log" ]]; then
+		print_result "task composition failure makes enrich fail closed" 0
+	else
+		printf '%s\n' "$output"
+		print_result "task composition failure makes enrich fail closed" 1
+	fi
+	return 0
+}
+
 main() {
 	test_workflow_push_sets_bounded_enrich
 	test_workflow_manual_enrich_has_full_pass_headroom
@@ -187,6 +210,7 @@ main() {
 	test_invalid_bounds_are_ignored
 	test_bounds_helpers_tolerate_missing_values
 	test_elapsed_bound_tolerates_date_failure
+	test_task_failure_propagates
 	printf 'Tests run: %s\n' "$TESTS_RUN"
 	printf 'Tests failed: %s\n' "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-scoped-ripgrep-searches.sh
+++ b/.agents/scripts/tests/test-scoped-ripgrep-searches.sh
@@ -45,6 +45,21 @@ related_files=$(
 assert_eq "issue sync treats task IDs as fixed strings" \
 	"$TEST_ROOT/project/todo/tasks/literal.md" "$related_files"
 
+printf '%s\n' '- [ ] t9000 multi-source task ref:todo/tasks/explicit.md' >>"$TEST_ROOT/project/TODO.md"
+printf '%s\n' 'Task t9000 explicit context.' >"$TEST_ROOT/project/todo/tasks/explicit.md"
+printf '%s\n' 'Task t9000 state context.' >"$TEST_ROOT/project/todo/tasks/state.md"
+related_files=$(
+	SCRIPT_DIR="$REPO_ROOT/.agents/scripts"
+	# shellcheck source=../issue-sync-lib-parse.sh
+	source "$REPO_ROOT/.agents/scripts/issue-sync-lib-parse.sh"
+	find_related_files 't9000' "$TEST_ROOT/project"
+)
+expected_related_files=$(printf '%s\n' \
+	"$TEST_ROOT/project/todo/tasks/explicit.md" \
+	"$TEST_ROOT/project/todo/tasks/state.md")
+assert_eq "issue sync emits one clean line per explicit and discovered reference" \
+	"$expected_related_files" "$related_files"
+
 mkdir -p "$TEST_ROOT/home/.aidevops/logs" "$TEST_ROOT/mission"
 artifact="$TEST_ROOT/mission/helper[1].sh"
 printf '%s\n' '# helper[1].sh' >"$artifact"
@@ -72,7 +87,7 @@ ci_result=$(bash -c 'source "$1"; discover_ci "$2"' _ \
 has_test_step=$(printf '%s' "$ci_result" | jq -r '.[0].has_test_step')
 assert_eq "CI discovery detects test commands with bounded search" "true" "$has_test_step"
 
-if rg -q 'rg -l -F --' "$REPO_ROOT/.agents/scripts/issue-sync-lib-parse.sh" && \
+if rg -q 'rg -l -F --' "$REPO_ROOT/.agents/scripts/issue-sync-lib-parse.sh" &&
 	rg -q 'grep -rlF --' "$REPO_ROOT/.agents/scripts/issue-sync-lib-parse.sh"; then
 	assert_eq "issue sync retains portable grep fallback" "true" "true"
 else


### PR DESCRIPTION
## Summary

Fix Related Files discovery to emit one clean path per record, validate every rendered path as a regular non-symlink file under todo/tasks, and propagate composition failures so push/enrich refuse unsafe public writes.

## Files Changed

.agents/scripts/issue-sync-helper-enrich.sh, .agents/scripts/issue-sync-helper.sh, .agents/scripts/issue-sync-lib-compose.sh, .agents/scripts/issue-sync-lib-parse.sh, .agents/scripts/tests/test-brief-inline-classifier.sh, .agents/scripts/tests/test-enrich-no-data-loss.sh, .agents/scripts/tests/test-issue-sync-enrich-bounds.sh, .agents/scripts/tests/test-scoped-ripgrep-searches.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Passed focused issue-sync suites (6 + 23 + 8 + 13 + 43 tests), ShellCheck on all 8 changed shell files, secret scanning, portability and complexity gates, and the complete changed-file local linter bundle.

Resolves #30903


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.295 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 34m and 360,782 tokens on this with the user in an interactive session.