### PR TITLE
GH#30973: fix: trust Mohave Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -23,6 +23,7 @@ elysia
 @types/bun
 @types/react
 @fontsource/dm-sans
+@fontsource/mohave
 @fontsource/poppins
 @fontsource/ibm-plex-serif
 @fontsource/source-serif-4

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
         "@fontsource/ibm-plex-sans": "5.2.8",
         "@fontsource/ibm-plex-serif": "5.3.0",
         "@fontsource/inter": "5.2.8",
-        "@fontsource/mohave": "5.2.10",
+        "@fontsource/mohave": "5.3.0",
         "@fontsource/playpen-sans": "5.3.0",
         "@fontsource/poppins": "5.3.0",
         "@fontsource/source-sans-3": "5.3.0",
@@ -108,7 +108,7 @@
 
     "@fontsource/inter": ["@fontsource/inter@5.2.8", "", {}, "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg=="],
 
-    "@fontsource/mohave": ["@fontsource/mohave@5.2.10", "", {}, "sha512-YyK9N7xedYTpFRPo5lpTeNhBOqzapv/WdRv6YtyOHiux/JA5C/sPa6+wL92nNq4sYN7acSFyQQaSFzIoK8VLGw=="],
+    "@fontsource/mohave": ["@fontsource/mohave@5.3.0", "", {}, "sha512-DxFmpRJfk6Ga43UPHRzYi1/2xOifiCxGHlZhDx9aY9vusnDNLRfyWooqv11dlarVCeAtU+09PoZf0587oYZNAA=="],
 
     "@fontsource/playpen-sans": ["@fontsource/playpen-sans@5.3.0", "", {}, "sha512-94O9WdgAmvFpAjsPOgg5JZII4clcNeeMqQdNZh7Jz40rmcNv05jzwxyuw25IRjTb4o2aMV7eXjXC8GTFo/+s8Q=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -13,7 +13,7 @@
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@fontsource/ibm-plex-serif": "5.3.0",
     "@fontsource/inter": "5.2.8",
-    "@fontsource/mohave": "5.2.10",
+    "@fontsource/mohave": "5.3.0",
     "@fontsource/playpen-sans": "5.3.0",
     "@fontsource/poppins": "5.3.0",
     "@fontsource/source-sans-3": "5.3.0",


### PR DESCRIPTION
## Summary

Updates @fontsource/mohave to 5.3.0 and explicitly allows this verified exact-head Dependabot update after the source PR's review gate classified it as external.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, bun.lock, packages/gui-web/package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile --ignore-scripts; bun audit; bun run gui:typecheck; bun run gui:test:components; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

Resolves #30973


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 7m and 65,784 tokens on this as a headless worker.