### PR TITLE
GH#30988: clarify supported extension QA routing

### DIFF
--- a/.agents/scripts/tests/test-playwriter-pin.sh
+++ b/.agents/scripts/tests/test-playwriter-pin.sh
@@ -150,3 +150,29 @@ assert [reply_disposition(message) for message in fixture] == [
 ]
 print("PASS Playwriter chat attribution contract recognizes support, operator, and ambiguous messages")
 PY
+
+python3 - "$REPO_ROOT" <<'PY'
+import pathlib
+import sys
+
+docs_root = pathlib.Path(sys.argv[1]) / ".agents/tools/browser"
+playwriter_doc = (docs_root / "playwriter.md").read_text()
+automation_doc = (docs_root / "browser-automation.md").read_text()
+extension_testing_doc = (docs_root / "extension-dev/testing.md").read_text()
+
+required_playwriter_contract = (
+    "Classify an extension UI target before activating Playwriter",
+    "`chrome://extensions` and arbitrary installed user-extension pages are not\n   supported Playwriter QA targets",
+    "do not activate Playwriter, enumerate tabs, or navigate",
+    "project-owned unpacked extension with an existing runner",
+    "Do not create test infrastructure or launch a replacement browser/profile",
+)
+for requirement in required_playwriter_contract:
+    assert requirement in playwriter_doc, requirement
+
+assert "EXTENSION UI QA?" in automation_doc
+assert "unsupported by Playwriter" in automation_doc
+assert "Project-owned unpacked extension with existing runner" in extension_testing_doc
+assert "have no supported Playwriter route" in extension_testing_doc
+print("PASS extension QA docs refuse unsupported pages and retain the existing-runner route")
+PY

--- a/.agents/tools/browser/browser-automation.md
+++ b/.agents/tools/browser/browser-automation.md
@@ -42,6 +42,11 @@ AUTOMATE?
   AI agent CLI-first → playwright-cli (Microsoft) or agent-browser (Vercel, Rust)
   Just fast → Playwright direct (0.9s form fill)
 
+EXTENSION UI QA?
+  chrome://extensions or arbitrary installed user extension → Stop before browser actions; unsupported by Playwriter
+  Project-owned unpacked extension with existing runner → Headed Chromium persistent-context runner → extension-dev/testing.md
+  No existing extension runner → Manual verification; do not create one or launch a replacement profile
+
 DEBUG/INSPECT → Chrome DevTools MCP (dev-browser :9222 or any Playwright instance)
 
 ANTI-DETECT?

--- a/.agents/tools/browser/extension-dev/testing.md
+++ b/.agents/tools/browser/extension-dev/testing.md
@@ -25,7 +25,9 @@ extension development. See `reference/ci-gate-policy.md`.
 **Decision tree**:
 
 ```text
-E2E with extension loaded?   → Playwright (Chromium only)
+Project-owned unpacked extension with existing runner? → Playwright (Chromium only)
+chrome://extensions or arbitrary installed extension?  → Manual verification; not a Playwriter QA target
+No existing runner?                                  → Manual verification; do not create infrastructure for routine QA
 Debug service worker?        → chrome://extensions → Inspect service worker
 Debug content scripts?       → DevTools → Sources → Content scripts
 Cross-browser verification?  → Chrome + Firefox + Edge (manual or CI)
@@ -49,6 +51,13 @@ path.
 4. For existing-profile sessions, approve the intended tab with Playwriter and
    run its authenticated-tab preflight. A Playwright persistent context is a
    separate profile and must not be treated as the user's authenticated session.
+
+For extension UI QA, distinguish the project-owned unpacked build from browser
+manager and user-installed pages before browser actions. `chrome://extensions`
+and arbitrary installed extensions have no supported Playwriter route. Do not
+attempt to reach them through Playwriter or launch a replacement browser or
+profile. The headed persistent-context E2E route below is supported only when
+the project already has a runner and stable build path.
 
 When the linked worktree is intentionally disposable but Chrome must retain one
 stable unpacked-extension path, deploy the reviewed build to an allowlisted

--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -116,6 +116,24 @@ closed without `--replace` or port-owner termination.
 5. On completion or cancellation, disconnect the Playwriter MCP. Never close
    user-owned pages, contexts, profiles, or browser windows.
 
+### Extension-page QA Preflight
+
+Classify an extension UI target before activating Playwriter or asking it to
+navigate. This prevents a browser-action attempt from implying support for a
+privileged or profile-bound page.
+
+1. `chrome://extensions` and arbitrary installed user-extension pages are not
+   supported Playwriter QA targets. Report this bounded limitation before
+   browser actions; do not activate Playwriter, enumerate tabs, or navigate.
+2. For a project-owned unpacked extension with an existing runner, use that
+   runner's headed Chromium persistent context and its stable build path. Get
+   the extension ID from its service worker, then navigate directly to the
+   expected `chrome-extension://<id>/...` page. The supported route is
+   documented in `tools/browser/extension-dev/testing.md`.
+3. When the project has no existing extension runner, use manual verification.
+   Do not create test infrastructure or launch a replacement browser/profile
+   merely to work around this limitation.
+
 ## Usage
 
 ### The `execute` Tool


### PR DESCRIPTION
Resolves #30988. Documents refusal for browser-manager and arbitrary installed extension pages before browser actions; retains project-owned unpacked-extension QA through an existing headed runner; adds contract coverage. Verified with ShellCheck and test-playwriter-pin.sh.
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra
