### PR TITLE
GH#30917: Bound GitHub request routing state

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -164,6 +164,23 @@ if ! type gh_attempt_count_for_logical >/dev/null 2>&1; then
 		return 0
 	}
 fi
+if ! type gh_request_attempt_state_begin >/dev/null 2>&1; then
+	gh_request_attempt_state_begin() {
+		local ignored_logical_id="$1"
+		: "$ignored_logical_id"
+		return 1
+	}
+fi
+if ! type gh_request_attempt_state_cleanup >/dev/null 2>&1; then
+	gh_request_attempt_state_cleanup() { return 0; }
+fi
+if ! type gh_request_has_http_failure >/dev/null 2>&1; then
+	gh_request_has_http_failure() {
+		local ignored_logical_id="$1"
+		: "$ignored_logical_id"
+		return 1
+	}
+fi
 if ! type gh_run_transport_attempt >/dev/null 2>&1; then
 	gh_run_transport_attempt() {
 		local ignored_path="$1"; shift
@@ -201,6 +218,11 @@ unset _cand _GHQA_LOADED
 # each explicit page, and any GraphQL fallback retry.
 AIDEVOPS_GH_LOGICAL_ID="${AIDEVOPS_GH_LOGICAL_ID:-$(gh_new_logical_id)}"
 export AIDEVOPS_GH_LOGICAL_ID
+_GH_REQUEST_ATTEMPT_STATE_READY=0
+if gh_request_attempt_state_begin "$AIDEVOPS_GH_LOGICAL_ID"; then
+	_GH_REQUEST_ATTEMPT_STATE_READY=1
+	trap 'gh_request_attempt_state_cleanup' EXIT
+fi
 
 # _shim_classify_endpoint <sub1> [<sub2>]
 # Classify a gh invocation for instrumentation. Returns one of:
@@ -398,13 +420,7 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 
 	_SHIM_REST_REWRITE_ATTEMPTED=0
 	_shim_rest_rewrite_has_http_failure() {
-		local log_file="${AIDEVOPS_GH_API_LOG:-${GH_API_LOG:-}}"
-		[[ -n "$log_file" && -r "$log_file" ]] || return 1
-		awk -F '\t' -v logical_id="$AIDEVOPS_GH_LOGICAL_ID" '
-			$8 == "v2" && $9 == "attempt" && $10 == logical_id &&
-			$15 ~ /^[45][0-9][0-9]$/ { found = 1 }
-			END { exit found ? 0 : 1 }
-		' "$log_file"
+		gh_request_has_http_failure "$AIDEVOPS_GH_LOGICAL_ID"
 		return $?
 	}
 
@@ -452,6 +468,7 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# low-GraphQL-budget fallback. This shares native GitHub quota pools instead
 		# of imposing a synthetic lower GraphQL budget.
 		_rest_read_first_enabled || _rest_should_fallback || return 1
+		[[ "$_GH_REQUEST_ATTEMPT_STATE_READY" -eq 1 ]] || return 1
 
 		# Extract repo and build stripped args.
 		_shim_extract_repo_and_args "$@" || return 1

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -408,16 +408,134 @@ gh_new_attempt_id() {
 	return 0
 }
 
+_GH_API_REQUEST_LOGICAL_ID=""
+_GH_API_REQUEST_ATTEMPT_COUNT=0
+_GH_API_REQUEST_HTTP_FAILURE=0
+_GH_API_REQUEST_ATTEMPT_STATE_OWNER=0
+
+_gh_request_attempt_state_temp_dir() {
+	local temp_dir="${AIDEVOPS_TEMP_DIR:-${_GH_API_HOME}/.aidevops/.agent-workspace/tmp}"
+	if [[ ! -e "$temp_dir" ]]; then
+		(umask 077 && mkdir -p "$temp_dir") 2>/dev/null || return 1
+	fi
+	[[ -d "$temp_dir" && ! -L "$temp_dir" && -O "$temp_dir" ]] || return 1
+	printf '%s\n' "${temp_dir%/}"
+	return 0
+}
+
+_gh_request_attempt_state_file_valid() {
+	local state_file="$1"
+	local temp_dir=""
+	local basename=""
+	temp_dir=$(_gh_request_attempt_state_temp_dir) || return 1
+	case "$state_file" in
+	"${temp_dir}"/gh-request-attempts.*) ;;
+	*) return 1 ;;
+	esac
+	basename="${state_file##*/}"
+	[[ "$basename" =~ ^gh-request-attempts\.[[:alnum:]]{6}$ ]] || return 1
+	[[ -f "$state_file" && ! -L "$state_file" && -O "$state_file" ]] || return 1
+	return 0
+}
+
+gh_request_attempt_state_begin() {
+	local logical_id="$1"
+	local state_file="${AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE:-}"
+	local state_logical_id="${AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_LOGICAL_ID:-}"
+	local temp_dir=""
+	[[ -n "$logical_id" ]] || return 1
+	_GH_API_REQUEST_LOGICAL_ID="$logical_id"
+	_GH_API_REQUEST_ATTEMPT_COUNT=0
+	_GH_API_REQUEST_HTTP_FAILURE=0
+	_GH_API_REQUEST_ATTEMPT_STATE_OWNER=0
+	if [[ "$state_logical_id" == "$logical_id" ]] &&
+		_gh_request_attempt_state_file_valid "$state_file"; then
+		return 0
+	fi
+	unset AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE
+	unset AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_LOGICAL_ID
+	temp_dir=$(_gh_request_attempt_state_temp_dir) || return 1
+	state_file=$(mktemp "${temp_dir}/gh-request-attempts.XXXXXX" 2>/dev/null) || return 1
+	chmod 0600 "$state_file" 2>/dev/null || {
+		rm -f "$state_file" 2>/dev/null || true
+		return 1
+	}
+	AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE="$state_file"
+	AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_LOGICAL_ID="$logical_id"
+	export AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE
+	export AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_LOGICAL_ID
+	_GH_API_REQUEST_ATTEMPT_STATE_OWNER=1
+	return 0
+}
+
+gh_request_attempt_state_cleanup() {
+	local state_file="${AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE:-}"
+	if [[ "${_GH_API_REQUEST_ATTEMPT_STATE_OWNER:-0}" == "1" ]] &&
+		_gh_request_attempt_state_file_valid "$state_file"; then
+		rm -f "$state_file" 2>/dev/null || true
+	fi
+	_GH_API_REQUEST_ATTEMPT_STATE_OWNER=0
+	unset AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE
+	unset AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_LOGICAL_ID
+	return 0
+}
+
+_gh_request_attempt_state_record() {
+	local logical_id="$1"
+	local http_status="$2"
+	local state_file="${AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE:-}"
+	[[ -n "${_GH_API_REQUEST_LOGICAL_ID:-}" &&
+		"$logical_id" == "$_GH_API_REQUEST_LOGICAL_ID" ]] || return 0
+	[[ "${_GH_API_REQUEST_ATTEMPT_COUNT:-}" =~ ^[0-9]+$ ]] || _GH_API_REQUEST_ATTEMPT_COUNT=0
+	_GH_API_REQUEST_ATTEMPT_COUNT=$((_GH_API_REQUEST_ATTEMPT_COUNT + 1))
+	if [[ "$http_status" =~ ^[45][0-9][0-9]$ ]]; then
+		_GH_API_REQUEST_HTTP_FAILURE=1
+	fi
+	if _gh_request_attempt_state_file_valid "$state_file"; then
+		printf '%s\t%s\n' "$logical_id" "$http_status" >>"$state_file" 2>/dev/null || true
+	fi
+	return 0
+}
+
 gh_attempt_count_for_logical() {
 	local logical_id="$1"
-	[[ -f "$GH_API_LOG" ]] || {
-		printf '0\n'
-		return 0
-	}
-	awk -F'\t' -v logical_id="$logical_id" \
-		'$8 == "v2" && $9 == "attempt" && $10 == logical_id { count++ } END { print count + 0 }' \
-		"$GH_API_LOG" 2>/dev/null || printf '0\n'
+	local state_file="${AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE:-}"
+	local recorded_logical_id=""
+	local ignored_http_status=""
+	local count=0
+	if [[ "$logical_id" == "${AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_LOGICAL_ID:-}" ]] &&
+		_gh_request_attempt_state_file_valid "$state_file"; then
+		while IFS=$'\t' read -r recorded_logical_id ignored_http_status; do
+			[[ "$recorded_logical_id" == "$logical_id" ]] || continue
+			count=$((count + 1))
+		done <"$state_file"
+	elif [[ -n "${_GH_API_REQUEST_LOGICAL_ID:-}" &&
+		"$logical_id" == "$_GH_API_REQUEST_LOGICAL_ID" &&
+		"${_GH_API_REQUEST_ATTEMPT_COUNT:-}" =~ ^[0-9]+$ ]]; then
+		count="$_GH_API_REQUEST_ATTEMPT_COUNT"
+	fi
+	printf '%s\n' "$count"
 	return 0
+}
+
+gh_request_has_http_failure() {
+	local logical_id="$1"
+	local state_file="${AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE:-}"
+	local recorded_logical_id=""
+	local http_status=""
+	if [[ "$logical_id" == "${AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_LOGICAL_ID:-}" ]] &&
+		_gh_request_attempt_state_file_valid "$state_file"; then
+		while IFS=$'\t' read -r recorded_logical_id http_status; do
+			if [[ "$recorded_logical_id" == "$logical_id" && "$http_status" =~ ^[45][0-9][0-9]$ ]]; then
+				return 0
+			fi
+		done <"$state_file"
+	elif [[ -n "${_GH_API_REQUEST_LOGICAL_ID:-}" &&
+		"$logical_id" == "$_GH_API_REQUEST_LOGICAL_ID" &&
+		"${_GH_API_REQUEST_HTTP_FAILURE:-0}" == "1" ]]; then
+		return 0
+	fi
+	return 1
 }
 
 _gh_append_v2() {
@@ -558,7 +676,6 @@ gh_record_efficiency_evidence() {
 # Record one completed native transport try/page. Arguments are metadata only;
 # command argv never enters the record.
 gh_record_attempt() {
-	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
 	local path="$1"
 	shift
 	local caller="$1"
@@ -593,6 +710,8 @@ gh_record_attempt() {
 	[[ -n "$api_pool" ]] || api_pool=$(_gh_default_pool "$path")
 	[[ -n "$auth_mode" ]] || auth_mode="${AIDEVOPS_GH_AUTH_MODE:-$(_gh_default_auth "$api_pool")}"
 	[[ -n "$route_decision" ]] || route_decision="${AIDEVOPS_GH_ROUTE_DECISION:-${api_pool}-selected}"
+	_gh_request_attempt_state_record "$logical_id" "$http_status" || true
+	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
 	_gh_append_v2 attempt "$caller" "$path" "$auth_mode" "$api_pool" "$route_decision" \
 		"$budget_remaining" "$logical_id" "$attempt_id" "$page" "$retry" "$outcome" \
 		"$http_status" "$elapsed_ms" "$quota_cost"

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -472,6 +472,35 @@ export AIDEVOPS_GH_API_LOG="$TMPDIR/gh-api-calls.log"
 export AIDEVOPS_GH_API_REPORT="$TMPDIR/report.json"
 unset AIDEVOPS_GH_API_EMPTY_LOCK_GRACE_TRIES
 
+# --- Test 10b: request-local attempt state ignores historical log size -----
+unset _GH_API_INSTRUMENT_LOADED
+# shellcheck source=../gh-api-instrument.sh
+source "${PARENT_DIR}/gh-api-instrument.sh"
+gh_clear_log
+now=$(date +%s)
+printf '%s\thistorical\trest\tgh-pat\trest-core\trest-selected\t4999\tv2\tattempt\tlogical-request\told-attempt\t1\t0\terror\t503\t1\t1\n' \
+	"$now" >>"$AIDEVOPS_GH_API_LOG"
+gh_request_attempt_state_begin logical-request
+assert_eq "request attempt count starts independently of historical log" "0" \
+	"$(gh_attempt_count_for_logical logical-request)"
+(gh_record_attempt rest request-caller logical-unrelated unrelated-attempt 1 0 error 500 1 1 gh-pat rest-core rest-selected 4999)
+(gh_record_attempt rest request-caller logical-request request-attempt-1 1 0 success 200 1 1 gh-pat rest-core rest-selected 4999)
+(gh_record_attempt rest request-caller logical-request request-attempt-2 1 1 error 503 1 1 gh-pat rest-core rest-selected 4998)
+assert_eq "request attempt count includes only current logical operation" "2" \
+	"$(gh_attempt_count_for_logical logical-request)"
+assert_eq "untracked logical operation has no request-local count" "0" \
+	"$(gh_attempt_count_for_logical logical-unrelated)"
+if gh_request_has_http_failure logical-request && ! gh_request_has_http_failure logical-unrelated; then
+	echo "  PASS: request-local HTTP failure state ignores unrelated and historical attempts"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: request-local HTTP failure state was not isolated"
+	FAIL=$((FAIL + 1))
+fi
+request_attempt_state_file="$AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE"
+gh_request_attempt_state_cleanup
+assert_path_absent "request-local attempt state is removed by its owner" "$request_attempt_state_file"
+
 # --- Test 11: exact replay separates events, attempts, pages, and retries --
 unset _GH_API_INSTRUMENT_LOADED
 # shellcheck source=../gh-api-instrument.sh
@@ -839,6 +868,7 @@ mkdir -p "$SHIM_FIXTURE" "$NATIVE_FIXTURE"
 cp "${PARENT_DIR}/gh" "$SHIM_FIXTURE/gh"
 cp "${PARENT_DIR}/gh-native-transport-lib.sh" "$SHIM_FIXTURE/gh-native-transport-lib.sh"
 cp "${PARENT_DIR}/gh-api-guards-lib.sh" "$SHIM_FIXTURE/gh-api-guards-lib.sh"
+cp "${PARENT_DIR}/managed-label-provisioning-lib.sh" "$SHIM_FIXTURE/managed-label-provisioning-lib.sh"
 cp "${PARENT_DIR}/gh-write-policy-lib.sh" "$SHIM_FIXTURE/gh-write-policy-lib.sh"
 cp "${PARENT_DIR}/gh-api-instrument.sh" "$SHIM_FIXTURE/gh-api-instrument.sh"
 cp "${PARENT_DIR}/gh-rest-pagination-lib.sh" "$SHIM_FIXTURE/gh-rest-pagination-lib.sh"

--- a/.agents/scripts/tests/test-gh-shim-routing-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-routing-cases.sh
@@ -204,6 +204,25 @@ else
 		"rc: $rest_failure_rc REST calls: $rest_api_calls native calls: $native_issue_calls log: $(cat "$default_api_log" 2>/dev/null || true)"
 fi
 
+_reset_log
+rest_failure_without_log_rc=0
+AIDEVOPS_GH_API_INSTRUMENT_DISABLE=1 AIDEVOPS_GH_API_LOG=/dev/null \
+	AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$TMP/rest-rewrite-no-log-state" AIDEVOPS_TEMP_DIR="$TMP" \
+	STUB_REST_READ_FAIL=1 STUB_REST_READ_EXIT_CODE=42 STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_CORE_USED=100 STUB_GH_DEBUG_RESOURCE=core STUB_GH_DEBUG_STATUS=403 \
+	STUB_GH_DEBUG_USED=101 STUB_GH_DEBUG_REMAINING=4899 STUB_GH_DEBUG_RESET=2000 \
+	"$SHIM_RUN" issue list --repo owner/repo --state open --json number,title \
+	>/dev/null 2>/dev/null || rest_failure_without_log_rc=$?
+rest_api_calls=$(awk -F '\t' '$1 == "api" && $2 ~ /^\/repos\// { count++ } END { print count + 0 }' "$STUB_GH_CALL_LOG")
+native_issue_calls=$(awk -F '\t' '$1 == "issue" && $2 == "list" { count++ } END { print count + 0 }' "$STUB_GH_CALL_LOG")
+if [[ "$rest_failure_without_log_rc" -ne 0 && "$rest_api_calls" -eq 1 && "$native_issue_calls" -eq 0 ]]; then
+	_pass "attempted REST failure remains authoritative without a historical API log"
+else
+	_fail "request-local REST failure propagation" \
+		"rc: $rest_failure_without_log_rc REST calls: $rest_api_calls native calls: $native_issue_calls"
+fi
+
 echo ""
 echo "Test 15a: issue --author @me maps to REST creator"
 _reset_log


### PR DESCRIPTION
## Summary

Replace historical API-log scans with private request-scoped attempt state shared across nested gh processes, preserving authoritative REST failures and retry counts

## Files Changed

.agents/scripts/gh, .agents/scripts/gh-api-instrument.sh, .agents/scripts/tests/test-gh-api-instrument.sh, .agents/scripts/tests/test-gh-shim-routing-cases.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime-verified with test-gh-shim.sh (146/146), test-gh-api-instrument.sh (240/240), test-gh-wrapper-rest-fallback.sh (100/100), ShellCheck, syntax checks, and linters-local.sh

Resolves #30917


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 2h 21m and 665,711 tokens on this with the user in an interactive session.