### PR TITLE
GH#30925: fix trusted blocked release recognition

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -372,8 +372,9 @@ build_dependency_graph_cache() {
 #   - `Terminal blocker detected`   — pulse-dispatch-core._apply_terminal_blocker
 #   - `ACTION REQUIRED`             — supervisor-posted human-action escalation
 #   - `HUMAN_UNBLOCK_REQUIRED`      — explicit machine-readable hold marker
+#   - `CLAIM_RELEASED reason=blocked` — terminal worker blocker lifecycle event
 #######################################
-_PULSE_DEP_GRAPH_NON_DEP_BLOCK_MARKERS='\*\*BLOCKED\*\*.*cannot proceed|Worker Watchdog Kill|Terminal blocker detected|ACTION REQUIRED|HUMAN_UNBLOCK_REQUIRED'
+_PULSE_DEP_GRAPH_NON_DEP_BLOCK_MARKERS='\*\*BLOCKED\*\*.*cannot proceed|Worker Watchdog Kill|Terminal blocker detected|ACTION REQUIRED|HUMAN_UNBLOCK_REQUIRED|CLAIM_RELEASED reason=blocked([[:space:]]|$)'
 
 #######################################
 # Decide whether to defer auto-unblock for an issue (t2031)
@@ -387,7 +388,7 @@ _PULSE_DEP_GRAPH_NON_DEP_BLOCK_MARKERS='\*\*BLOCKED\*\*.*cannot proceed|Worker W
 #
 # Two signals:
 #   (a) Defer/hold marker in the issue body (cached, zero API cost).
-#   (b) Non-dep BLOCKED markers in the 10 most recent comments (one API
+#   (b) Non-dep BLOCKED markers in trusted comments among the 10 most recent (one API
 #       call per unblock candidate — candidates are rare, cost is fine).
 #
 # Arguments:
@@ -414,7 +415,7 @@ _should_defer_auto_unblock() {
 		return 0
 	fi
 
-	# (b) Non-dep BLOCKED markers in recent comments. Use the paginated REST
+	# (b) Non-dep BLOCKED markers in recent trusted comments. Use the paginated REST
 	# issue-comments endpoint because only comment bodies are needed; native
 	# `gh issue view --json comments` is GraphQL-only and cannot expose
 	# response-owned cost. Unblock candidates are rare (typical cycle: 0-5
@@ -425,8 +426,12 @@ _should_defer_auto_unblock() {
 	recent_bodies=$(set -o pipefail; gh api \
 		"repos/${repo_slug}/issues/${issue_num}/comments?per_page=100" --paginate --slurp 2>/dev/null |
 		jq -r '
+			def trusted_association:
+				. == "OWNER" or . == "MEMBER" or . == "COLLABORATOR";
 			(if (type == "array" and ((.[0]? | type) == "array")) then add else . end)
-			| .[-10:] | map(.body // "") | join("\n---\n")
+			| .[-10:]
+			| map(select((.author_association // "") | trusted_association) | (.body // ""))
+			| join("\n---\n")
 		') || recent_bodies=""
 
 	if [[ -n "$recent_bodies" ]]; then

--- a/.agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh
+++ b/.agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh
@@ -84,7 +84,7 @@ assert_eq 'hold without for' 'false' "$(issue_body_has_defer_marker 'please hold
 # pulse-dep-graph.sh:212. Keep byte-identical.
 ###############################################################################
 
-_PULSE_DEP_GRAPH_NON_DEP_BLOCK_MARKERS='\*\*BLOCKED\*\*.*cannot proceed|Worker Watchdog Kill|Terminal blocker detected|ACTION REQUIRED|HUMAN_UNBLOCK_REQUIRED'
+_PULSE_DEP_GRAPH_NON_DEP_BLOCK_MARKERS='\*\*BLOCKED\*\*.*cannot proceed|Worker Watchdog Kill|Terminal blocker detected|ACTION REQUIRED|HUMAN_UNBLOCK_REQUIRED|CLAIM_RELEASED reason=blocked([[:space:]]|$)'
 
 comment_has_marker() {
 	local body="$1"
@@ -114,6 +114,12 @@ assert_eq 'ACTION REQUIRED escalation' 'true' \
 
 assert_eq 'HUMAN_UNBLOCK_REQUIRED tag' 'true' \
 	"$(comment_has_marker 'Setting HUMAN_UNBLOCK_REQUIRED until owner reviews.')"
+
+assert_eq 'blocked claim release' 'true' \
+	"$(comment_has_marker 'CLAIM_RELEASED reason=blocked runner=maintainer ts=2026-08-30T00:00:00Z')"
+
+assert_eq 'non-blocked claim release' 'false' \
+	"$(comment_has_marker 'CLAIM_RELEASED reason=worker_complete runner=maintainer ts=2026-08-30T00:00:00Z')"
 
 # Dedup operational comments like dispatch claims must NOT trip the gate.
 assert_eq 'dispatch claim' 'false' \
@@ -181,7 +187,8 @@ assert_eq 'clean body and empty comments → unblock' '__no_defer__' "$got"
 
 # Scenario 3: body defer flag false, comment contains **BLOCKED** → defer
 export GH_STUB_COMMENTS="$STUB_DIR/blocked-comment.json"
-jq -cn --arg body '**BLOCKED** — cannot proceed autonomously. Evidence: ...' '[{body:$body}]' >"$GH_STUB_COMMENTS"
+jq -cn --arg body '**BLOCKED** — cannot proceed autonomously. Evidence: ...' \
+	'[{author_association:"OWNER",body:$body}]' >"$GH_STUB_COMMENTS"
 : >"$GH_STUB_CALLS"
 got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
 assert_eq 'worker BLOCKED comment triggers defer' 'comment-marker' "$got"
@@ -189,24 +196,46 @@ rest_comment_calls=$(grep -cF 'api repos/owner/repo/issues/123/comments?per_page
 assert_eq 'comment marker read uses paginated REST' '1' "$rest_comment_calls"
 
 # Scenario 4: Worker Watchdog Kill comment → defer
-jq -cn --arg body $'## Worker Watchdog Kill\n\n**Reason:** idle' '[{body:$body}]' >"$GH_STUB_COMMENTS"
+jq -cn --arg body $'## Worker Watchdog Kill\n\n**Reason:** idle' \
+	'[{author_association:"MEMBER",body:$body}]' >"$GH_STUB_COMMENTS"
 got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
 assert_eq 'watchdog kill comment triggers defer' 'comment-marker' "$got"
 
 # Scenario 5: Terminal blocker comment → defer
-jq -cn --arg body '**Terminal blocker detected** (GH#5141) — skipping dispatch.' '[{body:$body}]' >"$GH_STUB_COMMENTS"
+jq -cn --arg body '**Terminal blocker detected** (GH#5141) — skipping dispatch.' \
+	'[{author_association:"COLLABORATOR",body:$body}]' >"$GH_STUB_COMMENTS"
 got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
 assert_eq 'terminal blocker comment triggers defer' 'comment-marker' "$got"
 
 # Scenario 6: clean comment (dispatch claim, merge summary) → unblock
-jq -cn --arg body $'DISPATCH_CLAIM nonce=abc123 runner=maintainer\n---\nPR #1234 merged.' '[{body:$body}]' >"$GH_STUB_COMMENTS"
+jq -cn --arg body $'DISPATCH_CLAIM nonce=abc123 runner=maintainer\n---\nPR #1234 merged.' \
+	'[{author_association:"OWNER",body:$body}]' >"$GH_STUB_COMMENTS"
 got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
 assert_eq 'clean operational comments → unblock' '__no_defer__' "$got"
 
 # Scenario 7: body defer takes precedence even with clean comments
-jq -cn --arg body 'DISPATCH_CLAIM nonce=abc123' '[{body:$body}]' >"$GH_STUB_COMMENTS"
+jq -cn --arg body 'DISPATCH_CLAIM nonce=abc123' \
+	'[{author_association:"OWNER",body:$body}]' >"$GH_STUB_COMMENTS"
 got=$(_should_defer_auto_unblock 'owner/repo' '123' 'true' || echo "__no_defer__")
 assert_eq 'body defer precedence over clean comments' 'body-defer' "$got"
+
+# Scenario 8: trusted structured blocked release → defer
+jq -cn --arg body 'CLAIM_RELEASED reason=blocked runner=maintainer ts=2026-08-30T00:00:00Z' \
+	'[{author_association:"OWNER",body:$body}]' >"$GH_STUB_COMMENTS"
+got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
+assert_eq 'trusted blocked claim release triggers defer' 'comment-marker' "$got"
+
+# Scenario 9: untrusted lookalike cannot create a durable hold
+jq -cn --arg body 'CLAIM_RELEASED reason=blocked runner=attacker ts=2026-08-30T00:00:00Z' \
+	'[{author_association:"NONE",body:$body}]' >"$GH_STUB_COMMENTS"
+got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
+assert_eq 'untrusted blocked claim release does not defer' '__no_defer__' "$got"
+
+# Scenario 10: other trusted release reasons remain eligible to unblock
+jq -cn --arg body 'CLAIM_RELEASED reason=worker_complete runner=maintainer ts=2026-08-30T00:00:00Z' \
+	'[{author_association:"OWNER",body:$body}]' >"$GH_STUB_COMMENTS"
+got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
+assert_eq 'trusted non-blocked claim release does not defer' '__no_defer__' "$got"
 
 printf '\n'
 printf 'Results: %d passed, %d failed\n' "$pass_count" "$fail_count"


### PR DESCRIPTION
## Summary

Recognize the exact terminal blocked claim-release marker during dependency refresh and restrict comment evidence to trusted repository actors.

## Files Changed

.agents/scripts/pulse-dep-graph.sh, .agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified — focused pulse dependency-graph integration suite passed 37/37; Bash syntax, ShellCheck, and changed-file linters passed.

Resolves #30925


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 4h 53m and 457,971 tokens on this with the user in an interactive session.