### PR TITLE
GH#30957: promote OpenCode 1.18.25 compatibility pin

### DIFF
--- a/.agents/plugins/opencode-aidevops/package-lock.json
+++ b/.agents/plugins/opencode-aidevops/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
-        "@opencode-ai/plugin": "^1.18.23"
+        "@opencode-ai/plugin": "^1.18.25"
       },
       "peerDependencies": {
         "opencode-ai": ">=1.3.0"
@@ -113,13 +113,13 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.23",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.23.tgz",
-      "integrity": "sha512-a+LbJe+wyyiwOQ7DeYOY4MkI/6VL45wkgYunVNZGC93UQgaj6sMGemS45CsLXrjyF4bvJMtqGd66GJvgjzbXAg==",
+      "version": "1.18.25",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.25.tgz",
+      "integrity": "sha512-Kb34zFqYosFNiMd1IuYiZGjX17z+18Srm7tHZMCz+uMVRTYNkEw1FTrfAK2FLbggwYdgzifGwKMNF1slLT8eLw==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.23",
+        "@opencode-ai/sdk": "1.18.25",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.23",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.23.tgz",
-      "integrity": "sha512-VouYbL8O2ynLq0atr5fjzCv8YLtFi/zKLQ/uYkCvTJ4CmUdA01XwPn8om+u3TvxnGEfQsBfmThGU141vt3sg5w==",
+      "version": "1.18.25",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.25.tgz",
+      "integrity": "sha512-GwgwhW+vE8FWSDw730SjzqNhsWXB0uJjbFOiqFkmM+USFuG13HuTlGe6SR2ixt+WXxoD6FV1hILWqsXyqej9hQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/.agents/plugins/opencode-aidevops/package.json
+++ b/.agents/plugins/opencode-aidevops/package.json
@@ -17,7 +17,7 @@
   "author": "Marcus Quinn",
   "license": "MIT",
   "opencode": {
-    "tracked_version": "1.18.23",
+    "tracked_version": "1.18.25",
     "repo": "anomalyco/opencode"
   },
   "peerDependencies": {
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0",
-    "@opencode-ai/plugin": "^1.18.23"
+    "@opencode-ai/plugin": "^1.18.25"
   }
 }

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -184,18 +184,19 @@ aidevops_ensure_symlink_target() {
 # after 1.18.9 passed the isolated Linux-headless canary; GH#29964 promoted
 # 1.18.16 after a credential-free same-revision baseline comparison; GH#30393
 # promoted 1.18.18 after making that comparison self-contained; GH#30695
-# promoted 1.18.23 after the isolated baseline and candidate probes passed. Keep
-# the complete compatibility decision visible and machine-readable; general
-# installs track latest because the observed failure scope is Linux headless.
-readonly OPENCODE_PINNED_VERSION="1.18.23"
+# promoted 1.18.23 after the isolated baseline and candidate probes passed;
+# GH#30957 promoted 1.18.25 after the same isolated comparison passed. Keep the
+# complete compatibility decision visible and machine-readable; general installs
+# track latest because the observed failure scope is Linux headless.
+readonly OPENCODE_PINNED_VERSION="1.18.25"
 readonly OPENCODE_PIN_REASON="GH#28766 Linux headless bootstrap stalled with isolated XDG_DATA_HOME"
 readonly OPENCODE_PIN_PLATFORM="Linux"
 readonly OPENCODE_PIN_RUNTIME_MODE="headless"
 readonly OPENCODE_PIN_INTRODUCED_DATE="2026-07-30"
-readonly OPENCODE_PIN_LAST_CANARY_DATE="2026-08-25"
-readonly OPENCODE_PIN_LAST_CANARY_RESULT="pass:1.18.23"
-readonly OPENCODE_PIN_REVIEW_DEADLINE="2026-09-01"
-readonly OPENCODE_PLUGIN_TESTED_VERSION="1.18.23"
+readonly OPENCODE_PIN_LAST_CANARY_DATE="2026-09-01"
+readonly OPENCODE_PIN_LAST_CANARY_RESULT="pass:1.18.25"
+readonly OPENCODE_PIN_REVIEW_DEADLINE="2026-09-08"
+readonly OPENCODE_PLUGIN_TESTED_VERSION="1.18.25"
 
 aidevops_opencode_pin_applies() {
 	local platform="${1:-$(uname -s 2>/dev/null || printf 'unknown')}"

--- a/.agents/scripts/tests/test-opencode-pin-policy.sh
+++ b/.agents/scripts/tests/test-opencode-pin-policy.sh
@@ -19,13 +19,13 @@ assert_eq() {
 	fi
 }
 
-assert_eq "pin version is explicit" "1.18.23" "$OPENCODE_PINNED_VERSION"
+assert_eq "pin version is explicit" "1.18.25" "$OPENCODE_PINNED_VERSION"
 assert_eq "pin platform is scoped" "Linux" "$OPENCODE_PIN_PLATFORM"
 assert_eq "pin runtime is scoped" "headless" "$OPENCODE_PIN_RUNTIME_MODE"
 assert_eq "introduction date is recorded" "2026-07-30" "$OPENCODE_PIN_INTRODUCED_DATE"
-assert_eq "last canary is recorded" "2026-08-25" "$OPENCODE_PIN_LAST_CANARY_DATE"
-assert_eq "review deadline is recorded" "2026-09-01" "$OPENCODE_PIN_REVIEW_DEADLINE"
-assert_eq "plugin compatibility signal is explicit" "1.18.23" "$OPENCODE_PLUGIN_TESTED_VERSION"
+assert_eq "last canary is recorded" "2026-09-01" "$OPENCODE_PIN_LAST_CANARY_DATE"
+assert_eq "review deadline is recorded" "2026-09-08" "$OPENCODE_PIN_REVIEW_DEADLINE"
+assert_eq "plugin compatibility signal is explicit" "1.18.25" "$OPENCODE_PLUGIN_TESTED_VERSION"
 
 scope_rc=0
 aidevops_opencode_pin_applies Linux headless || scope_rc=$?
@@ -40,7 +40,7 @@ assert_eq "interactive setup is outside observed scope" "1" "$scope_rc"
 status=$(
 	PATH="/usr/bin:/bin" "$REPO_ROOT/.agents/scripts/opencode-pin-canary.sh" status
 )
-[[ "$status" == *"pinned=1.18.23"* && "$status" == *"registry-latest="* && "$status" == *"plugin-tested=1.18.23"* && "$status" == *"last-canary=2026-08-25"* ]] || {
+[[ "$status" == *"pinned=1.18.25"* && "$status" == *"registry-latest="* && "$status" == *"plugin-tested=1.18.25"* && "$status" == *"last-canary=2026-09-01"* ]] || {
 	printf 'FAIL: status omits compatibility evidence: %s\n' "$status" >&2
 	fail=$((fail + 1))
 }

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -91,7 +91,7 @@ extract_function
 printf 'Test 0: OpenCode remains pinned to the last verified headless release\n'
 # shellcheck source=../shared-constants.sh
 source "$SHARED_CONSTANTS"
-assert_eq "OpenCode headless regression pin" "1.18.23" "$OPENCODE_PINNED_VERSION"
+assert_eq "OpenCode headless regression pin" "1.18.25" "$OPENCODE_PINNED_VERSION"
 
 printf 'Test 0a: routine freshness tracks registry outside Linux headless dispatch\n'
 mkdir -p "$SANDBOX/routine-freshness/bin"
@@ -212,7 +212,7 @@ assert_eq "npm OpenCode upgrade command" "npm install -g opencode-ai@1.15.10" "$
 printf 'Test 4: headless guard provisions an isolated pin without changing newer general install\n'
 mkdir -p "$SANDBOX/version-guard/runtime" "$SANDBOX/version-guard/bin" "$SANDBOX/version-guard/state"
 write_executable "$SANDBOX/version-guard/runtime/opencode" '#!/usr/bin/env bash
-printf "1.18.24\n"'
+printf "1.18.26\n"'
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
 write_executable "$SANDBOX/version-guard/bin/npm" '#!/usr/bin/env bash
 printf "%s\n" "$*" >>"'"$SANDBOX"'/version-guard/calls"
@@ -224,7 +224,7 @@ done
 mkdir -p "$prefix/node_modules/opencode-linux-x64/bin"
 cat >"$prefix/node_modules/opencode-linux-x64/bin/opencode" <<"BIN"
 #!/usr/bin/env bash
-printf "1.18.23\n"
+printf "1.18.25\n"
 BIN
 chmod +x "$prefix/node_modules/opencode-linux-x64/bin/opencode"'
 guard_rc=0
@@ -244,10 +244,10 @@ headless_bin=""
 ) || guard_rc=$?
 assert_eq "headless pin repair status" "0" "$guard_rc"
 headless_bin=$(<"$SANDBOX/version-guard/headless-bin")
-assert_eq "general install remains newer" "1.18.24" "$("$SANDBOX/version-guard/runtime/opencode")"
-assert_eq "isolated headless runtime is pinned" "1.18.23" "$("$headless_bin")"
+assert_eq "general install remains newer" "1.18.26" "$("$SANDBOX/version-guard/runtime/opencode")"
+assert_eq "isolated headless runtime is pinned" "1.18.25" "$("$headless_bin")"
 install_call=$(<"$SANDBOX/version-guard/calls")
-[[ "$install_call" == "install --ignore-scripts --no-audit --no-fund --prefix "*"/opencode-runtimes/.1.18.23.install."*"/prefix opencode-ai@1.18.23" ]] && install_shape="valid" || install_shape="invalid"
+[[ "$install_call" == "install --ignore-scripts --no-audit --no-fund --prefix "*"/opencode-runtimes/.1.18.25.install."*"/prefix opencode-ai@1.18.25" ]] && install_shape="valid" || install_shape="invalid"
 assert_eq "isolated install requests exact pin" "valid" "$install_shape"
 
 printf 'Test 4b: existing isolated pin is reused without package-manager mutation\n'
@@ -270,7 +270,7 @@ assert_eq "existing isolated runtime avoids second install" "1" "$(wc -l <"$SAND
 printf 'Test 4c: stale pin repair locks are cleared after the bounded wait\n'
 mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes" "$SANDBOX/version-stale-lock/bin"
 write_executable "$SANDBOX/version-stale-lock/runtime-opencode" '#!/usr/bin/env bash
-printf "1.18.24\n"'
+printf "1.18.26\n"'
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
 write_executable "$SANDBOX/version-stale-lock/bin/npm" '#!/usr/bin/env bash
 prefix=""
@@ -281,14 +281,14 @@ done
 mkdir -p "$prefix/node_modules/opencode-linux-x64/bin"
 cat >"$prefix/node_modules/opencode-linux-x64/bin/opencode" <<"BIN"
 #!/usr/bin/env bash
-printf "1.18.23\n"
+printf "1.18.25\n"
 BIN
 chmod +x "$prefix/node_modules/opencode-linux-x64/bin/opencode"'
 (:) &
 dead_installer_pid=$!
 wait "$dead_installer_pid" || true
 mkdir -p "$SANDBOX/version-stale-lock/state/opencode-pin-repair.lock"
-mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.23.install.$dead_installer_pid"
+mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.25.install.$dead_installer_pid"
 stale_lock_rc=0
 (
 	source_extracted
@@ -306,14 +306,14 @@ stale_lock_rc=0
 ) || stale_lock_rc=$?
 assert_eq "stale lock repair status" "0" "$stale_lock_rc"
 assert_eq "stale lock is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-pin-repair.lock" ]] && printf '1\n' || printf '0\n')"
-assert_eq "dead install temp is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.23.install.$dead_installer_pid" ]] && printf '1\n' || printf '0\n')"
+assert_eq "dead install temp is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.25.install.$dead_installer_pid" ]] && printf '1\n' || printf '0\n')"
 stale_headless_bin=$(<"$SANDBOX/version-stale-lock/headless-bin")
-assert_eq "stale lock path provisions pinned runtime" "1.18.23" "$("$stale_headless_bin")"
+assert_eq "stale lock path provisions pinned runtime" "1.18.25" "$("$stale_headless_bin")"
 
 printf 'Test 5: headless version guard fails closed when isolated provisioning fails\n'
 mkdir -p "$SANDBOX/version-install-failure/state"
 write_executable "$SANDBOX/version-install-failure/opencode" '#!/usr/bin/env bash
-printf "1.18.24\n"'
+printf "1.18.26\n"'
 write_executable "$SANDBOX/version-install-failure/npm" '#!/usr/bin/env bash
 exit 42'
 guard_rc=0


### PR DESCRIPTION
## Summary

Advance the Linux-headless fail-closed OpenCode pin and plugin lock from 1.18.23 to the canary-verified 1.18.25 release, with refreshed compatibility evidence and regression fixtures.

## Files Changed

.agents/plugins/opencode-aidevops/package-lock.json, .agents/plugins/opencode-aidevops/package.json, .agents/scripts/shared-constants.sh, .agents/scripts/tests/test-opencode-pin-policy.sh, .agents/scripts/tests/test-tool-version-check-opencode.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified by the passing isolated Linux-headless baseline/candidate canary; test-opencode-pin-policy.sh, test-tool-version-check-opencode.sh, ShellCheck, linters-local.sh, npm ci lock validation, and all 687 plugin tests pass.

Resolves #30957


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 12m and 154,525 tokens on this with the user in an interactive session.