### PR TITLE
GH#30964: Add executable managed GitHub create subcommands

### DIFF
--- a/.agents/reference/gh-command-discipline.md
+++ b/.agents/reference/gh-command-discipline.md
@@ -72,9 +72,11 @@ their existing behavior.
   `gh_create_issue`, `gh_pr_comment`, or `gh_create_pr` with `--body-file`;
   wrappers sign at execution time. Create wrappers also accept `--body-file -`,
   securely buffer stdin once, and reuse that body for validation and fallback.
-- Safe edit pattern: run `gh-write-helper.sh issue edit` or
+- Executable managed-write pattern: run `gh-write-helper.sh issue create`,
+  `gh-write-helper.sh pr create`, `gh-write-helper.sh issue edit`, or
   `gh-write-helper.sh pr edit`. Use `--body-file -` for streamed bodies; the
-  executable loads the audited wrappers internally without caller-side `source`.
+  executable loads the audited create/edit wrappers internally without
+  caller-side `source`.
 - ANTI-PATTERN (blocked by t2893 enforcement): same-command heredoc, process
   substitution, command substitution, or shell-variable body construction such
   as passing a heredoc through command substitution to `--body`, passing

--- a/.agents/scripts/gh-write-helper.sh
+++ b/.agents/scripts/gh-write-helper.sh
@@ -11,7 +11,8 @@ trap '_run_cleanups' EXIT
 trap '_run_cleanups; exit 130' HUP INT TERM
 
 usage() {
-	printf 'Usage: gh-write-helper.sh {issue|pr} edit <number-or-url> [gh edit options]\n'
+	printf 'Usage: gh-write-helper.sh {issue|pr} create [gh create options]\n'
+	printf '       gh-write-helper.sh {issue|pr} edit <number-or-url> [gh edit options]\n'
 	printf 'Bodies may use --body-file - to read stdin once through the safe wrapper.\n'
 	return 0
 }
@@ -23,14 +24,16 @@ main() {
 		usage
 		return 0
 	fi
-	if [[ "$action" != "edit" ]]; then
+	if [[ "$action" != "create" && "$action" != "edit" ]]; then
 		usage >&2
 		return 2
 	fi
 	shift 2
-	case "$resource" in
-	issue) gh_issue_edit_safe "$@" ;;
-	pr) gh_pr_edit_safe "$@" ;;
+	case "${resource}:${action}" in
+	issue:create) gh_create_issue "$@" ;;
+	issue:edit) gh_issue_edit_safe "$@" ;;
+	pr:create) gh_create_pr "$@" ;;
+	pr:edit) gh_pr_edit_safe "$@" ;;
 	*)
 		usage >&2
 		return 2

--- a/.agents/scripts/tests/test-gh-wrapper-stdin.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-stdin.sh
@@ -183,10 +183,58 @@ printf '%s\n' "$*" >>"$GH_CALLS"
 case "${1:-} ${2:-}" in
 "issue view" | "pr view") printf '%s\n' '{"title":"Existing","body":"Existing","labels":[]}' ;;
 "api repos/test/repo" | "api graphql") printf '%s\n' 'false' ;;
+"api /repos/test/repo/issues/999") printf '%s\n' 'origin:interactive' ;;
+"issue create") printf '%s\n' 'https://github.com/test/repo/issues/999' ;;
+"pr create") printf '%s\n' 'https://github.com/test/repo/pull/999' ;;
 esac
 exit 0
 STUB
 chmod +x "${STUB_BIN}/gh"
+
+EXECUTABLE_CREATE_BODY="${TMP}/executable-create-body.md"
+printf 'Executable path-backed issue body\n' >"$EXECUTABLE_CREATE_BODY"
+: >"$GH_CALLS"
+PATH="${STUB_BIN}:$PATH" "${SCRIPTS_DIR}/gh-write-helper.sh" issue create \
+	--repo test/repo --title "Executable issue create" \
+	--body-file "$EXECUTABLE_CREATE_BODY" >/dev/null 2>&1
+issue_create_rc=$?
+if [[ $issue_create_rc -eq 0 ]] && [[ "$(grep -c '^issue create ' "$GH_CALLS")" -eq 1 ]]; then
+	pass "standalone helper routes path-backed issue creation exactly once"
+else
+	fail "standalone helper routes path-backed issue creation exactly once" "rc=${issue_create_rc}"
+fi
+
+: >"$GH_CALLS"
+printf 'Executable streamed PR body\n' | PATH="${STUB_BIN}:$PATH" \
+	"${SCRIPTS_DIR}/gh-write-helper.sh" pr create --repo test/repo \
+	--title "Executable PR create" --body-file - >/dev/null 2>&1
+pr_create_helper_rc=$?
+if [[ $pr_create_helper_rc -eq 0 ]] && [[ "$(grep -c '^pr create ' "$GH_CALLS")" -eq 1 ]]; then
+	pass "standalone helper routes streamed PR creation exactly once"
+else
+	fail "standalone helper routes streamed PR creation exactly once" "rc=${pr_create_helper_rc}"
+fi
+
+: >"$GH_CALLS"
+printf '' | PATH="${STUB_BIN}:$PATH" "${SCRIPTS_DIR}/gh-write-helper.sh" issue create \
+	--repo test/repo --title "Rejected empty issue" --body-file - >/dev/null 2>&1
+empty_helper_rc=$?
+if [[ $empty_helper_rc -eq 1 && ! -s "$GH_CALLS" ]]; then
+	pass "standalone helper rejects an empty create body before a GitHub write"
+else
+	fail "standalone helper rejects an empty create body before a GitHub write" "rc=${empty_helper_rc}"
+fi
+
+: >"$GH_CALLS"
+PATH="${STUB_BIN}:$PATH" "${SCRIPTS_DIR}/gh-write-helper.sh" issue delete 123 \
+	--repo test/repo >/dev/null 2>&1
+unsupported_helper_rc=$?
+if [[ $unsupported_helper_rc -eq 2 && ! -s "$GH_CALLS" ]]; then
+	pass "standalone helper rejects unsupported actions before a GitHub write"
+else
+	fail "standalone helper rejects unsupported actions before a GitHub write" "rc=${unsupported_helper_rc}"
+fi
+
 : >"$GH_CALLS"
 printf 'Edited body\n' | PATH="${STUB_BIN}:$PATH" \
 	"${SCRIPTS_DIR}/gh-write-helper.sh" issue edit 123 --repo test/repo --body-file - >/dev/null 2>&1


### PR DESCRIPTION
## Summary

Expose fixed issue/pr create actions through gh-write-helper while preserving the audited wrapper boundary and existing edit behavior.

## Files Changed

.agents/reference/gh-command-discipline.md, .agents/scripts/gh-write-helper.sh, .agents/scripts/tests/test-gh-wrapper-stdin.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: test-gh-wrapper-stdin.sh 14/14; canonical Git command guard 93/93; ShellCheck and linters-local.sh --changed passed.

Resolves #30964


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 21m and 177,197 tokens on this with the user in an interactive session.