### PR TITLE
GH#30910: feat: report missing agent intent coverage

### DIFF
--- a/.agents/reference/observability.md
+++ b/.agents/reference/observability.md
@@ -249,8 +249,15 @@ session-introspect-helper.sh sessions 5
 
 The `patterns` subcommand flags files read/edited more than 3× in the
 current session — a common stuck-worker signature when file comprehension
-isn't landing. When this fires, break out of the loop: `git diff`,
-`git status`, or step back to re-read the brief.
+isn't landing. It also reports exact `calls.intent_present`,
+`calls.intent_missing`, and `calls.intent_coverage_percent` fields in JSON
+(with matching text totals). Null, empty, and whitespace-only legacy values
+count as missing. When intent is missing, `errors` renders `<missing>` and
+retains only the tool, duration, and outcome category as fallback context;
+it never reads or displays tool arguments, paths, prompts, commands, or
+credentials. A missing-intent notice means root-cause clustering is limited.
+When repeated access fires, break out of the loop: `git diff`, `git status`,
+or step back to re-read the brief.
 
 Stuck-worker thresholds (informational):
 

--- a/.agents/scripts/session-introspect-helper.sh
+++ b/.agents/scripts/session-introspect-helper.sh
@@ -243,14 +243,21 @@ cmd_patterns() {
 			SUM(CASE WHEN success=0 THEN 1 ELSE 0 END) AS errors,
 			MIN(timestamp) AS first_ts,
 			MAX(timestamp) AS last_ts,
-			COALESCE(AVG(duration_ms),0) AS avg_dur
+			COALESCE(AVG(duration_ms),0) AS avg_dur,
+			COALESCE(SUM(CASE WHEN TRIM(COALESCE(intent,''))<>'' THEN 1 ELSE 0 END),0) AS intent_present
 		FROM tool_calls
 		WHERE session_id='${sid_esc}' ${since};
 	")
-	local total errors first_ts last_ts avg_dur
-	IFS='|' read -r total errors first_ts last_ts avg_dur <<<"$stats"
+	local total errors first_ts last_ts avg_dur intent_present intent_missing intent_coverage
+	IFS='|' read -r total errors first_ts last_ts avg_dur intent_present <<<"$stats"
 	total="${total:-0}"
 	errors="${errors:-0}"
+	intent_present="${intent_present:-0}"
+	intent_missing=$((total - intent_present))
+	intent_coverage="0.00"
+	if [[ "$total" -gt 0 ]]; then
+		intent_coverage=$(sqlite3 "$db" "SELECT printf('%.2f', ${intent_present}*100.0/${total});")
+	fi
 
 	# Per-tool counts.
 	local by_tool
@@ -303,10 +310,12 @@ cmd_patterns() {
 
 	if [[ "$json_flag" == "true" ]]; then
 		_patterns_json "$sid" "$total" "$errors" "$first_ts" "$last_ts" \
-			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes"
+			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes" \
+			"$intent_present" "$intent_missing" "$intent_coverage"
 	else
 		_patterns_table "$sid" "$total" "$errors" "$first_ts" "$last_ts" \
-			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes"
+			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes" \
+			"$intent_present" "$intent_missing" "$intent_coverage"
 	fi
 	return 0
 }
@@ -314,11 +323,17 @@ cmd_patterns() {
 _patterns_table() {
 	local sid="$1" total="$2" errors="$3" first_ts="$4" last_ts="$5"
 	local avg_dur="$6" rate="$7" by_tool="$8" rereads="$9"
-	local outcomes="${10}"
+	local outcomes="${10}" intent_present="${11}" intent_missing="${12}" intent_coverage="${13}"
 	printf 'Session: %s\n' "$sid"
 	printf 'Window:  %s → %s\n' "${first_ts:-?}" "${last_ts:-?}"
 	printf 'Calls:   %s total, %s error(s), %s calls/min, avg %sms\n\n' \
 		"$total" "$errors" "$rate" "${avg_dur%.*}"
+	printf 'Intent:  %s present, %s missing, %s%% coverage\n' \
+		"$intent_present" "$intent_missing" "$intent_coverage"
+	if [[ "$intent_missing" -gt 0 ]]; then
+		printf 'Notice: missing intents limit root-cause clustering to tool, duration, and outcome category.\n'
+	fi
+	printf '\n'
 
 	printf 'Per-tool:\n'
 	if [[ -n "$by_tool" ]]; then
@@ -356,7 +371,7 @@ _patterns_table() {
 _patterns_json() {
 	local sid="$1" total="$2" errors="$3" first_ts="$4" last_ts="$5"
 	local avg_dur="$6" rate="$7" by_tool="$8" rereads="$9"
-	local outcomes="${10}"
+	local outcomes="${10}" intent_present="${11}" intent_missing="${12}" intent_coverage="${13}"
 	command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
 	local by_tool_json
 	by_tool_json=$(printf '%s' "$by_tool" | jq -R -s '
@@ -383,6 +398,8 @@ _patterns_json() {
 	jq -n \
 		--arg sid "$sid" --arg first_ts "$first_ts" --arg last_ts "$last_ts" \
 		--argjson total "${total:-0}" --argjson errors "${errors:-0}" \
+		--argjson intent_present "${intent_present:-0}" --argjson intent_missing "${intent_missing:-0}" \
+		--argjson intent_coverage "${intent_coverage:-0}" \
 		--argjson avg_dur "${avg_dur:-0}" --arg rate "$rate" \
 		--argjson by_tool "$by_tool_json" --argjson outcomes "$outcomes_json" \
 		--argjson rereads "$rereads_json" \
@@ -393,6 +410,9 @@ _patterns_json() {
 			calls: {
 				total: $total,
 				errors: $errors,
+				intent_present: $intent_present,
+				intent_missing: $intent_missing,
+				intent_coverage_percent: $intent_coverage,
 				rate_per_min: ($rate|tonumber),
 				avg_ms: $avg_dur,
 				outcomes: $outcomes
@@ -429,7 +449,10 @@ cmd_errors() {
 	outcome_expr=$(_outcome_category_sql "$db")
 
 	local query="
-		SELECT timestamp, tool_name, COALESCE(intent,''), COALESCE(duration_ms,0), ${outcome_expr}
+		SELECT timestamp, tool_name,
+			CASE WHEN TRIM(COALESCE(intent,''))='' THEN '<missing>' ELSE intent END,
+			CASE WHEN TRIM(COALESCE(intent,''))='' THEN 0 ELSE 1 END,
+			COALESCE(duration_ms,0), ${outcome_expr}
 		FROM tool_calls
 		WHERE session_id='${sid_esc}' AND success=0 ${since}
 		ORDER BY timestamp DESC
@@ -439,15 +462,15 @@ cmd_errors() {
 		command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
 		sqlite3 -separator '|' "$db" "$query" | jq -R -s --arg sid "$sid" '
 			split("\n") | map(select(length > 0) | split("|") | {
-				timestamp: .[0], tool: .[1], intent: .[2],
-				duration_ms: (.[3] | tonumber? // 0), category: .[4]
+				timestamp: .[0], tool: .[1], intent: .[2], intent_present: (.[3] == "1"),
+				duration_ms: (.[4] | tonumber? // 0), category: .[5]
 			}) | { session: $sid, errors: . }'
 	else
 		printf 'Session: %s\n\n' "$sid"
 		printf '%-23s  %-8s  %-6s  %-18s  %s\n' "TIMESTAMP" "TOOL" "MS" "CATEGORY" "INTENT"
 		printf '%-23s  %-8s  %-6s  %-18s  %s\n' "-----------------------" "--------" "------" "------------------" "----------------------------------------"
 		local count=0
-		while IFS='|' read -r ts tool intent dur category; do
+		while IFS='|' read -r ts tool intent intent_present dur category; do
 			[[ -z "$ts" ]] && continue
 			printf '%-23s  %-8s  %-6s  %-18s  %s\n' \
 				"${ts:0:23}" "${tool:0:8}" "${dur}" "${category:0:18}" "${intent:0:60}"

--- a/.agents/scripts/tests/test-session-introspect.sh
+++ b/.agents/scripts/tests/test-session-introspect.sh
@@ -80,9 +80,9 @@ INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, durat
  ('2026-04-18T04:00:10Z', 'sess-A', 'Read',   'rechecking auth handler',       1,  88, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
  ('2026-04-18T04:00:15Z', 'sess-A', 'Read',   're-reading auth handler',       1,  95, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
  ('2026-04-18T04:00:20Z', 'sess-A', 'Read',   'reading auth handler AGAIN',    1,  80, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
- ('2026-04-18T04:00:25Z', 'sess-A', 'Edit',   'patching auth handler',         1, 240, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
+ ('2026-04-18T04:00:25Z', 'sess-A', 'Edit',   '',                              1, 240, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
  ('2026-04-18T04:00:30Z', 'sess-A', 'Bash',   'running shellcheck',            0, 850, '{}', 'command_failure'),
- ('2026-04-18T04:00:35Z', 'sess-A', 'Bash',   'running blocked retry',         0, 910, '{}', 'policy_block'),
+ ('2026-04-18T04:00:35Z', 'sess-A', 'Bash',   NULL,                            0, 910, '{"args":{"redaction_probe":"never-expose"}}', 'policy_block'),
  ('2026-04-18T04:00:40Z', 'sess-A', 'Bash',   'running shellcheck final',      1, 780, '{}', 'success'),
  ('2026-04-18T04:00:45Z', 'sess-A', 'Task',   'handling runtime error',        0,  50, '{}', 'tool_error');
 
@@ -96,6 +96,14 @@ INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, durat
 
 INSERT INTO session_summaries (session_id, first_seen, last_seen, request_count, total_tool_calls, total_errors, total_cost, models_used)
 VALUES ('sess-B', '2026-04-17T10:00:00Z', '2026-04-17T10:00:05Z', 2, 2, 0, 0.0041, 'claude-sonnet-4');
+
+-- Session C (legacy missing intents)
+INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, duration_ms, metadata, outcome_category) VALUES
+ ('2026-04-16T10:00:00Z', 'sess-C', 'Read',  NULL, 1, 100, '{"args":{"filePath":"/repo/legacy.sh"}}', 'success'),
+ ('2026-04-16T10:00:05Z', 'sess-C', 'Bash',  '',   0, 200, '{}', 'command_failure');
+
+INSERT INTO session_summaries (session_id, first_seen, last_seen, request_count, total_tool_calls, total_errors, total_cost, models_used)
+VALUES ('sess-C', '2026-04-16T10:00:00Z', '2026-04-16T10:00:05Z', 2, 2, 1, 0.0041, 'claude-sonnet-4');
 SQL
 
 # ----------------------------------------------------------------------------
@@ -137,12 +145,26 @@ assert_contains "patterns: separates tool errors"    "$out" "tool_error"
 assert_contains "patterns: preserves unknown legacy outcomes" "$out" "legacy_unknown"
 assert_contains "patterns: reports repeated-path evidence" "$out" "/repo/b.sh"
 assert_contains "patterns: requires contextual interpretation" "$out" "Interpret in context"
+assert_contains "patterns: reports mixed intent coverage" "$out" "8 present, 2 missing, 80.00% coverage"
+assert_contains "patterns: warns about missing intents" "$out" "missing intents limit root-cause clustering"
+
+out=$("$HELPER" patterns --session sess-B 2>&1) || true
+assert_contains "patterns: reports complete intent coverage" "$out" "2 present, 0 missing, 100.00% coverage"
+
+out=$("$HELPER" patterns --session sess-C 2>&1) || true
+assert_contains "patterns: reports zero intent coverage" "$out" "0 present, 2 missing, 0.00% coverage"
 
 printf '\n%s=== errors ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" errors 2>&1) || true
 assert_contains "errors: shows failed Bash call"     "$out" "shellcheck"
 assert_contains "errors: shows outcome category"     "$out" "command_failure"
 assert_contains "errors: excludes succeeded calls"   "$out" "3 error"
+assert_contains "errors: marks missing intent"       "$out" "<missing>"
+if ! printf '%s' "$out" | grep -qF "redaction_probe"; then
+	pass "errors: excludes raw metadata arguments"
+else
+	fail "errors: exposed raw metadata arguments" "$out"
+fi
 
 printf '\n%s=== sessions ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" sessions 2>&1) || true
@@ -184,6 +206,29 @@ if command -v jq >/dev/null 2>&1; then
 	else
 		fail "patterns --json: missing outcome category counters" "$out"
 	fi
+	if printf '%s' "$out" | jq -e '
+		.calls.intent_present == 8 and
+		.calls.intent_missing == 2 and
+		.calls.intent_coverage_percent == 80
+	' >/dev/null 2>&1; then
+		pass "patterns --json: reports mixed intent coverage"
+	else
+		fail "patterns --json: missing mixed intent coverage" "$out"
+	fi
+
+	out=$("$HELPER" patterns --session sess-B --json 2>&1) || true
+	if printf '%s' "$out" | jq -e '.calls.intent_present == 2 and .calls.intent_missing == 0 and .calls.intent_coverage_percent == 100' >/dev/null 2>&1; then
+		pass "patterns --json: reports complete intent coverage"
+	else
+		fail "patterns --json: missing complete intent coverage" "$out"
+	fi
+
+	out=$("$HELPER" patterns --session sess-C --json 2>&1) || true
+	if printf '%s' "$out" | jq -e '.calls.intent_present == 0 and .calls.intent_missing == 2 and .calls.intent_coverage_percent == 0' >/dev/null 2>&1; then
+		pass "patterns --json: reports zero intent coverage"
+	else
+		fail "patterns --json: missing zero intent coverage" "$out"
+	fi
 
 	out=$("$HELPER" errors --json 2>&1) || true
 	if printf '%s' "$out" | jq -e '.errors | map(.category) | index("policy_block") != null' >/dev/null 2>&1; then
@@ -191,10 +236,20 @@ if command -v jq >/dev/null 2>&1; then
 	else
 		fail "errors --json: missing outcome categories" "$out"
 	fi
+	if printf '%s' "$out" | jq -e '.errors | map(select(.intent == "<missing>" and .intent_present == false)) | length == 1' >/dev/null 2>&1; then
+		pass "errors --json: marks missing intent safely"
+	else
+		fail "errors --json: missing intent marker absent" "$out"
+	fi
+	if ! printf '%s' "$out" | grep -qF "redaction_probe"; then
+		pass "errors --json: excludes raw metadata arguments"
+	else
+		fail "errors --json: exposed raw metadata arguments" "$out"
+	fi
 
 	out=$("$HELPER" sessions --json 2>&1) || true
-	if printf '%s' "$out" | jq -e 'length == 2' >/dev/null 2>&1; then
-		pass "sessions --json: returns 2 sessions"
+	if printf '%s' "$out" | jq -e 'length == 3' >/dev/null 2>&1; then
+		pass "sessions --json: returns 3 sessions"
 	else
 		fail "sessions --json: wrong length" "$out"
 	fi


### PR DESCRIPTION
## Summary

Adds privacy-safe intent coverage totals and missing markers to session diagnostics.

## Files Changed

.agents/reference/observability.md, .agents/scripts/session-introspect-helper.sh, .agents/scripts/tests/test-session-introspect.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: local exact-session errors JSON smoke test emitted missing markers with tool, duration, and outcome fields only; shellcheck; test-session-introspect.sh (39 tests); OpenCode intent schema and stripping tests (16 tests)

Resolves #30910


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.295 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 5m and 89,757 tokens on this as a headless worker.