### PR TITLE
GH#30971: trust IBM Plex Sans Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -24,6 +24,7 @@ elysia
 @types/react
 @fontsource/dm-sans
 @fontsource/poppins
+@fontsource/ibm-plex-sans
 @fontsource/ibm-plex-serif
 @fontsource/source-serif-4
 @fontsource/ubuntu


### PR DESCRIPTION
Resolves #30971

## Summary

Allowlists the verified `@fontsource/ibm-plex-sans` Dependabot update so its exact-head, same-repository dependency-only PR can use the existing narrow trust gate.

The source PR's non-review checks and security audit are green; its sole terminal failure is the policy-ineligible review gate.

## Verification

- `bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh`
- `bun --filter @aidevops/gui-web test`
- `bun audit --filter @aidevops/gui-web`

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra
