### PR TITLE
GH#30919: Bind Pulse terminal health to the cycle owner

### DIFF
--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -34,6 +34,7 @@ PULSE_CYCLE_STATE_OBJECT_TYPE="object"
 _PULSE_CYCLE_STATE_INITIALIZED=0
 _PULSE_CYCLE_STATE_TERMINAL=0
 _PULSE_CYCLE_ID=""
+_PULSE_CYCLE_OWNER_EXECUTOR_PID=""
 _PULSE_CYCLE_PHASE=""
 _PULSE_CYCLE_OUTCOME=""
 _PULSE_CYCLE_HEARTBEAT_AT=""
@@ -86,8 +87,29 @@ _pulse_cycle_state_hash() {
 	return 0
 }
 
+_pulse_cycle_state_resolve_executor_pid() {
+	local executor_pid="${BASHPID:-}"
+	if [[ -z "$executor_pid" ]]; then
+		# Bash 3.2 has no BASHPID and $$ remains the parent PID in subshells.
+		# This command-substitution child reports the actual calling shell as PPID.
+		executor_pid="$(exec sh -c 'printf "%s" "$PPID"')" || return 1
+	fi
+	[[ "$executor_pid" =~ ^[1-9][0-9]*$ ]] || return 1
+	_PULSE_CYCLE_STATE_EXECUTOR_PID="$executor_pid"
+	return 0
+}
+
+_pulse_cycle_state_executor_is_owner() {
+	local owner_pid="${_PULSE_CYCLE_OWNER_EXECUTOR_PID:-}"
+	[[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || return 1
+	_pulse_cycle_state_resolve_executor_pid || return 1
+	[[ "$_PULSE_CYCLE_STATE_EXECUTOR_PID" == "$owner_pid" ]]
+	return $?
+}
+
 _pulse_cycle_state_start() {
 	local now=""
+	local owner_pid=""
 	local previous_fields=""
 	local prior_progress_last_at=""
 	local prior_progress_kinds_json="[]"
@@ -95,6 +117,10 @@ _pulse_cycle_state_start() {
 	local prior_blocker_kind="$PULSE_CYCLE_STATE_BLOCKER_NONE"
 	local prior_blocker_fingerprint=""
 	local prior_same_blocker="0"
+	_PULSE_CYCLE_STATE_INITIALIZED=0
+	_PULSE_CYCLE_OWNER_EXECUTOR_PID=""
+	_pulse_cycle_state_resolve_executor_pid || return 1
+	owner_pid="$_PULSE_CYCLE_STATE_EXECUTOR_PID"
 	now=$(_pulse_cycle_state_now)
 	if [[ -f "${PULSE_HEALTH_FILE:-}" ]]; then
 		previous_fields=$(jq -r --arg schema "$PULSE_CYCLE_STATE_SCHEMA" \
@@ -152,6 +178,7 @@ _pulse_cycle_state_start() {
 	_PULSE_CYCLE_STATE_INITIALIZED=1
 	_PULSE_CYCLE_STATE_TERMINAL=0
 	_PULSE_CYCLE_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+	_PULSE_CYCLE_OWNER_EXECUTOR_PID="$owner_pid"
 	_PULSE_CYCLE_PHASE="admitted"
 	_PULSE_CYCLE_OUTCOME="running"
 	_PULSE_CYCLE_HEARTBEAT_AT="$now"
@@ -222,6 +249,7 @@ _pulse_cycle_state_finalize() {
 	local now=""
 	local same_blocker=0
 	[[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" == "1" ]] || return 1
+	_pulse_cycle_state_executor_is_owner || return 1
 	case "$outcome" in
 	progressed | idle | blocked | interrupted) ;;
 	*) return 1 ;;
@@ -337,6 +365,11 @@ _pulse_cycle_state_commit_legacy_outcome() {
 
 _pulse_cycle_state_write_terminal_if_current() {
 	[[ "${_PULSE_CYCLE_STATE_TERMINAL:-0}" == "1" ]] || return 1
+	if ! _pulse_cycle_state_executor_is_owner; then
+		printf '[pulse-wrapper] Cycle state: skipped terminal publish for cycle %s because executor does not own the cycle\n' \
+			"${_PULSE_CYCLE_ID:-unknown}" >>"${WRAPPER_LOGFILE:-/dev/null}"
+		return 0
+	fi
 	if [[ "${_LOCK_OWNED:-false}" == "true" ]]; then
 		_pulse_cycle_state_commit_legacy_outcome
 		write_pulse_health_file
@@ -367,6 +400,7 @@ _pulse_cycle_state_write_terminal_if_current() {
 _pulse_cycle_state_finish_if_needed() {
 	local outcome="${1:-interrupted}"
 	[[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" == "1" ]] || return 0
+	_pulse_cycle_state_executor_is_owner || return 0
 	[[ "${_PULSE_CYCLE_STATE_TERMINAL:-0}" != "1" ]] || return 0
 	if [[ "$outcome" == "interrupted" \
 		&& "${_PULSE_CYCLE_BLOCKER_KIND:-$PULSE_CYCLE_STATE_BLOCKER_NONE}" == "$PULSE_CYCLE_STATE_BLOCKER_NONE" ]]; then
@@ -620,6 +654,13 @@ append_cycle_index() {
 # Non-fatal: any failure is logged and silently ignored.
 #######################################
 write_pulse_health_file() {
+	if [[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" == "1" &&
+		"${_PULSE_CYCLE_STATE_TERMINAL:-0}" == "1" ]] &&
+		! _pulse_cycle_state_executor_is_owner; then
+		printf '[pulse-wrapper] Cycle state: skipped terminal health write for cycle %s because executor does not own the cycle\n' \
+			"${_PULSE_CYCLE_ID:-unknown}" >>"${WRAPPER_LOGFILE:-/dev/null}"
+		return 0
+	fi
 	local ts
 	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	local cycle_state_json=null

--- a/.agents/scripts/pulse-watchdog.sh
+++ b/.agents/scripts/pulse-watchdog.sh
@@ -219,7 +219,12 @@ run_stage_with_timeout() {
 	stage_start=$(date +%s)
 	echo "[pulse-wrapper] Stage start: ${stage_name} (timeout ${timeout_seconds}s)" >>"$LOGFILE"
 
-	"$@" &
+	(
+		# Background stages inherit the parent's shell state but must never run
+		# process-owner EXIT cleanup such as terminal Pulse cycle publication.
+		trap - EXIT
+		"$@"
+	) &
 	local stage_pid=$!
 
 	while kill -0 "$stage_pid" 2>/dev/null; do

--- a/.agents/scripts/tests/test-pulse-cycle-state-contract.sh
+++ b/.agents/scripts/tests/test-pulse-cycle-state-contract.sh
@@ -40,6 +40,7 @@ assert_health() {
 
 export HOME="${TMP_DIR}/home"
 export SCRIPT_DIR="$SOURCE_DIR"
+export AIDEVOPS_DISPATCH_LEDGER_DIR="$TMP_DIR"
 export AIDEVOPS_DISPATCH_LEDGER_FILE="${TMP_DIR}/dispatch-ledger.jsonl"
 mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/tmp"
 
@@ -264,6 +265,53 @@ if cmp -s "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-stale-terminal.json" \
 else
 	fail "older terminal publication cannot overwrite newer cycle health"
 fi
+
+: >"$AIDEVOPS_DISPATCH_LEDGER_FILE"
+_PULSE_HEALTH_PRS_MERGED=0
+_pulse_cycle_state_start
+write_pulse_health_file
+child_cleanup_cycle_id="$_PULSE_CYCLE_ID"
+cp "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-child-cleanup.json"
+_LOCK_OWNED=true
+(
+	trap '_pulse_cycle_state_finish_interrupted' EXIT
+)
+if cmp -s "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-child-cleanup.json" \
+	&& [[ "$_PULSE_CYCLE_STATE_TERMINAL" -eq 0 ]] \
+	&& jq -e --arg cycle_id "$child_cleanup_cycle_id" '
+		.cycle_state.cycle_id == $cycle_id
+		and .cycle_state.phase == "admitted"
+		and .cycle_state.outcome == "running"
+	' "$PULSE_HEALTH_FILE" >/dev/null; then
+	pass "child EXIT cleanup cannot publish terminal state for the live owner"
+else
+	fail "child EXIT cleanup cannot publish terminal state for the live owner"
+fi
+
+cp "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-child-terminal-write.json"
+(
+	_PULSE_CYCLE_STATE_TERMINAL=1
+	_PULSE_CYCLE_PHASE="completed"
+	_PULSE_CYCLE_OUTCOME="interrupted"
+	write_pulse_health_file
+)
+if cmp -s "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-child-terminal-write.json"; then
+	pass "child executor cannot directly publish inherited terminal health"
+else
+	fail "child executor cannot directly publish inherited terminal health"
+fi
+
+post_label_dispatch_before=$(_pulse_capture_dispatch_total)
+printf '{"session_key":"post-label-test","status":"in-flight","pid":%s,"lease_phase":"prelaunch","dispatched_at":"2026-01-01T00:00:00Z"}\n' \
+	"$$" >"$AIDEVOPS_DISPATCH_LEDGER_FILE"
+_pulse_record_cycle_outcome "$post_label_dispatch_before"
+_pulse_cycle_state_write_terminal_if_current
+assert_health "owner finalization records successful post-label dispatch" '
+	.issues_dispatched == 1
+	and .cycle_state.phase == "completed"
+	and .cycle_state.outcome == "progressed"
+	and .cycle_state.progress.kinds == ["worker-dispatched"]
+'
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Capture the cycle owner executor independently from the compatible cycle ID, reject child terminal finalization and direct terminal health writes, and clear inherited EXIT cleanup in background stages

## Files Changed

.agents/scripts/pulse-logging.sh, .agents/scripts/pulse-watchdog.sh, .agents/scripts/tests/test-pulse-cycle-state-contract.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime-verified with test-pulse-cycle-state-contract.sh (17/17), pulse wrapper characterization (42/42), timeout regressions (16/16 combined), targeted ShellCheck, syntax checks, and linters-local.sh

Resolves #30919


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 2h 46m and 825,215 tokens on this with the user in an interactive session.