### PR TITLE
GH#30943: fix(setup): reconcile RTK readiness

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
@@ -45,6 +45,58 @@ _status_file_discovery_readiness() {
 	return 0
 }
 
+_status_rtk_version_relation() {
+	local installed_version="$1"
+	local supported_version="$2"
+	local installed_major="" installed_minor="" installed_patch=""
+	local supported_major="" supported_minor="" supported_patch=""
+	local installed_part="" supported_part="" index=""
+	local installed_parts=() supported_parts=()
+
+	if [[ ! "$installed_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+		[[ ! "$supported_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		printf '%s\n' "unknown"
+		return 0
+	fi
+	IFS='.' read -r installed_major installed_minor installed_patch <<<"$installed_version"
+	IFS='.' read -r supported_major supported_minor supported_patch <<<"$supported_version"
+	installed_parts=("$installed_major" "$installed_minor" "$installed_patch")
+	supported_parts=("$supported_major" "$supported_minor" "$supported_patch")
+	for index in 0 1 2; do
+		installed_part="${installed_parts[$index]}"
+		supported_part="${supported_parts[$index]}"
+		[[ "$installed_part" == "$supported_part" ]] && continue
+		if ((10#$installed_part < 10#$supported_part)); then
+			printf '%s\n' "older"
+		else
+			printf '%s\n' "newer-untested"
+		fi
+		return 0
+	done
+	printf '%s\n' "tested"
+	return 0
+}
+
+_status_rtk_readiness() {
+	local rtk_supported_version="0.41.0"
+	local rtk_version="unknown"
+	local rtk_relation="unknown"
+
+	if ! check_cmd rtk; then
+		print_warning "rtk - not installed (optional token optimization proxy)"
+		return 0
+	fi
+	rtk_version=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || printf 'unknown')
+	rtk_relation=$(_status_rtk_version_relation "$rtk_version" "$rtk_supported_version")
+	case "$rtk_relation" in
+	tested) print_success "rtk v${rtk_version} (aidevops-tested token optimization proxy)" ;;
+	older) print_warning "rtk v${rtk_version} is older than aidevops-tested v${rtk_supported_version}; run: aidevops setup" ;;
+	newer-untested) print_info "rtk v${rtk_version} is newer than aidevops-tested v${rtk_supported_version}; available without an automatic downgrade" ;;
+	*) print_warning "rtk version output is unrecognized; availability detected but compatibility with v${rtk_supported_version} is unknown" ;;
+	esac
+	return 0
+}
+
 _status_recommended_tools() {
 	print_header "Recommended Tools"
 	if [[ "$(uname)" == "Darwin" ]]; then
@@ -272,6 +324,7 @@ cmd_status() {
 	echo ""
 	print_header "Optional Dependencies"
 	check_cmd sshpass && print_success "sshpass" || print_warning "sshpass - not installed (needed for password SSH)"
+	_status_rtk_readiness
 	echo ""
 	_status_recommended_tools
 	print_header "Git CLI Tools"

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -310,6 +310,38 @@ _setup_rtk_installed_version() {
 	return 0
 }
 
+_setup_rtk_version_relation() {
+	local installed_version="$1"
+	local supported_version="$2"
+	local installed_major="" installed_minor="" installed_patch=""
+	local supported_major="" supported_minor="" supported_patch=""
+	local installed_part="" supported_part="" index=""
+	local installed_parts=() supported_parts=()
+
+	if [[ ! "$installed_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+		[[ ! "$supported_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		printf '%s\n' "unknown"
+		return 0
+	fi
+	IFS='.' read -r installed_major installed_minor installed_patch <<<"$installed_version"
+	IFS='.' read -r supported_major supported_minor supported_patch <<<"$supported_version"
+	installed_parts=("$installed_major" "$installed_minor" "$installed_patch")
+	supported_parts=("$supported_major" "$supported_minor" "$supported_patch")
+	for index in 0 1 2; do
+		installed_part="${installed_parts[$index]}"
+		supported_part="${supported_parts[$index]}"
+		[[ "$installed_part" == "$supported_part" ]] && continue
+		if ((10#$installed_part < 10#$supported_part)); then
+			printf '%s\n' "older"
+		else
+			printf '%s\n' "newer-untested"
+		fi
+		return 0
+	done
+	printf '%s\n' "tested"
+	return 0
+}
+
 _setup_rtk_install_supported_version() {
 	local rtk_installer_url="$1"
 	local rtk_supported_version="$2"
@@ -371,18 +403,27 @@ setup_rtk() {
 
 	if command -v rtk >/dev/null 2>&1; then
 		local rtk_version
+		local rtk_relation
 		rtk_version=$(_setup_rtk_installed_version)
 		print_success "rtk found: v$rtk_version (token optimization proxy)"
-		if [[ "$rtk_version" != "$rtk_supported_version" ]]; then
+		rtk_relation=$(_setup_rtk_version_relation "$rtk_version" "$rtk_supported_version")
+		if [[ "$rtk_relation" == "older" ]]; then
 			if _setup_rtk_offer_supported_upgrade "$rtk_version" "$rtk_supported_version" "$rtk_installer_url"; then
 				rtk_version=$(_setup_rtk_installed_version)
-				if [[ "$rtk_version" == "$rtk_supported_version" ]]; then
+				rtk_relation=$(_setup_rtk_version_relation "$rtk_version" "$rtk_supported_version")
+				if [[ "$rtk_relation" == "tested" ]]; then
 					print_success "rtk now matches the aidevops-tested version"
+				elif [[ "$rtk_relation" == "newer-untested" ]]; then
+					print_info "rtk v${rtk_version} is newer than the aidevops-tested v${rtk_supported_version}; accepted without an automatic downgrade"
 				else
 					print_warning "rtk still reports v${rtk_version}; aidevops supports v${rtk_supported_version}"
 					_setup_rtk_print_manual_install "$rtk_installer_url"
 				fi
 			fi
+		elif [[ "$rtk_relation" == "newer-untested" ]]; then
+			print_info "rtk v${rtk_version} is newer than the aidevops-tested v${rtk_supported_version}; accepted without an automatic downgrade"
+		elif [[ "$rtk_relation" == "unknown" ]]; then
+			print_warning "rtk version output is unrecognized; availability detected but compatibility with v${rtk_supported_version} is unknown"
 		fi
 		# Fall through to ensure config is applied (telemetry, tee)
 	else

--- a/.agents/scripts/tests/test-status-rtk-readiness.sh
+++ b/.agents/scripts/tests/test-status-rtk-readiness.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUS_LIB="$SCRIPT_DIR/../aidevops-cli/aidevops-status-lib.sh"
+TEST_ROOT="$(mktemp -d -t aidevops-status-rtk.XXXXXX)"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+print_success() { printf 'SUCCESS: %s\n' "$1"; return 0; }
+print_warning() { printf 'WARNING: %s\n' "$1"; return 0; }
+print_info() { printf 'INFO: %s\n' "$1"; return 0; }
+check_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+# shellcheck source=../aidevops-cli/aidevops-status-lib.sh
+source "$STATUS_LIB"
+mkdir -p "$TEST_ROOT/bin"
+
+set_rtk_version() {
+	local version="$1"
+	printf '%s\n' '#!/usr/bin/env bash' "[[ \"\${1:-}\" == \"--version\" ]] && printf '%s\\n' 'rtk ${version}'" >"$TEST_ROOT/bin/rtk"
+	chmod +x "$TEST_ROOT/bin/rtk"
+	return 0
+}
+
+missing_output=$(PATH="/usr/bin:/bin" _status_rtk_readiness)
+if [[ "$missing_output" != *"rtk - not installed (optional token optimization proxy)"* ]]; then
+	printf 'FAIL: missing rtk status was not reported: %s\n' "$missing_output" >&2
+	exit 1
+fi
+
+set_rtk_version "0.41.0"
+tested_output=$(PATH="$TEST_ROOT/bin:/usr/bin:/bin" _status_rtk_readiness)
+if [[ "$tested_output" != *"aidevops-tested token optimization proxy"* ]]; then
+	printf 'FAIL: tested rtk status was not reported: %s\n' "$tested_output" >&2
+	exit 1
+fi
+
+set_rtk_version "0.40.0"
+older_output=$(PATH="$TEST_ROOT/bin:/usr/bin:/bin" _status_rtk_readiness)
+if [[ "$older_output" != *"is older than aidevops-tested v0.41.0"* ]]; then
+	printf 'FAIL: older rtk status was not actionable: %s\n' "$older_output" >&2
+	exit 1
+fi
+
+set_rtk_version "0.46.0"
+newer_output=$(PATH="$TEST_ROOT/bin:/usr/bin:/bin" _status_rtk_readiness)
+if [[ "$newer_output" != *"available without an automatic downgrade"* ]]; then
+	printf 'FAIL: newer rtk status was not reported: %s\n' "$newer_output" >&2
+	exit 1
+fi
+
+set_rtk_version "development"
+unknown_output=$(PATH="$TEST_ROOT/bin:/usr/bin:/bin" _status_rtk_readiness)
+if [[ "$unknown_output" != *"compatibility with v0.41.0 is unknown"* ]]; then
+	printf 'FAIL: unknown rtk status was not reported: %s\n' "$unknown_output" >&2
+	exit 1
+fi
+
+printf '%s\n' 'PASS: status reports RTK availability and compatibility states'
+exit 0

--- a/.agents/scripts/tests/test-tool-install-rtk.sh
+++ b/.agents/scripts/tests/test-tool-install-rtk.sh
@@ -32,6 +32,7 @@ assert_eq() {
 extract_functions() {
 	awk '
 		/^_setup_rtk_installed_version\(\)/, /^}$/ { print; next }
+		/^_setup_rtk_version_relation\(\)/, /^}$/ { print; next }
 		/^_setup_rtk_install_supported_version\(\)/, /^}$/ { print; next }
 		/^_setup_rtk_print_manual_install\(\)/, /^}$/ { print; next }
 		/^_setup_rtk_offer_supported_upgrade\(\)/, /^}$/ { print; next }
@@ -39,6 +40,10 @@ extract_functions() {
 	' "$TOOL_INSTALL" >"$SANDBOX/extract.sh"
 	if ! grep -q '^_setup_rtk_offer_supported_upgrade()' "$SANDBOX/extract.sh"; then
 		echo "FAIL: extraction did not capture rtk upgrade helpers" >&2
+		exit 1
+	fi
+	if ! grep -q '^_setup_rtk_version_relation()' "$SANDBOX/extract.sh"; then
+		echo "FAIL: extraction did not capture rtk version relation helper" >&2
 		exit 1
 	fi
 	return 0
@@ -99,6 +104,23 @@ chmod +x "$SANDBOX/bin/brew"
 
 assert_eq "existing mismatched rtk is upgraded" "rtk 0.41.0" "$(rtk --version)"
 assert_eq "setup reports matching version" "1" "$(grep -c 'rtk now matches the aidevops-tested version' "$SANDBOX/out")"
+
+cat >"$SANDBOX/bin/rtk" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && echo "rtk 0.46.0"
+EOF
+chmod +x "$SANDBOX/bin/rtk"
+(
+	source_extracted
+	setup_rtk
+) >"$SANDBOX/newer.out" 2>&1
+
+assert_eq "newer rtk is accepted without an upgrade" "1" "$(grep -c 'accepted without an automatic downgrade' "$SANDBOX/newer.out")"
+assert_eq "newer rtk does not prompt for an upgrade" "0" "$(grep -c 'version mismatch' "$SANDBOX/newer.out" || true)"
+assert_eq "tested relation is reported" "tested" "$(source_extracted; _setup_rtk_version_relation "0.41.0" "0.41.0")"
+assert_eq "older relation is reported" "older" "$(source_extracted; _setup_rtk_version_relation "0.40.0" "0.41.0")"
+assert_eq "newer relation is reported" "newer-untested" "$(source_extracted; _setup_rtk_version_relation "0.46.0" "0.41.0")"
+assert_eq "malformed relation is reported" "unknown" "$(source_extracted; _setup_rtk_version_relation "development" "0.41.0")"
 
 manual_upgrade_hint=$(
 	source_extracted


### PR DESCRIPTION
## Summary

Classify RTK versions as older, tested, newer-untested, or unknown so setup does not downgrade newer Homebrew installs, and report RTK readiness in aidevops status.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-status-lib.sh, .agents/scripts/setup/modules/tool-install.sh, .agents/scripts/tests/test-status-rtk-readiness.sh, .agents/scripts/tests/test-tool-install-rtk.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash -n and ShellCheck passed for the modified scripts; test-tool-install-rtk.sh and test-status-rtk-readiness.sh passed.

Resolves #30943


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 6m and 107,751 tokens on this as a headless worker.