### PR TITLE
GH#30933: fix(pulse): defer protected-branch TODO publication

### DIFF
--- a/.agents/scripts/planning-publisher.sh
+++ b/.agents/scripts/planning-publisher.sh
@@ -622,16 +622,29 @@ _planning_publish_push() {
 	local expected_sha="$4"
 	local candidate_sha="$5"
 	local branch_ref="${PLANNING_BRANCH_REF_PREFIX}${branch_name}"
+	local push_output_file=""
+	local push_output=""
+	local push_rc=0
+	push_output_file=$(mktemp "${TMPDIR:-/tmp}/planning-push.XXXXXX") || return 1
 	if [[ -n "${AIDEVOPS_PLANNING_FENCE_REF:-}" && -n "${AIDEVOPS_PLANNING_FENCE_SHA:-}" ]]; then
 		_planning_git -C "$repo_path" push -q --atomic \
 			--force-with-lease="${branch_ref}:${expected_sha}" \
 			--force-with-lease="${AIDEVOPS_PLANNING_FENCE_REF}:${AIDEVOPS_PLANNING_FENCE_SHA}" \
 			"$remote_name" "${candidate_sha}:${branch_ref}" \
-			"${AIDEVOPS_PLANNING_FENCE_SHA}:${AIDEVOPS_PLANNING_FENCE_REF}"
-		return $?
+			"${AIDEVOPS_PLANNING_FENCE_SHA}:${AIDEVOPS_PLANNING_FENCE_REF}" 2>"$push_output_file" || push_rc=$?
+	else
+		_planning_git -C "$repo_path" push -q --force-with-lease="${branch_ref}:${expected_sha}" \
+			"$remote_name" "${candidate_sha}:${branch_ref}" 2>"$push_output_file" || push_rc=$?
 	fi
-	_planning_git -C "$repo_path" push -q --force-with-lease="${branch_ref}:${expected_sha}" "$remote_name" "${candidate_sha}:${branch_ref}"
-	return $?
+	push_output=$(<"$push_output_file")
+	rm -f "$push_output_file"
+	if [[ "$push_rc" -ne 0 && "$push_output" == *"GH006: Protected branch update failed"* ]]; then
+		PLANNING_PUBLISH_RESULT="protected_branch_publication_deferred"
+		_planning_publish_log warning "Protected default-branch publication deferred; no retry will be attempted"
+		return 4
+	fi
+	[[ -z "$push_output" ]] || printf '%s\n' "$push_output" >&2
+	return "$push_rc"
 }
 
 _planning_publish_reset_result() {
@@ -824,8 +837,7 @@ _planning_publish_finish_noop_if_current() {
 }
 
 planning_publish() {
-	local repo_path="$1"
-	local commit_msg="$2"
+	local repo_path="$1" commit_msg="$2"
 	local remote_name="${3:-origin}"
 	local branch_name="${4:-}"
 	local paths="${5:-}"
@@ -919,6 +931,7 @@ planning_publish() {
 			rm -rf "$temp_dir"
 			return 0
 		fi
+		[[ "$push_rc" -ne 4 ]] || { rm -rf "$temp_dir"; return 4; }
 	done
 	_planning_publish_log_retryable_conflict "$publication_id"
 	rm -rf "$temp_dir"

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -672,6 +672,8 @@ sync_todo_refs_for_repo() (
 		"${PLANNING_PUBLISH_RESULT:-noop}" "$repo_slug" "${PLANNING_PUBLISHED_COMMIT:0:12}" >>"$WRAPPER_LOGFILE" ;;
 	2) printf '[pulse-wrapper] TODO ref sync status=retryable_conflict repo=%s base=%s\n' \
 		"$repo_slug" "${base_sha:0:12}" >>"$WRAPPER_LOGFILE" ;;
+	4) printf '[pulse-wrapper] TODO ref sync status=protected_branch_publication_deferred repo=%s\n' \
+		"$repo_slug" >>"$WRAPPER_LOGFILE" ;;
 	*) printf '[pulse-wrapper] TODO ref sync status=retryable_failure stage=publication repo=%s rc=%s\n' \
 		"$repo_slug" "$publication_rc" >>"$WRAPPER_LOGFILE" ;;
 	esac

--- a/.agents/scripts/tests/test-issue-sync-project-root.sh
+++ b/.agents/scripts/tests/test-issue-sync-project-root.sh
@@ -257,6 +257,47 @@ if only_todo_sync_workspace >/dev/null 2>&1; then
 	fail "retryable publication failure left an automation workspace behind"
 fi
 
+# A protected default branch is a deterministic publication mode mismatch, not
+# a snapshot conflict. Its GH006 rejection must be classified after one push
+# and must not consume the bounded retry slot.
+repo_protected="${TMP}/repo-protected"
+remote_protected="${TMP}/remote-protected.git"
+setup_sync_repo "$repo_protected" "$remote_protected"
+protected_git="${TMP}/protected-push-git.sh"
+cat >"$protected_git" <<'FIXTURE'
+#!/usr/bin/env bash
+if [[ "${3:-}" == "push" ]]; then
+	printf '%s\n' 'remote: error: GH006: Protected branch update failed for refs/heads/main.' >&2
+	printf '%s\n' 'remote: - Changes must be made through a pull request.' >&2
+	exit 1
+fi
+exec /usr/bin/git "$@"
+FIXTURE
+chmod +x "$protected_git"
+protected_refresh_repo_definition=$(declare -f _pulse_refresh_repo)
+_pulse_refresh_repo() {
+	local repo_path="$1"
+	: "$repo_path"
+	return 0
+}
+protected_rc=0
+AIDEVOPS_PLANNING_GIT_BIN="$protected_git" \
+	_pulse_sync_todo_repo_bounded owner/repo-protected "$repo_protected" 30 1 || protected_rc=$?
+eval "$protected_refresh_repo_definition"
+[[ "$protected_rc" -eq 4 ]] || fail "protected-branch publication was not classified as a bounded deferral"
+grep -q 'status=protected_branch_publication_deferred repo=owner/repo-protected' "$WRAPPER_LOGFILE" || \
+	fail "protected-branch deferral was not logged"
+[[ $(grep -c 'status=protected_branch_publication_deferred repo=owner/repo-protected' "$WRAPPER_LOGFILE") -eq 1 ]] || \
+	fail "protected-branch publication was deferred more than once"
+if grep -q 'status=retrying repo=owner/repo-protected' "$WRAPPER_LOGFILE"; then
+	fail "protected-branch publication consumed the snapshot retry slot"
+fi
+git --git-dir="$remote_protected" show main:TODO.md | grep -q '^synced:owner/repo-protected$' && \
+	fail "protected-branch fixture unexpectedly published directly"
+if only_todo_sync_workspace >/dev/null 2>&1; then
+	fail "protected-branch deferral left an automation workspace behind"
+fi
+
 # A remote default-branch advance after the isolated clone is created must be
 # retried from a newly cloned exact snapshot instead of failing the batch.
 repo_snapshot_retry="${TMP}/repo-snapshot-retry"


### PR DESCRIPTION
## Summary

Classify GH006 protected-branch rejections as bounded TODO sync deferrals without consuming snapshot retries.

## Files Changed

.agents/scripts/planning-publisher.sh, .agents/scripts/pulse-wrapper-cycle.sh, .agents/scripts/tests/test-issue-sync-project-root.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-issue-sync-project-root.sh; bash .agents/scripts/tests/test-planning-publisher.sh; bash .agents/scripts/tests/test-sync-pat-detection.sh; .agents/scripts/linters-local.sh --changed; .agents/scripts/pulse-check-helper.sh report --json

Resolves #30933


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 8m and 140,274 tokens on this as a headless worker.