### PR TITLE
GH#30928: narrow infrastructure advisory dispatch blocking

### DIFF
--- a/.agents/scripts/dispatch-dedup-assignment.sh
+++ b/.agents/scripts/dispatch-dedup-assignment.sh
@@ -38,6 +38,10 @@ fi
 # shellcheck disable=SC1091  # sibling library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/shared-constants.sh"
 
+# shellcheck source=./infrastructure-advisory-lib.sh
+# shellcheck disable=SC1091  # sibling library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/infrastructure-advisory-lib.sh"
+
 # --- Functions ---
 #######################################
 # Get the repo owner from the slug.
@@ -368,27 +372,44 @@ _is_assigned_check_maintainer_permissions() {
 }
 
 #######################################
-# is_assigned helper: check the infrastructure unconditional block.
+# is_assigned helper: check the infrastructure advisory block.
 #
-# Infrastructure issues often describe billing, runner, hosting, or platform
-# advisories that must remain visible for human operations rather than consume
-# worker dispatch capacity. Candidate enumeration filters this label, but the
-# dispatch path also checks it to close the race where a label is added after
-# candidate build and before worker launch.
+# CI failure-miner infrastructure advisories must remain visible for human
+# operations rather than consume worker dispatch capacity. The generic
+# infrastructure label alone describes valid code work in some repositories.
+# Candidate enumeration and this race-window guard source one jq predicate.
 #
 # Args:
 #   $1 = issue metadata JSON (from `gh issue view --json ...,labels`)
 #   $2 = (optional) issue number — included in GUARD_UNCERTAIN output
 #   $3 = (optional) repo slug — included in GUARD_UNCERTAIN output
-# Returns: exit 0 if infrastructure label found or jq fails (prints signal),
-#          exit 1 if label absent and jq succeeds
+# Returns: exit 0 if the advisory label pair is found or jq fails (prints signal),
+#          exit 1 if the advisory label pair is absent and jq succeeds
 #######################################
 _is_assigned_check_infrastructure() {
 	local meta_json="$1"
 	local issue_number="${2:-unknown}"
 	local repo_slug="${3:-unknown}"
-	_is_assigned_check_label_block "$meta_json" "$issue_number" "$repo_slug" \
-		"infrastructure" "INFRASTRUCTURE_BLOCKED" "infrastructure-check"
+	local infrastructure_advisory_jq="" advisory_hit="" jq_rc=0
+
+	infrastructure_advisory_jq=$(infrastructure_advisory_jq_definition) || jq_rc=$?
+	if [[ "$jq_rc" -eq 0 ]]; then
+		advisory_hit=$(printf '%s' "$meta_json" | jq -r "
+			${infrastructure_advisory_jq}
+			if ((.labels // []) | aidevops_infrastructure_advisory)
+			then \"source:ci-failure-miner\" else empty end
+		" 2>/dev/null) || jq_rc=$?
+	fi
+	if [[ "$jq_rc" -ne 0 ]]; then
+		printf 'GUARD_UNCERTAIN (reason=jq-failure call=infrastructure-advisory-check issue=%s repo=%s)\n' \
+			"$issue_number" "$repo_slug"
+		return 0
+	fi
+	if [[ -n "$advisory_hit" ]]; then
+		printf 'INFRASTRUCTURE_BLOCKED (label=infrastructure source=%s)\n' "$advisory_hit"
+		return 0
+	fi
+	return 1
 }
 
 #######################################

--- a/.agents/scripts/infrastructure-advisory-lib.sh
+++ b/.agents/scripts/infrastructure-advisory-lib.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Canonical infrastructure-advisory predicate shared by Pulse dispatch gates.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+[[ -n "${_INFRASTRUCTURE_ADVISORY_LIB_LOADED:-}" ]] && return 0
+_INFRASTRUCTURE_ADVISORY_LIB_LOADED=1
+
+# Print the jq definition used against a labels array. Infrastructure is a
+# general work category; only CI failure-miner infrastructure issues are
+# operational advisories that must remain outside worker dispatch.
+infrastructure_advisory_jq_definition() {
+	# shellcheck disable=SC2016  # jq variables are literal program syntax
+	printf '%s\n' '
+		def aidevops_infrastructure_advisory:
+			map(.name? // .) as $labels |
+			(($labels | index("infrastructure")) != null and
+			 ($labels | index("source:ci-failure-miner")) != null);'
+	return 0
+}

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -32,6 +32,10 @@ _PULSE_REPO_META_LOADED=1
 _PULSE_REPO_ROLE_MAINTAINER="maintainer"
 _PULSE_REPO_ROLE_CONTRIBUTOR="contributor"
 
+# shellcheck source=./infrastructure-advisory-lib.sh
+# shellcheck disable=SC1091  # sibling library resolved by the orchestrator
+source "${SCRIPT_DIR}/infrastructure-advisory-lib.sh"
+
 #######################################
 # Resolve managed repo path from slug
 # Arguments:
@@ -211,7 +215,8 @@ repo_allows_pulse_write_actions() {
 # The jq filter excludes only deterministic blockers:
 #   - status:blocked (explicit hold)
 #   - needs-* (waiting for maintainer action)
-#   - supervisor/persistent/routine-tracking/infrastructure (non-work telemetry/advisories)
+#   - supervisor/persistent/routine-tracking (non-work telemetry)
+#   - infrastructure + source:ci-failure-miner (operational advisories)
 #   - parent-task (decomposition tracker, never directly dispatchable; t2924)
 #   - no-auto-dispatch (explicit dispatch opt-out; t2924)
 #   - status:in-progress, status:in-review, status:claimed without auto-dispatch
@@ -345,7 +350,13 @@ list_dispatchable_issue_candidates_json() {
 
 _filter_dispatchable_issue_candidates_json() {
 	local issue_json="$1"
-	printf '%s' "$issue_json" | jq -c --arg auto_dispatch_label 'auto-dispatch' '
+	local infrastructure_advisory_jq="" jq_program=""
+	infrastructure_advisory_jq=$(infrastructure_advisory_jq_definition) || {
+		printf '[]\n'
+		return 0
+	}
+	# shellcheck disable=SC2016  # jq variables are literal program syntax
+	jq_program="${infrastructure_advisory_jq}"$'\n''
 		[
 			.[] |
 			(.labels | map(.name? // .)) as $labels |
@@ -360,11 +371,10 @@ _filter_dispatchable_issue_candidates_json() {
 			select(($labels | index("supervisor")) == null) |
 			select(($labels | index("persistent")) == null) |
 			select(($labels | index("routine-tracking")) == null) |
-			# GH#24152: infrastructure outage advisories are operational alerts, not
-			# implementation tasks. They may carry status:available after generic label
-			# normalization, but dispatching /full-loop workers would chase external
-			# billing/runner incidents with code changes.
-			select(($labels | index("infrastructure")) == null) |
+			# GH#24152/GH#30928: only CI failure-miner infrastructure advisories are
+			# operational alerts. A generic infrastructure label may describe valid
+			# implementation work and must remain dispatchable.
+			select(($labels | aidevops_infrastructure_advisory) | not) |
 			# t2924: filter non-dispatchable management labels at candidate-build
 			# time, not dispatch time. Reduces wasted GraphQL+CPU on every pulse cycle
 			# re-evaluating issues the dispatcher would always block.
@@ -388,7 +398,9 @@ _filter_dispatchable_issue_candidates_json() {
 				assignees: $assignees
 			}
 		]
-	' 2>/dev/null || printf '[]\n'
+	'
+	printf '%s' "$issue_json" | jq -c --arg auto_dispatch_label 'auto-dispatch' \
+		"$jq_program" 2>/dev/null || printf '[]\n'
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
@@ -6,7 +6,7 @@
 # Verifies that enumerate_blockers() in dispatch-dedup-helper.sh:
 #   - Reports ALL structural label blockers, not just the first
 #   - Emits newline-separated tokens for each matched signal
-#   - Blocks infrastructure labels even when they appear at dispatch time
+#   - Blocks only CI failure-miner infrastructure advisories at dispatch time
 #   - Returns exit 0 when at least one blocker is found, exit 1 when none
 #   - Is backward-compatible with the is-assigned API (that contract unchanged)
 #
@@ -249,7 +249,7 @@ test_hold_for_review_only() {
 }
 
 # -------------------------------------------------------------------
-# Test: only infrastructure → exit 0, INFRASTRUCTURE_BLOCKED emitted
+# Test: generic infrastructure work remains safe to dispatch
 # -------------------------------------------------------------------
 test_infrastructure_only() {
 	create_gh_stub "infrastructure,tier:standard"
@@ -257,15 +257,37 @@ test_infrastructure_only() {
 	local output exit_code=0
 	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
 
-	if [[ "$exit_code" -ne 0 ]]; then
-		print_result "infrastructure only → exit 0 (blocked)" 1 "Expected exit 0 but got exit ${exit_code}"
+	if [[ "$exit_code" -ne 1 ]]; then
+		print_result "infrastructure only → exit 1 (safe)" 1 "Expected exit 1 but got exit ${exit_code}"
 		return 0
 	fi
 
-	if printf '%s\n' "$output" | grep -q 'INFRASTRUCTURE_BLOCKED'; then
-		print_result "infrastructure only → emits INFRASTRUCTURE_BLOCKED" 0
+	if [[ -z "$output" ]]; then
+		print_result "infrastructure only → no structural blocker" 0
 	else
-		print_result "infrastructure only → emits INFRASTRUCTURE_BLOCKED" 1 "Signal not in output: '${output}'"
+		print_result "infrastructure only → no structural blocker" 1 "Unexpected output: '${output}'"
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Test: CI failure-miner infrastructure advisory remains blocked
+# -------------------------------------------------------------------
+test_infrastructure_advisory() {
+	create_gh_stub "infrastructure,source:ci-failure-miner,tier:standard"
+
+	local output exit_code=0
+	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		print_result "infrastructure advisory → exit 0 (blocked)" 1 "Expected exit 0 but got exit ${exit_code}"
+		return 0
+	fi
+
+	if [[ "$output" == *'INFRASTRUCTURE_BLOCKED'* && "$output" == *'source=source:ci-failure-miner'* ]]; then
+		print_result "infrastructure advisory → stable blocker reason" 0
+	else
+		print_result "infrastructure advisory → stable blocker reason" 1 "Signal not in output: '${output}'"
 	fi
 	return 0
 }
@@ -275,7 +297,7 @@ test_infrastructure_only() {
 # This is the core multi-blocker regression guard (t2894).
 # -------------------------------------------------------------------
 test_multi_blocker_both_signals_emitted() {
-	create_gh_stub "parent-task,publication:pending,no-auto-dispatch,infrastructure,hold-for-review,tier:standard"
+	create_gh_stub "parent-task,publication:pending,no-auto-dispatch,infrastructure,source:ci-failure-miner,hold-for-review,tier:standard"
 
 	local output exit_code=0
 	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
@@ -410,6 +432,7 @@ main() {
 	test_no_auto_dispatch_only
 	test_hold_for_review_only
 	test_infrastructure_only
+	test_infrastructure_advisory
 	test_multi_blocker_both_signals_emitted
 	test_api_failure_emits_guard_uncertain
 	test_meta_label_caught

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
@@ -287,7 +287,8 @@ test_list_dispatchable_candidates_default_open_except_needs_labels() {
 	  {"number":8,"title":"supervisor telemetry","updatedAt":"2026-03-31T00:07:00Z","assignees":[],"labels":[{"name":"supervisor"}]},
 	  {"number":9,"title":"in progress but runnable","updatedAt":"2026-03-31T00:08:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"status:in-progress"}]},
 	  {"number":10,"title":"Infrastructure outage: 2 checks affected","updatedAt":"2026-03-31T00:09:00Z","assignees":[],"labels":[{"name":"infrastructure"},{"name":"source:ci-failure-miner"},{"name":"status:available"}]},
-	  {"number":11,"title":"auto dispatch in review","updatedAt":"2026-03-31T00:10:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"status:in-review"},{"name":"auto-dispatch"}]}
+	  {"number":11,"title":"auto dispatch in review","updatedAt":"2026-03-31T00:10:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"status:in-review"},{"name":"auto-dispatch"}]},
+	  {"number":12,"title":"Implement infrastructure code","updatedAt":"2026-03-31T00:11:00Z","assignees":[],"labels":[{"name":"infrastructure"},{"name":"status:available"},{"name":"auto-dispatch"},{"name":"tier:standard"}]}
 	]'
 	GH_PR_LIST_JSON='[]'
 
@@ -298,7 +299,7 @@ test_list_dispatchable_candidates_default_open_except_needs_labels() {
 	# re-evaluating always-blocked candidates every pulse cycle. auto-dispatch is
 	# the exception: it must reach Layer 6 so stale assignment recovery can unstick
 	# worker-intended issues left with status:in-review.
-	if [[ "$output" == *$'1|unassigned'* && "$output" == *$'2|owner assigned'* && "$output" == *$'3|maintainer assigned'* && "$output" == *$'4|runner assigned'* && "$output" == *$'5|owner queued'* && "$output" == *$'11|auto dispatch in review'* && "$output" != *$'6|needs review'* && "$output" != *$'7|needs docs'* && "$output" != *$'8|supervisor telemetry'* && "$output" != *$'9|in progress but runnable'* && "$output" != *$'10|Infrastructure outage: 2 checks affected'* ]]; then
+	if [[ "$output" == *$'1|unassigned'* && "$output" == *$'2|owner assigned'* && "$output" == *$'3|maintainer assigned'* && "$output" == *$'4|runner assigned'* && "$output" == *$'5|owner queued'* && "$output" == *$'11|auto dispatch in review'* && "$output" == *$'12|Implement infrastructure code'* && "$output" != *$'6|needs review'* && "$output" != *$'7|needs docs'* && "$output" != *$'8|supervisor telemetry'* && "$output" != *$'9|in progress but runnable'* && "$output" != *$'10|Infrastructure outage: 2 checks affected'* ]]; then
 		print_result "list_dispatchable_issue_candidates lets auto-dispatch active-status issues reach dedup" 0
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Keep generic infrastructure implementation issues dispatchable while blocking only infrastructure issues sourced from the CI failure miner at candidate-build and dispatch-time gates.

## Files Changed

.agents/scripts/dispatch-dedup-assignment.sh, .agents/scripts/infrastructure-advisory-lib.sh, .agents/scripts/pulse-repo-meta.sh, .agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh, .agents/scripts/tests/test-pulse-wrapper-worker-count.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified — candidate-filter suite passed 37/37 and dispatch blocker suite passed 13/13; Bash syntax, ShellCheck, and changed-file linters passed.

Resolves #30928


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 5h 38m and 876,367 tokens on this with the user in an interactive session.