### PR TITLE
GH#30930: align Pulse systemd timeout with runtime budget

### DIFF
--- a/.agents/scripts/setup/modules/schedulers-pulse.sh
+++ b/.agents/scripts/setup/modules/schedulers-pulse.sh
@@ -547,6 +547,42 @@ _seconds_to_cron_schedule() {
 	return 0
 }
 
+# Return the longest internal supervisor Pulse watchdog/stage ceiling. Keep this
+# list aligned with pulse-wrapper-config.sh defaults so the outer service manager
+# cannot terminate a healthy cycle before its own watchdog does.
+_pulse_supervisor_runtime_budget_seconds() {
+	local scheduler_stale_threshold="${1:-${PULSE_STALE_THRESHOLD_SECONDS:-1800}}"
+	local longest_budget=0 candidate=""
+	while IFS= read -r candidate; do
+		[[ "$candidate" =~ ^[1-9][0-9]*$ ]] || continue
+		if [[ "$candidate" -gt "$longest_budget" ]]; then
+			longest_budget="$candidate"
+		fi
+	done <<EOF
+${scheduler_stale_threshold}
+${PULSE_IDLE_TIMEOUT:-1800}
+${PULSE_PROGRESS_TIMEOUT:-1800}
+${PULSE_COLD_START_TIMEOUT:-1800}
+${PULSE_COLD_START_TIMEOUT_UNDERFILLED:-1200}
+${PULSE_UNDERFILLED_STALE_RECOVERY_TIMEOUT:-3600}
+${PRE_RUN_STAGE_TIMEOUT:-600}
+EOF
+
+	[[ "$longest_budget" -gt 0 ]] || longest_budget=3600
+	printf '%s\n' "$longest_budget"
+	return 0
+}
+
+# Add shutdown/reaping headroom beyond the longest internal runtime ceiling.
+_pulse_supervisor_service_timeout_seconds() {
+	local scheduler_stale_threshold="${1:-${PULSE_STALE_THRESHOLD_SECONDS:-1800}}"
+	local runtime_budget="" margin="${PULSE_SYSTEMD_TIMEOUT_MARGIN_SECONDS:-60}"
+	runtime_budget=$(_pulse_supervisor_runtime_budget_seconds "$scheduler_stale_threshold") || return 1
+	[[ "$margin" =~ ^[1-9][0-9]*$ ]] || margin=60
+	printf '%s\n' "$((runtime_budget + margin))"
+	return 0
+}
+
 _install_supervisor_pulse() {
 	local _os="$1"
 	local pulse_label="$2"
@@ -574,7 +610,8 @@ _install_supervisor_pulse() {
 		_pulse_interval_label="${_pulse_interval_sec}s"
 	fi
 
-	local _pulse_timeout_sec=$((PULSE_STALE_THRESHOLD_SECONDS + 60))
+	local _pulse_timeout_sec=""
+	_pulse_timeout_sec=$(_pulse_supervisor_service_timeout_seconds "$PULSE_STALE_THRESHOLD_SECONDS") || return 1
 	local _pulse_env=""
 	# GH#18439 Bug 2: thread resolved runtime binary path through to the
 	# Linux env builder so OPENCODE_BIN is embedded in the systemd service

--- a/.agents/scripts/tests/test-pulse-systemd-timeout.sh
+++ b/.agents/scripts/tests/test-pulse-systemd-timeout.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SCHEDULERS_SCRIPT="${REPO_ROOT}/.agents/scripts/setup/modules/schedulers.sh"
 TMP_DIR="$(mktemp -d)"
 

--- a/tests/test-pulse-systemd-timeout.sh
+++ b/tests/test-pulse-systemd-timeout.sh
@@ -101,8 +101,8 @@ setup_supervisor_pulse "Linux"
 
 SERVICE_FILE="$HOME/.config/systemd/user/aidevops-supervisor-pulse.service"
 
-if ! grep -q '^TimeoutStartSec=1860$' "$SERVICE_FILE"; then
-	echo "expected TimeoutStartSec=1860 in ${SERVICE_FILE}" >&2
+if ! grep -q '^TimeoutStartSec=3660$' "$SERVICE_FILE"; then
+	echo "expected TimeoutStartSec=3660 in ${SERVICE_FILE}" >&2
 	exit 1
 fi
 
@@ -116,7 +116,19 @@ if ! grep -q '^Environment=AIDEVOPS_PULSE_ASYNC_POST_DISPATCH_HOUSEKEEPING="0"$'
 	exit 1
 fi
 
-printf 'PASS %s\n' "pulse systemd service timeout exceeds watchdog threshold"
+if [[ "$(_pulse_supervisor_runtime_budget_seconds 1800)" != "3600" ]]; then
+	echo "expected canonical Pulse runtime budget to include the 3600s underfilled recovery ceiling" >&2
+	exit 1
+fi
+
+PULSE_UNDERFILLED_STALE_RECOVERY_TIMEOUT=4200
+if [[ "$(_pulse_supervisor_service_timeout_seconds 1800)" != "4260" ]]; then
+	echo "expected Pulse service timeout to track a longer internal ceiling plus margin" >&2
+	exit 1
+fi
+unset PULSE_UNDERFILLED_STALE_RECOVERY_TIMEOUT
+
+printf 'PASS %s\n' "pulse systemd service timeout exceeds the longest internal runtime ceiling"
 
 # GH#18439 Bug 1 regression: _scheduler_systemd_env_lines() emits a trailing
 # newline, but $() strips it. The caller MUST re-add the separator or


### PR DESCRIPTION
## Summary

Derive the supervisor service timeout from the longest internal watchdog or stage ceiling plus reaping margin, raising the default Linux timeout from 1860 to 3660 seconds.

## Files Changed

.agents/scripts/setup/modules/schedulers-pulse.sh, tests/test-pulse-systemd-timeout.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified — focused generated-systemd-unit test passed all four assertions, including the 3600-second underfilled recovery ceiling and a longer override; ShellCheck and changed-file linters passed.

Resolves #30930


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 6h 12m and 1,237,058 tokens on this with the user in an interactive session.