### PR TITLE
GH#30960: fix(profile): close fixture dependencies

### DIFF
--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -18,6 +18,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 SOURCE_HELPER="${SCRIPT_DIR}/../profile-readme-helper.sh"
 SOURCE_DATA_LIB="${SCRIPT_DIR}/../profile-readme-data-lib.sh"
 SOURCE_RENDER_LIB="${SCRIPT_DIR}/../profile-readme-render-lib.sh"
+# shellcheck source=./lib/test-helpers.sh
+source "${SCRIPT_DIR}/lib/test-helpers.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -79,8 +81,8 @@ install_helper_with_libs() {
 	chmod +x "${helper_path}"
 	cp "${SOURCE_DATA_LIB}" "${helper_dir}/profile-readme-data-lib.sh"
 	cp "${SOURCE_RENDER_LIB}" "${helper_dir}/profile-readme-render-lib.sh"
+	_test_copy_shared_deps "${SOURCE_HELPER%/*}" "${helper_dir}" || return 1
 	cp "${SOURCE_HELPER%/*}/audit-worktree-removal-helper.sh" \
-		"${SOURCE_HELPER%/*}/shared-constants.sh" \
 		"${SOURCE_HELPER%/*}/shared-sqlite-backup.sh" \
 		"${SOURCE_HELPER%/*}/shared-worktree-registry.sh" \
 		"${SOURCE_HELPER%/*}/portable-stat.sh" \
@@ -91,7 +93,8 @@ install_helper_with_libs() {
 		"${SOURCE_HELPER%/*}/screen_time_linux.py" \
 		"${SOURCE_HELPER%/*}/screen_time_linux_logind.py" \
 		"${SOURCE_HELPER%/*}/screen_time_linux_wtmp.py" \
-		"${SOURCE_HELPER%/*}/screen_time_history.py" "$helper_dir/"
+		"${SOURCE_HELPER%/*}/screen_time_history.py" \
+		"${SOURCE_HELPER%/*}/worktree-recovery-cache-policy.py" "$helper_dir/"
 	# Keep this profile-boundary fixture independent of host /proc visibility.
 	# Shared worktree-removal guard behaviour has dedicated tests; this stub proves
 	# the profile helper invokes cleanup from the canonical checkout after its


### PR DESCRIPTION
## Summary

Make the isolated profile README fixture copy the current shared-constants dependency closure and the archive cache-policy helper.

## Files Changed

.agents/scripts/tests/test-profile-readme-boundary.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — .agents/scripts/tests/test-profile-readme-boundary.sh (21/21); shellcheck .agents/scripts/tests/test-profile-readme-boundary.sh; .agents/scripts/linters-local.sh

Resolves #30960


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 11m and 235,420 tokens on this as a headless worker.