### PR TITLE
GH#30990: defer unsupported file-type major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 7
+    # file-type 22 requires Node 22, while this package supports Node 20.
+    # Revisit major updates when the project's supported Node baseline changes.
+    ignore:
+      - dependency-name: "file-type"
+        update-types:
+          - "version-update:semver-major"
     open-pull-requests-limit: 5
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
Resolves #30990

## Summary

- defer incompatible major `file-type` upgrades while the package supports Node 20

## Testing

- `git diff --check`
- pre-commit validation
- pre-push `bun run typecheck`

## Runtime Testing

- Risk: low (Dependabot configuration)
- Evidence: self-assessed; no runtime path changed

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 3m and 88,838 tokens on this as a headless worker.
