### PR TITLE
GH#30926: circuit-break unchanged terminal outcomes

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -101,6 +101,10 @@ source "${SCRIPT_DIR}/dispatch-dedup-pr.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/dispatch-dedup-recovery-loop.sh"
 
+# Cross-runner hold for repeated unchanged terminal worker blockers.
+# shellcheck source=terminal-blocker-circuit.sh
+source "${SCRIPT_DIR}/terminal-blocker-circuit.sh"
+
 _DDH_ORPHAN_PR_HINT_NONE="none found"
 
 #######################################
@@ -985,6 +989,10 @@ has_dispatch_comment() {
 	if [[ -z "$comments_json" || "$comments_json" == "null" || "$comments_json" == "[]" ]]; then
 		return 1
 	fi
+	if terminal_blocker_circuit_active "$comments_json" "${ISSUE_META_JSON:-}" \
+		"$repo_slug" "$issue_number" "${DISPATCH_REPO_PATH:-}"; then
+		return 0
+	fi
 
 	# t3194: Opportunistic peer-quarantine event detection — extracted to
 	# _dd_opportunistic_peer_scan to keep this function below the
@@ -1191,6 +1199,10 @@ classify_dispatch_blocker_reason() {
 			;;
 		*runner-health*circuit* | *runner_health*circuit*)
 			printf 'runner_health_circuit_breaker\n'
+			return 0
+			;;
+		*terminal_blocker_circuit*)
+			printf 'terminal_blocker_circuit\n'
 			return 0
 			;;
 		*dispatch_block_reason*ever_nmr_without_approval* | *blocked*ever*nmr*lacks*approval* | *requires*cryptographic*approval*)

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -42,6 +42,8 @@ if [[ -r "${_HRFF_SCRIPT_DIR}/shared-repo-state-guard.sh" ]]; then
 	# shellcheck source=shared-repo-state-guard.sh
 	source "${_HRFF_SCRIPT_DIR}/shared-repo-state-guard.sh"
 fi
+# shellcheck source=terminal-blocker-circuit.sh
+source "${_HRFF_SCRIPT_DIR}/terminal-blocker-circuit.sh"
 # shellcheck source=fast-fail-release-policy.sh
 source "${_HRFF_SCRIPT_DIR}/fast-fail-release-policy.sh"
 unset _HRFF_SCRIPT_DIR
@@ -522,6 +524,69 @@ _hrff_post_claim_released_comment() {
 	return 1
 }
 
+_hrff_prepare_terminal_blocker_release() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local machine_readable_part="$3"
+	local repo_path="${AIDEVOPS_TERMINAL_BLOCKER_REPO_PATH:-}"
+	local blocker_fingerprint="${AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT:-}"
+	local issue_json="" comments_json="" task_revision="" mode=""
+	_HRFF_TERMINAL_BLOCKER_MODE="normal"
+	_HRFF_TERMINAL_BLOCKER_FRAGMENT=""
+	_HRFF_TERMINAL_BLOCKER_CIRCUIT_BODY=""
+	[[ -n "$repo_path" && "$blocker_fingerprint" =~ ^[a-f0-9]{24}$ ]] || return 0
+	issue_json=$(gh api "repos/${repo_slug}/issues/${issue_number}" \
+		--jq '{title: (.title // ""), body: (.body // "")}' 2>/dev/null) || return 0
+	comments_json=$(terminal_blocker_fetch_trusted_comments "$issue_number" "$repo_slug") || return 0
+	task_revision=$(terminal_blocker_task_revision \
+		"$issue_json" "$repo_slug" "$issue_number" "$repo_path") || return 0
+	mode=$(terminal_blocker_release_mode \
+		"$comments_json" "$task_revision" "$blocker_fingerprint") || return 0
+	case "$mode" in
+	first)
+		_HRFF_TERMINAL_BLOCKER_FRAGMENT=$(terminal_blocker_observation_fragment \
+			"$task_revision" "$blocker_fingerprint") || _HRFF_TERMINAL_BLOCKER_FRAGMENT=""
+		;;
+	circuit)
+		_HRFF_TERMINAL_BLOCKER_MODE="circuit"
+		_HRFF_TERMINAL_BLOCKER_CIRCUIT_BODY=$(terminal_blocker_circuit_comment \
+			"$machine_readable_part" "$task_revision" "$blocker_fingerprint") || {
+			_HRFF_TERMINAL_BLOCKER_MODE="normal"
+			_HRFF_TERMINAL_BLOCKER_CIRCUIT_BODY=""
+		}
+		;;
+	open)
+		_HRFF_TERMINAL_BLOCKER_MODE="open"
+		;;
+	esac
+	return 0
+}
+
+_hrff_handle_terminal_blocker_release() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local machine_readable_part="$3"
+	_hrff_prepare_terminal_blocker_release "$issue_number" "$repo_slug" "$machine_readable_part"
+	case "${_HRFF_TERMINAL_BLOCKER_MODE:-normal}" in
+	circuit)
+		if ! _hrff_post_claim_released_comment "$issue_number" "$repo_slug" \
+			"$_HRFF_TERMINAL_BLOCKER_CIRCUIT_BODY"; then
+			print_warning "Terminal blocker circuit for #${issue_number} remains unpersisted and retryable; retaining issue lifecycle state"
+			return 11
+		fi
+		print_info "Opened unchanged terminal-blocker circuit on #${issue_number}"
+		_hrff_release_rate_limit_circuit_cleanup "$issue_number" "$repo_slug"
+		return 10
+		;;
+	open)
+		print_info "Unchanged terminal-blocker circuit already active on #${issue_number}; suppressing duplicate release diagnostics"
+		_hrff_release_rate_limit_circuit_cleanup "$issue_number" "$repo_slug"
+		return 10
+		;;
+	esac
+	return 0
+}
+
 #######################################
 # Release a dispatch claim by posting a CLAIM_RELEASED comment.
 # The dedup guard recognises this and allows immediate re-dispatch
@@ -581,8 +646,16 @@ _release_dispatch_claim() {
 
 	runner_name=$(_hrff_resolve_release_runner_login)
 	machine_readable_part=$(_hrff_build_claim_released_line "$reason" "$runner_name" "$exit_code_arg" "$session_count_arg")
+	local terminal_blocker_fragment=""
+	if [[ "$reason" == "blocked" ]]; then
+		local terminal_blocker_rc=0
+		_hrff_handle_terminal_blocker_release "$issue_number" "$repo_slug" "$machine_readable_part" || terminal_blocker_rc=$?
+		[[ "$terminal_blocker_rc" -eq 10 ]] && return 0
+		[[ "$terminal_blocker_rc" -eq 11 ]] && return 1
+		terminal_blocker_fragment="${_HRFF_TERMINAL_BLOCKER_FRAGMENT:-}"
+	fi
 	comment_body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
-${machine_readable_part}
+${machine_readable_part}${terminal_blocker_fragment}
 <!-- ops:end -->"
 
 	if ! _hrff_post_claim_released_comment "$issue_number" "$repo_slug" "$comment_body"; then

--- a/.agents/scripts/headless-runtime-result.sh
+++ b/.agents/scripts/headless-runtime-result.sh
@@ -153,6 +153,9 @@ _handle_run_result_success_output() {
 			_run_failure_reason="$_RUN_RESULT_BLOCKED"
 			_run_classification_source="$_RUN_RESULT_MODEL_BLOCKED_SIGNAL"
 			_run_classification_pattern="terminal_blocked"
+			if declare -F terminal_blocker_capture_output >/dev/null 2>&1; then
+				terminal_blocker_capture_output "$output_file" || true
+			fi
 			rm -f "$output_file"
 			print_warning "$selected_model worker reported a terminal BLOCKED state"
 			return 83

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -2001,11 +2001,13 @@ _hrw_preserve_draft_checkpoint_handoff() {
 
 _hrw_preserve_blocked_outcome() {
 	local session_key="$1"
+	local work_dir="$2"
 
 	# A structured terminal blocker is meaningful model output, even when it
 	# cannot produce a commit or PR. Preserve that classification instead of
 	# routing it through zero-output/no_work accounting.
-	_hrw_release_dispatch_claim "$session_key" "${_run_failure_reason:-$_HRW_STATUS_BLOCKED}"
+	AIDEVOPS_TERMINAL_BLOCKER_REPO_PATH="$work_dir" \
+		_hrw_release_dispatch_claim "$session_key" "${_run_failure_reason:-$_HRW_STATUS_BLOCKED}"
 	_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
 	_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_DEFERRED"
 	_HRW_FINAL_RUNTIME_STATUS="$_HRW_STATUS_BLOCKED"
@@ -2020,7 +2022,7 @@ _hrw_finish_success_run() {
 	local finish_status=0
 	local permission_pending_file=""
 	if [[ "${_run_result_label:-}" == "$_HRW_STATUS_BLOCKED" ]]; then
-		_hrw_preserve_blocked_outcome "$session_key"
+		_hrw_preserve_blocked_outcome "$session_key" "$work_dir"
 		return 0
 	fi
 	if [[ "${_run_result_label:-}" == "post_pr_handoff" ]] &&

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1676,7 +1676,7 @@ _dispatch_dedup_check_layers() {
 	_dss_t0=$(_ds_now_ns)
 	local _dedup_rc=0
 	local _dedup_signal=""
-	_dedup_signal=$(ISSUE_META_JSON="$issue_meta_json" \
+	_dedup_signal=$(ISSUE_META_JSON="$issue_meta_json" DISPATCH_REPO_PATH="$repo_path" \
 		check_dispatch_dedup "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" "$self_login") || _dedup_rc=$?
 	if [[ "$_dedup_rc" -eq 0 || "$_dedup_rc" -eq 3 ]]; then
 		local _dedup_block_signal="dedup_guard_blocked"

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -254,7 +254,9 @@ _dedup_layer5_dispatch_comment() {
 	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
 	if [[ -x "$dedup_helper" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
 		local dispatch_comment_output=""
-		if dispatch_comment_output=$("$dedup_helper" has-dispatch-comment "$issue_number" "$repo_slug" "$self_login" 2>>"$LOGFILE"); then
+		if dispatch_comment_output=$(ISSUE_META_JSON="${ISSUE_META_JSON:-}" \
+			DISPATCH_REPO_PATH="${DISPATCH_REPO_PATH:-}" \
+			"$dedup_helper" has-dispatch-comment "$issue_number" "$repo_slug" "$self_login" 2>>"$LOGFILE"); then
 			echo "[pulse-wrapper] Dedup: #${issue_number} in ${repo_slug} has active dispatch comment — ${dispatch_comment_output}" >>"$LOGFILE"
 			printf '%s\n' "$dispatch_comment_output"
 			return 0

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -283,7 +283,7 @@ _dispatch_stats_increment() {
 _dispatch_stats_increment_candidate_failed() {
 	local reason="$1"
 	case "$reason" in
-		blocked_by_native_lookup_unavailable | blocked_by_unresolved | canary_failed | consolidated | cooldown_no_worker_process | cost_budget_exceeded | dedup_active_claim | dirty_worktree_recovery | ever_nmr_without_approval | footprint_overlap | graphql_circuit_breaker | healthy_pr_backlog | interactive_review_hold | issue_closed | launch_error | local_capacity_gate | missing_worker_context | no_auto_dispatch | no_dispatchable_evidence | no_recent_log_evidence | parent_task | policy_gate | pr_lookup_uncertain | pr_target_not_dispatchable | provider_rate_limit_pressure | renovate_dependency_dashboard | repeated_failure_pressure | runner_health_circuit_breaker | unclassified_signal)
+		blocked_by_native_lookup_unavailable | blocked_by_unresolved | canary_failed | consolidated | cooldown_no_worker_process | cost_budget_exceeded | dedup_active_claim | dirty_worktree_recovery | ever_nmr_without_approval | footprint_overlap | graphql_circuit_breaker | healthy_pr_backlog | interactive_review_hold | issue_closed | launch_error | local_capacity_gate | missing_worker_context | no_auto_dispatch | no_dispatchable_evidence | no_recent_log_evidence | parent_task | policy_gate | pr_lookup_uncertain | pr_target_not_dispatchable | provider_rate_limit_pressure | renovate_dependency_dashboard | repeated_failure_pressure | runner_health_circuit_breaker | terminal_blocker_circuit | unclassified_signal)
 			;;
 		*)
 			reason="unclassified_signal"
@@ -369,7 +369,7 @@ _dispatch_candidate_failure_reason() {
 _dispatch_candidate_benign_block_reason() {
 	local reason="$1"
 	case "$reason" in
-		blocked_by_unresolved | consolidated | dedup_active_claim | dirty_worktree_recovery | footprint_overlap | interactive_review_hold | issue_closed | no_auto_dispatch | parent_task | pr_target_not_dispatchable | renovate_dependency_dashboard)
+		blocked_by_unresolved | consolidated | dedup_active_claim | dirty_worktree_recovery | footprint_overlap | interactive_review_hold | issue_closed | no_auto_dispatch | parent_task | pr_target_not_dispatchable | renovate_dependency_dashboard | terminal_blocker_circuit)
 			return 0
 			;;
 	esac

--- a/.agents/scripts/terminal-blocker-circuit.sh
+++ b/.agents/scripts/terminal-blocker-circuit.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Durable, cross-runner suppression for unchanged terminal worker blockers.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+[[ -n "${_TERMINAL_BLOCKER_CIRCUIT_LOADED:-}" ]] && return 0
+_TERMINAL_BLOCKER_CIRCUIT_LOADED=1
+
+_TBC_OBSERVATION_MARKER='aidevops:terminal-blocker-observation'
+_TBC_CIRCUIT_MARKER='aidevops:terminal-blocker-circuit'
+_TBC_RETRY_MARKER='terminal-blocker-circuit:retry'
+
+_terminal_blocker_hash() {
+	local value="$1"
+	local digest=""
+	if command -v shasum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$value" | shasum -a 256 2>/dev/null | cut -c1-24) || digest=""
+	elif command -v sha256sum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$value" | sha256sum 2>/dev/null | cut -c1-24) || digest=""
+	fi
+	[[ "$digest" =~ ^[a-f0-9]{24}$ ]] || return 1
+	printf '%s\n' "$digest"
+	return 0
+}
+
+# Capture the final model-owned BLOCKED dossier before the ephemeral output is
+# removed. Volatile runner/session/attempt identities and timestamps are
+# normalized so equivalent blockers converge across workers and hosts.
+terminal_blocker_capture_output() {
+	local output_file="$1"
+	local normalized="" fingerprint=""
+	AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT=""
+	[[ -f "$output_file" ]] || return 1
+	normalized=$(
+		python3 - "$output_file" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_text(errors="ignore")
+parts = []
+text_field = "text"
+for raw_line in raw.splitlines():
+    line = raw_line.strip()
+    if not line.startswith("{"):
+        continue
+    try:
+        event = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        continue
+    if not isinstance(event, dict) or event.get("type") != text_field:
+        continue
+    part = event.get("part") if isinstance(event.get("part"), dict) else {}
+    text = event.get(text_field) or part.get(text_field) or ""
+    if text:
+        parts.append(text)
+
+marker = re.compile(r"(^|\n)\s*BLOCKED(?:\s*:|\s*$)", re.IGNORECASE)
+candidates = [part for part in parts if marker.search(part)]
+candidate = candidates[-1] if candidates else raw
+if not marker.search(candidate):
+    raise SystemExit(1)
+
+candidate = re.sub(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]+Z?\b", "<timestamp>", candidate)
+candidate = re.sub(r"\b[0-9]{10,16}\b", "<timestamp>", candidate)
+candidate = re.sub(
+    r"\b(runner|session|attempt(?:_id)?|device|claim(?:_id)?)\s*[=:]\s*\S+",
+    lambda match: f"{match.group(1).lower()}=<volatile>",
+    candidate,
+    flags=re.IGNORECASE,
+)
+candidate = re.sub(r"\s+", " ", candidate).strip().lower()
+if not candidate:
+    raise SystemExit(1)
+print(candidate[-2000:])
+PY
+	) || normalized=""
+	[[ -n "$normalized" ]] || return 1
+	fingerprint=$(_terminal_blocker_hash "$normalized") || return 1
+	AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT="$fingerprint"
+	return 0
+}
+
+_terminal_blocker_dependency_signature() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	local owner="${repo_slug%%/*}"
+	local repo_name="${repo_slug#*/}"
+	local response="" signature=""
+	[[ "$repo_slug" == */* && "$issue_number" =~ ^[0-9]+$ ]] || return 1
+	# shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub.
+	response=$(gh api graphql \
+		-f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){blockedBy(first:50){nodes{number state}pageInfo{hasNextPage}}}}}' \
+		-F owner="$owner" -F name="$repo_name" -F number="$issue_number" 2>/dev/null) || return 1
+	signature=$(printf '%s' "$response" | jq -c '
+		.data.repository.issue.blockedBy as $blocked
+		| {truncated: ($blocked.pageInfo.hasNextPage // true),
+		   nodes: ([($blocked.nodes // [])[] | {number, state}] | sort_by(.number))}
+	' 2>/dev/null) || return 1
+	[[ -n "$signature" && "$signature" != "null" ]] || return 1
+	printf '%s\n' "$signature"
+	return 0
+}
+
+_terminal_blocker_target_revision() {
+	local repo_path="$1"
+	local revision="" remote_head=""
+	[[ -d "$repo_path" ]] || return 1
+	remote_head=$(git -C "$repo_path" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null) || remote_head=""
+	if [[ -n "$remote_head" ]]; then
+		revision=$(git -C "$repo_path" rev-parse "${remote_head}^{commit}" 2>/dev/null) || revision=""
+	fi
+	if [[ -z "$revision" ]]; then
+		revision=$(git -C "$repo_path" rev-parse 'origin/main^{commit}' 2>/dev/null) || revision=""
+	fi
+	if [[ -z "$revision" ]]; then
+		revision=$(git -C "$repo_path" rev-parse 'origin/master^{commit}' 2>/dev/null) || revision=""
+	fi
+	[[ "$revision" =~ ^[a-f0-9]{40,64}$ ]] || return 1
+	printf '%s\n' "$revision"
+	return 0
+}
+
+terminal_blocker_task_revision() {
+	local issue_json="$1"
+	local repo_slug="$2"
+	local issue_number="$3"
+	local repo_path="$4"
+	local task_json="" dependency_signature="" target_revision="" canonical=""
+	task_json=$(printf '%s' "$issue_json" | jq -c '{title: (.title // ""), body: (.body // "")}' 2>/dev/null) || return 1
+	dependency_signature=$(_terminal_blocker_dependency_signature "$repo_slug" "$issue_number") || return 1
+	target_revision=$(_terminal_blocker_target_revision "$repo_path") || return 1
+	canonical=$(jq -nc --argjson task "$task_json" --argjson dependencies "$dependency_signature" \
+		--arg target "$target_revision" '{task: $task, dependencies: $dependencies, target_revision: $target}') || return 1
+	_terminal_blocker_hash "$canonical"
+	return $?
+}
+
+terminal_blocker_fetch_trusted_comments() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local raw=""
+	raw=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" \
+		--paginate --slurp 2>/dev/null) || return 1
+	printf '%s' "$raw" | jq -c '
+		def trusted: . == "OWNER" or . == "MEMBER" or . == "COLLABORATOR";
+		[(if type == "array" and ((.[0]? | type) == "array") then .[] else . end)[]
+		| {body: (.body // ""), created_at: .created_at,
+		   author_association: (.author_association // "")}
+		| select(.author_association | trusted)]
+	' 2>/dev/null || return 1
+	return 0
+}
+
+_terminal_blocker_latest_marker() {
+	local comments_json="$1"
+	local marker="$2"
+	printf '%s' "$comments_json" | jq -c --arg marker "$marker" '
+		[.[] | select((.body // "") | contains($marker))]
+		| sort_by(.created_at) | last // empty
+	' 2>/dev/null
+	return $?
+}
+
+_terminal_blocker_latest_retry_at() {
+	local comments_json="$1"
+	printf '%s' "$comments_json" | jq -r --arg marker "$_TBC_RETRY_MARKER" \
+		--arg circuit_marker "$_TBC_CIRCUIT_MARKER" '
+		[.[] | select((.body // "") as $body
+		| ($body | contains($marker)) and (($body | contains($circuit_marker)) | not))
+		| .created_at]
+		| sort | last // ""
+	' 2>/dev/null
+	return $?
+}
+
+terminal_blocker_release_mode() {
+	local comments_json="$1"
+	local task_revision="$2"
+	local blocker_fingerprint="$3"
+	local retry_at="" circuit="" observation="" circuit_at="" observation_at=""
+	retry_at=$(_terminal_blocker_latest_retry_at "$comments_json") || retry_at=""
+	circuit=$(_terminal_blocker_latest_marker "$comments_json" "$_TBC_CIRCUIT_MARKER revision=${task_revision} blocker=${blocker_fingerprint}") || circuit=""
+	observation=$(_terminal_blocker_latest_marker "$comments_json" "$_TBC_OBSERVATION_MARKER revision=${task_revision} blocker=${blocker_fingerprint}") || observation=""
+	circuit_at=$(printf '%s' "$circuit" | jq -r '.created_at // ""' 2>/dev/null) || circuit_at=""
+	observation_at=$(printf '%s' "$observation" | jq -r '.created_at // ""' 2>/dev/null) || observation_at=""
+	if [[ -n "$circuit_at" && (-z "$retry_at" || "$circuit_at" > "$retry_at") ]]; then
+		printf 'open\n'
+	elif [[ -n "$observation_at" && (-z "$retry_at" || "$observation_at" > "$retry_at") ]]; then
+		printf 'circuit\n'
+	else
+		printf 'first\n'
+	fi
+	return 0
+}
+
+terminal_blocker_observation_fragment() {
+	local task_revision="$1"
+	local blocker_fingerprint="$2"
+	printf '\n<!-- %s revision=%s blocker=%s -->\n\nTerminal blocker identity: %s. Detailed evidence remains in protected worker telemetry.\n' \
+		"$_TBC_OBSERVATION_MARKER" "$task_revision" "$blocker_fingerprint" "$blocker_fingerprint"
+	return 0
+}
+
+terminal_blocker_circuit_comment() {
+	local machine_readable_release="$1"
+	local task_revision="$2"
+	local blocker_fingerprint="$3"
+	printf '<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\n%s\n<!-- %s revision=%s blocker=%s -->\nTERMINAL_BLOCKER_CIRCUIT active=true observations=2 task_revision=%s blocker=%s\n\nAutomatic redispatch is held because two workers returned the same terminal blocker against unchanged task, dependency, and target revisions. Detailed evidence remains in protected worker telemetry.\n\nA maintainer can retry without deleting history by posting %s. A task, dependency, or target revision change also re-arms dispatch.\n<!-- ops:end -->\n' \
+		"$machine_readable_release" "$_TBC_CIRCUIT_MARKER" "$task_revision" \
+		"$blocker_fingerprint" "$task_revision" "$blocker_fingerprint" \
+		"$_TBC_RETRY_MARKER"
+	return 0
+}
+
+terminal_blocker_circuit_active() {
+	local comments_json="$1"
+	local issue_json="$2"
+	local repo_slug="$3"
+	local issue_number="$4"
+	local repo_path="$5"
+	local circuit="" circuit_at="" retry_at="" current_revision=""
+	circuit=$(_terminal_blocker_latest_marker "$comments_json" "$_TBC_CIRCUIT_MARKER revision=") || circuit=""
+	[[ -n "$circuit" ]] || return 1
+	current_revision=$(terminal_blocker_task_revision "$issue_json" "$repo_slug" "$issue_number" "$repo_path") || return 1
+	circuit=$(_terminal_blocker_latest_marker "$comments_json" "$_TBC_CIRCUIT_MARKER revision=${current_revision} blocker=") || circuit=""
+	[[ -n "$circuit" ]] || return 1
+	circuit_at=$(printf '%s' "$circuit" | jq -r '.created_at // ""' 2>/dev/null) || return 1
+	retry_at=$(_terminal_blocker_latest_retry_at "$comments_json") || retry_at=""
+	if [[ -n "$retry_at" && "$retry_at" > "$circuit_at" ]]; then
+		return 1
+	fi
+	printf 'TERMINAL_BLOCKER_CIRCUIT task_revision=%s\n' "$current_revision"
+	return 0
+}

--- a/.agents/scripts/tests/test-headless-runtime-provider-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-provider-tests.sh
@@ -188,7 +188,7 @@ test_blocked_completion_records_blocked_label() {
 	printf '%s\n' '{"type":"text","sessionID":"ses_blocked","text":"BLOCKED: missing dependency credentials"}' >"$output_file"
 	local rc=0
 	_handle_run_result 0 "$output_file" "worker" "openai" "issue-456" "openai/gpt-5.5" || rc=$?
-	[[ "$rc" -eq 83 && "${_run_result_label:-}" == "blocked" && "${_run_failure_reason:-}" == "blocked" && "${_run_classification_source:-}" == "model_blocked_signal" && "${_run_classification_pattern:-}" == "terminal_blocked" ]] && {
+	[[ "$rc" -eq 83 && "${_run_result_label:-}" == "blocked" && "${_run_failure_reason:-}" == "blocked" && "${_run_classification_source:-}" == "model_blocked_signal" && "${_run_classification_pattern:-}" == "terminal_blocked" && "${AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT:-}" =~ ^[a-f0-9]{24}$ && ! -f "$output_file" ]] && {
 		print_result "generic BLOCKED signal remains terminal without capability escalation" 0
 		return 0
 	}

--- a/.agents/scripts/tests/test-rate-limit-release-circuit.sh
+++ b/.agents/scripts/tests/test-rate-limit-release-circuit.sh
@@ -113,6 +113,14 @@ gh() {
 # shellcheck source=../headless-runtime-failure.sh
 source "${SCRIPT_DIR}/headless-runtime-failure.sh"
 
+# This focused test exercises release-circuit behavior, not repository
+# authority discovery. Keep the managed-repository precondition deterministic.
+aidevops_can_manage_repo_issue_state() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]]
+	return $?
+}
+
 export DISPATCH_REPO_SLUG="owner/repo"
 
 iso_offset() {

--- a/.agents/scripts/tests/test-terminal-blocker-circuit.sh
+++ b/.agents/scripts/tests/test-terminal-blocker-circuit.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#30926 unchanged terminal-blocker suppression.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_DEPENDENCIES='{"nodes":[],"truncated":false}'
+TEST_TARGET_REVISION='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+print_result() {
+	local name="$1"
+	local status="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s\n' "$name"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# shellcheck source=../terminal-blocker-circuit.sh
+source "${SCRIPT_DIR}/terminal-blocker-circuit.sh"
+# shellcheck source=../headless-runtime-failure.sh
+source "${SCRIPT_DIR}/headless-runtime-failure.sh"
+
+_terminal_blocker_dependency_signature() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	[[ -n "$repo_slug" && "$issue_number" =~ ^[0-9]+$ ]] || return 1
+	[[ "$TEST_DEPENDENCIES" != "unavailable" ]] || return 1
+	printf '%s\n' "$TEST_DEPENDENCIES"
+	return 0
+}
+
+_terminal_blocker_target_revision() {
+	local repo_path="$1"
+	[[ -n "$repo_path" && "$TEST_TARGET_REVISION" != "unavailable" ]] || return 1
+	printf '%s\n' "$TEST_TARGET_REVISION"
+	return 0
+}
+
+test_normalized_blocker_fingerprint() {
+	local first_output="${TEST_ROOT}/first.ndjson"
+	local second_output="${TEST_ROOT}/second.ndjson"
+	printf '%s\n' '{"type":"text","text":"BLOCKED: Files Scope excludes required path. runner=alpha session=ses_123 attempt_id=one 2026-08-31T12:30:00Z"}' >"$first_output"
+	printf '%s\n' '{"type":"text","text":"BLOCKED: Files Scope excludes required path. runner=beta session=ses_999 attempt_id=two 2026-09-01T01:45:00Z"}' >"$second_output"
+	terminal_blocker_capture_output "$first_output"
+	local first_fingerprint="$AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT"
+	terminal_blocker_capture_output "$second_output"
+	local second_fingerprint="$AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT"
+	local status=1
+	if [[ "$first_fingerprint" =~ ^[a-f0-9]{24}$ && "$first_fingerprint" == "$second_fingerprint" ]]; then
+		status=0
+	fi
+	print_result "volatile worker identities normalize to one blocker fingerprint" "$status"
+	return 0
+}
+
+test_task_revision_inputs() {
+	local issue_json='{"title":"Fix scope","body":"Files Scope: a.sh"}'
+	local first="" same="" changed_body="" changed_dependency="" changed_target=""
+	first=$(terminal_blocker_task_revision "$issue_json" "owner/repo" 42 "$TEST_ROOT")
+	same=$(terminal_blocker_task_revision "$issue_json" "owner/repo" 42 "$TEST_ROOT")
+	changed_body=$(terminal_blocker_task_revision '{"title":"Fix scope","body":"Files Scope: b.sh"}' "owner/repo" 42 "$TEST_ROOT")
+	TEST_DEPENDENCIES='{"nodes":[{"number":9,"state":"CLOSED"}],"truncated":false}'
+	changed_dependency=$(terminal_blocker_task_revision "$issue_json" "owner/repo" 42 "$TEST_ROOT")
+	TEST_DEPENDENCIES='{"nodes":[],"truncated":false}'
+	TEST_TARGET_REVISION='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+	changed_target=$(terminal_blocker_task_revision "$issue_json" "owner/repo" 42 "$TEST_ROOT")
+	TEST_TARGET_REVISION='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+	local status=1
+	if [[ "$first" == "$same" && "$first" != "$changed_body" &&
+		"$first" != "$changed_dependency" && "$first" != "$changed_target" ]]; then
+		status=0
+	fi
+	print_result "task revision binds brief, dependency state, and target revision" "$status"
+	return 0
+}
+
+test_release_modes_and_retry() {
+	local revision='111111111111111111111111'
+	local blocker='222222222222222222222222'
+	local observation="<!-- aidevops:terminal-blocker-observation revision=${revision} blocker=${blocker} -->"
+	local circuit="<!-- aidevops:terminal-blocker-circuit revision=${revision} blocker=${blocker} -->"
+	local empty='[]'
+	local observed="[{\"body\":\"${observation}\",\"created_at\":\"2026-08-31T10:00:00Z\"}]"
+	local opened="[{\"body\":\"${observation}\",\"created_at\":\"2026-08-31T10:00:00Z\"},{\"body\":\"${circuit}\",\"created_at\":\"2026-08-31T10:05:00Z\"}]"
+	local retried="[{\"body\":\"${observation}\",\"created_at\":\"2026-08-31T10:00:00Z\"},{\"body\":\"${circuit}\",\"created_at\":\"2026-08-31T10:05:00Z\"},{\"body\":\"terminal-blocker-circuit:retry\",\"created_at\":\"2026-08-31T10:10:00Z\"}]"
+	local status=1
+	if [[ "$(terminal_blocker_release_mode "$empty" "$revision" "$blocker")" == "first" &&
+	"$(terminal_blocker_release_mode "$observed" "$revision" "$blocker")" == "circuit" &&
+	"$(terminal_blocker_release_mode "$opened" "$revision" "$blocker")" == "open" &&
+	"$(terminal_blocker_release_mode "$retried" "$revision" "$blocker")" == "first" ]]; then
+		status=0
+	fi
+	print_result "second identical blocker opens a durable hold and maintainer retry re-arms it" "$status"
+	return 0
+}
+
+test_dispatch_hold_revalidates_revision() {
+	local issue_json='{"title":"Fix scope","body":"Files Scope: a.sh"}'
+	local revision=""
+	revision=$(terminal_blocker_task_revision "$issue_json" "owner/repo" 42 "$TEST_ROOT")
+	local comments="[{\"body\":\"<!-- aidevops:terminal-blocker-circuit revision=${revision} blocker=222222222222222222222222 -->\",\"created_at\":\"2026-08-31T10:05:00Z\"}]"
+	local same_status=0 changed_status=0 ambiguous_status=0
+	terminal_blocker_circuit_active "$comments" "$issue_json" "owner/repo" 42 "$TEST_ROOT" >/dev/null || same_status=$?
+	terminal_blocker_circuit_active "$comments" '{"title":"Fix scope","body":"Files Scope: b.sh"}' \
+		"owner/repo" 42 "$TEST_ROOT" >/dev/null && changed_status=1
+	TEST_DEPENDENCIES="unavailable"
+	terminal_blocker_circuit_active "$comments" "$issue_json" "owner/repo" 42 "$TEST_ROOT" >/dev/null && ambiguous_status=1
+	TEST_DEPENDENCIES='{"nodes":[],"truncated":false}'
+	local status=1
+	if [[ "$same_status" -eq 0 && "$changed_status" -eq 0 && "$ambiguous_status" -eq 0 ]]; then
+		status=0
+	fi
+	print_result "dispatch hold is cross-runner durable but fails open on changed or ambiguous identity" "$status"
+	return 0
+}
+
+test_release_integration_bounds_comments() {
+	local test_comments='[]'
+	local posted_count=0 first_body="" second_body="" cleanup_count=0
+	terminal_blocker_fetch_trusted_comments() {
+		local issue_number="$1"
+		local repo_slug="$2"
+		[[ "$issue_number" == "42" && "$repo_slug" == "owner/repo" ]] || return 1
+		printf '%s\n' "$test_comments"
+		return 0
+	}
+	_hrff_release_repo_state_is_managed() { return 0; }
+	_hrff_resolve_release_runner_login() {
+		printf 'runner-one\n'
+		return 0
+	}
+	clear_active_status_on_release() {
+		cleanup_count=$((cleanup_count + 1))
+		return 0
+	}
+	_unlock_issue_after_dispatch_release() {
+		cleanup_count=$((cleanup_count + 1))
+		return 0
+	}
+	gh() {
+		if [[ "$1" == "api" && "$2" == "repos/owner/repo/issues/42" ]]; then
+			printf '%s\n' '{"title":"Fix scope","body":"Files Scope: a.sh"}'
+			return 0
+		fi
+		return 1
+	}
+	_hrff_post_claim_released_comment() {
+		local issue_number="$1"
+		local repo_slug="$2"
+		local body="$3"
+		[[ "$issue_number" == "42" && "$repo_slug" == "owner/repo" ]] || return 1
+		posted_count=$((posted_count + 1))
+		if [[ "$posted_count" -eq 1 ]]; then
+			first_body="$body"
+		else
+			second_body="$body"
+		fi
+		local created_at="2026-08-31T10:0${posted_count}:00Z"
+		test_comments=$(printf '%s' "$test_comments" | jq -c \
+			--arg body "$body" --arg created_at "$created_at" \
+			'. + [{body: $body, created_at: $created_at, author_association: "MEMBER"}]')
+		return 0
+	}
+
+	export DISPATCH_REPO_SLUG="owner/repo"
+	export WORKER_ISSUE_NUMBER=42
+	export AIDEVOPS_TERMINAL_BLOCKER_REPO_PATH="$TEST_ROOT"
+	export AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT='222222222222222222222222'
+	_release_dispatch_claim "issue-42" "blocked"
+	_release_dispatch_claim "issue-42" "blocked"
+	_release_dispatch_claim "issue-42" "blocked"
+	unset DISPATCH_REPO_SLUG WORKER_ISSUE_NUMBER AIDEVOPS_TERMINAL_BLOCKER_REPO_PATH \
+		AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT
+
+	local status=1
+	if [[ "$posted_count" -eq 2 && "$first_body" == *"aidevops:terminal-blocker-observation"* &&
+		"$second_body" == *"TERMINAL_BLOCKER_CIRCUIT active=true observations=2"* &&
+		"$second_body" == *"CLAIM_RELEASED reason=blocked"* && "$cleanup_count" -eq 6 ]]; then
+		status=0
+	fi
+	print_result "release path posts one observation and one circuit comment across repeated blockers" "$status"
+	return 0
+}
+
+main() {
+	test_normalized_blocker_fingerprint
+	test_task_revision_inputs
+	test_release_modes_and_retry
+	test_dispatch_hold_revalidates_revision
+	test_release_integration_bounds_comments
+	printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Stop repeated workers after the same unchanged terminal blocker by recording a durable cross-runner circuit keyed to blocker and task revision.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh, .agents/scripts/headless-runtime-failure.sh, .agents/scripts/headless-runtime-result.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/pulse-dispatch-dedup-layers.sh, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/terminal-blocker-circuit.sh, .agents/scripts/tests/test-headless-runtime-provider-tests.sh, .agents/scripts/tests/test-rate-limit-release-circuit.sh, .agents/scripts/tests/test-terminal-blocker-circuit.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: changed-file quality gates, ShellCheck, 272 headless runtime tests, and focused terminal-blocker, rate-limit release, and stale dispatch suites passed.

Resolves #30926


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 7h 34m and 1,900,491 tokens on this with the user in an interactive session.