### PR TITLE
GH#30939: prevalidate runtime-risk evidence before Git mutation

### DIFF
--- a/.agents/scripts/full-loop-helper-risk.sh
+++ b/.agents/scripts/full-loop-helper-risk.sh
@@ -7,6 +7,7 @@
 [[ -n "${_FULL_LOOP_RISK_LIB_LOADED:-}" ]] && return 0
 _FULL_LOOP_RISK_LIB_LOADED=1
 _full_loop_runtime_verified_marker="runtime-verified"
+_full_loop_pending_diff_target="WORKTREE"
 
 # Normalize a caller-supplied risk level to the spelling used in PR bodies.
 _normalize_runtime_risk() {
@@ -115,19 +116,52 @@ _runtime_paths_keyword_context() {
 	return 0
 }
 
+# Print diff hunks for the requested files without mutating the real index.
+# WORKTREE includes tracked branch/index/worktree changes plus untracked files.
+_runtime_diff_output() {
+	local base_ref="$1"
+	local diff_target="${2:-HEAD}"
+	local files_changed="${3:-}"
+	local path="" untracked="" diff_rc=0
+
+	git rev-parse --verify "${base_ref}^{commit}" >/dev/null 2>&1 || return 1
+	while IFS= read -r path; do
+		path="${path#"${path%%[![:space:]]*}"}"
+		[[ -z "$path" ]] && continue
+		if [[ "$diff_target" == "$_full_loop_pending_diff_target" ]]; then
+			git diff --unified=0 --no-color --no-ext-diff "$base_ref" -- "$path" 2>/dev/null || return 1
+			untracked=$(git ls-files --others --exclude-standard -- "$path") || return 1
+			if [[ "$untracked" == "$path" ]]; then
+				diff_rc=0
+				git diff --unified=0 --no-color --no-ext-diff --no-index \
+					/dev/null "$path" 2>/dev/null || diff_rc=$?
+				if [[ "$diff_rc" -ne 0 && "$diff_rc" -ne 1 ]]; then
+					return "$diff_rc"
+				fi
+			fi
+		else
+			git diff --unified=0 --no-color --no-ext-diff \
+				"${base_ref}..${diff_target}" -- "$path" 2>/dev/null || return 1
+		fi
+	done < <(printf '%s\n' "$files_changed" | tr ',' '\n')
+	return 0
+}
+
 # Print diff hunks only for runtime-relevant files. Documentation, tests,
 # fixtures, and linter configuration remain evidence that the branch changed,
 # but their prose must not raise the risk of unrelated runtime code.
 _runtime_diff_keyword_context() {
 	local base_ref="$1"
+	local diff_target="${2:-HEAD}"
+	local files_changed="${3:-}"
 	local path=""
-	git rev-parse --verify "${base_ref}^{commit}" >/dev/null 2>&1 || return 1
 	while IFS= read -r path; do
+		path="${path#"${path%%[![:space:]]*}"}"
 		[[ -z "$path" ]] && continue
 		if ! _runtime_path_is_low "$path"; then
-			git diff --unified=0 --no-color --no-ext-diff "${base_ref}..HEAD" -- "$path" 2>/dev/null || true
+			_runtime_diff_output "$base_ref" "$diff_target" "$path" || return 1
 		fi
-	done < <(git diff --name-only "${base_ref}..HEAD" 2>/dev/null)
+	done < <(printf '%s\n' "$files_changed" | tr ',' '\n')
 	return 0
 }
 
@@ -135,10 +169,11 @@ _runtime_diff_keyword_context() {
 # whitespace. Ambiguous block-comment edits fail upward to Medium.
 _runtime_diff_is_comments_only() {
 	local base_ref="$1"
+	local diff_target="${2:-HEAD}"
+	local files_changed="${3:-}"
 	local line="" content="" trimmed="" trailing="" current_path=""
 	local block_kind="" c_block_end="*/" html_block_end="-->"
 	local saw_change=0
-	git rev-parse --verify "${base_ref}^{commit}" >/dev/null 2>&1 || return 1
 
 	while IFS= read -r line; do
 		case "$line" in
@@ -205,7 +240,7 @@ _runtime_diff_is_comments_only() {
 			;;
 		*) return 1 ;;
 		esac
-	done < <(git diff --unified=0 --no-color --no-ext-diff "${base_ref}..HEAD" -- 2>/dev/null)
+	done < <(_runtime_diff_output "$base_ref" "$diff_target" "$files_changed")
 
 	[[ "$saw_change" -eq 1 && -z "$block_kind" ]] && return 0
 	return 1
@@ -367,12 +402,14 @@ _select_conservative_runtime_risk() {
 # metadata and branch diff. Explicit levels can raise ambiguous classifications
 # but cannot downgrade policy patterns. Unmatched runtime changes fail upward to
 # Medium; policy-listed non-runtime and comment-only changes remain Low.
-# Arguments: requested_risk, files_changed, summary_what, base_ref (optional)
+# Arguments: requested_risk, files_changed, summary_what, base_ref (optional),
+#            diff_target (optional; HEAD or WORKTREE)
 _derive_runtime_risk() {
 	local requested_risk="${1:-}"
 	local files_changed="${2:-}"
 	local summary_what="${3:-}"
 	local base_ref="${4:-}"
+	local diff_target="${5:-HEAD}"
 	local runtime_paths=""
 	local context="${summary_what}"
 	local diff_context=""
@@ -381,13 +418,14 @@ _derive_runtime_risk() {
 
 	if _runtime_paths_are_low "$files_changed"; then
 		detected_risk="Low"
-	elif [[ -n "$base_ref" ]] && _runtime_diff_is_comments_only "$base_ref"; then
+	elif [[ -n "$base_ref" ]] &&
+		_runtime_diff_is_comments_only "$base_ref" "$diff_target" "$files_changed"; then
 		detected_risk="Low"
 	else
 		runtime_paths=$(_runtime_paths_keyword_context "$files_changed") || return 1
 		runtime_context="${context} ${runtime_paths}"
 		if [[ -n "$base_ref" ]]; then
-			if ! diff_context=$(_runtime_diff_keyword_context "$base_ref"); then
+			if ! diff_context=$(_runtime_diff_keyword_context "$base_ref" "$diff_target" "$files_changed"); then
 				return 1
 			fi
 		fi
@@ -472,5 +510,38 @@ _resolve_runtime_testing_level() {
 	fi
 
 	printf '%s\n' "$testing_level"
+	return 0
+}
+
+# Collect the complete prospective PR file list without staging pending files.
+_pending_runtime_files_changed() {
+	local base_ref="$1"
+	local files_changed=""
+	git rev-parse --verify "${base_ref}^{commit}" >/dev/null 2>&1 || return 1
+	files_changed=$(
+		{
+			git diff --name-only "$base_ref" --
+			git ls-files --others --exclude-standard
+		} | LC_ALL=C sort -u | tr '\n' ',' | sed 's/,$//; s/,/, /g'
+	) || return 1
+	printf '%s\n' "$files_changed"
+	return 0
+}
+
+# Reject missing High/Critical runtime evidence before staging or committing.
+# Final-diff validation still runs after validators/rebase to catch later drift.
+_validate_pending_runtime_metadata() {
+	local requested_risk="${1:-}"
+	local requested_testing_level="${2:-}"
+	local summary_testing="${3:-}"
+	local summary_what="${4:-}"
+	local base_ref="$5"
+	local files_changed="" runtime_risk=""
+
+	files_changed=$(_pending_runtime_files_changed "$base_ref") || return 1
+	runtime_risk=$(_derive_runtime_risk "$requested_risk" "$files_changed" \
+		"$summary_what" "$base_ref" "$_full_loop_pending_diff_target") || return 1
+	_resolve_runtime_testing_level "$runtime_risk" "$requested_testing_level" \
+		"$summary_testing" >/dev/null || return 1
 	return 0
 }

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -97,12 +97,16 @@ cmd_commit_and_pr() {
 	_parse_commit_and_pr_args "$@" || return 1
 
 	# Validate inputs and detect repo/branch (sets $repo and $branch in this scope)
-	local repo="" branch=""
+	local repo="" branch="" base_branch="" base_ref=""
 	_validate_commit_and_pr_inputs "$issue_number" "$commit_message" || return 1
 	_validate_explicit_pr_metadata "$runtime_risk" "$testing_level" || return 1
 	_validate_completion_bookkeeping_request "$completion_bookkeeping" "$bookkeeping_proof_pr" \
 		"$bookkeeping_task_id" "$allow_parent_close" "$repo" \
 		"${extra_labels[@]+"${extra_labels[@]}"}" || return 1
+	base_branch=$(_resolve_remote_default_branch origin) || return 1
+	base_ref="origin/${base_branch}"
+	_validate_pending_runtime_metadata "$runtime_risk" "$testing_level" \
+		"$summary_testing" "$summary_what" "$base_ref" || return 1
 
 	_stage_and_commit "$commit_message" || return 1
 	# GH#27902: WIP commits are durable checkpoints, not publishable history.
@@ -118,7 +122,6 @@ cmd_commit_and_pr() {
 	# Derive final-diff metadata after rebase but before any remote mutation.
 	# Invalid risk/testing evidence must not leave a pushed orphan branch.
 	local files_changed=""
-	local base_branch="" base_ref=""
 	local closing_keyword="Resolves"
 	if [[ "$completion_bookkeeping" -eq 1 ]]; then
 		closing_keyword="For"

--- a/.agents/scripts/tests/test-full-loop-runtime-risk.sh
+++ b/.agents/scripts/tests/test-full-loop-runtime-risk.sh
@@ -323,17 +323,32 @@ exit 0
 EOF
 chmod +x "${MUTATION_BIN}/git" "${MUTATION_BIN}/gh"
 : >"$MUTATION_TRACE"
+mutation_head_before=$(/usr/bin/git -C "$MUTATION_REPO" rev-parse HEAD)
 if (cd "$MUTATION_REPO" && PATH="${MUTATION_BIN}:$PATH" MUTATION_TRACE="$MUTATION_TRACE" \
 	"${SCRIPT_DIR_TEST}/full-loop-helper.sh" commit-and-pr --issue 9 --message "fix: update runtime behavior" \
 	--summary "Adjust helper behavior" --testing "unit tests pass" >/dev/null 2>&1); then
 	printf 'FAIL commit-and-pr accepted invalid derived runtime evidence\n'
 	TESTS_FAILED=$((TESTS_FAILED + 1))
-elif grep -Eq '^git push|^gh (pr|api .*POST)' "$MUTATION_TRACE" ||
+elif grep -Eq '^git (add|commit|rebase|reset|push)|^gh (pr|api .*POST)' "$MUTATION_TRACE" ||
+	[[ "$(/usr/bin/git -C "$MUTATION_REPO" rev-parse HEAD)" != "$mutation_head_before" ]] ||
 	/usr/bin/git --git-dir="$MUTATION_REMOTE" show-ref --verify --quiet refs/heads/feature/risk-order; then
-	printf 'FAIL invalid derived evidence allowed remote mutations\n'
+	printf 'FAIL invalid derived evidence allowed local or remote mutations\n'
 	TESTS_FAILED=$((TESTS_FAILED + 1))
 else
-	printf 'PASS invalid derived evidence avoids remote mutations\n'
+	printf 'PASS invalid derived evidence avoids local and remote mutations\n'
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+
+prevalidation_line=$(grep -n '^[[:space:]]*_validate_pending_runtime_metadata ' \
+	"${SCRIPT_DIR_TEST}/full-loop-helper.sh" | cut -d: -f1)
+stage_line=$(grep -n '^[[:space:]]*_stage_and_commit ' \
+	"${SCRIPT_DIR_TEST}/full-loop-helper.sh" | cut -d: -f1)
+if [[ "$prevalidation_line" =~ ^[0-9]+$ && "$stage_line" =~ ^[0-9]+$ &&
+	"$prevalidation_line" -lt "$stage_line" ]]; then
+	printf 'PASS pending runtime evidence validation precedes staging\n'
+else
+	printf 'FAIL pending runtime evidence validation must precede staging\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 TESTS_RUN=$((TESTS_RUN + 1))
 


### PR DESCRIPTION
## Summary

Derive risk from the branch, index, working tree, and untracked files before staging so invalid High or Critical runtime evidence fails without changing local or remote Git state.

## Files Changed

.agents/scripts/full-loop-helper-risk.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/tests/test-full-loop-runtime-risk.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified — focused full-loop runtime-risk suite passed 27/27; changed-file linters, Bash syntax, shfmt, and ShellCheck passed.

Resolves #30939


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 5h 19m and 703,738 tokens on this with the user in an interactive session.