### PR TITLE
GH#30956: surface Pulse runtime freshness and secondary cooldown

### DIFF
--- a/.agents/scripts/auto-update-helper-check.sh
+++ b/.agents/scripts/auto-update-helper-check.sh
@@ -337,33 +337,8 @@ _cmd_check_stale_agent_redeploy() {
 _cmd_check_git_update() {
 	local remote="$1"
 
-	# The install checkout may contain deliberate local fixes or diagnostics.
-	# Generated setup output belongs outside the source checkout, so unknown
-	# tracked changes are never safe for an unattended updater to discard.
-	if ! git -C "$INSTALL_DIR" diff --quiet 2>/dev/null || ! git -C "$INSTALL_DIR" diff --cached --quiet 2>/dev/null; then
-		log_warn "Skipping update because tracked local changes exist in $INSTALL_DIR"
-		git -C "$INSTALL_DIR" status --short >>"$LOG_FILE" 2>&1 || true
-		update_state "update" "$remote" "local_changes"
-		return 1
-	fi
-
-	# Ensure we're on the main branch (detached HEAD or stale branch blocks pull)
-	# Mirrors recovery logic from aidevops.sh cmd_update()
-	# See: https://github.com/marcusquinn/aidevops/issues/4142
-	local current_branch
-	current_branch=$(git -C "$INSTALL_DIR" branch --show-current 2>/dev/null || echo "")
-	if [[ "$current_branch" != "main" ]]; then
-		log_info "Not on main branch ($current_branch), switching..."
-		if ! git -C "$INSTALL_DIR" checkout main --quiet 2>>"$LOG_FILE" &&
-			! git -C "$INSTALL_DIR" checkout -b main origin/main --quiet 2>>"$LOG_FILE"; then
-			log_error "Failed to switch to main branch from '$current_branch' in $INSTALL_DIR"
-			update_state "update" "$remote" "branch_switch_failed"
-			return 1
-		fi
-	fi
-
-	# Fetch once, then merge the exact fetched commit. Refuse local-ahead
-	# history so unattended setup never executes unreviewed local commits.
+	# Fetch before evaluating local blockers. A same-version release can still
+	# contain merged script fixes, so VERSION equality is not freshness proof.
 	if ! git -C "$INSTALL_DIR" fetch origin main --quiet 2>>"$LOG_FILE"; then
 		log_error "git fetch failed"
 		update_state "update" "$remote" "fetch_failed"
@@ -373,9 +348,37 @@ _cmd_check_git_update() {
 	local remote_hash=""
 	local_hash=$(git -C "$INSTALL_DIR" rev-parse HEAD 2>>"$LOG_FILE") || return 1
 	remote_hash=$(git -C "$INSTALL_DIR" rev-parse origin/main 2>>"$LOG_FILE") || return 1
-	if [[ "$local_hash" != "$remote_hash" ]] && git -C "$INSTALL_DIR" merge-base --is-ancestor "$remote_hash" "$local_hash" 2>/dev/null; then
+	# The install checkout may contain deliberate local fixes or diagnostics.
+	# Preserve them and record that they are blocking activation of upstream.
+	if ! git -C "$INSTALL_DIR" diff --quiet 2>/dev/null || ! git -C "$INSTALL_DIR" diff --cached --quiet 2>/dev/null; then
+		local dirty_status="local_changes"
+		if [[ "$local_hash" != "$remote_hash" ]]; then
+			dirty_status="runtime_stale_local_changes"
+		fi
+		log_warn "Skipping update because tracked local changes exist in the canonical checkout"
+		git -C "$INSTALL_DIR" status --short >>"$LOG_FILE" 2>&1 || true
+		update_state "update" "$remote" "$dirty_status"
+		return 1
+	fi
+	local current_branch=""
+	current_branch=$(git -C "$INSTALL_DIR" branch --show-current 2>/dev/null || true)
+	if [[ "$current_branch" != "main" ]]; then
+		log_error "Runtime is stale because the canonical checkout is not on main"
+		update_state "update" "$remote" "runtime_stale_branch"
+		return 1
+	fi
+	if [[ "$local_hash" == "$remote_hash" ]]; then
+		return 0
+	fi
+
+	if git -C "$INSTALL_DIR" merge-base --is-ancestor "$remote_hash" "$local_hash" 2>/dev/null; then
 		log_error "Local commits exist on main; refusing unattended update"
-		update_state "update" "$remote" "local_commits"
+		update_state "update" "$remote" "runtime_stale_local_commits"
+		return 1
+	fi
+	if ! git -C "$INSTALL_DIR" merge-base --is-ancestor "$local_hash" "$remote_hash" 2>/dev/null; then
+		log_error "Canonical main has diverged from origin/main; refusing unattended update"
+		update_state "update" "$remote" "runtime_stale_diverged"
 		return 1
 	fi
 
@@ -536,7 +539,11 @@ cmd_check() {
 	fi
 
 	if [[ "$current" == "$remote" ]]; then
-		log_info "Already up to date (v$current)"
+		log_info "Version matches upstream (v$current); verifying commit freshness"
+		if ! _cmd_check_git_update "$remote"; then
+			run_freshness_checks
+			return 1
+		fi
 		update_state "check" "$current" "up_to_date"
 		_cmd_check_stale_agent_redeploy "$current"
 		run_freshness_checks

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -649,33 +649,8 @@ _cmd_check_stale_agent_redeploy() {
 _cmd_check_git_update() {
 	local remote="$1"
 
-	# The install checkout may contain deliberate local fixes or diagnostics.
-	# Generated setup output belongs outside the source checkout, so unknown
-	# tracked changes are never safe for an unattended updater to discard.
-	if ! git -C "$INSTALL_DIR" diff --quiet 2>/dev/null || ! git -C "$INSTALL_DIR" diff --cached --quiet 2>/dev/null; then
-		log_warn "Skipping update because tracked local changes exist in $INSTALL_DIR"
-		git -C "$INSTALL_DIR" status --short >>"$LOG_FILE" 2>&1 || true
-		update_state "update" "$remote" "local_changes"
-		return 1
-	fi
-
-	# Ensure we're on the main branch (detached HEAD or stale branch blocks pull)
-	# Mirrors recovery logic from aidevops.sh cmd_update()
-	# See: https://github.com/marcusquinn/aidevops/issues/4142
-	local current_branch
-	current_branch=$(git -C "$INSTALL_DIR" branch --show-current 2>/dev/null || echo "")
-	if [[ "$current_branch" != "main" ]]; then
-		log_info "Not on main branch ($current_branch), switching..."
-		if ! git -C "$INSTALL_DIR" checkout main --quiet 2>>"$LOG_FILE" &&
-			! git -C "$INSTALL_DIR" checkout -b main origin/main --quiet 2>>"$LOG_FILE"; then
-			log_error "Failed to switch to main branch from '$current_branch' in $INSTALL_DIR"
-			update_state "update" "$remote" "branch_switch_failed"
-			return 1
-		fi
-	fi
-
-	# Fetch once, then merge the exact fetched commit. Refuse local-ahead
-	# history so unattended setup never executes unreviewed local commits.
+	# Fetch before evaluating local blockers. A same-version release can still
+	# contain merged script fixes, so VERSION equality is not freshness proof.
 	if ! git -C "$INSTALL_DIR" fetch origin main --quiet 2>>"$LOG_FILE"; then
 		log_error "git fetch failed"
 		update_state "update" "$remote" "fetch_failed"
@@ -685,9 +660,37 @@ _cmd_check_git_update() {
 	local remote_hash=""
 	local_hash=$(git -C "$INSTALL_DIR" rev-parse HEAD 2>>"$LOG_FILE") || return 1
 	remote_hash=$(git -C "$INSTALL_DIR" rev-parse origin/main 2>>"$LOG_FILE") || return 1
-	if [[ "$local_hash" != "$remote_hash" ]] && git -C "$INSTALL_DIR" merge-base --is-ancestor "$remote_hash" "$local_hash" 2>/dev/null; then
+	# The install checkout may contain deliberate local fixes or diagnostics.
+	# Preserve them and record that they are blocking activation of upstream.
+	if ! git -C "$INSTALL_DIR" diff --quiet 2>/dev/null || ! git -C "$INSTALL_DIR" diff --cached --quiet 2>/dev/null; then
+		local dirty_status="local_changes"
+		if [[ "$local_hash" != "$remote_hash" ]]; then
+			dirty_status="runtime_stale_local_changes"
+		fi
+		log_warn "Skipping update because tracked local changes exist in the canonical checkout"
+		git -C "$INSTALL_DIR" status --short >>"$LOG_FILE" 2>&1 || true
+		update_state "update" "$remote" "$dirty_status"
+		return 1
+	fi
+	local current_branch=""
+	current_branch=$(git -C "$INSTALL_DIR" branch --show-current 2>/dev/null || true)
+	if [[ "$current_branch" != "main" ]]; then
+		log_error "Runtime is stale because the canonical checkout is not on main"
+		update_state "update" "$remote" "runtime_stale_branch"
+		return 1
+	fi
+	if [[ "$local_hash" == "$remote_hash" ]]; then
+		return 0
+	fi
+
+	if git -C "$INSTALL_DIR" merge-base --is-ancestor "$remote_hash" "$local_hash" 2>/dev/null; then
 		log_error "Local commits exist on main; refusing unattended update"
-		update_state "update" "$remote" "local_commits"
+		update_state "update" "$remote" "runtime_stale_local_commits"
+		return 1
+	fi
+	if ! git -C "$INSTALL_DIR" merge-base --is-ancestor "$local_hash" "$remote_hash" 2>/dev/null; then
+		log_error "Canonical main has diverged from origin/main; refusing unattended update"
+		update_state "update" "$remote" "runtime_stale_diverged"
 		return 1
 	fi
 
@@ -856,7 +859,11 @@ cmd_check() {
 	fi
 
 	if [[ "$current" == "$remote" ]]; then
-		log_info "Already up to date (v$current)"
+		log_info "Version matches upstream (v$current); verifying commit freshness"
+		if ! _cmd_check_git_update "$remote"; then
+			run_freshness_checks
+			return 1
+		fi
 		update_state "check" "$current" "up_to_date"
 		_cmd_check_stale_agent_redeploy "$current"
 		run_freshness_checks

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -192,6 +192,7 @@ _render_text_report() {
 	local report_json="$1"
 	printf '%s' "$report_json" | jq -r '
 		def percent_text: if . == null then "n/a" else (. | tostring) + "%" end;
+		def unknown: "unknown";
 		"Pulse Check — " + .generated_at,
 		"",
 		"## Current utilisation",
@@ -200,8 +201,10 @@ _render_text_report() {
 		"- Queue scan state: " + (.summary.auto_dispatch_scan_state // "scanned"),
 		"- Current window launches: " + (.summary.worker_launches_in_window | tostring) + "; terminal worker events: " + (.summary.worker_terminal_events_in_window | tostring),
 		"- Recent worker metric events: " + (.summary.recent_worker_events | tostring) + "; " + .inputs.historical_window + " runtime handoff rate: " + (.summary.historical_runtime_handoff_rate | percent_text) + "; delivered success rate: " + (.summary.historical_delivery_success_rate | percent_text),
-		"- GraphQL/API: " + (.summary.graphql_budget_status // "unknown"),
-		"- Runner health: " + (.summary.runner_health // "unknown"),
+		"- GraphQL/API: " + (.summary.graphql_budget_status // unknown),
+		"- Secondary cooldown: " + (.summary.secondary_cooldown_state // unknown),
+		"- Runtime freshness: " + (.summary.runtime_freshness_status // unknown),
+		"- Runner health: " + (.summary.runner_health // unknown),
 		"- Retained supervisor permission blockers: " + (.summary.retained_supervisor_permission_blockers | tostring) + " (advisory only; does not change runner health)",
 		"",
 		"## Findings",

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -58,6 +58,10 @@ end) as $max_workers |
       or (((.source // "") | contains("supervisor-pulse")))))] | length) as $bounded_retained_supervisor_permission_blockers |
 ($progress_blockers.retained_supervisor_permission_total // $bounded_retained_supervisor_permission_blockers | number_or_zero) as $retained_supervisor_permission_blockers |
 ($api.graphql_circuit_breaker_trips // 0 | number_or_zero) as $graphql_trips |
+($api.secondary_cooldown_state // "unknown") as $secondary_cooldown_state |
+($secondary_cooldown_state | contains("active=yes")) as $secondary_cooldown_active |
+($current.runtime_freshness // {}) as $runtime_freshness |
+($runtime_freshness.stale // false) as $runtime_stale |
 {
   generated_at: (now | todateiso8601),
   inputs: {current_window: $window, historical_window: $since, recent_window: $recent},
@@ -90,9 +94,13 @@ end) as $max_workers |
     auto_dispatch_scan_errors: $gh_errors,
     auto_dispatch_scan_state: (if $queue_error == "" then "scanned" else $queue_error end),
     graphql_budget_status: ($current.graphql_budget_status // "unknown"),
+    secondary_cooldown_state: $secondary_cooldown_state,
+    secondary_cooldown_active: $secondary_cooldown_active,
     runner_health: ($runner.finding // "unknown"),
     retained_supervisor_permission_blockers: $retained_supervisor_permission_blockers,
     canonical_reconciliation_refusals: $canonical_reconciliation_refusal_count,
+    runtime_freshness_status: ($runtime_freshness.status // "unknown"),
+    runtime_stale: $runtime_stale,
     zero_worker_active_claim_actionable: $zero_worker_active_claim_actionable,
     recurrent_failure_families: ([$failure_families[] | select((.count // 0) >= $failure_threshold and (.confidence // "low") == "high" and (.family // "") != "other-failure")] | length)
   },
@@ -109,6 +117,7 @@ end) as $max_workers |
       classification: $canonical_reconciliation_classification,
       canonical_recovery_advisory_observed: $canonical_recovery_advisory_observed
     },
+    runtime_freshness: $runtime_freshness,
     active_worker_processes: ($current.active_worker_processes // null),
     active_claim_state: $active_claim_state,
     top_pre_launch_blockers: ($current.top_pre_launch_blockers // [])
@@ -151,10 +160,40 @@ end) as $max_workers |
     graphql_circuit_breaker_trips: ($api.graphql_circuit_breaker_trips // 0),
     reserve_mode_cycles: ($api.reserve_mode_cycles // 0),
     deferred_optional_stages: ($api.deferred_optional_stages // 0),
-    secondary_cooldown_state: ($api.secondary_cooldown_state // "unknown"),
+    secondary_cooldown_state: $secondary_cooldown_state,
     cadence_api_risk: ($api.cadence_api_risk // "unknown")
   },
   findings: ([
+    if $secondary_cooldown_active then
+      finding(
+        "github-secondary-cooldown-active";
+        "high";
+        "GitHub secondary cooldown is active despite available GraphQL budget";
+        [
+          ("graphql_budget_status=" + ($current.graphql_budget_status // "unknown")),
+          ("secondary_cooldown_state=" + $secondary_cooldown_state),
+          ("queue_scan_state=" + (if $queue_error == "" then "scanned" else $queue_error end))
+        ];
+        "Defer nonessential GitHub reads and writes until the shared secondary cooldown expires; preserve only essential safety reads.";
+        false
+      )
+    else empty end,
+    if $runtime_stale then
+      finding(
+        "pulse-runtime-stale";
+        "high";
+        "Merged Pulse fixes are not active in the local runtime";
+        [
+          ("runtime_freshness_status=" + ($runtime_freshness.status // "unknown")),
+          ("canonical_dirty=" + (($runtime_freshness.canonical_dirty // false) | tostring)),
+          ("canonical_behind_upstream=" + (($runtime_freshness.canonical_behind_upstream // false) | tostring)),
+          ("deployed_behind_upstream=" + (($runtime_freshness.deployed_behind_upstream // false) | tostring)),
+          ("auto_update_status=" + ($runtime_freshness.auto_update_status // "unknown"))
+        ];
+        ($runtime_freshness.operator_action // "Verify the canonical checkout and active runtime bundle before attributing live Pulse behaviour to merged source");
+        false
+      )
+    else empty end,
     if $canonical_reconciliation_refusal_count > 0 then
       finding(
         "pulse-canonical-reconciliation-stops";

--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+UNKNOWN_STATUS="unknown"
 
 _usage() {
 	cat <<'EOF'
@@ -42,6 +43,120 @@ _state_file_json() {
 	return 0
 }
 
+_runtime_manifest_value() {
+	local manifest_file="$1"
+	local key="$2"
+	local line=""
+	[[ -r "$manifest_file" ]] || return 1
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		case "$line" in
+		"${key}="*) printf '%s' "${line#*=}"; return 0 ;;
+		esac
+	done <"$manifest_file"
+	return 1
+}
+
+_runtime_freshness_json() {
+	local repo_path="$1"
+	local agents_path="${AIDEVOPS_RUNTIME_AGENTS_PATH:-${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}}"
+	local manifest_file="${AIDEVOPS_RUNTIME_MANIFEST_FILE:-${agents_path}/.bundle-manifest}"
+	local stamp_file="${AIDEVOPS_DEPLOYED_SHA_FILE:-${HOME}/.aidevops/.deployed-sha}"
+	local update_state_file="${AIDEVOPS_AUTO_UPDATE_STATE_FILE:-${HOME}/.aidevops/cache/auto-update-state.json}"
+	local upstream_ref="${AIDEVOPS_RUNTIME_UPSTREAM_REF:-}"
+	local canonical_sha="" upstream_sha="" deployed_sha="" manifest_sha="" stamp_sha=""
+	local auto_update_status="$UNKNOWN_STATUS" auto_update_at=""
+	local status="$UNKNOWN_STATUS" action="Verify the canonical checkout and active runtime bundle"
+	local canonical_dirty=false canonical_on_main=false canonical_behind=false
+	local canonical_ahead=false canonical_diverged=false deployed_behind=false stale=false
+
+	if [[ -z "$upstream_ref" ]]; then
+		upstream_ref=$(git -C "$repo_path" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+		[[ -n "$upstream_ref" ]] || upstream_ref="origin/main"
+	fi
+	canonical_sha=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null || true)
+	upstream_sha=$(git -C "$repo_path" rev-parse "$upstream_ref" 2>/dev/null || true)
+	if [[ "$(git -C "$repo_path" symbolic-ref --quiet HEAD 2>/dev/null || true)" == "refs/heads/main" ]]; then
+		canonical_on_main=true
+	fi
+	manifest_sha=$(_runtime_manifest_value "$manifest_file" git_sha 2>/dev/null || true)
+	if [[ -r "$stamp_file" ]]; then
+		IFS= read -r stamp_sha <"$stamp_file" || stamp_sha=""
+		stamp_sha="${stamp_sha//[[:space:]]/}"
+	fi
+	if [[ "$manifest_sha" =~ ^[0-9a-fA-F]{7,64}$ ]]; then
+		deployed_sha="$manifest_sha"
+	elif [[ "$stamp_sha" =~ ^[0-9a-fA-F]{7,64}$ ]]; then
+		deployed_sha="$stamp_sha"
+	fi
+	if [[ -r "$update_state_file" ]]; then
+		auto_update_status=$(jq -r --arg unknown "$UNKNOWN_STATUS" '.last_status // $unknown' "$update_state_file" 2>/dev/null || printf '%s' "$UNKNOWN_STATUS")
+		auto_update_at=$(jq -r '.last_timestamp // ""' "$update_state_file" 2>/dev/null || true)
+	fi
+	if ! git -C "$repo_path" diff --quiet 2>/dev/null || ! git -C "$repo_path" diff --cached --quiet 2>/dev/null; then
+		canonical_dirty=true
+	fi
+
+	if [[ "$canonical_sha" =~ ^[0-9a-fA-F]{7,64}$ && "$upstream_sha" =~ ^[0-9a-fA-F]{7,64}$ ]]; then
+		if [[ "$canonical_sha" != "$upstream_sha" ]]; then
+			if git -C "$repo_path" merge-base --is-ancestor "$canonical_sha" "$upstream_sha" 2>/dev/null; then
+				canonical_behind=true
+			elif git -C "$repo_path" merge-base --is-ancestor "$upstream_sha" "$canonical_sha" 2>/dev/null; then
+				canonical_ahead=true
+			else
+				canonical_diverged=true
+			fi
+		fi
+		if [[ -n "$deployed_sha" && "$deployed_sha" != "$upstream_sha" ]] && git -C "$repo_path" merge-base --is-ancestor "$deployed_sha" "$upstream_sha" 2>/dev/null; then
+			deployed_behind=true
+		fi
+	fi
+
+	if [[ "$canonical_dirty" == true ]]; then
+		status="blocked_dirty_canonical"
+		action="Preserve the local changes, reconcile the canonical checkout, then run aidevops update in an attached terminal"
+	elif [[ -n "$canonical_sha" && "$canonical_on_main" != true ]]; then
+		status="canonical_non_main"
+		action="Restore the canonical checkout to main without discarding local history, then run aidevops update in an attached terminal"
+	elif [[ "$canonical_behind" == true ]]; then
+		status="canonical_behind_upstream"
+		action="Wait for auto-update or run aidevops update in an attached terminal"
+	elif [[ "$canonical_ahead" == true ]]; then
+		status="canonical_ahead_upstream"
+		action="Preserve and reconcile the local canonical commits before updating the runtime"
+	elif [[ "$canonical_diverged" == true ]]; then
+		status="canonical_diverged_upstream"
+		action="Preserve and reconcile the divergent canonical history before updating the runtime"
+	elif [[ -n "$deployed_sha" && -n "$canonical_sha" && "$deployed_sha" != "$canonical_sha" ]]; then
+		status="deployed_behind_canonical"
+		action="Run setup.sh --stage ai-session from the canonical checkout"
+	elif [[ -n "$deployed_sha" && -n "$upstream_sha" && "$deployed_sha" == "$upstream_sha" && "$canonical_sha" == "$upstream_sha" ]]; then
+		status="current"
+		action="No action required"
+	elif [[ "$deployed_behind" == true ]]; then
+		status="deployed_behind_upstream"
+		action="Run aidevops update in an attached terminal"
+	fi
+	[[ "$status" == "current" || "$status" == "$UNKNOWN_STATUS" ]] || stale=true
+
+	jq -n \
+		--arg status "$status" --arg action "$action" --arg upstream_ref "$upstream_ref" \
+		--arg canonical_sha "$canonical_sha" --arg upstream_sha "$upstream_sha" --arg deployed_sha "$deployed_sha" \
+		--arg auto_status "$auto_update_status" --arg auto_at "$auto_update_at" \
+		--argjson stale "$stale" --argjson dirty "$canonical_dirty" \
+		--argjson canonical_on_main "$canonical_on_main" --argjson canonical_behind "$canonical_behind" \
+		--argjson canonical_ahead "$canonical_ahead" --argjson canonical_diverged "$canonical_diverged" \
+		--argjson deployed_behind "$deployed_behind" '{
+			status:$status, stale:$stale, canonical_dirty:$dirty, canonical_on_main:$canonical_on_main,
+			canonical_behind_upstream:$canonical_behind, deployed_behind_upstream:$deployed_behind,
+			canonical_ahead_upstream:$canonical_ahead, canonical_diverged_upstream:$canonical_diverged,
+			upstream_ref:$upstream_ref, canonical_sha:$canonical_sha,
+			upstream_sha:$upstream_sha, deployed_sha:$deployed_sha,
+			auto_update_status:$auto_status, auto_update_at:$auto_at,
+			operator_action:$action
+		}'
+	return 0
+}
+
 _observability_overlay_json() {
 	local nmr_state_file="${AIDEVOPS_NMR_REVALIDATION_STATE_FILE:-${HOME}/.aidevops/cache/nmr-revalidation-state.json}"
 	local family_state_file="${PULSE_CHECK_FAILURE_FAMILY_STATE_FILE:-${HOME}/.aidevops/cache/failure-family-remediation.json}"
@@ -49,13 +164,13 @@ _observability_overlay_json() {
 	local family_state="{}"
 	nmr_state=$(_state_file_json "$nmr_state_file")
 	family_state=$(_state_file_json "$family_state_file")
-	jq -n --argjson nmr "$nmr_state" --argjson families "$family_state" '
+	jq -n --arg unknown "$UNKNOWN_STATUS" --argjson nmr "$nmr_state" --argjson families "$family_state" '
 		($nmr.entries // {} | [.[]]) as $entries
 		| {
 			nmr_revalidation: {
 				total: ($entries | length),
 				reason_counts: (reduce $entries[] as $entry ({}; .[$entry.code // "authority"] += 1)),
-				status_counts: (reduce $entries[] as $entry ({}; .[$entry.status // "unknown"] += 1)),
+				status_counts: (reduce $entries[] as $entry ({}; .[$entry.status // $unknown] += 1)),
 				temporary_count: ([$entries[] | select(.class == "temporary")] | length),
 				genuine_authority_count: ([$entries[] | select(.class == "genuine-authority")] | length),
 				oldest_age_seconds: ([$entries[] | try (now - (.label_at | fromdateiso8601) | floor) catch empty] | if length > 0 then max else 0 end)
@@ -130,6 +245,7 @@ main() {
 	local worker_worktree_count="0"
 	local graphql_budget_status=""
 	local runtime_state_file=""
+	local runtime_freshness="{}"
 	local objective_state_file="${AIDEVOPS_OBJECTIVE_STATE_FILE:-$HOME/.aidevops/state/objective-reconciliation.json}"
 	local as_json=0
 	while [[ $# -gt 0 ]]; do
@@ -163,6 +279,7 @@ main() {
 		graphql_budget_status="$("${SCRIPT_DIR}/pulse-rate-limit-circuit-breaker.sh" \
 			status --cached 2>/dev/null || true)"
 	fi
+	runtime_freshness=$(_runtime_freshness_json "$repo_path")
 	runtime_state_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-pulse-runtime-state.XXXXXX") || runtime_state_file=""
 	local projection_status=0
 	local projection_output=""
@@ -181,13 +298,13 @@ main() {
 	local active_claim_json="{}"
 	active_claim_json=$(_active_claim_state_json "$log_dir" "$active_worker_processes")
 	if [[ "$projection_status" -eq 0 && "$as_json" -eq 1 ]] && printf '%s' "$projection_output" | jq empty >/dev/null 2>&1; then
-		projection_output=$(jq -n --argjson base "$projection_output" --argjson overlay "$overlay_json" --argjson claims "$active_claim_json" '
+		projection_output=$(jq -n --argjson base "$projection_output" --argjson overlay "$overlay_json" --argjson claims "$active_claim_json" --argjson freshness "$runtime_freshness" '
 			($base.pre_launch_blockers.dedup_active_claim // 0) as $legacy_claims
 			| ($claims.classification_counts.unverified // 0) as $classified_unverified
 			| ($claims
 				| .classification_counts.unverified = ([$legacy_claims, $classified_unverified] | max)
 				| .zero_worker_actionable = (.zero_worker_actionable or (.active_workers == 0 and $legacy_claims > 0))) as $enriched_claims
-			| $base + $overlay + {active_claim_state:$enriched_claims}')
+			| $base + $overlay + {active_claim_state:$enriched_claims, runtime_freshness:$freshness}')
 	elif [[ "$projection_status" -eq 0 ]]; then
 		projection_output+=$'\n'
 		projection_output+="NMR revalidation: $(printf '%s' "$overlay_json" | jq -c '.nmr_revalidation')"
@@ -195,13 +312,16 @@ main() {
 		projection_output+="Failure-family remediation: $(printf '%s' "$overlay_json" | jq -c '.failure_family_remediation')"
 		projection_output+=$'\n'
 		projection_output+="Active claim state: $(printf '%s' "$active_claim_json" | jq -c '.')"
+		projection_output+=$'\n'
+		projection_output+="Runtime freshness: $(printf '%s' "$runtime_freshness" | jq -c '.')"
 	fi
 	printf '%s\n' "$projection_output"
 	if [[ "$projection_status" -eq 0 && -s "$runtime_state_file" ]] && command -v node >/dev/null 2>&1; then
 		local runtime_tmp=""
 		runtime_tmp=$(mktemp "${TMPDIR:-/tmp}/aidevops-pulse-runtime-overlay.XXXXXX") || runtime_tmp=""
-		if [[ -n "$runtime_tmp" ]] && jq --argjson overlay "$overlay_json" '. + {
+		if [[ -n "$runtime_tmp" ]] && jq --argjson overlay "$overlay_json" --argjson freshness "$runtime_freshness" '. + {
 			nmr_revalidation: $overlay.nmr_revalidation,
+			runtime_freshness: $freshness,
 			failure_family_remediation: {
 				recurrent_count: $overlay.failure_family_remediation.recurrent_count,
 				recovery_candidate_count: $overlay.failure_family_remediation.recovery_candidate_count

--- a/.agents/scripts/pulse-prefetch-infra.sh
+++ b/.agents/scripts/pulse-prefetch-infra.sh
@@ -95,6 +95,12 @@ _pulse_gh_err_is_rate_limit() {
 _pulse_verify_rate_limit_live() {
 	local threshold="${1:-100}"
 	local remaining
+	# Once a shared secondary cooldown is active, the corroboration probe is
+	# itself nonessential read pressure. Trust the observed classifier signal
+	# until the cooldown expires instead of producing another HTTP 403.
+	if declare -F _gh_secondary_cooldown_preflight >/dev/null 2>&1; then
+		_gh_secondary_cooldown_preflight read >/dev/null 2>&1 || return 0
+	fi
 	# The REST rate_limit resource does not hit the --label/--search cache.
 	# Failure modes: network error, auth error — treat as "can't verify, trust classifier".
 	remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null) || return 0

--- a/.agents/scripts/tests/test-agent-deploy-pulse-runtime.sh
+++ b/.agents/scripts/tests/test-agent-deploy-pulse-runtime.sh
@@ -43,6 +43,18 @@ pass() {
 	return 0
 }
 
+assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+	if [[ "$expected" != "$actual" ]]; then
+		fail "$message (expected=$expected actual=$actual)"
+		return 1
+	fi
+	pass "$message"
+	return 0
+}
+
 write_runtime_bundle() {
 	local bundle_root="$1"
 	local bundle_id="$2"
@@ -239,6 +251,99 @@ SH
 	return 0
 }
 
+runtime_freshness_output() {
+	local manifest_file="$1"
+	local update_state_file="$2"
+	local canonical_repo="$3"
+	local log_dir="$4"
+	AIDEVOPS_RUNTIME_MANIFEST_FILE="$manifest_file" \
+		AIDEVOPS_DEPLOYED_SHA_FILE="$TEST_ROOT/missing-deployed-sha" \
+		AIDEVOPS_AUTO_UPDATE_STATE_FILE="$update_state_file" \
+		"$REPO_ROOT/.agents/scripts/pulse-current-state-helper.sh" \
+		--repo-path "$canonical_repo" --log-dir "$log_dir" --json
+	return 0
+}
+
+test_runtime_freshness_diagnostics() {
+	local remote_repo="$TEST_ROOT/runtime-origin.git"
+	local canonical_repo="$TEST_ROOT/runtime-canonical"
+	local peer_repo="$TEST_ROOT/runtime-peer"
+	local log_dir="$TEST_ROOT/runtime-logs"
+	local manifest_file="$TEST_ROOT/runtime-manifest"
+	local update_state_file="$TEST_ROOT/auto-update-state.json"
+	local base_sha="" upstream_sha="" second_upstream_sha="" output=""
+
+	git init -q --bare -b main "$remote_repo"
+	git init -q -b main "$canonical_repo"
+	git -C "$canonical_repo" config user.name Test
+	git -C "$canonical_repo" config user.email test@example.invalid
+	printf 'base\n' >"$canonical_repo/runtime.txt"
+	git -C "$canonical_repo" add runtime.txt
+	git -C "$canonical_repo" commit -qm base
+	git -C "$canonical_repo" remote add origin "$remote_repo"
+	git -C "$canonical_repo" push -qu origin main
+	base_sha=$(git -C "$canonical_repo" rev-parse HEAD)
+	git clone -q "$remote_repo" "$peer_repo"
+	git -C "$peer_repo" config user.name Test
+	git -C "$peer_repo" config user.email test@example.invalid
+	printf 'upstream\n' >>"$peer_repo/runtime.txt"
+	git -C "$peer_repo" commit -am upstream -q
+	git -C "$peer_repo" push -q origin main
+	upstream_sha=$(git -C "$peer_repo" rev-parse HEAD)
+	git -C "$canonical_repo" fetch -q origin main
+	mkdir -p "$log_dir"
+	printf 'schema=1\nstatus=validated\ngit_sha=%s\n' "$base_sha" >"$manifest_file"
+	printf '%s\n' '{"last_status":"up_to_date","last_timestamp":"2026-09-01T00:00:00Z"}' >"$update_state_file"
+
+	output=$(runtime_freshness_output "$manifest_file" "$update_state_file" "$canonical_repo" "$log_dir")
+	assert_eq "canonical_behind_upstream" "$(printf '%s' "$output" | jq -r '.runtime_freshness.status')" \
+		"current-state reports a stale canonical checkout"
+
+	printf 'local diagnostic\n' >>"$canonical_repo/runtime.txt"
+	printf '%s\n' '{"last_status":"runtime_stale_local_changes","last_timestamp":"2026-09-01T00:01:00Z"}' >"$update_state_file"
+	output=$(runtime_freshness_output "$manifest_file" "$update_state_file" "$canonical_repo" "$log_dir")
+	assert_eq "blocked_dirty_canonical" "$(printf '%s' "$output" | jq -r '.runtime_freshness.status')" \
+		"dirty canonical state is preserved and classified"
+	git -C "$canonical_repo" checkout -q -- runtime.txt
+	git -C "$canonical_repo" merge -q --ff-only "$upstream_sha"
+
+	output=$(runtime_freshness_output "$manifest_file" "$update_state_file" "$canonical_repo" "$log_dir")
+	assert_eq "deployed_behind_canonical" "$(printf '%s' "$output" | jq -r '.runtime_freshness.status')" \
+		"current-state distinguishes a stale deployed bundle"
+	printf 'schema=1\nstatus=validated\ngit_sha=%s\n' "$upstream_sha" >"$manifest_file"
+	output=$(runtime_freshness_output "$manifest_file" "$update_state_file" "$canonical_repo" "$log_dir")
+	assert_eq "current" "$(printf '%s' "$output" | jq -r '.runtime_freshness.status')" \
+		"clean fast-forward and deployment report current runtime"
+
+	printf 'dirty at upstream tip\n' >>"$canonical_repo/runtime.txt"
+	output=$(runtime_freshness_output "$manifest_file" "$update_state_file" "$canonical_repo" "$log_dir")
+	assert_eq "blocked_dirty_canonical" "$(printf '%s' "$output" | jq -r '.runtime_freshness.status')" \
+		"dirty upstream-tip canonical state remains blocked"
+	git -C "$canonical_repo" checkout -q -- runtime.txt
+
+	printf 'local ahead\n' >>"$canonical_repo/runtime.txt"
+	git -C "$canonical_repo" commit -am local-ahead -q
+	output=$(runtime_freshness_output "$manifest_file" "$update_state_file" "$canonical_repo" "$log_dir")
+	assert_eq "canonical_ahead_upstream" "$(printf '%s' "$output" | jq -r '.runtime_freshness.status')" \
+		"local-ahead canonical history remains stale"
+
+	printf 'second upstream\n' >>"$peer_repo/runtime.txt"
+	git -C "$peer_repo" commit -am second-upstream -q
+	git -C "$peer_repo" push -q origin main
+	second_upstream_sha=$(git -C "$peer_repo" rev-parse HEAD)
+	git -C "$canonical_repo" fetch -q origin main
+	output=$(runtime_freshness_output "$manifest_file" "$update_state_file" "$canonical_repo" "$log_dir")
+	assert_eq "canonical_diverged_upstream" "$(printf '%s' "$output" | jq -r '.runtime_freshness.status')" \
+		"divergent canonical history remains stale"
+
+	git -C "$canonical_repo" checkout -q --detach "$second_upstream_sha"
+	printf 'schema=1\nstatus=validated\ngit_sha=%s\n' "$second_upstream_sha" >"$manifest_file"
+	output=$(runtime_freshness_output "$manifest_file" "$update_state_file" "$canonical_repo" "$log_dir")
+	assert_eq "canonical_non_main" "$(printf '%s' "$output" | jq -r '.runtime_freshness.status')" \
+		"detached exact-SHA canonical checkout remains stale"
+	return 0
+}
+
 main() {
 	local stale_root=""
 	local active_root=""
@@ -274,6 +379,7 @@ main() {
 	test_concurrent_transition_converges_on_active_bundle "$stale_root" "$active_root" "$active_link"
 	test_launchd_disabled_service_stays_stopped "$active_root" "$active_link"
 	test_launchd_enabled_service_owns_restart "$active_root" "$active_link"
+	test_runtime_freshness_diagnostics
 
 	printf 'Results: %s checks passed\n' "$TESTS_RUN"
 	return 0

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -175,6 +175,12 @@ chmod +x "${TEST_ROOT}/runner-health.sh"
 
 cat >"${TEST_ROOT}/pulse-diagnose.sh" <<'SH'
 #!/usr/bin/env bash
+if [[ "${PULSE_CHECK_SECONDARY_COOLDOWN_FIXTURE:-}" == "active" ]]; then
+  cat <<'JSON'
+{"graphql_circuit_breaker_trips":0,"reserve_mode_cycles":0,"deferred_optional_stages":1,"secondary_cooldown_state":"active=yes expires_in_s=240 reason=secondary-rate-limit endpoint_family=issues body=secondary recent_secondary_5m=3 cooldown_events=1","cadence_api_risk":"risk=secondary-cooldown"}
+JSON
+  exit 0
+fi
 cat <<'JSON'
 {"graphql_circuit_breaker_trips":0,"reserve_mode_cycles":0,"deferred_optional_stages":0,"secondary_cooldown_state":"active=no","cadence_api_risk":"risk=ok"}
 JSON
@@ -183,6 +189,9 @@ chmod +x "${TEST_ROOT}/pulse-diagnose.sh"
 
 cat >"${BIN_DIR}/gh" <<'SH'
 #!/usr/bin/env bash
+if [[ -n "${PULSE_CHECK_GH_CALL_LOG:-}" ]]; then
+  printf '%s\n' "$*" >>"$PULSE_CHECK_GH_CALL_LOG"
+fi
 if [[ " $* " == *" repo view "* ]]; then
   printf 'owner/aidevops\n'
   exit 0
@@ -377,6 +386,55 @@ assert_eq "json reports canonical reconciliation classification" "dirty_or_uncom
 assert_eq "zero-worker active claim is actionable" "true" "$(printf '%s' "$JSON_OUT" | jq -r '.summary.zero_worker_active_claim_actionable')"
 assert_contains "underfill preserves named active-claim evidence" "zero_worker_infrastructure_hold:1" "$JSON_OUT"
 assert_not_contains "json omits canonical branch detail" "origin/develop" "$JSON_OUT"
+
+cat >"${TEST_ROOT}/current-state-stale-runtime.sh" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "dispatch_alive": true,
+  "active_worker_processes": 1,
+  "current_state_guardrails": {"available_slots_last": 5},
+  "pulse_gauges": {"dispatch_capacity_final_max_workers": 6},
+  "worker_outcomes": {"spawned": 0},
+  "runtime_freshness": {
+    "status": "blocked_dirty_canonical",
+    "stale": true,
+    "canonical_dirty": true,
+    "canonical_behind_upstream": true,
+    "deployed_behind_upstream": true,
+    "auto_update_status": "runtime_stale_local_changes",
+    "operator_action": "Preserve the local changes, reconcile the canonical checkout, then run aidevops update in an attached terminal"
+  },
+  "graphql_budget_status": "OK fixture"
+}
+JSON
+SH
+chmod +x "${TEST_ROOT}/current-state-stale-runtime.sh"
+STALE_RUNTIME_JSON=$(env "${COMMON_ENV[@]}" \
+	"PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-stale-runtime.sh" "$HELPER" json 2>&1)
+assert_eq "stale runtime is a first-class finding" "1" "$(printf '%s' "$STALE_RUNTIME_JSON" | jq -r '[.findings[] | select(.id == "pulse-runtime-stale")] | length')"
+assert_eq "stale runtime status is summarized" "blocked_dirty_canonical" "$(printf '%s' "$STALE_RUNTIME_JSON" | jq -r '.summary.runtime_freshness_status')"
+assert_contains "stale runtime preserves safe operator action" "Preserve the local changes" "$STALE_RUNTIME_JSON"
+STALE_RUNTIME_TEXT=$(env "${COMMON_ENV[@]}" \
+	"PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-stale-runtime.sh" "$HELPER" report 2>&1)
+assert_contains "text report shows runtime freshness" "Runtime freshness: blocked_dirty_canonical" "$STALE_RUNTIME_TEXT"
+
+SECONDARY_GH_CALL_LOG="${TEST_ROOT}/secondary-gh-calls.log"
+rm -f "$SECONDARY_GH_CALL_LOG"
+SECONDARY_JSON=$(env "${COMMON_ENV[@]}" \
+	"PULSE_CHECK_SECONDARY_COOLDOWN_FIXTURE=active" \
+	"PULSE_CHECK_GH_CALL_LOG=${SECONDARY_GH_CALL_LOG}" "$HELPER" json 2>&1)
+assert_eq "secondary cooldown stays distinct from healthy GraphQL budget" "OK fixture" "$(printf '%s' "$SECONDARY_JSON" | jq -r '.summary.graphql_budget_status')"
+assert_eq "secondary cooldown is active in summary" "true" "$(printf '%s' "$SECONDARY_JSON" | jq -r '.summary.secondary_cooldown_active')"
+assert_contains "secondary cooldown emits a dedicated finding" "github-secondary-cooldown-active" "$SECONDARY_JSON"
+assert_contains "secondary cooldown skips the queue scan" "pulse-check-queue-scan-skipped" "$SECONDARY_JSON"
+if [[ -s "$SECONDARY_GH_CALL_LOG" ]]; then
+	assert_eq "secondary cooldown suppresses nonessential GitHub reads" "" "$(<"$SECONDARY_GH_CALL_LOG")"
+else
+	assert_eq "secondary cooldown suppresses nonessential GitHub reads" "" ""
+fi
+SECONDARY_TEXT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_SECONDARY_COOLDOWN_FIXTURE=active" "$HELPER" report 2>&1)
+assert_contains "text report exposes active secondary cooldown" "Secondary cooldown: active=yes" "$SECONDARY_TEXT"
 
 MALFORMED_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=malformed" "$HELPER" json 2>&1)
 assert_contains "malformed queue emits normalization shortfall" "pulse-eligible-queue-under-target" "$MALFORMED_OUT"

--- a/.agents/scripts/tests/test-pulse-rate-limit-classifier.sh
+++ b/.agents/scripts/tests/test-pulse-rate-limit-classifier.sh
@@ -197,6 +197,29 @@ else
 	FAIL=$((FAIL + 1))
 fi
 
+# ----- Active secondary cooldown suppresses the corroboration read -----
+_gh_secondary_cooldown_preflight() {
+	local op_class="$1"
+	: "$op_class"
+	return 1
+}
+: >"$GH_CALL_LOG"
+_pulse_mark_rate_limited "secondary_cooldown:owner/repo"
+if [[ ! -s "$GH_CALL_LOG" ]]; then
+	echo "PASS: secondary-cooldown-suppresses-live-probe"
+	PASS=$((PASS + 1))
+else
+	echo "FAIL: secondary-cooldown-suppresses-live-probe — calls: $(tr '\n' ';' <"$GH_CALL_LOG")" >&2
+	FAIL=$((FAIL + 1))
+fi
+if grep -q "secondary_cooldown:owner/repo" "$PULSE_RATE_LIMIT_FLAG" 2>/dev/null; then
+	echo "PASS: secondary-cooldown-preserves-classified-suppression"
+	PASS=$((PASS + 1))
+else
+	echo "FAIL: secondary-cooldown-preserves-classified-suppression" >&2
+	FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ "$FAIL" == "0" ]] || exit 1

--- a/.agents/scripts/tests/test-update-preserves-local-work.sh
+++ b/.agents/scripts/tests/test-update-preserves-local-work.sh
@@ -56,6 +56,16 @@ setup_repo() {
 	return 0
 }
 
+setup_synced_repo() {
+	local repo="$1"
+	local remote="$2"
+	git init -q --bare -b main "$remote"
+	setup_repo "$repo"
+	git -C "$repo" remote add origin "$remote"
+	git -C "$repo" push -qu origin main
+	return 0
+}
+
 setup_ahead_repo() {
 	local repo="$1"
 	local remote="$2"
@@ -131,7 +141,15 @@ _migrate_settings_supervisor_to_orchestration() { :; }
 log_info() { :; }
 log_warn() { :; }
 log_error() { :; }
-update_state() { :; }
+LAST_UPDATE_STATUS=""
+update_state() {
+	local action="$1"
+	local version="${2:-}"
+	local status="${3:-success}"
+	: "$action" "$version"
+	LAST_UPDATE_STATUS="$status"
+	return 0
+}
 AGENTS_DIR="$TEST_ROOT/no-agents"
 AIDEVOPS_SKIP_PULSE_RESTART=1
 _AIDEVOPS_UPDATE_TRUE=true
@@ -189,6 +207,45 @@ elif [[ "$(git -C "$auto_behind_repo" rev-parse HEAD)" != "$auto_remote_commit" 
 	fail 'auto update fast-forwards after fetch' 'HEAD does not match fetched commit'
 else
 	pass 'auto update fast-forwards after fetch'
+fi
+
+auto_dirty_behind_repo="$TEST_ROOT/auto-update-dirty-behind"
+auto_dirty_behind_remote="$TEST_ROOT/auto-update-dirty-behind.git"
+auto_dirty_behind_peer="$TEST_ROOT/auto-update-dirty-behind-peer"
+setup_behind_repo "$auto_dirty_behind_repo" "$auto_dirty_behind_remote" "$auto_dirty_behind_peer"
+auto_dirty_behind_commit="$(git -C "$auto_dirty_behind_repo" rev-parse HEAD)"
+printf 'preserved local diagnostic\n' >>"$auto_dirty_behind_repo/VERSION"
+INSTALL_DIR="$auto_dirty_behind_repo"
+LOG_FILE="$TEST_ROOT/auto-update-dirty-behind.log"
+LAST_UPDATE_STATUS=""
+if _cmd_check_git_update 1.0.1 >/dev/null 2>&1; then
+	fail 'auto update reports stale dirty canonical checkout' 'unexpected success'
+elif [[ "$(git -C "$auto_dirty_behind_repo" rev-parse HEAD)" != "$auto_dirty_behind_commit" ]]; then
+	fail 'auto update reports stale dirty canonical checkout' 'HEAD changed'
+elif [[ "$LAST_UPDATE_STATUS" != "runtime_stale_local_changes" ]]; then
+	fail 'auto update reports stale dirty canonical checkout' "status=$LAST_UPDATE_STATUS"
+elif [[ "$(<"$auto_dirty_behind_repo/VERSION")" != *"preserved local diagnostic"* ]]; then
+	fail 'auto update reports stale dirty canonical checkout' 'local diagnostic content changed'
+else
+	pass 'auto update reports stale dirty canonical checkout'
+fi
+
+auto_detached_repo="$TEST_ROOT/auto-update-detached"
+auto_detached_remote="$TEST_ROOT/auto-update-detached.git"
+setup_synced_repo "$auto_detached_repo" "$auto_detached_remote"
+auto_detached_commit="$(git -C "$auto_detached_repo" rev-parse HEAD)"
+git -C "$auto_detached_repo" checkout -q --detach
+INSTALL_DIR="$auto_detached_repo"
+LOG_FILE="$TEST_ROOT/auto-update-detached.log"
+LAST_UPDATE_STATUS=""
+if _cmd_check_git_update 1.0.1 >/dev/null 2>&1; then
+	fail 'auto update rejects detached exact-SHA checkout' 'unexpected success'
+elif [[ "$(git -C "$auto_detached_repo" rev-parse HEAD)" != "$auto_detached_commit" ]]; then
+	fail 'auto update rejects detached exact-SHA checkout' 'HEAD changed'
+elif [[ "$LAST_UPDATE_STATUS" != "runtime_stale_branch" ]]; then
+	fail 'auto update rejects detached exact-SHA checkout' "status=$LAST_UPDATE_STATUS"
+else
+	pass 'auto update rejects detached exact-SHA checkout'
 fi
 
 interactive_repo="$TEST_ROOT/cmd-update-diverged"
@@ -278,6 +335,24 @@ elif [[ "$(git -C "$check_lib_behind_repo" rev-parse HEAD)" != "$check_lib_remot
 	fail 'check library fast-forwards after fetch' 'HEAD does not match fetched commit'
 else
 	pass 'check library fast-forwards after fetch'
+fi
+
+check_lib_detached_repo="$TEST_ROOT/check-lib-detached"
+check_lib_detached_remote="$TEST_ROOT/check-lib-detached.git"
+setup_synced_repo "$check_lib_detached_repo" "$check_lib_detached_remote"
+check_lib_detached_commit="$(git -C "$check_lib_detached_repo" rev-parse HEAD)"
+git -C "$check_lib_detached_repo" checkout -q --detach
+INSTALL_DIR="$check_lib_detached_repo"
+LOG_FILE="$TEST_ROOT/check-lib-detached.log"
+LAST_UPDATE_STATUS=""
+if _cmd_check_git_update 1.0.1 >/dev/null 2>&1; then
+	fail 'check library rejects detached exact-SHA checkout' 'unexpected success'
+elif [[ "$(git -C "$check_lib_detached_repo" rev-parse HEAD)" != "$check_lib_detached_commit" ]]; then
+	fail 'check library rejects detached exact-SHA checkout' 'HEAD changed'
+elif [[ "$LAST_UPDATE_STATUS" != "runtime_stale_branch" ]]; then
+	fail 'check library rejects detached exact-SHA checkout' "status=$LAST_UPDATE_STATUS"
+else
+	pass 'check library rejects detached exact-SHA checkout'
 fi
 
 check_lib_diverged_repo="$TEST_ROOT/check-lib-diverged"


### PR DESCRIPTION
## Summary

Fetch same-version upstream changes without destroying canonical state, report canonical/deployed/upstream drift, and enforce active secondary cooldown before nonessential GitHub reads. This PR also Resolves #30958.

## Files Changed

.agents/scripts/auto-update-helper-check.sh, .agents/scripts/auto-update-helper.sh, .agents/scripts/pulse-check-helper.sh, .agents/scripts/pulse-check-report.jq, .agents/scripts/pulse-current-state-helper.sh, .agents/scripts/pulse-prefetch-infra.sh, .agents/scripts/tests/test-agent-deploy-pulse-runtime.sh, .agents/scripts/tests/test-pulse-check-helper.sh, .agents/scripts/tests/test-pulse-rate-limit-classifier.sh, .agents/scripts/tests/test-update-preserves-local-work.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime-verified: test-update-preserves-local-work.sh (17/17), test-agent-deploy-pulse-runtime.sh (16/16), test-pulse-check-helper.sh (120/120), test-pulse-rate-limit-classifier.sh (21/21), test-atomic-runtime-bundle-deploy.sh (46/46), test-aidevops-update-transaction.sh (18/18), test-cmd-update-sha-drift.sh (15/15), test-gh-secondary-cooldown.sh (19/19), linters-local.sh, version-manager.sh validate, and live pulse-check JSON freshness evidence.

Resolves #30956


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.296 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 53m and 588,302 tokens on this with the user in an interactive session.