### PR TITLE
GH#30910: report missing agent intent coverage

### DIFF
--- a/.agents/reference/observability.md
+++ b/.agents/reference/observability.md
@@ -252,6 +252,12 @@ current session — a common stuck-worker signature when file comprehension
 isn't landing. When this fires, break out of the loop: `git diff`,
 `git status`, or step back to re-read the brief.
 
+`patterns` also reports populated and missing `agent__intent` totals plus a
+coverage percentage in text and JSON. Null, empty, and whitespace-only legacy
+values count as missing. `errors` renders missing values as `<missing>` rather
+than exposing commands, arguments, prompts, paths, or other transcript content;
+the helper never infers intent from those private inputs.
+
 Stuck-worker thresholds (informational):
 
 | Signal                  | Value         | Interpretation                      |

--- a/.agents/scripts/session-introspect-helper.sh
+++ b/.agents/scripts/session-introspect-helper.sh
@@ -243,14 +243,20 @@ cmd_patterns() {
 			SUM(CASE WHEN success=0 THEN 1 ELSE 0 END) AS errors,
 			MIN(timestamp) AS first_ts,
 			MAX(timestamp) AS last_ts,
-			COALESCE(AVG(duration_ms),0) AS avg_dur
+			COALESCE(AVG(duration_ms),0) AS avg_dur,
+			SUM(CASE WHEN intent IS NOT NULL AND LENGTH(TRIM(intent)) > 0 THEN 1 ELSE 0 END) AS intent_present,
+			SUM(CASE WHEN intent IS NULL OR LENGTH(TRIM(intent)) = 0 THEN 1 ELSE 0 END) AS intent_missing,
+			printf('%.1f', 100.0 * SUM(CASE WHEN intent IS NOT NULL AND LENGTH(TRIM(intent)) > 0 THEN 1 ELSE 0 END) / MAX(1, COUNT(*))) AS intent_coverage
 		FROM tool_calls
 		WHERE session_id='${sid_esc}' ${since};
 	")
-	local total errors first_ts last_ts avg_dur
-	IFS='|' read -r total errors first_ts last_ts avg_dur <<<"$stats"
+	local total errors first_ts last_ts avg_dur intent_present intent_missing intent_coverage
+	IFS='|' read -r total errors first_ts last_ts avg_dur intent_present intent_missing intent_coverage <<<"$stats"
 	total="${total:-0}"
 	errors="${errors:-0}"
+	intent_present="${intent_present:-0}"
+	intent_missing="${intent_missing:-0}"
+	intent_coverage="${intent_coverage:-0.0}"
 
 	# Per-tool counts.
 	local by_tool
@@ -303,10 +309,12 @@ cmd_patterns() {
 
 	if [[ "$json_flag" == "true" ]]; then
 		_patterns_json "$sid" "$total" "$errors" "$first_ts" "$last_ts" \
-			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes"
+			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes" \
+			"$intent_present" "$intent_missing" "$intent_coverage"
 	else
 		_patterns_table "$sid" "$total" "$errors" "$first_ts" "$last_ts" \
-			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes"
+			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes" \
+			"$intent_present" "$intent_missing" "$intent_coverage"
 	fi
 	return 0
 }
@@ -315,10 +323,17 @@ _patterns_table() {
 	local sid="$1" total="$2" errors="$3" first_ts="$4" last_ts="$5"
 	local avg_dur="$6" rate="$7" by_tool="$8" rereads="$9"
 	local outcomes="${10}"
+	local intent_present="${11}" intent_missing="${12}" intent_coverage="${13}"
 	printf 'Session: %s\n' "$sid"
 	printf 'Window:  %s → %s\n' "${first_ts:-?}" "${last_ts:-?}"
-	printf 'Calls:   %s total, %s error(s), %s calls/min, avg %sms\n\n' \
+	printf 'Calls:   %s total, %s error(s), %s calls/min, avg %sms\n' \
 		"$total" "$errors" "$rate" "${avg_dur%.*}"
+	printf 'Intent:  %s populated, %s missing (%s%% coverage)\n' \
+		"$intent_present" "$intent_missing" "$intent_coverage"
+	if [[ "$intent_missing" -gt 0 ]]; then
+		printf 'Notice: missing intents limit reliable root-cause clustering.\n'
+	fi
+	printf '\n'
 
 	printf 'Per-tool:\n'
 	if [[ -n "$by_tool" ]]; then
@@ -357,6 +372,7 @@ _patterns_json() {
 	local sid="$1" total="$2" errors="$3" first_ts="$4" last_ts="$5"
 	local avg_dur="$6" rate="$7" by_tool="$8" rereads="$9"
 	local outcomes="${10}"
+	local intent_present="${11}" intent_missing="${12}" intent_coverage="${13}"
 	command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
 	local by_tool_json
 	by_tool_json=$(printf '%s' "$by_tool" | jq -R -s '
@@ -386,6 +402,8 @@ _patterns_json() {
 		--argjson avg_dur "${avg_dur:-0}" --arg rate "$rate" \
 		--argjson by_tool "$by_tool_json" --argjson outcomes "$outcomes_json" \
 		--argjson rereads "$rereads_json" \
+		--argjson intent_present "$intent_present" --argjson intent_missing "$intent_missing" \
+		--arg intent_coverage "$intent_coverage" \
 		--argjson minimum_repeat_count "$REPEATED_PATH_MIN_COUNT" '
 		{
 			session: $sid,
@@ -395,7 +413,12 @@ _patterns_json() {
 				errors: $errors,
 				rate_per_min: ($rate|tonumber),
 				avg_ms: $avg_dur,
-				outcomes: $outcomes
+				outcomes: $outcomes,
+				intent_coverage: {
+					populated: $intent_present,
+					missing: $intent_missing,
+					percentage: ($intent_coverage | tonumber)
+				}
 			},
 			by_tool: $by_tool,
 			repeated_file_access: {
@@ -429,7 +452,9 @@ cmd_errors() {
 	outcome_expr=$(_outcome_category_sql "$db")
 
 	local query="
-		SELECT timestamp, tool_name, COALESCE(intent,''), COALESCE(duration_ms,0), ${outcome_expr}
+		SELECT timestamp, tool_name,
+			CASE WHEN intent IS NULL OR LENGTH(TRIM(intent)) = 0 THEN '<missing>' ELSE intent END,
+			COALESCE(duration_ms,0), ${outcome_expr}
 		FROM tool_calls
 		WHERE session_id='${sid_esc}' AND success=0 ${since}
 		ORDER BY timestamp DESC

--- a/.agents/scripts/tests/test-session-introspect.sh
+++ b/.agents/scripts/tests/test-session-introspect.sh
@@ -82,9 +82,9 @@ INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, durat
  ('2026-04-18T04:00:20Z', 'sess-A', 'Read',   'reading auth handler AGAIN',    1,  80, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
  ('2026-04-18T04:00:25Z', 'sess-A', 'Edit',   'patching auth handler',         1, 240, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
  ('2026-04-18T04:00:30Z', 'sess-A', 'Bash',   'running shellcheck',            0, 850, '{}', 'command_failure'),
- ('2026-04-18T04:00:35Z', 'sess-A', 'Bash',   'running blocked retry',         0, 910, '{}', 'policy_block'),
+ ('2026-04-18T04:00:35Z', 'sess-A', 'Bash',   NULL,                            0, 910, '{}', 'policy_block'),
  ('2026-04-18T04:00:40Z', 'sess-A', 'Bash',   'running shellcheck final',      1, 780, '{}', 'success'),
- ('2026-04-18T04:00:45Z', 'sess-A', 'Task',   'handling runtime error',        0,  50, '{}', 'tool_error');
+ ('2026-04-18T04:00:45Z', 'sess-A', 'Task',   '',                              0,  50, '{}', 'tool_error');
 
 INSERT INTO session_summaries (session_id, first_seen, last_seen, request_count, total_tool_calls, total_errors, total_cost, models_used)
 VALUES ('sess-A', '2026-04-18T04:00:00Z', '2026-04-18T04:00:45Z', 10, 10, 3, 0.0184, 'claude-sonnet-4');
@@ -96,6 +96,14 @@ INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, durat
 
 INSERT INTO session_summaries (session_id, first_seen, last_seen, request_count, total_tool_calls, total_errors, total_cost, models_used)
 VALUES ('sess-B', '2026-04-17T10:00:00Z', '2026-04-17T10:00:05Z', 2, 2, 0, 0.0041, 'claude-sonnet-4');
+
+-- Session C (legacy all-missing intent rows)
+INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, duration_ms, metadata, outcome_category) VALUES
+ ('2026-04-16T10:00:00Z', 'sess-C', 'Read', NULL,  1, 100, '{}', 'success'),
+ ('2026-04-16T10:00:05Z', 'sess-C', 'Bash', '   ', 0, 200, '{}', 'command_failure');
+
+INSERT INTO session_summaries (session_id, first_seen, last_seen, request_count, total_tool_calls, total_errors, total_cost, models_used)
+VALUES ('sess-C', '2026-04-16T10:00:00Z', '2026-04-16T10:00:05Z', 2, 2, 1, 0.0021, 'legacy-model');
 SQL
 
 # ----------------------------------------------------------------------------
@@ -137,12 +145,20 @@ assert_contains "patterns: separates tool errors"    "$out" "tool_error"
 assert_contains "patterns: preserves unknown legacy outcomes" "$out" "legacy_unknown"
 assert_contains "patterns: reports repeated-path evidence" "$out" "/repo/b.sh"
 assert_contains "patterns: requires contextual interpretation" "$out" "Interpret in context"
+assert_contains "patterns: reports mixed intent coverage" "$out" "8 populated, 2 missing (80.0% coverage)"
+assert_contains "patterns: warns when intent is missing" "$out" "missing intents limit reliable root-cause clustering"
+
+out=$($HELPER patterns --session sess-B 2>&1) || true
+assert_contains "patterns: reports complete intent coverage" "$out" "2 populated, 0 missing (100.0% coverage)"
+out=$($HELPER patterns --session sess-C 2>&1) || true
+assert_contains "patterns: reports zero intent coverage" "$out" "0 populated, 2 missing (0.0% coverage)"
 
 printf '\n%s=== errors ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" errors 2>&1) || true
 assert_contains "errors: shows failed Bash call"     "$out" "shellcheck"
 assert_contains "errors: shows outcome category"     "$out" "command_failure"
 assert_contains "errors: excludes succeeded calls"   "$out" "3 error"
+assert_contains "errors: marks missing intent"        "$out" "<missing>"
 
 printf '\n%s=== sessions ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" sessions 2>&1) || true
@@ -178,23 +194,29 @@ if command -v jq >/dev/null 2>&1; then
 		.calls.outcomes.command_failure == 1 and
 		.calls.outcomes.policy_block == 1 and
 		.calls.outcomes.tool_error == 1 and
-		.calls.outcomes.legacy_unknown == 1
+		.calls.outcomes.legacy_unknown == 1 and
+		.calls.intent_coverage.populated == 8 and
+		.calls.intent_coverage.missing == 2 and
+		.calls.intent_coverage.percentage == 80
 	' >/dev/null 2>&1; then
-		pass "patterns --json: separates outcome categories"
+		pass "patterns --json: separates outcomes and reports intent coverage"
 	else
-		fail "patterns --json: missing outcome category counters" "$out"
+		fail "patterns --json: missing outcome or intent coverage counters" "$out"
 	fi
 
 	out=$("$HELPER" errors --json 2>&1) || true
-	if printf '%s' "$out" | jq -e '.errors | map(.category) | index("policy_block") != null' >/dev/null 2>&1; then
-		pass "errors --json: includes outcome categories"
+	if printf '%s' "$out" | jq -e '
+		(.errors | map(.category) | index("policy_block") != null) and
+		(.errors | map(.intent) | index("<missing>") != null)
+	' >/dev/null 2>&1; then
+		pass "errors --json: includes outcomes and missing intent markers"
 	else
-		fail "errors --json: missing outcome categories" "$out"
+		fail "errors --json: missing outcomes or intent marker" "$out"
 	fi
 
 	out=$("$HELPER" sessions --json 2>&1) || true
-	if printf '%s' "$out" | jq -e 'length == 2' >/dev/null 2>&1; then
-		pass "sessions --json: returns 2 sessions"
+	if printf '%s' "$out" | jq -e 'length == 3' >/dev/null 2>&1; then
+		pass "sessions --json: returns 3 sessions"
 	else
 		fail "sessions --json: wrong length" "$out"
 	fi


### PR DESCRIPTION
## Summary

Add populated, missing, and percentage intent coverage to session patterns and explicit missing markers to error diagnostics.

## Files Changed

.agents/reference/observability.md, .agents/scripts/session-introspect-helper.sh, .agents/scripts/tests/test-session-introspect.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified against the live local observability database: patterns reported 186 total, 15 populated, 171 missing, and 8.1 percent coverage; errors returned bounded <missing> markers without arguments. ShellCheck; 33 focused introspection tests; 16 intent producer tests; linters-local --changed.

Resolves #30910


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.295 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 51m and 312,696 tokens on this with the user in an interactive session.