### PR TITLE
GH#30941: fix OpenAI intent tracing

### DIFF
--- a/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
@@ -8,6 +8,7 @@
 
 import { getAccounts, patchAccount, rotateOpenAIPoolToken } from "./oauth-pool.mjs";
 import { handleOpenAITokenRefreshFailure, isOpenAITokenRefreshRequest, readOpenAITokenRefreshBody } from "./openai-auth-refresh-recovery.mjs";
+import { injectIntentSchemaProperty } from "./provider-auth-body.mjs";
 
 export { isOpenAITokenRefreshRequest } from "./openai-auth-refresh-recovery.mjs";
 
@@ -24,6 +25,39 @@ const USAGE_LIMIT_MARKERS = [
 ];
 
 let installed = false;
+
+function transformOpenAITool(tool) {
+  if (tool?.type !== "function") return tool;
+  if (tool.function?.parameters) {
+    const parameters = injectIntentSchemaProperty(tool.function.parameters);
+    if (parameters === tool.function.parameters) return tool;
+    return { ...tool, function: { ...tool.function, parameters } };
+  }
+  if (tool.parameters) {
+    const parameters = injectIntentSchemaProperty(tool.parameters);
+    if (parameters === tool.parameters) return tool;
+    return { ...tool, parameters };
+  }
+  return tool;
+}
+
+/** Inject intent into OpenAI Responses and Chat Completions function schemas. */
+export function injectOpenAIIntentParameter(tools) {
+  return tools.map(transformOpenAITool);
+}
+
+/** Transform a serialized OpenAI request body without retaining its contents. */
+export function transformOpenAIRequestBody(body) {
+  if (!body || typeof body !== "string") return body;
+  try {
+    const parsed = JSON.parse(body);
+    if (!Array.isArray(parsed.tools)) return body;
+    parsed.tools = injectOpenAIIntentParameter(parsed.tools);
+    return JSON.stringify(parsed);
+  } catch {
+    return body;
+  }
+}
 
 export function parseRetryAfterMs(response) {
   const raw = response.headers?.get?.("retry-after");
@@ -99,12 +133,31 @@ function buildRetryRequest(input) {
   return input;
 }
 
+function extendRequestInit(init, overrides) {
+  if (init == null) return { ...overrides };
+  return Object.assign(Object.create(Object(init)), overrides);
+}
+
+async function prepareOpenAIRequest(input, init) {
+  const initHasBody = init != null && "body" in Object(init);
+  if (initHasBody && typeof init.body !== "string") return { input, init };
+  let body = initHasBody ? init.body : "";
+  if (!initHasBody && typeof Request !== "undefined" && input instanceof Request) {
+    try {
+      body = await input.clone().text();
+    } catch {
+      return { input, init };
+    }
+  }
+  const transformedBody = transformOpenAIRequestBody(body);
+  if (!body || transformedBody === body) return { input, init };
+  return { input, init: extendRequestInit(init, { body: transformedBody }) };
+}
+
 function buildRetryInit(input, init, accessToken) {
-  const retryInit = { ...(init || {}) };
   const retryHeaders = headersFrom(input, init);
   retryHeaders.set("authorization", `Bearer ${accessToken}`);
-  retryInit.headers = retryHeaders;
-  return retryInit;
+  return extendRequestInit(init, { headers: retryHeaders });
 }
 
 async function handleOpenAIUsageLimit(ctx) {
@@ -140,9 +193,12 @@ async function handleOpenAIFetchRequest(ctx) {
   const openaiRequest = isOpenAIProviderRequest(input);
   const tokenRefreshRequest = isOpenAITokenRefreshRequest(input);
   const tokenRefreshBody = tokenRefreshRequest ? await readOpenAITokenRefreshBody(input, init) : "";
-  const retryInput = openaiRequest ? buildRetryRequest(input) : input;
-  const firstInit = openaiRequest ? await maybeRotateBeforeOpenAIFetch(client, input, init) : init;
-  const response = await originalFetch(input, firstInit);
+  const prepared = openaiRequest ? await prepareOpenAIRequest(input, init) : { input, init };
+  const retryInput = openaiRequest ? buildRetryRequest(prepared.input) : prepared.input;
+  const firstInit = openaiRequest
+    ? await maybeRotateBeforeOpenAIFetch(client, prepared.input, prepared.init)
+    : prepared.init;
+  const response = await originalFetch(prepared.input, firstInit);
   let result = response;
 
   if (tokenRefreshRequest) {
@@ -152,7 +208,14 @@ async function handleOpenAIFetchRequest(ctx) {
       bodyText: tokenRefreshBody,
     });
   } else if (openaiRequest && await isOpenAIUsageLimitResponse(response)) {
-    result = await handleOpenAIUsageLimit({ client, originalFetch, input, init: firstInit, response, retryInput });
+    result = await handleOpenAIUsageLimit({
+      client,
+      originalFetch,
+      input: prepared.input,
+      init: firstInit,
+      response,
+      retryInput,
+    });
   }
   return result;
 }

--- a/.agents/plugins/opencode-aidevops/provider-auth-body.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth-body.mjs
@@ -63,32 +63,37 @@ function redistributeSystemToMessages(parsed) {
   console.error(`[aidevops] provider-auth: redistributed ${overflow.length} system blocks (${overflowText.length} chars) to user message to stay under third-party detection threshold`);
 }
 
-const INTENT_PARAM_NAME = "agent__intent";
+export const INTENT_PARAM_NAME = "agent__intent";
 
-const INTENT_PARAM_SCHEMA = Object.freeze({
+export const INTENT_PARAM_SCHEMA = Object.freeze({
   type: "string",
   description:
     "Intent tracing: one sentence in present participle form describing your intent for this tool call (no trailing period).",
 });
 
+/** Inject agent__intent into one object-typed JSON schema without mutation. */
+export function injectIntentSchemaProperty(schema) {
+  if (!schema || schema.type !== "object") return schema;
+  const properties = schema.properties ?? {};
+  if (Object.prototype.hasOwnProperty.call(properties, INTENT_PARAM_NAME)) return schema;
+  return {
+    ...schema,
+    properties: {
+      ...properties,
+      [INTENT_PARAM_NAME]: INTENT_PARAM_SCHEMA,
+    },
+  };
+}
+
 /** Inject agent__intent as an optional property on object-typed tool schemas. */
 export function injectIntentParameter(tools) {
   return tools.map((tool) => {
     const schema = tool?.input_schema;
-    if (!schema || schema.type !== "object") return tool;
-    const properties = schema.properties ?? {};
-    if (Object.prototype.hasOwnProperty.call(properties, INTENT_PARAM_NAME)) {
-      return tool;
-    }
+    const transformed = injectIntentSchemaProperty(schema);
+    if (transformed === schema) return tool;
     return {
       ...tool,
-      input_schema: {
-        ...schema,
-        properties: {
-          ...properties,
-          [INTENT_PARAM_NAME]: INTENT_PARAM_SCHEMA,
-        },
-      },
+      input_schema: transformed,
     };
   });
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
@@ -37,6 +37,35 @@ test("detects OpenAI usage-limit responses", async () => {
   assert.equal(await isOpenAIUsageLimitResponse(new Response("ok", { status: 200 })), false);
 });
 
+test("injects optional intent into OpenAI provider tool-schema variants", async () => {
+  const { transformOpenAIRequestBody } = await loadModule();
+  const source = JSON.stringify({
+    tools: [
+      {
+        type: "function",
+        name: "read_file",
+        parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+      },
+      {
+        type: "function",
+        function: {
+          name: "run_command",
+          parameters: { type: "object", properties: { command: { type: "string" } }, required: ["command"] },
+        },
+      },
+      { type: "web_search_preview" },
+    ],
+  });
+
+  const transformed = JSON.parse(transformOpenAIRequestBody(source));
+  assert.equal(transformed.tools[0].parameters.properties.agent__intent.type, "string");
+  assert.deepEqual(transformed.tools[0].parameters.required, ["path"]);
+  assert.equal(transformed.tools[1].function.parameters.properties.agent__intent.type, "string");
+  assert.deepEqual(transformed.tools[1].function.parameters.required, ["command"]);
+  assert.deepEqual(transformed.tools[2], { type: "web_search_preview" });
+  assert.equal(transformOpenAIRequestBody("not-json"), "not-json");
+});
+
 test("installed fetch guard rotates on response failures and pre-request cooldowns", async () => {
   const script = String.raw`
     import assert from "node:assert/strict";
@@ -57,7 +86,7 @@ test("installed fetch guard rotates on response failures and pre-request cooldow
       installOpenAIProviderFetchRotation({
         auth: { set: async (entry) => authWrites.push(entry) },
       });
-      const response = await fetch(request.url, request.init);
+      const response = await fetch(request.input ?? request.url, request.init);
       return { response, calls, authWrites, pool: JSON.parse(readFileSync(poolPath, "utf-8")) };
     }
 
@@ -67,7 +96,10 @@ test("installed fetch guard rotates on response failures and pre-request cooldow
         { email: "healthy@example.com", access: "healthy-token", refresh: "healthy-refresh", expires: Date.now() + 3600_000, status: "idle", cooldownUntil: 0, lastUsed: "2026-01-01T00:00:00Z", accountId: "acct_healthy" },
       ],
     }, async (input, init, calls) => {
-      calls.push(new Headers(init?.headers).get("authorization"));
+      calls.push({
+        authorization: new Headers(init?.headers).get("authorization"),
+        body: JSON.parse(String(init?.body || "{}")),
+      });
       if (calls.length === 1) {
         return new Response(JSON.stringify({ error: { code: "insufficient_quota", message: "usage limit" } }), {
           status: 403,
@@ -77,15 +109,91 @@ test("installed fetch guard rotates on response failures and pre-request cooldow
       return new Response("ok", { status: 200 });
     }, {
       url: "https://api.openai.com/v1/chat/completions",
-      init: { method: "POST", headers: { authorization: "Bearer limited-token" }, body: "{}" },
+      init: {
+        method: "POST",
+        headers: { authorization: "Bearer limited-token" },
+        body: JSON.stringify({ tools: [{
+          type: "function",
+          function: {
+            name: "read_file",
+            parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+          },
+        }] }),
+      },
     });
 
     assert.equal(responseRotation.response.status, 200);
-    assert.deepEqual(responseRotation.calls, ["Bearer limited-token", "Bearer healthy-token"]);
+    assert.deepEqual(responseRotation.calls.map((call) => call.authorization), ["Bearer limited-token", "Bearer healthy-token"]);
+    for (const call of responseRotation.calls) {
+      const parameters = call.body.tools[0].function.parameters;
+      assert.equal(parameters.properties.agent__intent.type, "string");
+      assert.deepEqual(parameters.required, ["path"]);
+    }
     assert.equal(responseRotation.pool.openai[0].status, "rate-limited");
     assert.equal(responseRotation.pool.openai[1].status, "active");
     assert.equal(responseRotation.authWrites[0].path.id, "openai");
     assert.equal(responseRotation.authWrites[0].body.accountId, "acct_healthy");
+
+    const requestSource = JSON.stringify({ tools: [{
+      type: "function",
+      name: "read_file",
+      parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+    }] });
+    const requestInput = new Request("https://api.openai.com/v1/responses", {
+      method: "POST",
+      headers: { authorization: "Bearer healthy-token" },
+      body: requestSource,
+    });
+    const requestTransform = await withInstalledGuard({
+      openai: [{ email: "healthy@example.com", access: "healthy-token", expires: Date.now() + 3600_000, status: "active", cooldownUntil: 0 }],
+    }, async (input, init, calls) => {
+      calls.push(await new Request(input, init).text());
+      return new Response("ok", { status: 200 });
+    }, { input: requestInput });
+    assert.equal(JSON.parse(requestTransform.calls[0]).tools[0].parameters.properties.agent__intent.type, "string");
+
+    const transformedInheritedInit = Object.create({
+      body: requestSource,
+      method: "PUT",
+      headers: { authorization: "Bearer inherited-token", "x-request-source": "inherited" },
+    });
+    const inheritedTransform = await withInstalledGuard({
+      openai: [{ email: "inherited@example.com", access: "inherited-token", expires: Date.now() + 3600_000, status: "active", cooldownUntil: 0 }],
+    }, async (input, init, calls) => {
+      const normalized = new Request(input, init);
+      calls.push({
+        method: normalized.method,
+        authorization: normalized.headers.get("authorization"),
+        source: normalized.headers.get("x-request-source"),
+        body: await normalized.text(),
+      });
+      return new Response("ok", { status: 200 });
+    }, { input: requestInput, init: transformedInheritedInit });
+    assert.equal(inheritedTransform.calls[0].method, "PUT");
+    assert.equal(inheritedTransform.calls[0].authorization, "Bearer inherited-token");
+    assert.equal(inheritedTransform.calls[0].source, "inherited");
+    assert.equal(JSON.parse(inheritedTransform.calls[0].body).tools[0].parameters.properties.agent__intent.type, "string");
+
+    const inheritedInit = Object.create({ body: "inherited-override" });
+    const overrideCases = [
+      { init: { body: "" }, expected: "" },
+      { init: { body: new URLSearchParams({ payload: "replacement" }) }, expected: "payload=replacement" },
+      { init: inheritedInit, expected: "inherited-override" },
+    ];
+    for (const overrideCase of overrideCases) {
+      const overrideInput = new Request("https://api.openai.com/v1/responses", {
+        method: "POST",
+        headers: { authorization: "Bearer healthy-token" },
+        body: requestSource,
+      });
+      const overrideResult = await withInstalledGuard({
+        openai: [{ email: "healthy@example.com", access: "healthy-token", expires: Date.now() + 3600_000, status: "active", cooldownUntil: 0 }],
+      }, async (input, init, calls) => {
+        calls.push(await new Request(input, init).text());
+        return new Response("ok", { status: 200 });
+      }, { input: overrideInput, init: overrideCase.init });
+      assert.equal(overrideResult.calls[0], overrideCase.expected);
+    }
 
     const tokenRefreshRecovery = await withInstalledGuard({
       openai: [


### PR DESCRIPTION
## Summary

Inject optional agent__intent metadata into OpenAI Responses and Chat Completions function schemas while preserving Fetch request semantics across initial requests and auth retries.

## Files Changed

.agents/plugins/opencode-aidevops/openai-provider-auth.mjs, .agents/plugins/opencode-aidevops/provider-auth-body.mjs, .agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: installed fetch-guard integration tests exercised native Request normalization, both OpenAI schema variants, initial requests, cooldown rotation, usage-limit retry, inherited RequestInit values, and body pass-through; focused suite passed 21/21, syntax checks and changed-file linters passed, and independent high-risk review was clean. The unrelated v2 adapter test could not load optional @opencode-ai/plugin in this worktree environment.

Resolves #30941


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 21m and 443,387 tokens on this with the user in an interactive session.