### PR TITLE
GH#30932: fix(pulse-check): exclude persistent dashboards from underfill

### DIFF
--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -37,6 +37,9 @@ BLOCKING_LABELS = frozenset({
     "status:blocked",
     "status:in-review",
 })
+PERSISTENT_DASHBOARD_LABELS = frozenset({"persistent", "quality-review"})
+
+
 def _int_from_env(name: str, default: int) -> int:
     try:
         return int(os.environ.get(name, str(default)))
@@ -50,6 +53,7 @@ def _empty_aggregate() -> dict[str, int]:
         "auto_dispatch_open": 0,
         "available_unassigned": 0,
         "eligible_available_unassigned": 0,
+        "excluded_persistent_dashboard": 0,
         "available_old": 0,
         "oldest_available_age_min": 0,
         "repos_with_available": 0,
@@ -209,7 +213,17 @@ def _count_issue(
         )
     aggregate["no_auto_dispatch"] += int("no-auto-dispatch" in labels)
     aggregate["infrastructure"] += int("infrastructure" in labels)
-    available = "status:available" in labels and not assigned and not blocked and not dependency_inconsistent
+    available_candidate = (
+        "status:available" in labels
+        and not assigned
+        and not blocked
+        and not dependency_inconsistent
+    )
+    excluded_persistent_dashboard = bool(labels & PERSISTENT_DASHBOARD_LABELS)
+    aggregate["excluded_persistent_dashboard"] += int(
+        available_candidate and excluded_persistent_dashboard
+    )
+    available = available_candidate and not excluded_persistent_dashboard
     if available:
         aggregate["available_unassigned"] += 1
         aggregate["eligible_available_unassigned"] += int(has_tier and has_status)

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -23,6 +23,7 @@ end) as $max_workers |
 (if $active_worker_processes == null then $available_slots else ([$max_workers - $active_worker_processes, 0] | max) end) as $effective_available_slots |
 ($queue.aggregate.available_unassigned // 0 | number_or_zero) as $available_issues |
 ($queue.aggregate.eligible_available_unassigned // $queue.aggregate.available_unassigned // 0 | number_or_zero) as $eligible_issues |
+($queue.aggregate.excluded_persistent_dashboard // 0 | number_or_zero) as $excluded_persistent_dashboard |
 ($queue.aggregate.available_old // 0 | number_or_zero) as $old_available |
 ($queue.aggregate.dependency_inconsistent_available // 0 | number_or_zero) as $dependency_inconsistent |
 ($queue.aggregate.needs_tier // 0 | number_or_zero) as $needs_tier |
@@ -80,6 +81,7 @@ end) as $max_workers |
     auto_dispatch_open: ($queue.aggregate.auto_dispatch_open // 0),
     auto_dispatch_available_unassigned: $available_issues,
     auto_dispatch_eligible_available_unassigned: $eligible_issues,
+    auto_dispatch_excluded_persistent_dashboard: $excluded_persistent_dashboard,
     auto_dispatch_available_old: $old_available,
     auto_dispatch_dependency_inconsistent_available: $dependency_inconsistent,
     auto_dispatch_repos_with_available: ($queue.aggregate.repos_with_available // 0),
@@ -195,6 +197,7 @@ end) as $max_workers |
         [
           ("active_workers=" + ($active_workers | tostring) + "/" + ($max_workers | tostring)),
           ("eligible_available_unassigned_auto_dispatch=" + ($eligible_issues | tostring)),
+          ("excluded_persistent_dashboard=" + ($excluded_persistent_dashboard | tostring)),
           ("available_older_than_threshold=" + ($old_available | tostring)),
           "dispatch_alive=true",
           ("dispatch_stage_events=" + (($current.dispatch_stage_events // 0) | tostring))
@@ -216,6 +219,7 @@ end) as $max_workers |
           ("auto_dispatch_open=" + (($queue.aggregate.auto_dispatch_open // 0) | tostring)),
           ("assigned_in_flight=" + (($queue.aggregate.assigned_in_flight // $queue.aggregate.assigned // 0) | tostring)),
           ("blocked_explicit_hold=" + (($queue.aggregate.blocked_explicit_hold // $queue.aggregate.blocked_labels // 0) | tostring)),
+          ("excluded_persistent_dashboard=" + ($excluded_persistent_dashboard | tostring)),
           ("needs_maintainer_review=" + (($queue.aggregate.nmr // 0) | tostring)),
           ("missing_tier=" + ($needs_tier | tostring)),
           ("missing_status=" + ($needs_status | tostring))

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -253,6 +253,18 @@ JSON
   fi
   exit 0
 fi
+if [[ "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "persistent-dashboard" ]]; then
+  if [[ " $* " == *"private/repo-one"* ]]; then
+    cat <<'JSON'
+[
+  {"number":31,"title":"private quality dashboard","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"},{"name":"persistent"},{"name":"quality-review"},{"name":"source:quality-sweep"}]}
+]
+JSON
+  else
+    printf '[]\n'
+  fi
+  exit 0
+fi
 if [[ "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "shortfall" || "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "scan-error" || "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "truncation" || "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "dependency-scan-error" ]]; then
   if [[ " $* " == *"private/repo-one"* ]]; then
     cat <<'JSON'
@@ -367,6 +379,13 @@ MALFORMED_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=malformed" "$H
 assert_contains "malformed queue emits normalization shortfall" "pulse-eligible-queue-under-target" "$MALFORMED_OUT"
 assert_contains "malformed queue reports missing tiers" "auto-dispatch-missing-tier-labels" "$MALFORMED_OUT"
 assert_not_contains "malformed queue cannot trigger worker-retention underfill" "pulse-underfilled-auto-dispatch-queue" "$MALFORMED_OUT"
+
+PERSISTENT_DASHBOARD_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=persistent-dashboard" "$HELPER" json 2>&1)
+assert_eq "persistent quality dashboard is excluded from runnable availability" "0" "$(printf '%s' "$PERSISTENT_DASHBOARD_OUT" | jq -r '.queue.available_unassigned')"
+assert_eq "persistent quality dashboard is excluded from eligible queue depth" "0" "$(printf '%s' "$PERSISTENT_DASHBOARD_OUT" | jq -r '.queue.eligible_available_unassigned')"
+assert_eq "persistent quality dashboard exclusion is reported separately" "1" "$(printf '%s' "$PERSISTENT_DASHBOARD_OUT" | jq -r '.summary.auto_dispatch_excluded_persistent_dashboard')"
+assert_not_contains "persistent quality dashboard cannot trigger worker-retention underfill" "pulse-underfilled-auto-dispatch-queue" "$PERSISTENT_DASHBOARD_OUT"
+assert_not_contains "persistent quality dashboard JSON omits private issue title" "private quality dashboard" "$PERSISTENT_DASHBOARD_OUT"
 
 cat >"${TEST_ROOT}/current-state-active.sh" <<'SH'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

Exclude status:available persistent quality-review dashboard issues from runnable queue depth while reporting their aggregate separately.

## Files Changed

.agents/scripts/pulse-check-queue-scan.py, .agents/scripts/pulse-check-report.jq, .agents/scripts/tests/test-pulse-check-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-check-helper.sh

Resolves #30932


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 5m and 101,390 tokens on this as a headless worker.