### PR TITLE
GH#30997: trust Ubuntu Mono Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -30,6 +30,7 @@ elysia
 @fontsource/source-serif-4
 @fontsource/tilt-neon
 @fontsource/ubuntu
+@fontsource/ubuntu-mono
 @secretlint/secretlint-rule-preset-recommend
 typescript
 actions:actions/checkout

--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,7 @@
         "@fontsource/source-serif-4": "5.3.0",
         "@fontsource/tilt-neon": "5.3.0",
         "@fontsource/ubuntu": "5.3.0",
-        "@fontsource/ubuntu-mono": "5.2.8",
+        "@fontsource/ubuntu-mono": "5.3.0",
         "@fontsource/zilla-slab": "5.3.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -122,7 +122,7 @@
 
     "@fontsource/ubuntu": ["@fontsource/ubuntu@5.3.0", "", {}, "sha512-LsjJXgE430QLs8LKfn1RIFbbdGAiZBU1gao8ASa4Z2kGNGh7lMb7Rzx09v3bLLuuK+3XA/JSLgPWTAbLD6r1fg=="],
 
-    "@fontsource/ubuntu-mono": ["@fontsource/ubuntu-mono@5.2.8", "", {}, "sha512-N4nT8+GYWWcDODVSBLU4f3PycZQH9YIF6SypDI0rti3HrLqcXFS9u6wMvAd9vx1FmjAQkYv7Ld9CZ8XYTEOD0A=="],
+    "@fontsource/ubuntu-mono": ["@fontsource/ubuntu-mono@5.3.0", "", {}, "sha512-hLwLkeAV9YvLSOWExn0heOXy+EB4wKnt648qS5FaqsiCZDS8X9kR/ueIBzzX/vNSXjFkhLRSTKqlOfFvHdD4Bw=="],
 
     "@fontsource/zilla-slab": ["@fontsource/zilla-slab@5.3.0", "", {}, "sha512-xbdDx5OESJDQqp3GIp4pjBgI+qpcg4AxnHLN15ekfJbG+ZYaOXg3uBjDpYlkuPQpey91afxHBNaqZgzluJ2FWA=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -20,7 +20,7 @@
     "@fontsource/source-serif-4": "5.3.0",
     "@fontsource/tilt-neon": "5.3.0",
     "@fontsource/ubuntu": "5.3.0",
-    "@fontsource/ubuntu-mono": "5.2.8",
+    "@fontsource/ubuntu-mono": "5.3.0",
     "@fontsource/zilla-slab": "5.3.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",


### PR DESCRIPTION
## Summary

Allowlist the verified Ubuntu Mono update and apply its exact manifest and lockfile changes.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, bun.lock, packages/gui-web/package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile --ignore-scripts; bun run gui:typecheck; bun run gui:test:components; bun run gui:build; bun audit

## Regression Evidence

The platform guard is triggered only by the Ubuntu Mono package name; this manifest-only update changes no platform implementation. Frozen install, GUI typecheck, component tests, production build, and audit verify the package update directly.

Resolves #30997


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 4m and 78,566 tokens on this as a headless worker.
