### PR TITLE
GH#30996: fix: trust Inter Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -27,6 +27,7 @@ elysia
 @fontsource/poppins
 @fontsource/ibm-plex-sans
 @fontsource/ibm-plex-serif
+@fontsource/inter
 @fontsource/source-serif-4
 @fontsource/tilt-neon
 @fontsource/ubuntu

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -531,6 +531,20 @@ test_repository_allows_fontsource_ibm_plex_serif() {
 	return 0
 }
 
+test_repository_allows_fontsource_inter() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "bun" "@fontsource/inter"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits @fontsource/inter Bun updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits @fontsource/inter Bun updates" 1
+	return 0
+}
+
 test_repository_allows_fontsource_source_serif_4() {
 	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
 
@@ -661,6 +675,7 @@ main() {
 	test_repository_allows_elysia
 	test_repository_allows_fontsource_ubuntu
 	test_repository_allows_fontsource_ibm_plex_serif
+	test_repository_allows_fontsource_inter
 	test_repository_allows_fontsource_source_serif_4
 	test_repository_allows_secretlint_recommend
 	test_repository_allows_trusted_actions

--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,7 @@
         "@fontsource/ibm-plex-mono": "5.2.7",
         "@fontsource/ibm-plex-sans": "5.2.8",
         "@fontsource/ibm-plex-serif": "5.3.0",
-        "@fontsource/inter": "5.2.8",
+        "@fontsource/inter": "5.3.0",
         "@fontsource/mohave": "5.3.0",
         "@fontsource/playpen-sans": "5.3.0",
         "@fontsource/poppins": "5.3.0",
@@ -106,7 +106,7 @@
 
     "@fontsource/ibm-plex-serif": ["@fontsource/ibm-plex-serif@5.3.0", "", {}, "sha512-zwPfHB7EJbS5B8qnitPigJYzNdnt6PUeaoOA1gAAt//1pjpTVZN5sOU14NIAZ+C1xypL6GWsUG2VMYJW9bhJqQ=="],
 
-    "@fontsource/inter": ["@fontsource/inter@5.2.8", "", {}, "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg=="],
+    "@fontsource/inter": ["@fontsource/inter@5.3.0", "", {}, "sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g=="],
 
     "@fontsource/mohave": ["@fontsource/mohave@5.3.0", "", {}, "sha512-DxFmpRJfk6Ga43UPHRzYi1/2xOifiCxGHlZhDx9aY9vusnDNLRfyWooqv11dlarVCeAtU+09PoZf0587oYZNAA=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -12,7 +12,7 @@
     "@fontsource/ibm-plex-mono": "5.2.7",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@fontsource/ibm-plex-serif": "5.3.0",
-    "@fontsource/inter": "5.2.8",
+    "@fontsource/inter": "5.3.0",
     "@fontsource/mohave": "5.3.0",
     "@fontsource/playpen-sans": "5.3.0",
     "@fontsource/poppins": "5.3.0",


### PR DESCRIPTION
## Summary

Allowlists the verified @fontsource/inter update, preserves the exact Dependabot dependency commit, and covers the Bun allowlist decision.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, bun.lock, packages/gui-web/package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile; bun run --filter @aidevops/gui-web test; bun run gui:typecheck; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; shellcheck .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; aidevops security supply-chain scan

Resolves #30996


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 4m and 74,697 tokens on this as a headless worker.