### PR TITLE
GH#30912: keep generated framework issue bodies public-safe

### DIFF
--- a/.agents/scripts/framework-issue-helper.sh
+++ b/.agents/scripts/framework-issue-helper.sh
@@ -266,7 +266,7 @@ get_aidevops_repo_path() {
 gather_diagnostics() {
 	local log_issue_helper="${SCRIPT_DIR}/log-issue-helper.sh"
 	if [[ -x "$log_issue_helper" ]]; then
-		"$log_issue_helper" diagnostics 2>/dev/null || true
+		"$log_issue_helper" diagnostics --public-safe 2>/dev/null || true
 		return 0
 	fi
 
@@ -279,7 +279,7 @@ gather_diagnostics() {
 	cat <<EOF
 - **aidevops version**: $version
 - **OS**: $(uname -s) $(uname -r)
-- **Working repo**: $(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo 'none')")
+- **Shell**: bash ${BASH_VERSION:-unknown}
 - **gh CLI**: $(gh --version 2>/dev/null | head -1 || echo "not installed")
 EOF
 	return 0
@@ -426,8 +426,6 @@ ${diagnostics}
 ## Context
 
 This issue was automatically routed to the aidevops framework repo by \`framework-issue-helper.sh\` because it contains framework-level indicators (references to ~/.aidevops/ files, framework scripts, or supervisor/pulse concepts).
-
-Filed from: $(git rev-parse --show-toplevel 2>/dev/null || echo 'unknown repo')
 EOF
 	return 0
 }

--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -5,7 +5,7 @@
 # aidevops Issue Logger Helper
 # =============================================================================
 # Gathers diagnostic information for issue reporting
-# Usage: log-issue-helper.sh [diagnostics|check-auth|search "query"]
+# Usage: log-issue-helper.sh [diagnostics [--public-safe]|check-auth|search "query"]
 
 set -euo pipefail
 
@@ -104,15 +104,13 @@ get_git_context() {
 }
 
 gather_diagnostics() {
-	local current_version latest_version ai_assistant install_method
-	local os_info shell_info git_context ai_model_line=""
+	local mode="${1:-local}"
+	local current_version ai_assistant
+	local os_info shell_info ai_model_line=""
 
 	current_version=$(get_aidevops_version)
-	latest_version=$(get_latest_version)
 	ai_assistant=$(detect_ai_assistant)
-	install_method=$(get_install_method)
-	git_context=$(get_git_context)
-	if [[ -n "${AIDEVOPS_SIG_MODEL:-}" ]]; then
+	if [[ "$mode" != "public-safe" && -n "${AIDEVOPS_SIG_MODEL:-}" ]]; then
 		ai_model_line=$'\n- **AI Model**: '"${AIDEVOPS_SIG_MODEL//$'\n'/}"
 	fi
 
@@ -136,7 +134,23 @@ gather_diagnostics() {
 		shell_info="bash $BASH_VERSION"
 	fi
 
-	# Output in markdown format
+	if [[ "$mode" == "public-safe" ]]; then
+		cat <<EOF
+- **aidevops version**: $current_version
+- **AI Assistant**: $ai_assistant
+- **OS**: $os_info
+- **Shell**: $shell_info
+- **gh CLI**: $(gh --version 2>/dev/null | head -1 || echo "not installed")
+EOF
+		return 0
+	fi
+
+	local latest_version install_method git_context
+	latest_version=$(get_latest_version)
+	install_method=$(get_install_method)
+	git_context=$(get_git_context)
+
+	# Output in markdown format for local diagnostics.
 	cat <<EOF
 - **aidevops version**: $current_version
 - **Latest version**: $latest_version
@@ -474,7 +488,15 @@ main() {
 
 	case "$command" in
 	diagnostics)
-		gather_diagnostics
+		local diagnostics_mode="${2:-}"
+		if [[ -z "$diagnostics_mode" ]]; then
+			gather_diagnostics
+		elif [[ "$diagnostics_mode" == "--public-safe" ]]; then
+			gather_diagnostics public-safe
+		else
+			echo "Usage: log-issue-helper.sh diagnostics [--public-safe]" >&2
+			return 1
+		fi
 		;;
 	check-auth)
 		check_gh_auth
@@ -530,7 +552,7 @@ aidevops Issue Logger Helper
 Usage: log-issue-helper.sh [command]
 
 Commands:
-  diagnostics                          Gather system and aidevops diagnostic info (default)
+  diagnostics [--public-safe]          Gather diagnostics; public mode omits local identity
   check-auth                           Verify GitHub CLI authentication
   search "query"                       Search existing issues for duplicates
   prompt-reproducer                    Output the reproducer section template for framework bugs
@@ -541,6 +563,7 @@ Commands:
 
 Examples:
   log-issue-helper.sh diagnostics
+  log-issue-helper.sh diagnostics --public-safe
   log-issue-helper.sh check-auth
   log-issue-helper.sh search "update check"
   log-issue-helper.sh prompt-reproducer

--- a/.agents/scripts/tests/test-framework-issue-helper.sh
+++ b/.agents/scripts/tests/test-framework-issue-helper.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER="${SCRIPT_DIR}/../framework-issue-helper.sh"
+LOG_ISSUE_HELPER="${SCRIPT_DIR}/../log-issue-helper.sh"
+PRIVACY_HELPER="${SCRIPT_DIR}/../privacy-guard-helper.sh"
 
 PASS=0
 FAIL=0
@@ -77,8 +79,30 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
 	exit 0
 fi
 
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+	printf 'PUBLIC\n'
+	exit 0
+fi
+
 if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
+	if [[ -n "${TEST_GH_BODY_FILE:-}" ]]; then
+		previous=""
+		for argument in "$@"; do
+			if [[ "$previous" == "--body" ]]; then
+				printf '%s' "$argument" >"$TEST_GH_BODY_FILE"
+			elif [[ "$previous" == "--body-file" && "$argument" != "-" ]]; then
+				body_from_file=$(<"$argument")
+				printf '%s' "$body_from_file" >"$TEST_GH_BODY_FILE"
+			fi
+			previous="$argument"
+		done
+	fi
 	printf '%s\n' "${TEST_CREATED_URL:-https://github.com/marcusquinn/aidevops/issues/9001}"
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == repos/* ]]; then
+	printf 'false\n'
 	exit 0
 fi
 
@@ -198,6 +222,9 @@ run_missing_value_case() {
 
 TMP_DIR=$(mktemp -d -t framework-issue-helper-test.XXXXXX)
 trap 'rm -rf "$TMP_DIR"' EXIT
+export AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="${TMP_DIR}/gh-secondary-cooldown.json"
+export AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE="${TMP_DIR}/gh-cooldown-events.jsonl"
+export AIDEVOPS_GH_READ_RAMP_STATE_FILE="${TMP_DIR}/gh-read-ramp-state.tsv"
 
 empty_output="${TMP_DIR}/empty.out"
 run_case "[]" "https://github.com/marcusquinn/aidevops/issues/9001" "${TMP_DIR}" "$empty_output"
@@ -330,6 +357,104 @@ else
 	missing_value_text=$(<"$missing_value_output")
 	assert_contains "$missing_value_text" "--title requires a value" "missing option value explains the failing flag"
 fi
+
+public_diagnostics=$(
+	AIDEVOPS_SIG_MODEL="Private model at /Users/example/Git/ConfidentialCustomerPortal" \
+		"$LOG_ISSUE_HELPER" diagnostics --public-safe
+)
+assert_contains "$public_diagnostics" "**aidevops version**" "public diagnostics retain version"
+assert_contains "$public_diagnostics" "**AI Assistant**" "public diagnostics retain assistant"
+assert_contains "$public_diagnostics" "**OS**" "public diagnostics retain OS"
+assert_contains "$public_diagnostics" "**Shell**" "public diagnostics retain shell"
+assert_contains "$public_diagnostics" "**gh CLI**" "public diagnostics retain GitHub CLI"
+assert_not_contains "$public_diagnostics" "**Working repo**" "public diagnostics omit repository identity"
+assert_not_contains "$public_diagnostics" "**Install method**" "public diagnostics omit install paths"
+assert_not_contains "$public_diagnostics" "Private model" "public diagnostics omit unverified model identity"
+
+generated_stub_dir="${TMP_DIR}/ConfidentialCustomerPortal"
+mkdir -p "$generated_stub_dir"
+cp "${TMP_DIR}/gh" "${generated_stub_dir}/gh"
+cat >"${generated_stub_dir}/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--show-toplevel" ]]; then
+	printf '/Users/example/Git/ConfidentialCustomerPortal\n'
+	exit 0
+fi
+if [[ "${1:-}" == "branch" && "${2:-}" == "--show-current" ]]; then
+	printf 'private-client-branch\n'
+	exit 0
+fi
+exit 1
+EOF
+chmod +x "${generated_stub_dir}/gh" "${generated_stub_dir}/git"
+
+generated_body_file="${TMP_DIR}/generated-body.md"
+generated_output="${TMP_DIR}/generated.out"
+if TEST_DUPLICATE_VALUE="" \
+	TEST_CREATED_URL="https://github.com/marcusquinn/aidevops/issues/9106" \
+	TEST_GH_BODY_FILE="$generated_body_file" \
+	PATH="${generated_stub_dir}:$PATH" \
+	"$HELPER" log --title "fix: generated public body" >"$generated_output" 2>&1; then
+	generated_text=$(<"$generated_output")
+	generated_body=$(<"$generated_body_file")
+	assert_contains "$generated_text" "status=created" "generated public body reaches managed issue creation"
+	assert_not_contains "$generated_body" "/Users/example/Git/ConfidentialCustomerPortal" "generated body omits checkout path"
+	assert_not_contains "$generated_body" "ConfidentialCustomerPortal" "generated body omits private repository basename"
+	assert_not_contains "$generated_body" "Filed from:" "generated body omits local provenance field"
+	assert_contains "$generated_body" "**aidevops version**" "generated body retains public-safe diagnostics"
+	entities_file="${TMP_DIR}/private-entities.tsv"
+	printf 'repo\tConfidentialCustomerPortal\n' >"$entities_file"
+	# shellcheck source=../privacy-guard-helper.sh
+	source "$PRIVACY_HELPER"
+	set +e
+	privacy_hits=$(privacy_scan_public_text "$generated_body" "$entities_file")
+	privacy_rc=$?
+	set -e
+	if [[ "$privacy_rc" -eq 0 && -z "$privacy_hits" ]]; then
+		pass "generated body passes the public privacy scanner"
+	else
+		fail "generated body passes the public privacy scanner" "rc=${privacy_rc}; hits=${privacy_hits}"
+	fi
+else
+	generated_text=$(<"$generated_output")
+	fail "generated public body reaches managed issue creation" "$generated_text"
+fi
+
+explicit_body_file="${TMP_DIR}/explicit-body.md"
+explicit_output="${TMP_DIR}/explicit.out"
+if TEST_DUPLICATE_VALUE="" \
+	TEST_CREATED_URL="https://github.com/marcusquinn/aidevops/issues/9107" \
+	TEST_GH_BODY_FILE="$explicit_body_file" \
+	PATH="${generated_stub_dir}:$PATH" \
+	"$HELPER" log --title "fix: explicit body contract" --body "EXPLICIT-CALLER-BODY" >"$explicit_output" 2>&1; then
+	explicit_body=$(<"$explicit_body_file")
+	assert_contains "$explicit_body" "EXPLICIT-CALLER-BODY" "explicit caller body is preserved"
+	assert_not_contains "$explicit_body" "## Environment" "explicit caller body is not replaced by generated content"
+else
+	explicit_text=$(<"$explicit_output")
+	fail "explicit caller body is preserved" "$explicit_text"
+fi
+
+unsafe_output="${TMP_DIR}/unsafe-explicit.out"
+unsafe_trace="${TMP_DIR}/unsafe-explicit.trace"
+set +e
+TEST_DUPLICATE_VALUE="" \
+	TEST_GH_TRACE="$unsafe_trace" \
+	PATH="${generated_stub_dir}:$PATH" \
+	"$HELPER" log --title "fix: unsafe explicit body" \
+	--body "Unsafe local path /Users/example/Git/ConfidentialCustomerPortal" >"$unsafe_output" 2>&1
+unsafe_rc=$?
+set -e
+unsafe_text=$(<"$unsafe_output")
+unsafe_calls=$(<"$unsafe_trace")
+if [[ "$unsafe_rc" -ne 0 ]]; then
+	pass "unsafe explicit caller body remains fail-closed"
+else
+	fail "unsafe explicit caller body remains fail-closed" "helper unexpectedly succeeded"
+fi
+assert_contains "$unsafe_text" "[privacy-guard][BLOCK]" "unsafe explicit body reports privacy block"
+assert_not_contains "$unsafe_calls" "issue create" "unsafe explicit body never reaches issue creation"
 
 help_output="${TMP_DIR}/help.out"
 "$HELPER" help >"$help_output" 2>&1


### PR DESCRIPTION
## Summary

Add a public-safe diagnostics mode and remove local checkout provenance from auto-generated framework issue bodies without weakening the managed privacy guard.

## Files Changed

.agents/scripts/framework-issue-helper.sh, .agents/scripts/log-issue-helper.sh, .agents/scripts/tests/test-framework-issue-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified public-safe diagnostics returned only aidevops version, OpenCode assistant, OS, shell, and GitHub CLI fields. Focused framework issue suite: 64 passed, including managed creation, public scanner, explicit-body preservation, and fail-closed unsafe content. Privacy guard suite: 27 passed. ShellCheck and linters-local --changed passed.

Resolves #30912


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.295 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 2h 10m and 789,748 tokens on this with the user in an interactive session.