### PR TITLE
GH#30965: bound recovery maintenance scans

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -235,11 +235,13 @@ the store exceeds 5 GiB, filesystem free space is below 10 GiB, or filesystem
 free space is below 10 percent. If bounded aggregate sizing times out, the pass
 enters conservative pressure mode with `aggregate-size-unavailable` rather than
 silently disabling the store limit; exact per-bucket sizing and all terminal
-evidence remain mandatory before deletion. One pass scans at most 50 rotating
-inventory entries, stops after a 120-second classification deadline, and applies
-at most 20 candidates or 5 GiB. A persistent cursor advances after a deadline
-stop so large inventories cannot starve later entries. Operators may tune these
-soft limits with:
+evidence remain mandatory before deletion. One pass cheaply enumerates paths,
+then validates and classifies at most 50 rotating inventory entries inside a
+120-second deadline, and applies at most 20 candidates or 5 GiB. Expensive
+per-archive Git validation is limited to that cursor window and bounded by the
+same deadline. A persistent cursor advances after a deadline stop so large
+inventories cannot starve later entries. Operators may tune these soft limits
+with:
 
 - `AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_RETENTION_DAYS`
 - `AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_SCAN`

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -79,7 +79,9 @@ _WT_RECOVERY_FORMAT="$_WT_RECOVERY_FORMAT_V2"
 _WT_RECOVERY_DIR_NAME=".aidevops-worktree-recovery"
 _WT_RECOVERY_COMPLETE_MARKER="archive-complete"
 _WT_RECOVERY_STORAGE_OWNER="framework"
+_WT_RECOVERY_STORAGE_OWNER_JOINT="joint"
 _WT_RECOVERY_ROOT_UNAVAILABLE="$_WT_STATE_UNAVAILABLE"
+_WT_PLATFORM_DARWIN="Darwin"
 _WT_RECOVERY_BRANCH_DETACHED="detached"
 _WT_RECOVERY_OUTCOME_PENDING="pending"
 _WT_RECOVERY_OUTCOME_REMOVED="removed"
@@ -816,8 +818,27 @@ _worktree_write_recovery_identity() {
 	return 0
 }
 
+_worktree_recovery_run_before_epoch() {
+	local deadline_epoch="$1"
+	shift
+	local current_epoch=0
+	local remaining_seconds=0
+
+	if [[ "$deadline_epoch" -eq 0 ]]; then
+		"$@"
+		return $?
+	fi
+	current_epoch=$(date +%s) || return 1
+	remaining_seconds=$((deadline_epoch - current_epoch))
+	[[ "$remaining_seconds" -gt 0 ]] || return 124
+	declare -F timeout_sec >/dev/null 2>&1 || return 124
+	timeout_sec "$remaining_seconds" "$@"
+	return $?
+}
+
 _worktree_recovery_archive_is_valid() {
 	local archive_path="$1"
+	local deadline_epoch="${2:-0}"
 	local recovery_dir=""
 	local recovery_admin=""
 	local recovery_admin_real=""
@@ -845,12 +866,16 @@ _worktree_recovery_archive_is_valid() {
 	fi
 	real_git=$(_worktree_cleanup_real_git) || return 1
 	recovery_admin_real=$(cd "$recovery_admin" 2>/dev/null && pwd -P) || return 1
-	actual_admin=$("$real_git" -C "$archive_path" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+	actual_admin=$(_worktree_recovery_run_before_epoch "$deadline_epoch" \
+		"$real_git" -C "$archive_path" rev-parse --absolute-git-dir 2>/dev/null) || return $?
 	actual_admin=$(cd "$actual_admin" 2>/dev/null && pwd -P) || return 1
 	[[ "$actual_admin" == "$recovery_admin_real" ]] || return 1
-	actual_head=$("$real_git" -C "$archive_path" rev-parse --verify HEAD 2>/dev/null) || return 1
+	actual_head=$(_worktree_recovery_run_before_epoch "$deadline_epoch" \
+		"$real_git" -C "$archive_path" rev-parse --verify HEAD 2>/dev/null) || return $?
 	[[ "$actual_head" == "$expected_head" ]] || return 1
-	"$real_git" -C "$archive_path" status --porcelain=v1 -z --untracked-files=all >/dev/null 2>&1 || return 1
+	_worktree_recovery_run_before_epoch "$deadline_epoch" \
+		"$real_git" -C "$archive_path" status --porcelain=v1 -z --untracked-files=all \
+		>/dev/null 2>&1 || return $?
 	return 0
 }
 
@@ -916,13 +941,14 @@ _worktree_legacy_recovery_root() {
 	if [[ -z "$platform" ]]; then
 		platform=$(uname -s 2>/dev/null) || return 1
 	fi
-	[[ "$platform" != "Darwin" ]] || return 1
+	[[ "$platform" != "$_WT_PLATFORM_DARWIN" ]] || return 1
 	printf '%s/.Trash\n' "$HOME"
 	return 0
 }
 
 _worktree_legacy_recovery_bucket_is_valid() {
 	local bucket="$1"
+	local deadline_epoch="${2:-0}"
 	local recovery_dir="${bucket}/${_WT_RECOVERY_DIR_NAME}"
 	local recorded_gitdir=""
 	local archive_path=""
@@ -934,7 +960,7 @@ _worktree_legacy_recovery_bucket_is_valid() {
 	*) return 1 ;;
 	esac
 	[[ "${archive_path%/*}" == "$bucket" ]] || return 1
-	_worktree_recovery_archive_is_valid "$archive_path" || return 1
+	_worktree_recovery_archive_is_valid "$archive_path" "$deadline_epoch" || return $?
 	return 0
 }
 
@@ -976,6 +1002,67 @@ _worktree_recovery_storage_contract_is_valid() {
 	return 0
 }
 
+_worktree_recovery_inventory_bucket_state() {
+	local bucket="$1"
+	local root_real="$2"
+	local deadline_epoch="${3:-0}"
+	local completion=""
+	local format=""
+	local state="unknown"
+	local validation_status=1
+
+	if [[ -d "$bucket" && ! -L "$bucket" &&
+		-d "$bucket/${_WT_RECOVERY_DIR_NAME}" &&
+		! -L "$bucket/${_WT_RECOVERY_DIR_NAME}" &&
+		-f "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
+		! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
+		-f "$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" &&
+		! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" ]]; then
+		IFS= read -r format <"$bucket/${_WT_RECOVERY_DIR_NAME}/format" || format=""
+		IFS= read -r completion < \
+			"$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || completion=""
+		validation_status=1
+		if _worktree_recovery_format_is_supported "$format" &&
+			[[ "$completion" == "$format" ]] &&
+			_worktree_recovery_storage_contract_is_valid "$bucket" "$root_real"; then
+			validation_status=0
+			_worktree_legacy_recovery_bucket_is_valid "$bucket" "$deadline_epoch" || validation_status=$?
+			[[ "$validation_status" -ne 0 ]] || state="attributed"
+		fi
+	elif [[ -d "$bucket" && ! -L "$bucket" &&
+		-f "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
+		! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/format" ]]; then
+		IFS= read -r format <"$bucket/${_WT_RECOVERY_DIR_NAME}/format" || format=""
+		validation_status=1
+		if [[ "$format" == "$_WT_RECOVERY_FORMAT_V1" ]] &&
+			! _worktree_recovery_extended_metadata_is_present "$bucket"; then
+			validation_status=0
+			_worktree_legacy_recovery_bucket_is_valid "$bucket" "$deadline_epoch" || validation_status=$?
+			[[ "$validation_status" -ne 0 ]] || state="attributed-legacy"
+		fi
+	fi
+	[[ "$validation_status" -ne 124 ]] || return 124
+	printf '%s\n' "$state"
+	return 0
+}
+
+_worktree_recovery_inventory_paths_root() {
+	local root_path="$1"
+	local store_role="$2"
+	local root_owner="$3"
+	local root_real="$root_path"
+	local bucket=""
+
+	[[ -d "$root_path" && ! -L "$root_path" ]] || return 0
+	root_real=$(cd "$root_path" 2>/dev/null && pwd -P) || return 1
+	for bucket in "$root_real"/aidevops-worktree-cleanup-*; do
+		[[ -e "$bucket" || -L "$bucket" ]] || continue
+		printf 'bucket\t%s\t%s\t%s\n' \
+			"$store_role" "$root_owner" "$bucket"
+	done
+	return 0
+}
+
 _worktree_recovery_inventory_root() {
 	local root_path="$1"
 	local store_role="$2"
@@ -983,8 +1070,6 @@ _worktree_recovery_inventory_root() {
 	local root_real="$root_path"
 	local root_state="missing"
 	local bucket=""
-	local completion=""
-	local format=""
 	local state="unknown"
 
 	if [[ -d "$root_path" ]]; then
@@ -998,33 +1083,7 @@ _worktree_recovery_inventory_root() {
 	[[ "$root_state" == "present" ]] || return 0
 	for bucket in "$root_real"/aidevops-worktree-cleanup-*; do
 		[[ -e "$bucket" || -L "$bucket" ]] || continue
-		state="unknown"
-		if [[ -d "$bucket" && ! -L "$bucket" &&
-			-d "$bucket/${_WT_RECOVERY_DIR_NAME}" &&
-			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}" &&
-			-f "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
-			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
-			-f "$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" &&
-			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" ]]; then
-			IFS= read -r format <"$bucket/${_WT_RECOVERY_DIR_NAME}/format" || format=""
-			IFS= read -r completion < \
-				"$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || completion=""
-			if _worktree_recovery_format_is_supported "$format" &&
-				[[ "$completion" == "$format" ]] &&
-				_worktree_recovery_storage_contract_is_valid "$bucket" "$root_real" &&
-				_worktree_legacy_recovery_bucket_is_valid "$bucket"; then
-				state="attributed"
-			fi
-		elif [[ -d "$bucket" && ! -L "$bucket" &&
-			-f "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
-			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/format" ]]; then
-			IFS= read -r format <"$bucket/${_WT_RECOVERY_DIR_NAME}/format" || format=""
-			if [[ "$format" == "$_WT_RECOVERY_FORMAT_V1" ]] &&
-				! _worktree_recovery_extended_metadata_is_present "$bucket" &&
-				_worktree_legacy_recovery_bucket_is_valid "$bucket"; then
-				state="attributed-legacy"
-			fi
-		fi
+		state=$(_worktree_recovery_inventory_bucket_state "$bucket" "$root_real") || return 1
 		printf 'bucket\t%s\t%s\t%s\t%s\n' \
 			"$store_role" "$_WT_RECOVERY_STORAGE_OWNER" "$state" "$bucket"
 	done
@@ -1037,16 +1096,16 @@ worktree_recovery_inventory() {
 	local platform="${1:-}"
 	local current_root=""
 	local current_root_compare=""
-	local current_owner="framework"
+	local current_owner="$_WT_RECOVERY_STORAGE_OWNER"
 	local legacy_root=""
 	local legacy_root_compare=""
 
 	if [[ -z "$platform" ]]; then
 		platform=$(uname -s 2>/dev/null) || return 1
 	fi
-	if [[ "$platform" == "Darwin" ||
+	if [[ "$platform" == "$_WT_PLATFORM_DARWIN" ||
 		-n "${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}" ]]; then
-		current_owner="joint"
+		current_owner="$_WT_RECOVERY_STORAGE_OWNER_JOINT"
 	fi
 	current_root=$(_worktree_recovery_store_root "$platform") || return 1
 	current_root_compare="$current_root"
@@ -1060,7 +1119,44 @@ worktree_recovery_inventory() {
 			legacy_root_compare=$(cd "$legacy_root" 2>/dev/null && pwd -P) || return 1
 		fi
 		if [[ "$legacy_root_compare" != "$current_root_compare" ]]; then
-			_worktree_recovery_inventory_root "$legacy_root" "legacy" "joint" || return 1
+			_worktree_recovery_inventory_root "$legacy_root" "legacy" \
+				"$_WT_RECOVERY_STORAGE_OWNER_JOINT" || return 1
+		fi
+	fi
+	return 0
+}
+
+# Cheap path-only enumeration for bounded consumers. Bucket attribution remains
+# fail-closed and must be performed separately inside the consumer's work window.
+worktree_recovery_inventory_paths() {
+	local platform="${1:-}"
+	local current_root=""
+	local current_root_compare=""
+	local current_owner="$_WT_RECOVERY_STORAGE_OWNER"
+	local legacy_root=""
+	local legacy_root_compare=""
+
+	if [[ -z "$platform" ]]; then
+		platform=$(uname -s 2>/dev/null) || return 1
+	fi
+	if [[ "$platform" == "$_WT_PLATFORM_DARWIN" ||
+		-n "${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}" ]]; then
+		current_owner="$_WT_RECOVERY_STORAGE_OWNER_JOINT"
+	fi
+	current_root=$(_worktree_recovery_store_root "$platform") || return 1
+	current_root_compare="$current_root"
+	if [[ -d "$current_root" ]]; then
+		current_root_compare=$(cd "$current_root" 2>/dev/null && pwd -P) || return 1
+	fi
+	_worktree_recovery_inventory_paths_root "$current_root" "current" "$current_owner" || return 1
+	if legacy_root=$(_worktree_legacy_recovery_root "$platform"); then
+		legacy_root_compare="$legacy_root"
+		if [[ -d "$legacy_root" ]]; then
+			legacy_root_compare=$(cd "$legacy_root" 2>/dev/null && pwd -P) || return 1
+		fi
+		if [[ "$legacy_root_compare" != "$current_root_compare" ]]; then
+			_worktree_recovery_inventory_paths_root "$legacy_root" "legacy" \
+				"$_WT_RECOVERY_STORAGE_OWNER_JOINT" || return 1
 		fi
 	fi
 	return 0

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -1250,10 +1250,75 @@ test_automatic_maintenance_deadline_advances_cursor() {
 	local home_path="${TEST_DIR}/automatic-deadline-home"
 	local recovery_root="${home_path}/.aidevops/recovery/worktrees"
 	local state_dir="${home_path}/maintenance-state"
-	local output=""
+	local bucket_path="" output=""
+	local started_epoch=0 elapsed_seconds=0
+	local index=0 remaining_buckets=0
 	local rc=0
 
 	mkdir -p "$recovery_root" || rc=1
+	while [[ "$index" -lt 300 ]]; do
+		printf -v bucket_path '%s/aidevops-worktree-cleanup-%03d' "$recovery_root" "$index"
+		mkdir "$bucket_path" || rc=1
+		index=$((index + 1))
+	done
+	started_epoch=$(date +%s) || rc=1
+	output=$(
+		uname() {
+			printf 'Linux\n'
+			return 0
+		}
+		aidevops_disk_capacity_snapshot() {
+			local ignored_path="$1"
+			: "$ignored_path"
+			AIDEVOPS_DISK_CAPACITY_TOTAL_KB=100000
+			AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB=1
+			AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT=0
+			return 0
+		}
+		_worktree_recovery_inventory_bucket_state() {
+			local ignored_bucket="$1"
+			local ignored_root="$2"
+			local deadline_epoch="$3"
+			: "$ignored_bucket" "$ignored_root"
+			_worktree_recovery_run_before_epoch "$deadline_epoch" sleep 5
+			return $?
+		}
+		HOME="$home_path" AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_STATE_DIR="$state_dir" \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_SCAN=1 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_SECONDS=1 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_KB=10 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_PERCENT=0 \
+			worktree_recovery_maintenance_run
+	) || rc=1
+	elapsed_seconds=$(($(date +%s) - started_epoch)) || rc=1
+	for bucket_path in "$recovery_root"/aidevops-worktree-cleanup-*; do
+		[[ -d "$bucket_path" ]] && remaining_buckets=$((remaining_buckets + 1))
+	done
+	printf '%s\n' "$output" | jq -e '
+		.outcome == "no-candidates" and .policy.pressure_active == true and
+		.diagnostics.inventory_count == 300 and .diagnostics.scanned_count == 1 and
+		.diagnostics.cursor_before == 0 and .diagnostics.cursor_after == 1 and
+		.diagnostics.deadline_seconds == 1 and .diagnostics.deadline_exhausted == true and
+		.diagnostics.reason_counts.unknown_archive == 1
+	' >/dev/null || rc=1
+	[[ "$elapsed_seconds" -le 6 && "$remaining_buckets" -eq 300 ]] || rc=1
+	print_result "automatic_maintenance_deadline_advances_cursor" "$rc" \
+		"Expected 300 delayed validations to stop within the deadline, advance one cursor entry, and preserve every bucket"
+	return 0
+}
+
+test_automatic_maintenance_bounds_classification_subprocesses() {
+	local home_path="${TEST_DIR}/automatic-classification-timeout-home"
+	local recovery_root="${home_path}/.aidevops/recovery/worktrees"
+	local state_dir="${home_path}/maintenance-state"
+	local bucket_path="${recovery_root}/aidevops-worktree-cleanup-timeout"
+	local output=""
+	local started_epoch=0
+	local elapsed_seconds=0
+	local rc=0
+
+	mkdir -p "$bucket_path" || rc=1
+	started_epoch=$(date +%s) || rc=1
 	output=$(
 		uname() {
 			printf 'Linux\n'
@@ -1271,13 +1336,21 @@ test_automatic_maintenance_deadline_advances_cursor() {
 			local output_path="$1"
 			local ignored_platform="$2"
 			: "$ignored_platform"
-			printf 'attributed\t%s/a\nattributed\t%s/b\nattributed\t%s/c\n' \
-				"$recovery_root" "$recovery_root" "$recovery_root" >"$output_path"
+			printf '%s\n' "$bucket_path" >"$output_path"
 			return $?
+		}
+		_worktree_recovery_inventory_bucket_state() {
+			local ignored_bucket="$1"
+			local ignored_root="$2"
+			local ignored_deadline="$3"
+			: "$ignored_bucket" "$ignored_root" "$ignored_deadline"
+			printf 'attributed\n'
+			return 0
 		}
 		_worktree_recovery_measure_path() {
 			local ignored_path="$1"
-			: "$ignored_path"
+			local ignored_timeout="$2"
+			: "$ignored_path" "$ignored_timeout"
 			printf '1024|exact|\n'
 			return 0
 		}
@@ -1286,26 +1359,27 @@ test_automatic_maintenance_deadline_advances_cursor() {
 			local ignored_path="$2"
 			local ignored_bytes="$3"
 			: "$ignored_role" "$ignored_path" "$ignored_bytes"
-			sleep 2
-			jq -cn --arg disposition "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" \
-				'{disposition:$disposition,reasons:["source-removal-not-complete"]}'
-			return $?
+			sleep 5
+			return 1
 		}
 		HOME="$home_path" AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_STATE_DIR="$state_dir" \
-			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_SCAN=3 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_SCAN=1 \
 			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_SECONDS=1 \
 			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_KB=10 \
 			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_PERCENT=0 \
 			worktree_recovery_maintenance_run
 	) || rc=1
+	elapsed_seconds=$(($(date +%s) - started_epoch)) || rc=1
 	printf '%s\n' "$output" | jq -e '
 		.outcome == "no-candidates" and .policy.pressure_active == true and
-		.diagnostics.inventory_count == 3 and .diagnostics.scanned_count == 1 and
-		.diagnostics.cursor_before == 0 and .diagnostics.cursor_after == 1 and
-		.diagnostics.deadline_seconds == 1 and .diagnostics.deadline_exhausted == true
+		.diagnostics.inventory_count == 1 and .diagnostics.scanned_count == 1 and
+		.diagnostics.cursor_before == 0 and .diagnostics.cursor_after == 0 and
+		.diagnostics.deadline_exhausted == true and
+		.diagnostics.reason_counts.unknown_classification == 1
 	' >/dev/null || rc=1
-	print_result "automatic_maintenance_deadline_advances_cursor" "$rc" \
-		"Expected a bounded pass to stop at its deadline and advance the durable cursor"
+	[[ "$elapsed_seconds" -le 6 && -d "$bucket_path" ]] || rc=1
+	print_result "automatic_maintenance_bounds_classification_subprocesses" "$rc" \
+		"Expected classification and descendants to stop at the aggregate deadline without deleting the bucket"
 	return 0
 }
 
@@ -1390,9 +1464,20 @@ run_zero_candidate_cycle_fixture() {
 		local output_path="$1"
 		local ignored_platform="$2"
 		: "$ignored_platform"
-		printf 'legacy\t%s/unknown-a\nattributed\t%s/protected\nlegacy\t%s/unknown-b\n' \
+		printf '%s/unknown-a\n%s/protected\n%s/unknown-b\n' \
 			"$recovery_root" "$recovery_root" "$recovery_root" >"$output_path"
 		return $?
+	}
+	_worktree_recovery_inventory_bucket_state() {
+		local bucket_path="$1"
+		local ignored_root="$2"
+		local ignored_deadline="$3"
+		: "$ignored_root" "$ignored_deadline"
+		case "$bucket_path" in
+		*/protected) printf 'attributed\n' ;;
+		*) printf 'unknown\n' ;;
+		esac
+		return 0
 	}
 	_worktree_recovery_measure_path() {
 		local ignored_path="$1"
@@ -1669,6 +1754,7 @@ test_automatic_maintenance_is_bounded_and_policy_bound
 test_automatic_maintenance_checks_capacity_before_aggregate_size
 test_automatic_maintenance_enters_pressure_when_aggregate_size_times_out
 test_automatic_maintenance_deadline_advances_cursor
+test_automatic_maintenance_bounds_classification_subprocesses
 test_automatic_maintenance_preserves_bucket_when_exact_size_is_unavailable
 test_automatic_maintenance_escalates_completed_zero_candidate_cycle
 test_automatic_maintenance_resumes_interrupted_apply

--- a/.agents/scripts/worktree-recovery-maintenance-helper.sh
+++ b/.agents/scripts/worktree-recovery-maintenance-helper.sh
@@ -25,7 +25,11 @@ WORKTREE_RECOVERY_MAINTENANCE_BUCKET_COUNT=0
 WORKTREE_RECOVERY_MAINTENANCE_CURSOR_BEFORE=0
 WORKTREE_RECOVERY_MAINTENANCE_CURSOR_AFTER=0
 WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_SECONDS=0
+WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EPOCH=0
 WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=false
+WORKTREE_RECOVERY_MAINTENANCE_REASON_UNKNOWN_ARCHIVE="unknown-archive"
+WORKTREE_RECOVERY_MAINTENANCE_REASON_SIZING_UNAVAILABLE="sizing-unavailable"
+WORKTREE_RECOVERY_MAINTENANCE_REASON_CLASSIFICATION_UNAVAILABLE="classification-unavailable"
 WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_ARCHIVE=0
 WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING=0
 WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION=0
@@ -220,17 +224,16 @@ _worktree_recovery_maintenance_inventory_file() {
 	local record_type=""
 	local role=""
 	local owner=""
-	local state=""
 	local path=""
 
 	: >"$output_path" || return 1
-	inventory=$(GIT_OPTIONAL_LOCKS=0 worktree_recovery_inventory "$platform") || return 1
+	inventory=$(GIT_OPTIONAL_LOCKS=0 worktree_recovery_inventory_paths "$platform") || return 1
 	while IFS= read -r raw_record; do
 		record_type="${raw_record%%$'\t'*}"
 		[[ "$record_type" == "bucket" ]] || continue
-		IFS=$'\t' read -r record_type role owner state path <<<"$raw_record"
-		[[ "$role" == "current" && "$owner" == "framework" ]] || continue
-		printf '%s\t%s\n' "$state" "$path" >>"$output_path" || return 1
+		IFS=$'\t' read -r record_type role owner path <<<"$raw_record"
+		[[ "$role" == "current" && "$owner" == "$_WT_RECOVERY_STORAGE_OWNER" ]] || continue
+		printf '%s\n' "$path" >>"$output_path" || return 1
 	done <<<"$inventory"
 	return 0
 }
@@ -273,32 +276,32 @@ _worktree_recovery_maintenance_record_reason() {
 	local safe_reason=""
 
 	case "$reason" in
-		unknown-archive) safe_reason="unknown_archive" ;;
-		sizing-unavailable) safe_reason="sizing_unavailable" ;;
-		classification-unavailable) safe_reason="classification_unavailable" ;;
-		identity-or-size-changed) safe_reason="identity_or_size_changed" ;;
-		required-evidence-unavailable) safe_reason="required_evidence_unavailable" ;;
-		unrecognised-evidence-state) safe_reason="unrecognised_evidence_state" ;;
-		age-unavailable) safe_reason="age_unavailable" ;;
-		archive-worktree-dirty) safe_reason="archive_worktree_dirty" ;;
-		active-git-worktree-reference) safe_reason="active_git_worktree_reference" ;;
-		active-registry-owner) safe_reason="active_registry_owner" ;;
-		active-session-claim) safe_reason="active_session_claim" ;;
-		active-process-reference) safe_reason="active_process_reference" ;;
-		open-pull-request) safe_reason="open_pull_request" ;;
-		source-removal-not-complete) safe_reason="source_removal_not_complete" ;;
-		detached-or-unresolved-branch) safe_reason="detached_or_unresolved_branch" ;;
-		exact-commit-not-merged) safe_reason="exact_commit_not_merged" ;;
-		linked-task-not-closed) safe_reason="linked_task_not_closed" ;;
-		retention-policy) safe_reason="retention_policy" ;;
-		selection-limit) safe_reason="selection_limit" ;;
-		*)
-			if [[ "$disposition" == "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" ]]; then
-				safe_reason="protected_other"
-			else
-				safe_reason="classification_unavailable"
-			fi
-			;;
+	unknown-archive) safe_reason="unknown_archive" ;;
+	sizing-unavailable) safe_reason="sizing_unavailable" ;;
+	classification-unavailable) safe_reason="classification_unavailable" ;;
+	identity-or-size-changed) safe_reason="identity_or_size_changed" ;;
+	required-evidence-unavailable) safe_reason="required_evidence_unavailable" ;;
+	unrecognised-evidence-state) safe_reason="unrecognised_evidence_state" ;;
+	age-unavailable) safe_reason="age_unavailable" ;;
+	archive-worktree-dirty) safe_reason="archive_worktree_dirty" ;;
+	active-git-worktree-reference) safe_reason="active_git_worktree_reference" ;;
+	active-registry-owner) safe_reason="active_registry_owner" ;;
+	active-session-claim) safe_reason="active_session_claim" ;;
+	active-process-reference) safe_reason="active_process_reference" ;;
+	open-pull-request) safe_reason="open_pull_request" ;;
+	source-removal-not-complete) safe_reason="source_removal_not_complete" ;;
+	detached-or-unresolved-branch) safe_reason="detached_or_unresolved_branch" ;;
+	exact-commit-not-merged) safe_reason="exact_commit_not_merged" ;;
+	linked-task-not-closed) safe_reason="linked_task_not_closed" ;;
+	retention-policy) safe_reason="retention_policy" ;;
+	selection-limit) safe_reason="selection_limit" ;;
+	*)
+		if [[ "$disposition" == "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" ]]; then
+			safe_reason="protected_other"
+		else
+			safe_reason="classification_unavailable"
+		fi
+		;;
 	esac
 	printf '%s\n' "$safe_reason" >>"$output_path"
 	return $?
@@ -511,6 +514,89 @@ _worktree_recovery_maintenance_select_candidate() {
 	return 0
 }
 
+_worktree_recovery_maintenance_start_deadline() {
+	local deadline_seconds="$1"
+	local started_epoch=0
+
+	started_epoch=$(date +%s) || return 1
+	WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_SECONDS="$deadline_seconds"
+	WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EPOCH=$((started_epoch + deadline_seconds))
+	WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=false
+	return 0
+}
+
+_worktree_recovery_maintenance_run_function_before_epoch() {
+	local deadline_epoch="$1"
+	shift
+	local current_epoch=0
+	local command_pid=0
+	local command_pgid=0
+	local command_group=""
+	local monitor_was_enabled=false
+
+	if [[ "$deadline_epoch" -eq 0 ]]; then
+		"$@"
+		return $?
+	fi
+	current_epoch=$(date +%s) || return 1
+	[[ "$current_epoch" -lt "$deadline_epoch" ]] || return 124
+	[[ $- == *m* ]] && monitor_was_enabled=true
+	set -m
+	"$@" &
+	command_pid=$!
+	$monitor_was_enabled && set -m || set +m
+	command_pgid="$command_pid"
+	command_group="-${command_pgid}"
+	while kill -0 "$command_pid" 2>/dev/null; do
+		current_epoch=$(date +%s) || current_epoch="$deadline_epoch"
+		if [[ "$current_epoch" -ge "$deadline_epoch" ]]; then
+			kill -TERM -- "$command_group" 2>/dev/null || true
+			sleep 0.2
+			if kill -0 -- "$command_group" 2>/dev/null; then
+				kill -KILL -- "$command_group" 2>/dev/null || true
+			fi
+			wait "$command_pid" 2>/dev/null || true
+			return 124
+		fi
+		sleep 0.1
+	done
+	wait "$command_pid"
+	return $?
+}
+
+_worktree_recovery_maintenance_mark_unknown_archive() {
+	local reasons_path="$1"
+
+	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
+	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_ARCHIVE=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_ARCHIVE + 1))
+	_worktree_recovery_maintenance_record_reason "$reasons_path" \
+		"$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
+		"$WORKTREE_RECOVERY_MAINTENANCE_REASON_UNKNOWN_ARCHIVE"
+	return $?
+}
+
+_worktree_recovery_maintenance_mark_unknown_sizing() {
+	local reasons_path="$1"
+
+	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
+	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING + 1))
+	_worktree_recovery_maintenance_record_reason "$reasons_path" \
+		"$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
+		"$WORKTREE_RECOVERY_MAINTENANCE_REASON_SIZING_UNAVAILABLE"
+	return $?
+}
+
+_worktree_recovery_maintenance_mark_unknown_classification() {
+	local reasons_path="$1"
+
+	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
+	WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION + 1))
+	_worktree_recovery_maintenance_record_reason "$reasons_path" \
+		"$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
+		"$WORKTREE_RECOVERY_MAINTENANCE_REASON_CLASSIFICATION_UNAVAILABLE"
+	return $?
+}
+
 _worktree_recovery_maintenance_scan() {
 	local ordered_path="$1"
 	local selected_path="$2"
@@ -521,61 +607,76 @@ _worktree_recovery_maintenance_scan() {
 	local pressure_active="$7"
 	local reasons_path="$8"
 	local deadline_seconds="$9"
-	local raw_record=""
-	local state=""
-	local bucket_path=""
-	local measured=""
-	local bytes=""
-	local confidence=""
-	local entry_json=""
-	local disposition=""
-	local primary_reason=""
-	local started_epoch=0
-	local deadline_epoch=0
+	local deadline_epoch="${10}"
+	local raw_record="" state="" bucket_path="" measured=""
+	local bytes="" confidence="" entry_json="" disposition="" primary_reason=""
 	local current_epoch=0
+	local remaining_seconds=0
+	local state_status=0
+	local entry_status=0
 
 	_worktree_recovery_maintenance_reset_scan_counters || return 1
-	WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_SECONDS="$deadline_seconds"
-	WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=false
-	started_epoch=$(date +%s) || return 1
-	deadline_epoch=$((started_epoch + deadline_seconds))
+	[[ "$deadline_seconds" -eq "$WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_SECONDS" ]] || return 1
 	: >"$selected_path" || return 1
 	while IFS= read -r raw_record; do
 		[[ "$WORKTREE_RECOVERY_MAINTENANCE_SCANNED" -lt "$max_scan" ]] || break
-		if [[ "$WORKTREE_RECOVERY_MAINTENANCE_SCANNED" -gt 0 ]]; then
-			current_epoch=$(date +%s) || return 1
-			if [[ "$current_epoch" -ge "$deadline_epoch" ]]; then
-				WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=true
-				break
-			fi
+		current_epoch=$(date +%s) || return 1
+		if [[ "$current_epoch" -ge "$deadline_epoch" ]]; then
+			WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=true
+			break
 		fi
-		IFS=$'\t' read -r state bucket_path <<<"$raw_record"
+		bucket_path="$raw_record"
 		WORKTREE_RECOVERY_MAINTENANCE_SCANNED=$((WORKTREE_RECOVERY_MAINTENANCE_SCANNED + 1))
+		state_status=0
+		state=$(_worktree_recovery_inventory_bucket_state "$bucket_path" \
+			"${bucket_path%/*}" "$deadline_epoch") || state_status=$?
+		if [[ "$state_status" -eq 124 ]]; then
+			WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=true
+			_worktree_recovery_maintenance_mark_unknown_archive "$reasons_path" || return 1
+			break
+		elif [[ "$state_status" -ne 0 ]]; then
+			return 1
+		fi
 		if [[ "$state" != "attributed" ]]; then
-			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
-			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_ARCHIVE=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_ARCHIVE + 1))
-			_worktree_recovery_maintenance_record_reason "$reasons_path" "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" "unknown-archive" || return 1
+			_worktree_recovery_maintenance_mark_unknown_archive "$reasons_path" || return 1
 			continue
 		fi
-		measured=$(_worktree_recovery_measure_path "$bucket_path") || return 1
+		current_epoch=$(date +%s) || return 1
+		remaining_seconds=$((deadline_epoch - current_epoch))
+		if [[ "$remaining_seconds" -le 0 ]]; then
+			WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=true
+			_worktree_recovery_maintenance_mark_unknown_sizing "$reasons_path" || return 1
+			break
+		fi
+		measured=$(_worktree_recovery_measure_path "$bucket_path" \
+			"$((remaining_seconds * 10))") || return 1
 		IFS='|' read -r bytes confidence _ <<<"$measured"
 		if [[ "$confidence" != "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" || ! "$bytes" =~ ^[0-9]+$ ]]; then
-			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
-			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING + 1))
-			_worktree_recovery_maintenance_record_reason "$reasons_path" "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" "sizing-unavailable" || return 1
+			_worktree_recovery_maintenance_mark_unknown_sizing "$reasons_path" || return 1
 			continue
 		fi
-		if ! entry_json=$(_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" "$bytes"); then
-			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
-			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION + 1))
-			_worktree_recovery_maintenance_record_reason "$reasons_path" "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" "classification-unavailable" || return 1
+		entry_status=0
+		entry_json=$(_worktree_recovery_maintenance_run_function_before_epoch "$deadline_epoch" \
+			_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" "$bytes") || entry_status=$?
+		if [[ "$entry_status" -eq 124 ]]; then
+			WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=true
+			_worktree_recovery_maintenance_mark_unknown_classification "$reasons_path" || return 1
+			break
+		elif [[ "$entry_status" -ne 0 ]]; then
+			_worktree_recovery_maintenance_mark_unknown_classification "$reasons_path" || return 1
 			continue
+		fi
+		current_epoch=$(date +%s) || return 1
+		if [[ "$current_epoch" -ge "$deadline_epoch" ]]; then
+			WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=true
+			_worktree_recovery_maintenance_mark_unknown_classification "$reasons_path" || return 1
+			break
 		fi
 		disposition=$(printf '%s\n' "$entry_json" | jq -r '.disposition') || return 1
 		if [[ "$disposition" == "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" ]]; then
 			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
 			primary_reason=$(printf '%s\n' "$entry_json" | jq -r '.reasons[0] // empty') || return 1
-			if [[ "$primary_reason" == "sizing-unavailable" ]]; then
+			if [[ "$primary_reason" == "$WORKTREE_RECOVERY_MAINTENANCE_REASON_SIZING_UNAVAILABLE" ]]; then
 				WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING + 1))
 			else
 				WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION + 1))
@@ -744,6 +845,7 @@ _worktree_recovery_maintenance_prepare_selection() {
 	retention_seconds=$((retention_days * 86400))
 	pressure_active=$(printf '%s\n' "$limits_json" | jq -r '.pressure.active') || return 1
 	deadline_seconds=$(printf '%s\n' "$limits_json" | jq -r '.deadline_seconds') || return 1
+	_worktree_recovery_maintenance_start_deadline "$deadline_seconds" || return 1
 	_worktree_recovery_maintenance_create_selection_temp_files || return 1
 	inventory_path="$WORKTREE_RECOVERY_MAINTENANCE_TEMP_INVENTORY"
 	ordered_path="$WORKTREE_RECOVERY_MAINTENANCE_TEMP_ORDERED"
@@ -789,7 +891,7 @@ _worktree_recovery_maintenance_prepare_selection() {
 	if ! _worktree_recovery_maintenance_order_inventory "$inventory_path" "$ordered_path" "$offset" ||
 		! _worktree_recovery_maintenance_scan "$ordered_path" "$selected_path" "$scan_limit" \
 			"$max_candidates" "$max_bytes" "$retention_seconds" "$pressure_active" "$reasons_path" \
-			"$deadline_seconds"; then
+			"$deadline_seconds" "$WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EPOCH"; then
 		rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
 		return 1
 	fi
@@ -980,7 +1082,7 @@ worktree_recovery_maintenance_run() {
 	fi
 	command -v jq >/dev/null 2>&1 || return 1
 	platform=$(uname -s 2>/dev/null) || return 1
-	if [[ "$platform" == "Darwin" || -n "${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}" ]]; then
+	if [[ "$platform" == "$_WT_PLATFORM_DARWIN" || -n "${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}" ]]; then
 		jq -cn --arg schema "$WORKTREE_RECOVERY_MAINTENANCE_RUN_SCHEMA" \
 			'{schema:$schema,outcome:"joint-store-skipped",reclaimed_bytes:0}'
 		return 0


### PR DESCRIPTION
## Summary

Move recovery maintenance to cheap path enumeration, validate only the durable cursor window, and hard-bound archive validation and classification descendants while preserving every unvalidated archive.

## Files Changed

.agents/reference/storage-lifecycle.md, .agents/scripts/audit-worktree-removal-helper.sh, .agents/scripts/tests/test-worktree-recovery-lifecycle.sh, .agents/scripts/worktree-recovery-maintenance-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified with the recovery lifecycle suite (32/32), removal audit suite (50/50), async cleanup suite (14/14), ShellCheck, shfmt, changed-file linters, and a 300-bucket MAX_SCAN=1 deadline regression.

Resolves #30965


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 26m and 508,968 tokens on this with the user in an interactive session.