### PR TITLE
GH#30909: expose mandatory discovery-tool readiness

### DIFF
--- a/.agents/rules/no-glob-for-discovery.md
+++ b/.agents/rules/no-glob-for-discovery.md
@@ -16,4 +16,5 @@ Prefer faster file discovery methods over Glob:
 - Use `git ls-files '<pattern>'` for git-tracked files (instant)
 - Use `fd -e <ext>` or `fd -g '<pattern>'` for untracked/system files
 - Use `rg --files -g '<pattern>'` for content + file list
+- If `fd` is unavailable, use `rg --files -g '<pattern>'` or a scoped `git ls-files`; do not fall back to broad `find` or Glob-first discovery
 - Only use Glob as a last resort when Bash is unavailable

--- a/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
@@ -24,6 +24,27 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+_file_discovery_readiness_lib="${SCRIPT_DIR%/aidevops-cli}/file-discovery-readiness.sh"
+if [[ -f "$_file_discovery_readiness_lib" ]]; then
+	# shellcheck source=../file-discovery-readiness.sh
+	source "$_file_discovery_readiness_lib"
+fi
+unset _file_discovery_readiness_lib
+
+_status_file_discovery_readiness() {
+	local fd_state="unavailable"
+	if declare -F aidevops_fd_state >/dev/null 2>&1; then
+		fd_state=$(aidevops_fd_state || true)
+	fi
+	case "$fd_state" in
+	ready) print_success "fd" ;;
+	compatibility) print_error "fd - fdfind is installed but the required fd command is unavailable; run: aidevops setup" ;;
+	*) print_error "fd - not installed; run: aidevops setup" ;;
+	esac
+	check_cmd rg && print_success "rg" || print_error "rg - not installed; run: aidevops setup"
+	return 0
+}
+
 _status_recommended_tools() {
 	print_header "Recommended Tools"
 	if [[ "$(uname)" == "Darwin" ]]; then
@@ -247,6 +268,7 @@ cmd_status() {
 	echo ""
 	print_header "Required Dependencies"
 	for cmd in git curl jq ssh; do check_cmd "$cmd" && print_success "$cmd" || print_error "$cmd - not installed"; done
+	_status_file_discovery_readiness
 	echo ""
 	print_header "Optional Dependencies"
 	check_cmd sshpass && print_success "sshpass" || print_warning "sshpass - not installed (needed for password SSH)"

--- a/.agents/scripts/file-discovery-readiness.sh
+++ b/.agents/scripts/file-discovery-readiness.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Shared readiness contract for the fd command used by agent discovery rules.
+
+aidevops_fd_state() {
+	if command -v fd >/dev/null 2>&1; then
+		printf 'ready\n'
+		return 0
+	fi
+	if command -v fdfind >/dev/null 2>&1; then
+		printf 'compatibility\n'
+		return 0
+	fi
+	printf 'missing\n'
+	return 1
+}
+
+aidevops_ensure_fd_command() {
+	local fdfind_path=""
+	local shim_dir="${AIDEVOPS_FD_SHIM_DIR:-${HOME}/.local/bin}"
+	local shim_path="${shim_dir}/fd"
+
+	if command -v fd >/dev/null 2>&1; then
+		return 0
+	fi
+	fdfind_path=$(command -v fdfind 2>/dev/null || true)
+	if [[ "$fdfind_path" != /* ]]; then
+		return 1
+	fi
+	mkdir -p "$shim_dir" || return 1
+	ln -sfn "$fdfind_path" "$shim_path" || return 1
+	if [[ ":${PATH}:" != *":${shim_dir}:"* ]]; then
+		export PATH="${shim_dir}:${PATH}"
+	fi
+	command -v fd >/dev/null 2>&1 || return 1
+	return 0
+}

--- a/.agents/scripts/file-discovery-readiness.sh
+++ b/.agents/scripts/file-discovery-readiness.sh
@@ -22,6 +22,7 @@ aidevops_ensure_fd_command() {
 	local shim_dir="${AIDEVOPS_FD_SHIM_DIR:-${HOME}/.local/bin}"
 	local shim_path="${shim_dir}/fd"
 
+	hash -r 2>/dev/null || true
 	if command -v fd >/dev/null 2>&1; then
 		return 0
 	fi
@@ -30,6 +31,14 @@ aidevops_ensure_fd_command() {
 		return 1
 	fi
 	mkdir -p "$shim_dir" || return 1
+	if [[ -e "$shim_path" || -L "$shim_path" ]]; then
+		[[ -x "$shim_path" ]] || return 1
+		if [[ ":${PATH}:" != *":${shim_dir}:"* ]]; then
+			export PATH="${shim_dir}:${PATH}"
+		fi
+		command -v fd >/dev/null 2>&1 || return 1
+		return 0
+	fi
 	ln -sfn "$fdfind_path" "$shim_path" || return 1
 	if [[ ":${PATH}:" != *":${shim_dir}:"* ]]; then
 		export PATH="${shim_dir}:${PATH}"

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -11,6 +11,14 @@ IFS=$'\n\t'
 trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
 shopt -s inherit_errexit 2>/dev/null || true
 
+_tool_install_dir="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+_file_discovery_readiness_lib="${_tool_install_dir}/../../file-discovery-readiness.sh"
+if [[ -f "$_file_discovery_readiness_lib" ]]; then
+	# shellcheck source=../../file-discovery-readiness.sh
+	source "$_file_discovery_readiness_lib"
+fi
+unset _tool_install_dir _file_discovery_readiness_lib
+
 _print_gh_slurp_manual_upgrade() {
 	echo ""
 	echo "📋 GitHub CLI upgrade guidance:"
@@ -170,33 +178,6 @@ _print_file_discovery_manual_install() {
 	return 0
 }
 
-# Add fd=fdfind alias to shell rc files on Debian/Ubuntu after apt install.
-_add_fd_alias_debian() {
-	local rc_files=("$HOME/.bashrc" "$HOME/.zshrc")
-	local added_to=""
-	local rc_file
-
-	for rc_file in "${rc_files[@]}"; do
-		[[ ! -f "$rc_file" ]] && continue
-
-		if ! grep -q 'alias fd="fdfind"' "$rc_file" 2>/dev/null; then
-			if { echo '' >>"$rc_file" &&
-				echo '# fd-find alias for Debian/Ubuntu (added by aidevops)' >>"$rc_file" &&
-				echo 'alias fd="fdfind"' >>"$rc_file"; }; then
-				added_to="${added_to:+$added_to, }$rc_file"
-			fi
-		fi
-	done
-
-	if [[ -n "$added_to" ]]; then
-		print_success "Added alias fd=fdfind to: $added_to"
-		echo "  Restart your shell to activate"
-	else
-		print_success "fd alias already configured"
-	fi
-	return 0
-}
-
 # Resolve apt package names (fd→fd-find on Debian/Ubuntu) and install.
 _install_file_discovery_packages() {
 	local pkg_manager="$1"
@@ -225,9 +206,13 @@ _install_file_discovery_packages() {
 
 	if install_packages "$pkg_manager" "${actual_packages[@]}"; then
 		print_success "File discovery tools installed"
-		# On Debian/Ubuntu, fd is installed as fdfind — create alias in shell rc files
+		# Debian/Ubuntu installs fdfind; expose the fd command to non-interactive agents.
 		if [[ "$pkg_manager" == "apt" ]] && command -v fdfind >/dev/null 2>&1 && ! command -v fd >/dev/null 2>&1; then
-			_add_fd_alias_debian
+			if aidevops_ensure_fd_command; then
+				print_success "Installed fd compatibility command in ~/.local/bin"
+			else
+				print_warning "fdfind is installed but the required fd command could not be exposed"
+			fi
 		fi
 	else
 		print_warning "Failed to install some file discovery tools (non-critical)"
@@ -248,8 +233,13 @@ setup_file_discovery_tools() {
 		print_success "fd found: $fd_version"
 	elif command -v fdfind >/dev/null 2>&1; then
 		fd_version=$(fdfind --version 2>/dev/null | head -1 || echo "unknown")
-		print_success "fd found (as fdfind): $fd_version"
-		print_warning "Note: 'fd' alias not active in current shell. Restart shell or run: alias fd=fdfind"
+		if aidevops_ensure_fd_command; then
+			print_success "fd compatibility command installed for fdfind: $fd_version"
+		else
+			missing_tools+=("fd")
+			missing_packages+=("fd")
+			missing_names+=("fd command (fdfind exists but is not exposed as fd)")
+		fi
 	else
 		missing_tools+=("fd")
 		missing_packages+=("fd")

--- a/.agents/scripts/tests/test-file-discovery-readiness.sh
+++ b/.agents/scripts/tests/test-file-discovery-readiness.sh
@@ -63,6 +63,17 @@ aidevops_ensure_fd_command
 assert_equal "$TEST_ROOT/shims/fd" "$(command -v fd)" "fdfind compatibility command is executable"
 assert_equal "fd 10.0.0" "$(fd --version)" "compatibility command delegates to fdfind"
 
+mkdir -p "$TEST_ROOT/occupied"
+printf 'preserve-user-file\n' >"$TEST_ROOT/occupied/fd"
+PATH="$TEST_ROOT/fdfind-only:/usr/bin:/bin"
+AIDEVOPS_FD_SHIM_DIR="$TEST_ROOT/occupied"
+export PATH AIDEVOPS_FD_SHIM_DIR
+if aidevops_ensure_fd_command; then
+	printf 'FAIL: existing non-executable fd path was replaced or accepted\n' >&2
+	exit 1
+fi
+assert_equal "preserve-user-file" "$(<"$TEST_ROOT/occupied/fd")" "existing fd path is preserved"
+
 print_success() {
 	local text="$1"
 	printf 'SUCCESS: %s\n' "$text"

--- a/.agents/scripts/tests/test-file-discovery-readiness.sh
+++ b/.agents/scripts/tests/test-file-discovery-readiness.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+READINESS_LIB="${SCRIPT_DIR}/../file-discovery-readiness.sh"
+TEST_ROOT="$(mktemp -d -t aidevops-fd-readiness.XXXXXX)"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+# shellcheck source=../file-discovery-readiness.sh
+source "$READINESS_LIB"
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local name="$3"
+	if [[ "$actual" != "$expected" ]]; then
+		printf 'FAIL: %s (expected %s, got %s)\n' "$name" "$expected" "$actual" >&2
+		return 1
+	fi
+	printf 'PASS: %s\n' "$name"
+	return 0
+}
+
+assert_contains() {
+	local expected="$1"
+	local actual="$2"
+	local name="$3"
+	if [[ "$actual" != *"$expected"* ]]; then
+		printf 'FAIL: %s (missing %s)\n' "$name" "$expected" >&2
+		return 1
+	fi
+	printf 'PASS: %s\n' "$name"
+	return 0
+}
+
+missing_state=$(PATH="/usr/bin:/bin" aidevops_fd_state || true)
+assert_equal "missing" "$missing_state" "missing fd is reported"
+
+mkdir -p "$TEST_ROOT/fdfind-only" "$TEST_ROOT/fd-ready" "$TEST_ROOT/shims"
+printf '#!/usr/bin/env bash\nprintf "fd 10.0.0\\n"\n' >"$TEST_ROOT/fdfind-only/fdfind"
+printf '#!/usr/bin/env bash\nprintf "fd 10.0.0\\n"\n' >"$TEST_ROOT/fd-ready/fd"
+chmod +x "$TEST_ROOT/fdfind-only/fdfind" "$TEST_ROOT/fd-ready/fd"
+
+compatibility_state=$(PATH="$TEST_ROOT/fdfind-only:/usr/bin:/bin" aidevops_fd_state)
+assert_equal "compatibility" "$compatibility_state" "fdfind-only state is distinguished"
+
+ready_state=$(PATH="$TEST_ROOT/fd-ready:/usr/bin:/bin" aidevops_fd_state)
+assert_equal "ready" "$ready_state" "fd command is ready"
+
+PATH="$TEST_ROOT/fdfind-only:/usr/bin:/bin"
+export PATH
+AIDEVOPS_FD_SHIM_DIR="$TEST_ROOT/shims"
+export AIDEVOPS_FD_SHIM_DIR
+aidevops_ensure_fd_command
+assert_equal "$TEST_ROOT/shims/fd" "$(command -v fd)" "fdfind compatibility command is executable"
+assert_equal "fd 10.0.0" "$(fd --version)" "compatibility command delegates to fdfind"
+
+print_success() {
+	local text="$1"
+	printf 'SUCCESS: %s\n' "$text"
+	return 0
+}
+print_error() {
+	local text="$1"
+	printf 'ERROR: %s\n' "$text"
+	return 0
+}
+check_cmd() {
+	local command_name="$1"
+	command -v "$command_name" >/dev/null 2>&1 || return 1
+	return 0
+}
+
+# shellcheck source=../aidevops-cli/aidevops-status-lib.sh
+source "${SCRIPT_DIR}/../aidevops-cli/aidevops-status-lib.sh"
+missing_output=$(PATH="/usr/bin:/bin" _status_file_discovery_readiness)
+assert_contains "fd - not installed" "$missing_output" "status reports missing fd with remediation"
+compatibility_output=$(PATH="$TEST_ROOT/fdfind-only:/usr/bin:/bin" _status_file_discovery_readiness)
+assert_contains "fdfind is installed but the required fd command is unavailable" "$compatibility_output" "status reports fdfind compatibility gap"
+ready_output=$(PATH="$TEST_ROOT/fd-ready:/usr/bin:/bin" _status_file_discovery_readiness)
+assert_contains "SUCCESS: fd" "$ready_output" "status reports ready fd command"
+
+printf 'PASS: file-discovery readiness contract\n'
+exit 0


### PR DESCRIPTION
## Summary

Report fd and rg readiness in status, expose Debian fdfind as a non-interactive fd command, and document safe discovery fallbacks.

## Files Changed

.agents/rules/no-glob-for-discovery.md, .agents/scripts/aidevops-cli/aidevops-status-lib.sh, .agents/scripts/file-discovery-readiness.sh, .agents/scripts/setup/modules/tool-install.sh, .agents/scripts/tests/test-file-discovery-readiness.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck; focused fd missing, fdfind-only, and fd-ready states; status parity; OpenCode setup regression suite; linters-local --changed.

Resolves #30909


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.295 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 42m and 247,861 tokens on this with the user in an interactive session.