### PR TITLE
GH#30942: fix(pulse): classify zero-worker active claims

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1225,12 +1225,28 @@ classify_dispatch_blocker_reason() {
 			printf 'local_capacity_gate\n'
 			return 0
 			;;
-		*dedup*guard*blocked*)
-			printf 'dedup_active_claim\n'
+		*worker*already*running* | *live_worker=true* | *process_evidence=live*)
+			printf 'dedup_active_claim_live_owner\n'
 			return 0
 			;;
-		*assigned* | *claim* | *ledger* | *has-open-pr* | *pr*evidence* | *duplicate* | *stale_recovered*)
-			printf 'dedup_active_claim\n'
+		*stale_recovered* | *stale_owner=true*)
+			printf 'dedup_active_claim_stale_owner\n'
+			return 0
+			;;
+		*no*dispatch*claim* | *attempt_count=0* | *zero_attempt*)
+			printf 'dedup_active_claim_zero_attempt\n'
+			return 0
+			;;
+		*current*pulse*cycle* | *current_cycle=true*)
+			printf 'dedup_active_claim_current_cycle\n'
+			return 0
+			;;
+		*in-flight*ledger* | *has-open-pr* | *pr*evidence* | *dispatch*comment*)
+			printf 'dedup_active_claim_durable_launch\n'
+			return 0
+			;;
+		*dedup*guard*blocked* | *assigned* | *claim* | *ledger* | *duplicate*)
+			printf 'dedup_active_claim_unverified\n'
 			return 0
 			;;
 		"")

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -50,6 +50,8 @@ end) as $max_workers |
 ($current.canonical_reconciliation.refusal_count // 0 | number_or_zero) as $canonical_reconciliation_refusal_count |
 ($current.canonical_reconciliation.classification // "none") as $canonical_reconciliation_classification |
 ($current.canonical_reconciliation.canonical_recovery_advisory_observed // false) as $canonical_recovery_advisory_observed |
+($current.active_claim_state // {}) as $active_claim_state |
+($active_claim_state.zero_worker_actionable // false) as $zero_worker_active_claim_actionable |
 ([$progress_blockers.retained_unverified[]?
   | select(((.reason // "") | contains("permission"))
     and ((((.session_key // "") | startswith("supervisor-pulse")))
@@ -91,6 +93,7 @@ end) as $max_workers |
     runner_health: ($runner.finding // "unknown"),
     retained_supervisor_permission_blockers: $retained_supervisor_permission_blockers,
     canonical_reconciliation_refusals: $canonical_reconciliation_refusal_count,
+    zero_worker_active_claim_actionable: $zero_worker_active_claim_actionable,
     recurrent_failure_families: ([$failure_families[] | select((.count // 0) >= $failure_threshold and (.confidence // "low") == "high" and (.family // "") != "other-failure")] | length)
   },
   queue: ($queue.aggregate // {}),
@@ -107,6 +110,7 @@ end) as $max_workers |
       canonical_recovery_advisory_observed: $canonical_recovery_advisory_observed
     },
     active_worker_processes: ($current.active_worker_processes // null),
+    active_claim_state: $active_claim_state,
     top_pre_launch_blockers: ($current.top_pre_launch_blockers // [])
   },
   worker_activity: {
@@ -200,9 +204,15 @@ end) as $max_workers |
           ("excluded_persistent_dashboard=" + ($excluded_persistent_dashboard | tostring)),
           ("available_older_than_threshold=" + ($old_available | tostring)),
           "dispatch_alive=true",
-          ("dispatch_stage_events=" + (($current.dispatch_stage_events // 0) | tostring))
+          ("dispatch_stage_events=" + (($current.dispatch_stage_events // 0) | tostring)),
+          ("zero_worker_active_claim_actionable=" + ($zero_worker_active_claim_actionable | tostring)),
+          ("active_claim_classifications=" + (($active_claim_state.classification_counts // {}) | to_entries | map(.key + ":" + (.value | tostring)) | sort | join(",")))
         ];
-        "Inspect why the pulse did not retain active workers for visible status:available auto-dispatch issues; start with pulse-current-state-helper, worker-activity-helper, and pulse-diagnose-helper cycle-health.";
+        (if $zero_worker_active_claim_actionable then
+          "Inspect the named zero-worker active-claim state. Preserve live-owner and durable-launch claims; recheck current-cycle suppression or repair the reported infrastructure hold before the next floor refill."
+        else
+          "Inspect why the pulse did not retain active workers for visible status:available auto-dispatch issues; start with pulse-current-state-helper, worker-activity-helper, and pulse-diagnose-helper cycle-health."
+        end);
         true
       )
     else empty end,

--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -70,6 +70,57 @@ _observability_overlay_json() {
 	return 0
 }
 
+_active_claim_state_json() {
+	local log_dir="$1"
+	local active_workers="$2"
+	local pulse_log="${log_dir}/pulse-wrapper.log"
+	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
+	if [[ ! -f "$pulse_log" ]]; then
+		jq -n --argjson active "$active_workers" '{active_workers:$active, classification_counts:{}, zero_worker_actionable:false}'
+		return 0
+	fi
+
+	local counts="{}"
+	counts=$(awk '
+		/Instance lock acquired/ {
+			delete count
+			next
+		}
+		/ACTIVE_CLAIM_STATE classification=/ || /DISPATCH_BLOCK_REASON reason=dedup_active_claim_/ {
+			line = $0
+			if (match(line, /classification=[a-z_]+/)) {
+				key = substr(line, RSTART + 15, RLENGTH - 15)
+			} else if (match(line, /reason=dedup_active_claim_[a-z_]+/)) {
+				key = substr(line, RSTART + 26, RLENGTH - 26)
+			} else {
+				next
+			}
+			count[key]++
+		}
+		END {
+			printf "{"
+			separator = ""
+			for (key in count) {
+				printf "%s\"%s\":%d", separator, key, count[key]
+				separator = ","
+			}
+			printf "}"
+		}
+	' "$pulse_log" 2>/dev/null) || counts="{}"
+	printf '%s' "$counts" | jq --argjson active "$active_workers" '
+		. as $counts
+		| (["stale_owner", "zero_attempt", "current_cycle", "current_cycle_duplicate", "zero_worker_infrastructure_hold", "unverified"]
+			| map($counts[.] // 0) | add) as $actionable
+		| {
+			active_workers: $active,
+			classification_counts: $counts,
+			zero_worker_actionable: ($active == 0 and $actionable > 0),
+			live_owner_count: ($counts.live_owner // 0),
+			durable_launch_count: ($counts.durable_launch // 0)
+		}'
+	return 0
+}
+
 main() {
 	local window="15m"
 	local repo_path="${AIDEVOPS_REPO_PATH:-$HOME/Git/aidevops}"
@@ -127,13 +178,23 @@ main() {
 	) || projection_status=$?
 	local overlay_json="{}"
 	overlay_json=$(_observability_overlay_json)
+	local active_claim_json="{}"
+	active_claim_json=$(_active_claim_state_json "$log_dir" "$active_worker_processes")
 	if [[ "$projection_status" -eq 0 && "$as_json" -eq 1 ]] && printf '%s' "$projection_output" | jq empty >/dev/null 2>&1; then
-		projection_output=$(jq -n --argjson base "$projection_output" --argjson overlay "$overlay_json" '$base + $overlay')
+		projection_output=$(jq -n --argjson base "$projection_output" --argjson overlay "$overlay_json" --argjson claims "$active_claim_json" '
+			($base.pre_launch_blockers.dedup_active_claim // 0) as $legacy_claims
+			| ($claims.classification_counts.unverified // 0) as $classified_unverified
+			| ($claims
+				| .classification_counts.unverified = ([$legacy_claims, $classified_unverified] | max)
+				| .zero_worker_actionable = (.zero_worker_actionable or (.active_workers == 0 and $legacy_claims > 0))) as $enriched_claims
+			| $base + $overlay + {active_claim_state:$enriched_claims}')
 	elif [[ "$projection_status" -eq 0 ]]; then
 		projection_output+=$'\n'
 		projection_output+="NMR revalidation: $(printf '%s' "$overlay_json" | jq -c '.nmr_revalidation')"
 		projection_output+=$'\n'
 		projection_output+="Failure-family remediation: $(printf '%s' "$overlay_json" | jq -c '.failure_family_remediation')"
+		projection_output+=$'\n'
+		projection_output+="Active claim state: $(printf '%s' "$active_claim_json" | jq -c '.')"
 	fi
 	printf '%s\n' "$projection_output"
 	if [[ "$projection_status" -eq 0 && -s "$runtime_state_file" ]] && command -v node >/dev/null 2>&1; then

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -483,6 +483,61 @@ _dispatch_order_idle_borrowing_candidates() {
 }
 
 #######################################
+# Re-open a candidate that was suppressed only by this Pulse cycle's local
+# benign-block ledger while the worker pool is empty. The authoritative dedup
+# layers run again before any launch, so a live owner or durable launch remains
+# a hard block. The original claim and its log evidence are not mutated.
+#
+# Arguments:
+#   $1 - active worker count
+# Returns: 0 always
+#######################################
+_dispatch_recheck_zero_worker_active_claims() {
+	local active_workers="$1"
+	local ledger_file="${_DISPATCH_BENIGN_BLOCKS_FILE:-}"
+	[[ "$active_workers" == "0" && -n "$ledger_file" && -f "$ledger_file" ]] || return 0
+
+	local recheck_count="0"
+	recheck_count=$(awk -F '\t' '$3 == "dedup_active_claim" { count++ } END { print count + 0 }' "$ledger_file" 2>/dev/null) || recheck_count="0"
+	[[ "$recheck_count" =~ ^[0-9]+$ && "$recheck_count" -gt 0 ]] || return 0
+
+	local filtered_file=""
+	filtered_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-active-claim-ledger.XXXXXX") || return 0
+	if awk -F '\t' '$3 != "dedup_active_claim"' "$ledger_file" >"$filtered_file" 2>/dev/null; then
+		mv "$filtered_file" "$ledger_file"
+		echo "[pulse-wrapper] ACTIVE_CLAIM_STATE classification=current_cycle_duplicate active_workers=0 durable_launch=false attempt_count=unknown recovery=authoritative_recheck claims=${recheck_count}" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_active_claim_current_cycle_recheck"
+	else
+		rm -f "$filtered_file"
+	fi
+	return 0
+}
+
+#######################################
+# Emit an actionable state when an empty worker pool remains blocked after the
+# authoritative recheck. This is deliberately non-benign diagnostic evidence;
+# it does not relax the claim guard or mutate remote assignment state.
+#
+# Arguments:
+#   $1 - active worker count
+#   $2 - dispatched worker count
+# Returns: 0 always
+#######################################
+_dispatch_record_zero_worker_active_claim_hold() {
+	local active_workers="$1"
+	local dispatched_count="$2"
+	local ledger_file="${_DISPATCH_BENIGN_BLOCKS_FILE:-}"
+	[[ "$active_workers" == "0" && "$dispatched_count" == "0" && -n "$ledger_file" && -f "$ledger_file" ]] || return 0
+
+	local hold_count="0"
+	hold_count=$(awk -F '\t' '$3 == "dedup_active_claim" { count++ } END { print count + 0 }' "$ledger_file" 2>/dev/null) || hold_count="0"
+	[[ "$hold_count" =~ ^[0-9]+$ && "$hold_count" -gt 0 ]] || return 0
+	echo "[pulse-wrapper] ACTIVE_CLAIM_STATE classification=zero_worker_infrastructure_hold active_workers=0 durable_launch=false attempt_count=unknown recovery=blocked_actionable claims=${hold_count}" >>"$LOGFILE"
+	_dispatch_stats_increment "dispatch_active_claim_zero_worker_infrastructure_hold"
+	return 0
+}
+
+#######################################
 # Dispatch_max for obvious backlog.
 #
 # This is intentionally narrow: it only materializes already-eligible issues
@@ -577,6 +632,7 @@ dispatch_max() {
 		_dispatch_owns_benign_blocks_cycle=1
 	fi
 	export _DISPATCH_BENIGN_BLOCKS_FILE
+	_dispatch_recheck_zero_worker_active_claims "$active_workers"
 
 	# t3015: branch on dispatch path (max = parallel, floor = forced-serial).
 	# t3418/t3558: if the minimum worker floor is active, runtime launch
@@ -643,6 +699,7 @@ dispatch_max() {
 	read -r dispatched_count processed_count <<<"$loop_output"
 	[[ "$dispatched_count" =~ ^[0-9]+$ ]] || dispatched_count=0
 	[[ "$processed_count" =~ ^[0-9]+$ ]] || processed_count=0
+	_dispatch_record_zero_worker_active_claim_hold "$active_workers" "$dispatched_count"
 	rm -f "$_dispatch_candidate_file"
 	if [[ "$_dispatch_owns_benign_blocks_cycle" == "1" ]]; then
 		_dispatch_cleanup_benign_blocks_cycle

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
@@ -15,6 +15,7 @@ set -uo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+REAL_HELPER="${SCRIPTS_DIR}/dispatch-dedup-helper.sh"
 
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -64,6 +65,10 @@ if [[ "$cmd" == "is-assigned" ]]; then
 		printf '%s\n' 'STALE_RECOVERED: issue #2905 in exampleorg/examplerepo - unassigned runner (dispatch claim 900s old, last activity 900s old (threshold=600s, interactive=false))'
 		exit 1
 		;;
+	live_owner)
+		printf '%s\n' 'ASSIGNED: issue #2905 in exampleorg/examplerepo is assigned to runner live_worker=true durable_launch=true attempt_count=1'
+		exit 0
+		;;
 	blocked_by)
 		printf '%s\n' 'STALE_BLOCKED_BY_DEPENDENCY: issue #2905 in exampleorg/examplerepo - unassigned runner but kept status:blocked due to unresolved blocked-by (no_work)'
 		exit 1
@@ -84,7 +89,12 @@ if [[ "$cmd" == "is-assigned" ]]; then
 fi
 
 if [[ "$cmd" == "classify-blocker" ]]; then
-	printf 'assigned\n'
+	signal="${1:-}"
+	if [[ "$signal" == *"live_worker=true"* ]]; then
+		printf 'dedup_active_claim_live_owner\n'
+	else
+		printf 'dedup_active_claim_unverified\n'
+	fi
 	exit 0
 fi
 
@@ -113,6 +123,50 @@ reset_observations() {
 	LAST_CONSOLIDATION=""
 	: >"$LOGFILE"
 	: >"$CLASSIFY_LOG"
+	return 0
+}
+
+test_active_claim_classifier_preserves_evidence() {
+	local actual=""
+	actual=$("$REAL_HELPER" classify-blocker 'ASSIGNED: live_worker=true durable_launch=true attempt_count=1')
+	if [[ "$actual" != "dedup_active_claim_live_owner" ]]; then
+		fail "active claim classifier identifies live owner" "actual=${actual}"
+		return 0
+	fi
+	actual=$("$REAL_HELPER" classify-blocker 'STALE_RECOVERED stale_owner=true')
+	if [[ "$actual" != "dedup_active_claim_stale_owner" ]]; then
+		fail "active claim classifier identifies stale owner" "actual=${actual}"
+		return 0
+	fi
+	actual=$("$REAL_HELPER" classify-blocker 'ASSIGNED: attempt_count=0 no dispatch claim comment found')
+	if [[ "$actual" != "dedup_active_claim_zero_attempt" ]]; then
+		fail "active claim classifier identifies zero-attempt claim" "actual=${actual}"
+		return 0
+	fi
+	actual=$("$REAL_HELPER" classify-blocker 'skip from current pulse cycle current_cycle=true')
+	if [[ "$actual" != "dedup_active_claim_current_cycle" ]]; then
+		fail "active claim classifier identifies current-cycle suppression" "actual=${actual}"
+		return 0
+	fi
+	pass "active claim classifier preserves live, stale, zero-attempt, and current-cycle evidence"
+	return 0
+}
+
+test_live_owner_remains_blocked() {
+	export TEST_STALE_MODE="live_owner"
+	reset_observations
+	local rc=0
+	local output=""
+	output=$(_dedup_layer6_assignee_and_stale "2905" "exampleorg/examplerepo" "runner") || rc=$?
+	if [[ "$rc" -ne 0 || "$output" != *"live_worker=true"* ]]; then
+		fail "live-owner active claim remains blocked" "rc=${rc} output=${output}"
+		return 0
+	fi
+	if ! grep -q 'reason=dedup_active_claim_live_owner' "$LOGFILE" 2>/dev/null; then
+		fail "live-owner active claim logs named evidence" "log: $(tr '\n' ' ' <"$LOGFILE")"
+		return 0
+	fi
+	pass "live-owner active claim remains safely blocked"
 	return 0
 }
 
@@ -336,6 +390,8 @@ test_protected_draft_remains_immediate_pr_block() {
 	return 0
 }
 
+test_active_claim_classifier_preserves_evidence
+test_live_owner_remains_blocked
 test_stale_recovery_without_claim_skips_fast_fail
 test_prelaunch_canary_stale_recovery_skips_fast_fail
 test_stale_recovery_with_dispatch_claim_records_fast_fail

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -122,6 +122,7 @@ cat <<'JSON'
   "pulse_gauges": {"dispatch_capacity_final_max_workers": 6},
   "worker_outcomes": {"spawned": 4},
   "worker_terminal_events": 0,
+  "active_claim_state": {"active_workers": 0, "classification_counts": {"zero_worker_infrastructure_hold": 1}, "zero_worker_actionable": true, "live_owner_count": 0, "durable_launch_count": 0},
   "canonical_reconciliation": {"refusal_count": 2, "classification": "dirty_or_uncommitted", "canonical_recovery_advisory_observed": true},
   "graphql_budget_status": "OK fixture"
 }
@@ -373,6 +374,8 @@ SUCCESS_RATE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.historical_success_rate
 assert_eq "json delivered success rate is unknown without GitHub delivery check" "null" "$SUCCESS_RATE"
 assert_eq "json reports canonical reconciliation refusal aggregate" "2" "$(printf '%s' "$JSON_OUT" | jq -r '.current_state.canonical_reconciliation.refusal_count')"
 assert_eq "json reports canonical reconciliation classification" "dirty_or_uncommitted" "$(printf '%s' "$JSON_OUT" | jq -r '.current_state.canonical_reconciliation.classification')"
+assert_eq "zero-worker active claim is actionable" "true" "$(printf '%s' "$JSON_OUT" | jq -r '.summary.zero_worker_active_claim_actionable')"
+assert_contains "underfill preserves named active-claim evidence" "zero_worker_infrastructure_hold:1" "$JSON_OUT"
 assert_not_contains "json omits canonical branch detail" "origin/develop" "$JSON_OUT"
 
 MALFORMED_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=malformed" "$HELPER" json 2>&1)
@@ -398,6 +401,7 @@ cat <<'JSON'
   "pulse_gauges": {"dispatch_capacity_final_max_workers": 6},
   "worker_outcomes": {"spawned": 0},
   "worker_terminal_events": 0,
+  "active_claim_state": {"active_workers": 2, "classification_counts": {"live_owner": 1}, "zero_worker_actionable": false, "live_owner_count": 1, "durable_launch_count": 1},
   "graphql_budget_status": "OK fixture"
 }
 JSON
@@ -410,6 +414,8 @@ ACTIVE_IDS=$(printf '%s' "$JSON_ACTIVE_OUT" | jq -r '[.findings[].id] | sort | j
 assert_eq "json reports process-scan active workers" "2" "$ACTIVE_COUNT"
 assert_eq "json recomputes available slots from process count" "4" "$ACTIVE_AVAILABLE"
 assert_eq "process-scan active workers suppress underfill finding" "auto-dispatch-missing-tier-labels" "$ACTIVE_IDS"
+assert_eq "live-owner active claim remains non-actionable" "false" "$(printf '%s' "$JSON_ACTIVE_OUT" | jq -r '.summary.zero_worker_active_claim_actionable')"
+assert_eq "live-owner evidence remains visible" "1" "$(printf '%s' "$JSON_ACTIVE_OUT" | jq -r '.current_state.active_claim_state.live_owner_count')"
 
 cat >"${TEST_ROOT}/current-state-idle.sh" <<'SH'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

Classify active claim blocks by observable ownership evidence, recheck current-cycle suppression through authoritative dedup when no workers are active, and surface actionable zero-worker claim state in Pulse diagnostics.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh, .agents/scripts/pulse-check-report.jq, .agents/scripts/pulse-current-state-helper.sh, .agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh, .agents/scripts/tests/test-pulse-check-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh; bash .agents/scripts/tests/test-pulse-check-helper.sh; bash .agents/scripts/tests/test-pulse-current-state-helper.sh; bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh; .agents/scripts/pulse-check-helper.sh report --json

Resolves #30942


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 18m and 149,165 tokens on this as a headless worker.