### PR TITLE
GH#30902: bind recovery claims to archive identity

### DIFF
--- a/.agents/scripts/interactive-session-helper-stamp.sh
+++ b/.agents/scripts/interactive-session-helper-stamp.sh
@@ -253,15 +253,18 @@ _isc_extract_issue_from_branch() {
 _isc_branch_has_active_claim() {
 	local branch=""
 	local worktree_path=""
+	local worktree_supplied=0
 
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
 			--worktree)
+				worktree_supplied=1
 				worktree_path="${2:-}"
 				shift 2
 				;;
 			--worktree=*)
+				worktree_supplied=1
 				worktree_path="${_arg#--worktree=}"
 				shift
 				;;
@@ -284,13 +287,14 @@ _isc_branch_has_active_claim() {
 	issue=$(_isc_extract_issue_from_branch "$branch") || return 1
 	[[ -z "$issue" ]] && return 1
 
-	# Derive slug from worktree-path remote when supplied, else from CWD.
+	# An explicit worktree binds repository identity to that path. Only callers
+	# that omit the option may derive identity from their current directory.
 	local slug=""
-	if [[ -n "$worktree_path" && -d "$worktree_path" ]]; then
+	if [[ "$worktree_supplied" -eq 1 ]]; then
+		[[ -n "$worktree_path" && -d "$worktree_path" ]] || return 1
 		slug=$(git -C "$worktree_path" remote get-url origin 2>/dev/null \
 			| sed 's|.*github\.com[:/]||;s|\.git$||' || echo "")
-	fi
-	if [[ -z "$slug" ]]; then
+	else
 		slug=$(git remote get-url origin 2>/dev/null \
 			| sed 's|.*github\.com[:/]||;s|\.git$||' || echo "")
 	fi

--- a/.agents/scripts/tests/test-worktree-cleanup-claim-guard.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-claim-guard.sh
@@ -468,6 +468,12 @@ test_cli_subcommand() {
 
 	"$HELPER_PATH" branch-has-active-claim "feature/gh-${issue}-test" --worktree "$FAKE_REPO" >/dev/null 2>&1
 	local rc_alive=$?
+	local rc_missing_path=0
+	(
+		cd "$FAKE_REPO" || exit 9
+		"$HELPER_PATH" branch-has-active-claim "feature/gh-${issue}-test" \
+			--worktree "${TEST_ROOT}/removed-worktree" >/dev/null 2>&1
+	) || rc_missing_path=$?
 
 	rm -f "$stamp"
 	"$HELPER_PATH" branch-has-active-claim "feature/gh-${issue}-test" --worktree "$FAKE_REPO" >/dev/null 2>&1
@@ -477,11 +483,11 @@ test_cli_subcommand() {
 	"$HELPER_PATH" branch-has-active-claim >/dev/null 2>&1
 	local rc_usage=$?
 
-	if [[ $rc_alive -eq 0 && $rc_no_stamp -eq 1 && $rc_usage -eq 2 ]]; then
+	if [[ $rc_alive -eq 0 && $rc_missing_path -eq 1 && $rc_no_stamp -eq 1 && $rc_usage -eq 2 ]]; then
 		print_result "CLI subcommand round-trips" 0
 	else
 		print_result "CLI subcommand round-trips" 1 \
-			"(alive=$rc_alive, no_stamp=$rc_no_stamp, usage=$rc_usage)"
+			"(alive=$rc_alive, missing_path=$rc_missing_path, no_stamp=$rc_no_stamp, usage=$rc_usage)"
 	fi
 }
 test_cli_subcommand

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -200,6 +200,8 @@ test_exact_plan_writes_candidate_without_mutation() {
 	mkdir -p "$home_path" "$recovery_root" || rc=1
 	archive_path=$(create_archived_fixture "$repo_path" "$worktree_path" "$recovery_root" \
 		"bugfix/gh29388-recovery-plan") || rc=1
+	"$GIT_BIN" -C "$archive_path" remote add origin \
+		"https://github.com/example/repo.git" || rc=1
 	marker_path="${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}"
 	bucket_path="${archive_path%/*}"
 	marker_digest_before=$(_worktree_recovery_plan_sha256_file "$marker_path") || rc=1
@@ -262,6 +264,52 @@ test_git_state_detects_recovery_data() {
 	[[ "$state" == "dirty" ]] || rc=1
 	print_result "git_state_detects_recovery_data" "$rc" \
 		"Expected tracked, untracked, and ignored recovery data to veto candidates"
+	return 0
+}
+
+test_claim_state_uses_archive_repository() {
+	local home_path="${TEST_DIR}/claim-home"
+	local repo_path="${TEST_DIR}/claim-repo"
+	local worktree_path="${TEST_DIR}/claim-worktree"
+	local unrelated_repo="${TEST_DIR}/claim-unrelated-repo"
+	local recovery_root="${home_path}/recovery"
+	local claim_dir="${home_path}/.aidevops/.agent-workspace/interactive-claims"
+	local archive_path="" identity="" unavailable_identity="" state=""
+	local rc=0
+
+	mkdir -p "$home_path" "$recovery_root" "$claim_dir" || rc=1
+	archive_path=$(create_archived_fixture "$repo_path" "$worktree_path" "$recovery_root" \
+		"bugfix/gh30902-archive-claim") || rc=1
+	"$GIT_BIN" -C "$archive_path" remote add origin \
+		"https://github.com/archive/repo.git" || rc=1
+	identity=$(_worktree_recovery_plan_identity_json "${archive_path%/*}") || rc=1
+	"$GIT_BIN" init -q -b main "$unrelated_repo" || rc=1
+	"$GIT_BIN" -C "$unrelated_repo" remote add origin \
+		"https://github.com/unrelated/repo.git" || rc=1
+	jq -n '{issue:30902,slug:"unrelated/repo",pid:1,
+		hostname:"aidevops-remote-fixture.invalid"}' \
+		>"${claim_dir}/unrelated-repo-30902.json" || rc=1
+	state=$(
+		cd "$unrelated_repo" || exit 1
+		export HOME="$home_path"
+		_worktree_recovery_plan_claim_state "$identity"
+	) || rc=1
+	[[ "$state" == "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ]] || rc=1
+	jq -n '{issue:30902,slug:"archive/repo",pid:1,
+		hostname:"aidevops-remote-fixture.invalid"}' \
+		>"${claim_dir}/archive-repo-30902.json" || rc=1
+	state=$(
+		cd "$unrelated_repo" || exit 1
+		export HOME="$home_path"
+		_worktree_recovery_plan_claim_state "$identity"
+	) || rc=1
+	[[ "$state" == "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE" ]] || rc=1
+	unavailable_identity=$(printf '%s\n' "$identity" | jq -c \
+		--arg archive "${TEST_DIR}/missing-archive" '.archive_path = $archive') || rc=1
+	state=$(_worktree_recovery_plan_claim_state "$unavailable_identity") || rc=1
+	[[ "$state" == "$WORKTREE_RECOVERY_UNAVAILABLE" ]] || rc=1
+	print_result "claim_state_uses_archive_repository" "$rc" \
+		"Expected archive-bound claims, no unrelated CWD fallback, and unavailable invalid identity"
 	return 0
 }
 
@@ -1492,6 +1540,7 @@ source "${SCRIPTS_DIR}/worktree-helper-cmds.sh"
 setup
 printf '=== test-worktree-recovery-lifecycle.sh ===\n'
 test_git_state_detects_recovery_data
+test_claim_state_uses_archive_repository
 test_exact_plan_writes_candidate_without_mutation
 test_plan_output_refuses_unsafe_targets
 test_classification_fails_closed

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -584,15 +584,19 @@ _worktree_recovery_plan_registry_state() {
 
 _worktree_recovery_plan_claim_state() {
 	local identity_json="$1"
-	local source_path="" helper="" claim_rc=0
+	local archive_path="" helper="" claim_rc=0
 	local branch=""
 
-	source_path=$(printf '%s\n' "$identity_json" | jq -r '.source_path') || return 1
+	archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
 	branch=$(printf '%s\n' "$identity_json" | jq -r '.branch') || return 1
 	[[ "$branch" == refs/heads/* ]] || {
 		printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE"
 		return 0
 	}
+	if ! _worktree_recovery_plan_repo_slug "$archive_path" >/dev/null; then
+		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
+		return 0
+	fi
 	if [[ -x "$WORKTREE_RECOVERY_LIFECYCLE_DIR/interactive-session-helper.sh" ]]; then
 		helper="$WORKTREE_RECOVERY_LIFECYCLE_DIR/interactive-session-helper.sh"
 	elif [[ -x "${HOME:-}/.aidevops/agents/scripts/interactive-session-helper.sh" ]]; then
@@ -601,7 +605,7 @@ _worktree_recovery_plan_claim_state() {
 		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
 		return 0
 	fi
-	"$helper" branch-has-active-claim "${branch#refs/heads/}" --worktree "$source_path" \
+	"$helper" branch-has-active-claim "${branch#refs/heads/}" --worktree "$archive_path" \
 		>/dev/null 2>&1 || claim_rc=$?
 	case "$claim_rc" in
 	0) printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE" ;;


### PR DESCRIPTION
## Summary

Bind archived-worktree claim checks to the surviving archive repository and prevent explicit worktree paths from falling back to an unrelated caller CWD.

## Files Changed

.agents/scripts/interactive-session-helper-stamp.sh, .agents/scripts/tests/test-worktree-cleanup-claim-guard.sh, .agents/scripts/tests/test-worktree-recovery-lifecycle.sh, .agents/scripts/worktree-recovery-lifecycle-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified recovery lifecycle suite passes 29/29; claim guard suite passes 10/10; ShellCheck and local linters pass; independent safety review is clean.

Resolves #30902


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.295 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 34m and 254,723 tokens on this with the user in an interactive session.