### PR TITLE
GH#31003: fix: trust courier prime Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -23,6 +23,7 @@ elysia
 @types/bun
 @types/react
 @fontsource/dm-sans
+@fontsource/courier-prime
 @fontsource/mohave
 @fontsource/poppins
 @fontsource/ibm-plex-sans

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -517,6 +517,20 @@ test_repository_allows_fontsource_ubuntu() {
 	return 0
 }
 
+test_repository_allows_fontsource_courier_prime() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "bun" "@fontsource/courier-prime"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits @fontsource/courier-prime Bun updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits @fontsource/courier-prime Bun updates" 1
+	return 0
+}
+
 test_repository_allows_fontsource_ibm_plex_serif() {
 	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
 
@@ -674,6 +688,7 @@ main() {
 	test_repository_allows_vite_react_plugin
 	test_repository_allows_elysia
 	test_repository_allows_fontsource_ubuntu
+	test_repository_allows_fontsource_courier_prime
 	test_repository_allows_fontsource_ibm_plex_serif
 	test_repository_allows_fontsource_inter
 	test_repository_allows_fontsource_source_serif_4


### PR DESCRIPTION
## Summary

Allowlist the exact @fontsource/courier-prime Bun dependency and cover its trusted-Dependabot intake.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun --cwd packages/gui-web test; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

Resolves #31003


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 3m and 56,881 tokens on this as a headless worker.