### PR TITLE
GH#30911: preserve output finding category coverage

### DIFF
--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -65,6 +65,11 @@ duplicate results, repeated lines/blocks, successful oversized results, raw
 fallbacks, and exact-output bypasses, then estimates avoidable context from byte
 counts. It emits only tool names, metrics, and opaque fingerprints; tool inputs,
 commands, outputs, transcript paths, and background content remain omitted.
+The additive `category_summary` covers every non-zero finding kind independently
+of `max_findings`, with a finding count, occurrence count, aggregate bytes, and
+leading tool class in stable category order. Aggregate bytes use redundant bytes
+for repetition categories and total bytes for size categories; categories can
+overlap and must not be summed into a session-wide total.
 Findings are deterministic candidates for session-analysis judgment, not
 automatic proof that a safeguard or exact evidence should be removed.
 

--- a/.agents/scripts/session-output-efficiency.py
+++ b/.agents/scripts/session-output-efficiency.py
@@ -54,6 +54,16 @@ def print_text(report: dict[str, Any]) -> None:
     )
     if stats["parse_errors"]:
         print(f"Unparsed transcript records: {stats['parse_errors']}")
+    print("Category coverage:")
+    if not report["category_summary"]:
+        print("- None above deterministic thresholds")
+    for category in report["category_summary"]:
+        print(
+            f"- {category['kind']}: groups={category['finding_count']}, "
+            f"occurrences={category['occurrences']}, "
+            f"aggregate_bytes={category['aggregate_bytes']}, "
+            f"leading_tool={category['leading_tool']}"
+        )
     print("Candidates:")
     if not report["findings"]:
         print("- None above deterministic thresholds")

--- a/.agents/scripts/session_output_metrics.py
+++ b/.agents/scripts/session_output_metrics.py
@@ -216,6 +216,24 @@ def _visibility_metrics(
     return visibility, stats, _size_findings(fallback_groups, "raw-fallback"), _size_findings(success_groups, "success-verbosity")
 
 
+def _finding_bytes(finding: dict[str, Any]) -> int:
+    return int(finding.get("redundant_bytes", finding.get("total_bytes", finding.get("largest_bytes", 0))))
+
+
+def _category_summary(kind: str, findings: list[dict[str, Any]]) -> dict[str, Any]:
+    leading = min(
+        findings,
+        key=lambda item: (-_finding_bytes(item), -int(item["occurrences"]), str(item["tool"])),
+    )
+    return {
+        "kind": kind,
+        "finding_count": len(findings),
+        "occurrences": sum(int(item["occurrences"]) for item in findings),
+        "aggregate_bytes": sum(_finding_bytes(item) for item in findings),
+        "leading_tool": leading["tool"],
+    }
+
+
 def analyse(results: Iterable[ToolResult], config: AnalysisConfig) -> dict[str, Any]:
     materialized = list(results)
     total_bytes = sum(byte_length(result.output) for result in materialized)
@@ -229,7 +247,21 @@ def analyse(results: Iterable[ToolResult], config: AnalysisConfig) -> dict[str, 
     visibility, visibility_stats, fallbacks, success_verbosity = _visibility_metrics(
         materialized, config.oversized_bytes
     )
-    findings = unchanged + duplicates + repeated_blocks + repeated_lines + fallbacks + success_verbosity + oversized
+    categories = (
+        ("unchanged-snapshot", unchanged),
+        ("duplicate-output", duplicates),
+        ("repeated-block", repeated_blocks),
+        ("repeated-line", repeated_lines),
+        ("raw-fallback", fallbacks),
+        ("success-verbosity", success_verbosity),
+        ("oversized-output", oversized),
+    )
+    findings = [finding for _, category_findings in categories for finding in category_findings]
+    category_summary = [
+        _category_summary(kind, category_findings)
+        for kind, category_findings in categories
+        if category_findings
+    ]
     stats = {
         "completed_tool_results": len(materialized),
         "tool_output_bytes": total_bytes,
@@ -256,6 +288,7 @@ def analyse(results: Iterable[ToolResult], config: AnalysisConfig) -> dict[str, 
         },
         "stats": stats,
         "visibility": visibility,
+        "category_summary": category_summary,
         "findings": findings[: config.max_findings],
         "privacy": "Raw tool inputs, outputs, commands, and paths are omitted.",
     }

--- a/.agents/scripts/tests/test-session-output-efficiency.sh
+++ b/.agents/scripts/tests/test-session-output-efficiency.sh
@@ -53,18 +53,19 @@ assert_omits() {
 }
 
 normalized_fixture="${TMPDIR_TEST}/normalized.jsonl"
+starvation_fixture="${TMPDIR_TEST}/starvation.jsonl"
 claude_fixture="${TMPDIR_TEST}/claude.jsonl"
 opencode_db="${TMPDIR_TEST}/opencode history?#.db"
 active_data_home="${TMPDIR_TEST}/active-data"
 active_opencode_db="${active_data_home}/opencode/opencode.db"
 mkdir -p "${active_data_home}/opencode"
 
-python3 - "$normalized_fixture" "$claude_fixture" "$opencode_db" "$active_opencode_db" <<'PY'
+python3 - "$normalized_fixture" "$starvation_fixture" "$claude_fixture" "$opencode_db" "$active_opencode_db" <<'PY'
 import json
 import sqlite3
 import sys
 
-normalized_path, claude_path, database_path, active_database_path = sys.argv[1:]
+normalized_path, starvation_path, claude_path, database_path, active_database_path = sys.argv[1:]
 repeated = "unchanged status snapshot SECRET-MARKER " + ("x" * 100)
 oversized = "large setup output " + ("y" * 9000)
 duplicate = "duplicate tool result " + ("d" * 100)
@@ -101,6 +102,19 @@ with open(normalized_path, "w", encoding="utf-8") as handle:
     handle.write(json.dumps({"tool": "bash", "input": {"command": "json-receipt"}, "output": json_receipt, "success": True}) + "\n")
     handle.write(json.dumps({"tool": "bash", "input": {"command": "fallback"}, "output": "output_sandbox: evidence store unavailable; running with native output\nnative output", "success": True}) + "\n")
     handle.write(json.dumps({"tool": "bash", "input": {"command": "exact"}, "output": "output_sandbox: bypass exact/verbatim command\nexact output", "success": True}) + "\n")
+
+with open(starvation_path, "w", encoding="utf-8") as handle:
+    for group_index in range(6):
+        duplicate_output = f"duplicate group {group_index} " + ("d" * 100)
+        for input_index in range(2):
+            handle.write(json.dumps({
+                "tool": "bash",
+                "input": {"command": f"PRIVATE-STARVATION-{group_index}-{input_index}"},
+                "output": duplicate_output,
+                "success": True,
+            }) + "\n")
+    handle.write(json.dumps({"tool": "bash", "input": {}, "output": "b" * 9000, "success": True}) + "\n")
+    handle.write(json.dumps({"tool": "read", "input": {}, "output": "r" * 10000, "success": True}) + "\n")
 
 with open(claude_path, "w", encoding="utf-8") as handle:
     for call_id in ("call-1", "call-2"):
@@ -165,11 +179,22 @@ assert_contains "text reports raw fallback and exact bypass" "Raw fallback / exa
 assert_omits "text omits raw output" "SECRET-MARKER" "$text_output"
 
 json_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --input "$normalized_fixture" --json)
-if python3 -c 'import json,sys; report=json.load(sys.stdin); stats=report["stats"]; visibility=report["visibility"]; assert report["schema"] == "aidevops.session-output-efficiency/v1"; assert stats["redundant_tool_results"] == 2; assert stats["duplicate_output_groups"] == 1; assert stats["repeated_line_groups"] == 2; assert stats["repeated_block_groups"] >= 1; assert stats["oversized_tool_results"] == 2; assert stats["successful_oversized_results"] == 2; assert stats["raw_fallback_results"] == 1; assert stats["exact_output_bypass_results"] == 1; assert visibility["receipt_results"] == 2; assert visibility["declared_background_evidence_bytes"] == 27163; assert visibility["background_content_scanned"] is False' <<<"$json_output"; then
+if python3 -c 'import json,sys; report=json.load(sys.stdin); stats=report["stats"]; visibility=report["visibility"]; assert report["schema"] == "aidevops.session-output-efficiency/v1"; assert stats["redundant_tool_results"] == 2; assert stats["duplicate_output_groups"] == 1; assert stats["repeated_line_groups"] == 2; assert stats["repeated_block_groups"] >= 1; assert stats["oversized_tool_results"] == 2; assert stats["successful_oversized_results"] == 2; assert stats["raw_fallback_results"] == 1; assert stats["exact_output_bypass_results"] == 1; assert visibility["receipt_results"] == 2; assert visibility["declared_background_evidence_bytes"] == 27163; assert visibility["background_content_scanned"] is False; assert report["category_summary"]' <<<"$json_output"; then
 	pass "JSON contract exposes aggregate metrics"
 else
 	fail "JSON contract exposes aggregate metrics"
 fi
+
+starvation_json=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --input "$starvation_fixture" --max-findings 5 --json)
+if python3 -c 'import json,sys; report=json.load(sys.stdin); assert len(report["findings"]) == 5; assert {item["kind"] for item in report["findings"]} == {"duplicate-output"}; summary={item["kind"]: item for item in report["category_summary"]}; assert list(summary) == ["duplicate-output", "success-verbosity", "oversized-output"]; assert summary["oversized-output"] == {"kind": "oversized-output", "finding_count": 2, "occurrences": 2, "aggregate_bytes": 19000, "leading_tool": "read"}' <<<"$starvation_json"; then
+	pass "category summary prevents detailed-finding starvation"
+else
+	fail "category summary prevents detailed-finding starvation"
+fi
+assert_omits "category summary omits private inputs" "PRIVATE-STARVATION" "$starvation_json"
+
+starvation_text=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --input "$starvation_fixture" --max-findings 5)
+assert_contains "text renders oversized category coverage" "oversized-output: groups=2, occurrences=2, aggregate_bytes=19000, leading_tool=read" "$starvation_text"
 
 claude_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --runtime claude-code --input "$claude_fixture")
 assert_contains "Claude JSONL tool results are correlated" "Repeated unchanged snapshots: 1 groups, 1 redundant results" "$claude_output"


### PR DESCRIPTION
## Summary

Add a bounded deterministic category summary so max-findings cannot hide every actionable finding category.

## Files Changed

.agents/reference/context-efficient-output.md, .agents/scripts/session-output-efficiency.py, .agents/scripts/session_output_metrics.py, .agents/scripts/tests/test-session-output-efficiency.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified against the active OpenCode session: the report returned seven non-zero category summaries while detailed findings remained capped at five, including 26 oversized outputs and 25 successful oversized outputs led by the read tool class. Focused shell suite: 29 passed; Python compile; ShellCheck; linters-local --changed.

Resolves #30911


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.295 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 58m and 678,193 tokens on this with the user in an interactive session.