### PR TITLE
GH#30943: fix RTK version drift and readiness reporting

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
@@ -25,11 +25,16 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 fi
 
 _file_discovery_readiness_lib="${SCRIPT_DIR%/aidevops-cli}/file-discovery-readiness.sh"
+_rtk_readiness_lib="${SCRIPT_DIR%/aidevops-cli}/rtk-readiness.sh"
 if [[ -f "$_file_discovery_readiness_lib" ]]; then
 	# shellcheck source=../file-discovery-readiness.sh
 	source "$_file_discovery_readiness_lib"
 fi
-unset _file_discovery_readiness_lib
+if [[ -f "$_rtk_readiness_lib" ]]; then
+	# shellcheck source=../rtk-readiness.sh
+	source "$_rtk_readiness_lib"
+fi
+unset _file_discovery_readiness_lib _rtk_readiness_lib
 
 _status_file_discovery_readiness() {
 	local fd_state="unavailable"
@@ -42,6 +47,26 @@ _status_file_discovery_readiness() {
 	*) print_error "fd - not installed; run: aidevops setup" ;;
 	esac
 	check_cmd rg && print_success "rg" || print_error "rg - not installed; run: aidevops setup"
+	return 0
+}
+
+_status_rtk_readiness() {
+	local rtk_version="" rtk_tested_version="" rtk_state="unavailable"
+	if declare -F aidevops_rtk_tested_version >/dev/null 2>&1 &&
+		declare -F aidevops_rtk_installed_version >/dev/null 2>&1 &&
+		declare -F aidevops_rtk_version_state >/dev/null 2>&1; then
+		rtk_tested_version=$(aidevops_rtk_tested_version)
+		rtk_version=$(aidevops_rtk_installed_version)
+		rtk_state=$(aidevops_rtk_version_state "$rtk_version" "$rtk_tested_version")
+	fi
+	case "$rtk_state" in
+	missing) print_warning "RTK - not installed (optional; run: aidevops setup)" ;;
+	unknown) print_warning "RTK - available, version unknown (tested baseline v${rtk_tested_version})" ;;
+	older) print_warning "RTK v${rtk_version} - older than tested baseline v${rtk_tested_version}; run: aidevops setup" ;;
+	tested) print_success "RTK v${rtk_version} (tested baseline)" ;;
+	newer-untested) print_warning "RTK v${rtk_version} - available, newer than tested baseline v${rtk_tested_version}; compatibility unverified" ;;
+	*) print_warning "RTK - readiness unavailable (optional tool)" ;;
+	esac
 	return 0
 }
 
@@ -272,6 +297,7 @@ cmd_status() {
 	echo ""
 	print_header "Optional Dependencies"
 	check_cmd sshpass && print_success "sshpass" || print_warning "sshpass - not installed (needed for password SSH)"
+	_status_rtk_readiness
 	echo ""
 	_status_recommended_tools
 	print_header "Git CLI Tools"

--- a/.agents/scripts/rtk-readiness.sh
+++ b/.agents/scripts/rtk-readiness.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Shared optional RTK readiness and tested-baseline relation contract.
+
+aidevops_rtk_tested_version() {
+	printf '0.41.0\n'
+	return 0
+}
+
+aidevops_rtk_installed_version() {
+	local version_output=""
+	if ! command -v rtk >/dev/null 2>&1; then
+		printf 'missing\n'
+		return 0
+	fi
+	version_output=$(rtk --version 2>/dev/null || true)
+	if [[ "$version_output" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+	else
+		printf 'unknown\n'
+	fi
+	return 0
+}
+
+aidevops_rtk_version_state() {
+	local installed_version="$1"
+	local tested_version="${2:-}"
+	local installed_major="" installed_minor="" installed_patch=""
+	local tested_major="" tested_minor="" tested_patch=""
+	local semver_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+
+	if [[ -z "$tested_version" ]]; then
+		tested_version=$(aidevops_rtk_tested_version)
+	fi
+	case "$installed_version" in
+	missing)
+		printf 'missing\n'
+		return 0
+		;;
+	unknown)
+		printf 'unknown\n'
+		return 0
+		;;
+	esac
+	if [[ ! "$installed_version" =~ $semver_pattern ]] ||
+		[[ ! "$tested_version" =~ $semver_pattern ]]; then
+		printf 'unknown\n'
+		return 0
+	fi
+
+	IFS=. read -r installed_major installed_minor installed_patch <<<"$installed_version"
+	IFS=. read -r tested_major tested_minor tested_patch <<<"$tested_version"
+	if ((installed_major < tested_major)) ||
+		((installed_major == tested_major && installed_minor < tested_minor)) ||
+		((installed_major == tested_major && installed_minor == tested_minor && installed_patch < tested_patch)); then
+		printf 'older\n'
+	elif [[ "$installed_version" == "$tested_version" ]]; then
+		printf 'tested\n'
+	else
+		printf 'newer-untested\n'
+	fi
+	return 0
+}

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -13,11 +13,16 @@ shopt -s inherit_errexit 2>/dev/null || true
 
 _tool_install_dir="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 _file_discovery_readiness_lib="${_tool_install_dir}/../../file-discovery-readiness.sh"
+_rtk_readiness_lib="${_tool_install_dir}/../../rtk-readiness.sh"
 if [[ -f "$_file_discovery_readiness_lib" ]]; then
 	# shellcheck source=../../file-discovery-readiness.sh
 	source "$_file_discovery_readiness_lib"
 fi
-unset _tool_install_dir _file_discovery_readiness_lib
+if [[ -f "$_rtk_readiness_lib" ]]; then
+	# shellcheck source=../../rtk-readiness.sh
+	source "$_rtk_readiness_lib"
+fi
+unset _tool_install_dir _file_discovery_readiness_lib _rtk_readiness_lib
 
 _print_gh_slurp_manual_upgrade() {
 	echo ""
@@ -304,9 +309,11 @@ setup_file_discovery_tools() {
 }
 
 _setup_rtk_installed_version() {
-	local rtk_version="unknown"
-	rtk_version=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || printf 'unknown')
-	printf '%s\n' "$rtk_version"
+	if declare -F aidevops_rtk_installed_version >/dev/null 2>&1; then
+		aidevops_rtk_installed_version
+	else
+		printf 'unknown\n'
+	fi
 	return 0
 }
 
@@ -345,7 +352,7 @@ _setup_rtk_offer_supported_upgrade() {
 	local rtk_supported_version="$2"
 	local rtk_installer_url="$3"
 
-	print_warning "rtk version mismatch: found v${rtk_version}, aidevops supports v${rtk_supported_version}"
+	print_warning "rtk v${rtk_version} is older than the aidevops-tested baseline v${rtk_supported_version}"
 	setup_prompt upgrade_rtk "Upgrade rtk to the aidevops-tested v${rtk_supported_version}? [Y/n]: " "Y"
 	# shellcheck disable=SC2154  # set indirectly by setup_prompt via read
 	if [[ "$upgrade_rtk" =~ ^[Yy]?$ ]]; then
@@ -358,6 +365,22 @@ _setup_rtk_offer_supported_upgrade() {
 	return 1
 }
 
+_setup_rtk_report_upgrade_result() {
+	local rtk_state="$1"
+	local rtk_version="$2"
+	local rtk_supported_version="$3"
+	local rtk_installer_url="$4"
+	case "$rtk_state" in
+	tested) print_success "rtk now matches the aidevops-tested version" ;;
+	newer-untested) print_warning "rtk now reports v${rtk_version}, newer than the aidevops-tested baseline v${rtk_supported_version}; compatibility is not yet verified" ;;
+	*)
+		print_warning "rtk still reports v${rtk_version}; aidevops tested baseline is v${rtk_supported_version}"
+		_setup_rtk_print_manual_install "$rtk_installer_url"
+		;;
+	esac
+	return 0
+}
+
 setup_rtk() {
 	# rtk — CLI proxy that reduces LLM token consumption by 60-90% (t1430)
 	# Opinionated default optimization: compresses git/gh/test outputs before they reach LLM context
@@ -366,23 +389,33 @@ setup_rtk() {
 
 	# Pin to a tagged release for stability and auditability (Gemini review feedback).
 	# Update the tag when upstream-watch detects a new release.
-	local rtk_supported_version="0.41.0"
+	local rtk_supported_version=""
+	if ! declare -F aidevops_rtk_tested_version >/dev/null 2>&1 ||
+		! declare -F aidevops_rtk_installed_version >/dev/null 2>&1 ||
+		! declare -F aidevops_rtk_version_state >/dev/null 2>&1; then
+		print_warning "rtk readiness helper unavailable; leaving the optional tool unchanged"
+		return 0
+	fi
+	rtk_supported_version=$(aidevops_rtk_tested_version)
 	local rtk_installer_url="https://raw.githubusercontent.com/rtk-ai/rtk/v${rtk_supported_version}/install.sh"
 
 	if command -v rtk >/dev/null 2>&1; then
-		local rtk_version
+		local rtk_version rtk_state="unknown"
 		rtk_version=$(_setup_rtk_installed_version)
+		rtk_state=$(aidevops_rtk_version_state "$rtk_version" "$rtk_supported_version")
 		print_success "rtk found: v$rtk_version (token optimization proxy)"
-		if [[ "$rtk_version" != "$rtk_supported_version" ]]; then
+		if [[ "$rtk_state" == "older" ]]; then
 			if _setup_rtk_offer_supported_upgrade "$rtk_version" "$rtk_supported_version" "$rtk_installer_url"; then
 				rtk_version=$(_setup_rtk_installed_version)
-				if [[ "$rtk_version" == "$rtk_supported_version" ]]; then
-					print_success "rtk now matches the aidevops-tested version"
-				else
-					print_warning "rtk still reports v${rtk_version}; aidevops supports v${rtk_supported_version}"
-					_setup_rtk_print_manual_install "$rtk_installer_url"
-				fi
+				rtk_state=$(aidevops_rtk_version_state "$rtk_version" "$rtk_supported_version")
+				_setup_rtk_report_upgrade_result "$rtk_state" "$rtk_version" "$rtk_supported_version" "$rtk_installer_url"
 			fi
+		elif [[ "$rtk_state" == "newer-untested" ]]; then
+			print_warning "rtk v${rtk_version} is newer than the aidevops-tested baseline v${rtk_supported_version}; leaving the installed version unchanged"
+		elif [[ "$rtk_state" == "unknown" ]]; then
+			print_warning "rtk is available but its version could not be determined; leaving the optional tool unchanged"
+		else
+			print_success "rtk matches the aidevops-tested baseline"
 		fi
 		# Fall through to ensure config is applied (telemetry, tee)
 	else

--- a/.agents/scripts/tests/test-status-rtk-readiness.sh
+++ b/.agents/scripts/tests/test-status-rtk-readiness.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUS_LIB="$TEST_SCRIPT_DIR/../aidevops-cli/aidevops-status-lib.sh"
+TEST_ROOT="$(mktemp -d -t aidevops-status-rtk.XXXXXX)"
+ORIGINAL_PATH="$PATH"
+
+cleanup() {
+	export PATH="$ORIGINAL_PATH"
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+print_success() {
+	local text="$1"
+	printf 'SUCCESS: %s\n' "$text"
+	return 0
+}
+print_warning() {
+	local text="$1"
+	printf 'WARNING: %s\n' "$text"
+	return 0
+}
+
+# shellcheck source=../aidevops-cli/aidevops-status-lib.sh
+source "$STATUS_LIB"
+
+mkdir -p "$TEST_ROOT/bin"
+
+write_mock_rtk() {
+	local version_output="$1"
+	printf '%s\n' "#!$BASH" "printf '%s\\n' '$version_output'" >"$TEST_ROOT/bin/rtk"
+	chmod +x "$TEST_ROOT/bin/rtk"
+	return 0
+}
+
+use_isolated_path() {
+	export PATH="$TEST_ROOT/bin"
+	hash -r
+	return 0
+}
+
+use_original_path() {
+	export PATH="$ORIGINAL_PATH"
+	hash -r
+	return 0
+}
+
+assert_status_contains() {
+	local description="$1"
+	local expected="$2"
+	local output=""
+	output=$(_status_rtk_readiness)
+	if [[ "$output" != *"$expected"* ]]; then
+		printf 'FAIL: %s -- output: %s\n' "$description" "$output" >&2
+		return 1
+	fi
+	printf 'PASS: %s\n' "$description"
+	return 0
+}
+
+rm -f "$TEST_ROOT/bin/rtk"
+use_isolated_path
+assert_status_contains "missing RTK stays optional" "RTK - not installed (optional; run: aidevops setup)"
+
+use_original_path
+write_mock_rtk "rtk 0.41.0"
+use_isolated_path
+assert_status_contains "tested RTK is ready" "SUCCESS: RTK v0.41.0 (tested baseline)"
+
+use_original_path
+write_mock_rtk "rtk 0.40.0"
+use_isolated_path
+assert_status_contains "older RTK recommends setup" "RTK v0.40.0 - older than tested baseline v0.41.0; run: aidevops setup"
+
+use_original_path
+write_mock_rtk "rtk 0.46.0"
+use_isolated_path
+assert_status_contains "newer RTK is available but unverified" "RTK v0.46.0 - available, newer than tested baseline v0.41.0; compatibility unverified"
+
+use_original_path
+write_mock_rtk "rtk development build"
+use_isolated_path
+assert_status_contains "malformed RTK output is unknown" "RTK - available, version unknown (tested baseline v0.41.0)"
+
+for padded_patch in 08 09; do
+	use_original_path
+	write_mock_rtk "rtk 0.41.${padded_patch}"
+	use_isolated_path
+	assert_status_contains "zero-padded RTK 0.41.${padded_patch} is unknown" "RTK - available, version unknown (tested baseline v0.41.0)"
+done
+
+use_original_path
+unset -f aidevops_rtk_tested_version aidevops_rtk_installed_version aidevops_rtk_version_state
+assert_status_contains "missing readiness helper is explicit" "RTK - readiness unavailable (optional tool)"
+
+printf 'PASS: RTK status readiness states\n'
+exit 0

--- a/.agents/scripts/tests/test-tool-install-rtk.sh
+++ b/.agents/scripts/tests/test-tool-install-rtk.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 TOOL_INSTALL="$REPO_ROOT/.agents/scripts/setup/modules/tool-install.sh"
+RTK_READINESS="$REPO_ROOT/.agents/scripts/rtk-readiness.sh"
 
 SANDBOX="$(mktemp -d -t tool-install-rtk-XXXXXX)"
 trap 'rm -rf "$SANDBOX"' EXIT
@@ -35,6 +36,7 @@ extract_functions() {
 		/^_setup_rtk_install_supported_version\(\)/, /^}$/ { print; next }
 		/^_setup_rtk_print_manual_install\(\)/, /^}$/ { print; next }
 		/^_setup_rtk_offer_supported_upgrade\(\)/, /^}$/ { print; next }
+		/^_setup_rtk_report_upgrade_result\(\)/, /^}$/ { print; next }
 		/^setup_rtk\(\)/, /^}$/ { print; next }
 	' "$TOOL_INSTALL" >"$SANDBOX/extract.sh"
 	if ! grep -q '^_setup_rtk_offer_supported_upgrade()' "$SANDBOX/extract.sh"; then
@@ -46,11 +48,20 @@ extract_functions() {
 
 source_extracted() {
 	# shellcheck disable=SC2317
-	print_info() { echo "INFO: $*"; return 0; }
+	print_info() {
+		echo "INFO: $*"
+		return 0
+	}
 	# shellcheck disable=SC2317
-	print_success() { echo "OK: $*"; return 0; }
+	print_success() {
+		echo "OK: $*"
+		return 0
+	}
 	# shellcheck disable=SC2317
-	print_warning() { echo "WARN: $*"; return 0; }
+	print_warning() {
+		echo "WARN: $*"
+		return 0
+	}
 	# shellcheck disable=SC2317
 	setup_prompt() {
 		local var_name="$1"
@@ -61,7 +72,11 @@ source_extracted() {
 		return 0
 	}
 	# shellcheck disable=SC2317
-	run_with_spinner() { shift; "$@"; return $?; }
+	run_with_spinner() {
+		shift
+		"$@"
+		return $?
+	}
 	# shellcheck disable=SC2317
 	verified_install() {
 		local tool_name="$1"
@@ -74,18 +89,26 @@ INNER_EOF
 		chmod +x "$SANDBOX/bin/rtk"
 		return 0
 	}
+	# shellcheck source=../rtk-readiness.sh
+	source "$RTK_READINESS"
 	# shellcheck disable=SC1090
 	source "$SANDBOX/extract.sh"
 	return 0
 }
 
+write_mock_rtk() {
+	cat >"$SANDBOX/bin/rtk" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && printf '%s\n' "${MOCK_RTK_VERSION_OUTPUT:-rtk 0.41.0}"
+EOF
+	chmod +x "$SANDBOX/bin/rtk"
+	return 0
+}
+
 extract_functions
 
-cat >"$SANDBOX/bin/rtk" <<'EOF'
-#!/usr/bin/env bash
-[[ "${1:-}" == "--version" ]] && echo "rtk 0.40.0"
-EOF
-chmod +x "$SANDBOX/bin/rtk"
+export MOCK_RTK_VERSION_OUTPUT="rtk 0.40.0"
+write_mock_rtk
 cat >"$SANDBOX/bin/brew" <<'EOF'
 #!/usr/bin/env bash
 exit 1
@@ -99,6 +122,24 @@ chmod +x "$SANDBOX/bin/brew"
 
 assert_eq "existing mismatched rtk is upgraded" "rtk 0.41.0" "$(rtk --version)"
 assert_eq "setup reports matching version" "1" "$(grep -c 'rtk now matches the aidevops-tested version' "$SANDBOX/out")"
+
+export MOCK_RTK_VERSION_OUTPUT="rtk 0.46.0"
+write_mock_rtk
+(
+	source_extracted
+	setup_rtk
+) >"$SANDBOX/newer-out" 2>&1
+assert_eq "newer rtk is retained" "rtk 0.46.0" "$(rtk --version)"
+assert_eq "newer rtk is reported without an upgrade loop" "1" "$(grep -c 'newer than the aidevops-tested baseline v0.41.0; leaving the installed version unchanged' "$SANDBOX/newer-out")"
+
+export MOCK_RTK_VERSION_OUTPUT="rtk development build"
+write_mock_rtk
+(
+	source_extracted
+	setup_rtk
+) >"$SANDBOX/unknown-out" 2>&1
+assert_eq "malformed rtk output is retained" "rtk development build" "$(rtk --version)"
+assert_eq "malformed rtk output reports unknown readiness" "1" "$(grep -c 'version could not be determined; leaving the optional tool unchanged' "$SANDBOX/unknown-out")"
 
 manual_upgrade_hint=$(
 	source_extracted


### PR DESCRIPTION
## Summary

Centralize RTK tested-baseline relation states, stop setup from trying to downgrade newer Homebrew installations, and add optional RTK readiness to aidevops status.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-status-lib.sh, .agents/scripts/rtk-readiness.sh, .agents/scripts/setup/modules/tool-install.sh, .agents/scripts/tests/test-status-rtk-readiness.sh, .agents/scripts/tests/test-tool-install-rtk.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused setup and status harnesses exercised missing, tested, older, newer, malformed, zero-padded, and helper-unavailable states; RTK/setup/status/helper suites passed; Bash syntax, ShellCheck, changed-file gates, and independent high-risk review passed. The installed RTK v0.41.0 comparison preserved exit status and reduced git status output by 55.9%.

Resolves #30943


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 2h 1m and 628,439 tokens on this with the user in an interactive session.