### PR TITLE
GH#30970: fix: trust Tilt Neon Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -26,6 +26,7 @@ elysia
 @fontsource/poppins
 @fontsource/ibm-plex-serif
 @fontsource/source-serif-4
+@fontsource/tilt-neon
 @fontsource/ubuntu
 @secretlint/secretlint-rule-preset-recommend
 typescript

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "@fontsource/poppins": "5.3.0",
         "@fontsource/source-sans-3": "5.3.0",
         "@fontsource/source-serif-4": "5.3.0",
-        "@fontsource/tilt-neon": "5.2.10",
+        "@fontsource/tilt-neon": "5.3.0",
         "@fontsource/ubuntu": "5.3.0",
         "@fontsource/ubuntu-mono": "5.2.8",
         "@fontsource/zilla-slab": "5.3.0",
@@ -118,7 +118,7 @@
 
     "@fontsource/source-serif-4": ["@fontsource/source-serif-4@5.3.0", "", {}, "sha512-yQz8xmIgMzks8zQbpuca3UYtjxK798XCyQAGdDXmzBgvV7sdoK6d0YvE9F9kiYxORCEMRBgGZDZsSYcXj5KvwA=="],
 
-    "@fontsource/tilt-neon": ["@fontsource/tilt-neon@5.2.10", "", {}, "sha512-qBointHhyP7K/avRTmfYkHUrGoCOLt3EG0dpXKJdHua/2OjU74YrCUeVIFO9agSX6A0dM2dUUsrE2ZuxYwC1Eg=="],
+    "@fontsource/tilt-neon": ["@fontsource/tilt-neon@5.3.0", "", {}, "sha512-A9C6HZEwi8TWuLiSzJQdpeb7F3rbB+nfe5MswkiR27iZVgZ9DAAB3fORtYIkAbndhH9ydnwfOJC2oR04HXyW5w=="],
 
     "@fontsource/ubuntu": ["@fontsource/ubuntu@5.3.0", "", {}, "sha512-LsjJXgE430QLs8LKfn1RIFbbdGAiZBU1gao8ASa4Z2kGNGh7lMb7Rzx09v3bLLuuK+3XA/JSLgPWTAbLD6r1fg=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -18,7 +18,7 @@
     "@fontsource/poppins": "5.3.0",
     "@fontsource/source-sans-3": "5.3.0",
     "@fontsource/source-serif-4": "5.3.0",
-    "@fontsource/tilt-neon": "5.2.10",
+    "@fontsource/tilt-neon": "5.3.0",
     "@fontsource/ubuntu": "5.3.0",
     "@fontsource/ubuntu-mono": "5.2.8",
     "@fontsource/zilla-slab": "5.3.0",


### PR DESCRIPTION
## Summary

Reused the verified Tilt Neon 5.3.0 Dependabot update and allowlisted the exact package after confirming its same-repository bot identity, dependency-only diff, clean production audit, and green non-review checks.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, bun.lock, packages/gui-web/package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile --ignore-scripts; bun audit --production; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; bun run gui:typecheck; bun run gui:test:components; bun run gui:build

Resolves #30970


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 8m and 110,111 tokens on this as a headless worker.