### PR TITLE
GH#30956: recognize protected release merge trees

### DIFF
--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 UNKNOWN_STATUS="unknown"
+CURRENT_STATUS="current"
 
 _usage() {
 	cat <<'EOF'
@@ -56,6 +57,37 @@ _runtime_manifest_value() {
 	return 1
 }
 
+_runtime_commits_share_tree() {
+	local repo_path="$1"
+	local left_sha="$2"
+	local right_sha="$3"
+	local left_tree="" right_tree=""
+	left_tree=$(git -C "$repo_path" rev-parse "${left_sha}^{tree}" 2>/dev/null) || return 1
+	right_tree=$(git -C "$repo_path" rev-parse "${right_sha}^{tree}" 2>/dev/null) || return 1
+	[[ -n "$left_tree" && "$left_tree" == "$right_tree" ]]
+	return $?
+}
+
+_runtime_deployment_relation() {
+	local repo_path="$1"
+	local deployed_sha="$2"
+	local upstream_sha="$3"
+	if [[ -z "$deployed_sha" ]]; then
+		printf '%s' "$UNKNOWN_STATUS"
+	elif [[ "$deployed_sha" == "$upstream_sha" ]]; then
+		printf '%s' "$CURRENT_STATUS"
+	elif git -C "$repo_path" merge-base --is-ancestor "$deployed_sha" "$upstream_sha" 2>/dev/null; then
+		if _runtime_commits_share_tree "$repo_path" "$deployed_sha" "$upstream_sha"; then
+			printf '%s' "$CURRENT_STATUS"
+		else
+			printf '%s' "behind"
+		fi
+	else
+		printf '%s' "$UNKNOWN_STATUS"
+	fi
+	return 0
+}
+
 _runtime_freshness_json() {
 	local repo_path="$1"
 	local agents_path="${AIDEVOPS_RUNTIME_AGENTS_PATH:-${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}}"
@@ -64,10 +96,10 @@ _runtime_freshness_json() {
 	local update_state_file="${AIDEVOPS_AUTO_UPDATE_STATE_FILE:-${HOME}/.aidevops/cache/auto-update-state.json}"
 	local upstream_ref="${AIDEVOPS_RUNTIME_UPSTREAM_REF:-}"
 	local canonical_sha="" upstream_sha="" deployed_sha="" manifest_sha="" stamp_sha=""
-	local auto_update_status="$UNKNOWN_STATUS" auto_update_at=""
+	local auto_update_status="$UNKNOWN_STATUS" auto_update_at="" deployment_relation=""
 	local status="$UNKNOWN_STATUS" action="Verify the canonical checkout and active runtime bundle"
 	local canonical_dirty=false canonical_on_main=false canonical_behind=false
-	local canonical_ahead=false canonical_diverged=false deployed_behind=false stale=false
+	local canonical_ahead=false canonical_diverged=false deployed_current=false deployed_behind=false stale=false
 
 	if [[ -z "$upstream_ref" ]]; then
 		upstream_ref=$(git -C "$repo_path" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
@@ -106,9 +138,9 @@ _runtime_freshness_json() {
 				canonical_diverged=true
 			fi
 		fi
-		if [[ -n "$deployed_sha" && "$deployed_sha" != "$upstream_sha" ]] && git -C "$repo_path" merge-base --is-ancestor "$deployed_sha" "$upstream_sha" 2>/dev/null; then
-			deployed_behind=true
-		fi
+		deployment_relation=$(_runtime_deployment_relation "$repo_path" "$deployed_sha" "$upstream_sha")
+		[[ "$deployment_relation" == "$CURRENT_STATUS" ]] && deployed_current=true
+		[[ "$deployment_relation" == "behind" ]] && deployed_behind=true
 	fi
 
 	if [[ "$canonical_dirty" == true ]]; then
@@ -126,17 +158,17 @@ _runtime_freshness_json() {
 	elif [[ "$canonical_diverged" == true ]]; then
 		status="canonical_diverged_upstream"
 		action="Preserve and reconcile the divergent canonical history before updating the runtime"
+	elif [[ "$deployed_current" == true && "$canonical_sha" == "$upstream_sha" ]]; then
+		status="$CURRENT_STATUS"
+		action="No action required"
 	elif [[ -n "$deployed_sha" && -n "$canonical_sha" && "$deployed_sha" != "$canonical_sha" ]]; then
 		status="deployed_behind_canonical"
 		action="Run setup.sh --stage ai-session from the canonical checkout"
-	elif [[ -n "$deployed_sha" && -n "$upstream_sha" && "$deployed_sha" == "$upstream_sha" && "$canonical_sha" == "$upstream_sha" ]]; then
-		status="current"
-		action="No action required"
 	elif [[ "$deployed_behind" == true ]]; then
 		status="deployed_behind_upstream"
 		action="Run aidevops update in an attached terminal"
 	fi
-	[[ "$status" == "current" || "$status" == "$UNKNOWN_STATUS" ]] || stale=true
+	[[ "$status" == "$CURRENT_STATUS" || "$status" == "$UNKNOWN_STATUS" ]] || stale=true
 
 	jq -n \
 		--arg status "$status" --arg action "$action" --arg upstream_ref "$upstream_ref" \

--- a/.agents/scripts/tests/test-agent-deploy-pulse-runtime.sh
+++ b/.agents/scripts/tests/test-agent-deploy-pulse-runtime.sh
@@ -264,6 +264,43 @@ runtime_freshness_output() {
 	return 0
 }
 
+test_protected_release_merge_freshness() {
+	local remote_repo="$TEST_ROOT/protected-release-origin.git"
+	local canonical_repo="$TEST_ROOT/protected-release-canonical"
+	local log_dir="$TEST_ROOT/protected-release-logs"
+	local manifest_file="$TEST_ROOT/protected-release-manifest"
+	local update_state_file="$TEST_ROOT/protected-release-update-state.json"
+	local base_sha="" release_sha="" release_tree="" merge_sha="" output=""
+
+	git init -q --bare -b main "$remote_repo"
+	git init -q -b main "$canonical_repo"
+	git -C "$canonical_repo" config user.name Test
+	git -C "$canonical_repo" config user.email test@example.invalid
+	printf 'base\n' >"$canonical_repo/runtime.txt"
+	git -C "$canonical_repo" add runtime.txt
+	git -C "$canonical_repo" commit -qm base
+	git -C "$canonical_repo" remote add origin "$remote_repo"
+	git -C "$canonical_repo" push -qu origin main
+	base_sha=$(git -C "$canonical_repo" rev-parse HEAD)
+	printf 'release\n' >>"$canonical_repo/runtime.txt"
+	git -C "$canonical_repo" commit -am release -q
+	release_sha=$(git -C "$canonical_repo" rev-parse HEAD)
+	release_tree=$(git -C "$canonical_repo" rev-parse 'HEAD^{tree}')
+	merge_sha=$(printf 'protected release merge\n' | git -C "$canonical_repo" commit-tree "$release_tree" -p "$base_sha" -p "$release_sha")
+	git -C "$canonical_repo" update-ref refs/heads/main "$merge_sha"
+	git -C "$canonical_repo" push -q origin main
+	mkdir -p "$log_dir"
+	printf 'schema=1\nstatus=validated\ngit_sha=%s\n' "$release_sha" >"$manifest_file"
+	printf '%s\n' '{"last_status":"up_to_date","last_timestamp":"2026-09-01T00:00:00Z"}' >"$update_state_file"
+
+	output=$(runtime_freshness_output "$manifest_file" "$update_state_file" "$canonical_repo" "$log_dir")
+	assert_eq "current" "$(printf '%s' "$output" | jq -r '.runtime_freshness.status')" \
+		"signed release parent with protected-merge tree reports current"
+	assert_eq "false" "$(printf '%s' "$output" | jq -r '.runtime_freshness.deployed_behind_upstream')" \
+		"tree-equivalent signed release is not reported behind upstream"
+	return 0
+}
+
 test_runtime_freshness_diagnostics() {
 	local remote_repo="$TEST_ROOT/runtime-origin.git"
 	local canonical_repo="$TEST_ROOT/runtime-canonical"
@@ -379,6 +416,7 @@ main() {
 	test_concurrent_transition_converges_on_active_bundle "$stale_root" "$active_root" "$active_link"
 	test_launchd_disabled_service_stays_stopped "$active_root" "$active_link"
 	test_launchd_enabled_service_owns_restart "$active_root" "$active_link"
+	test_protected_release_merge_freshness
 	test_runtime_freshness_diagnostics
 
 	printf 'Results: %s checks passed\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Treat a deployed signed release commit as current when it is an ancestor of the canonical protected-main merge and both commits resolve to the same Git tree.

## Files Changed

.agents/scripts/pulse-current-state-helper.sh, .agents/scripts/tests/test-agent-deploy-pulse-runtime.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime regression fixture passed 18/18; Pulse report tests passed 120/120; linters-local.sh, ShellCheck, complexity gates, secret checks, and version validation passed.

Resolves #30956


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 2h 20m and 951,522 tokens on this with the user in an interactive session.