### PR TITLE
GH#30987: serialize fallback credential updates

### DIFF
--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -383,9 +383,17 @@ release_credentials_lock() {
 update_fallback_credential() {
 	local name="$1"
 	local escaped_value="$2"
+	local filter_status=0
 	local lock_dir=""
 	local tmp_file=""
 	local previous_umask=""
+
+	# The lock lives beside the credentials file, so its parent must exist before
+	# acquisition. File creation remains inside the lock to avoid truncation races.
+	if ! mkdir -p "$CONFIG_DIR" || ! chmod 700 "$CONFIG_DIR"; then
+		print_error "Unable to prepare credentials directory"
+		return 1
+	fi
 
 	if ! lock_dir=$(acquire_credentials_lock); then
 		return 1
@@ -406,7 +414,8 @@ update_fallback_credential() {
 	fi
 	umask "$previous_umask"
 
-	if ! grep -v "^export ${name}=" "$CREDENTIALS_FILE" >"$tmp_file" ||
+	grep -v "^export ${name}=" "$CREDENTIALS_FILE" >"$tmp_file" || filter_status=$?
+	if [[ "$filter_status" -gt 1 ]] ||
 		! printf 'export %s="%s"\n' "$name" "$escaped_value" >>"$tmp_file" ||
 		! chmod 600 "$tmp_file" ||
 		! mv -f "$tmp_file" "$CREDENTIALS_FILE"; then

--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -353,6 +353,73 @@ read_secret_input() {
 	return 0
 }
 
+# Acquire an exclusive directory lock for fallback credential mutations.
+# mkdir is atomic on local filesystems and portable across the supported shells.
+acquire_credentials_lock() {
+	local lock_dir="${CREDENTIALS_FILE}.lock"
+	local attempts=0
+
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		((++attempts))
+		if [[ "$attempts" -ge 300 ]]; then
+			print_error "Timed out waiting to update credentials.sh"
+			return 1
+		fi
+		sleep 0.1
+	done
+
+	printf '%s' "$lock_dir"
+	return 0
+}
+
+# Release a lock acquired by acquire_credentials_lock.
+release_credentials_lock() {
+	local lock_dir="$1"
+	rmdir "$lock_dir" 2>/dev/null || true
+	return 0
+}
+
+# Atomically replace one fallback credential while preserving every other entry.
+update_fallback_credential() {
+	local name="$1"
+	local escaped_value="$2"
+	local lock_dir=""
+	local tmp_file=""
+	local previous_umask=""
+
+	if ! lock_dir=$(acquire_credentials_lock); then
+		return 1
+	fi
+
+	if ! ensure_credentials_file "$CREDENTIALS_FILE"; then
+		release_credentials_lock "$lock_dir"
+		return 1
+	fi
+
+	previous_umask=$(umask)
+	umask 077
+	if ! tmp_file=$(mktemp "${CREDENTIALS_FILE}.tmp.XXXXXX"); then
+		umask "$previous_umask"
+		release_credentials_lock "$lock_dir"
+		print_error "Unable to create temporary credentials file"
+		return 1
+	fi
+	umask "$previous_umask"
+
+	if ! grep -v "^export ${name}=" "$CREDENTIALS_FILE" >"$tmp_file" ||
+		! printf 'export %s="%s"\n' "$name" "$escaped_value" >>"$tmp_file" ||
+		! chmod 600 "$tmp_file" ||
+		! mv -f "$tmp_file" "$CREDENTIALS_FILE"; then
+		rm -f "$tmp_file" || true
+		release_credentials_lock "$lock_dir"
+		print_error "Unable to update credentials.sh"
+		return 1
+	fi
+
+	release_credentials_lock "$lock_dir"
+	return 0
+}
+
 # Initialize gopass store for aidevops
 cmd_init() {
 	if ! command -v gopass &>/dev/null; then
@@ -432,23 +499,17 @@ cmd_set() {
 	else
 		print_warning "gopass not available, falling back to credentials.sh"
 
-		ensure_credentials_file "$CREDENTIALS_FILE"
 		# Escape backslashes then double quotes so the value can be safely embedded
 		# in a double-quoted shell assignment.  get_secret_value() strips the
 		# surrounding double quotes, so this round-trips correctly.
 		local escaped_value="${value//\\/\\\\}"
 		escaped_value="${escaped_value//\"/\\\"}"
-		if [[ -f "$CREDENTIALS_FILE" ]] && grep -q "^export ${name}=" "$CREDENTIALS_FILE" 2>/dev/null; then
-			local tmp_file="${CREDENTIALS_FILE}.tmp"
-			grep -v "^export ${name}=" "$CREDENTIALS_FILE" >"$tmp_file"
-			printf 'export %s="%s"\n' "${name}" "${escaped_value}" >>"$tmp_file"
-			mv "$tmp_file" "$CREDENTIALS_FILE"
-		else
-			printf 'export %s="%s"\n' "${name}" "${escaped_value}" >>"$CREDENTIALS_FILE"
+		if ! update_fallback_credential "$name" "$escaped_value"; then
+			return 1
 		fi
-		chmod 600 "$CREDENTIALS_FILE"
 		print_success "Stored $name in credentials.sh"
 		print_info "Recommend: aidevops secret init (to enable encrypted storage)"
+		print_info "Do not run concurrent refreshes for the same rotating refresh token"
 	fi
 	print_info "Verify key name only: aidevops secret list"
 

--- a/.agents/scripts/tests/test-secret-helper.sh
+++ b/.agents/scripts/tests/test-secret-helper.sh
@@ -267,6 +267,35 @@ test_set_rejects_command_literal_input() {
 	return 0
 }
 
+test_fallback_set_creates_credentials_store() {
+	setup
+	trap 'teardown' RETURN
+	cat >"$TEST_DIR/bin/gopass" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+	chmod +x "$TEST_DIR/bin/gopass"
+	local credentials_file="$TEST_DIR/home/.config/aidevops/credentials.sh"
+	local exit_code=0
+	local permissions=""
+
+	printf '%s\n' 'first-value' | HOME="$TEST_DIR/home" bash "$HELPER" set FIRST_KEY >/dev/null 2>&1 || exit_code=$?
+	if [[ -f "$credentials_file" ]]; then
+		permissions=$(stat -f '%Lp' "$credentials_file" 2>/dev/null || stat -c '%a' "$credentials_file" 2>/dev/null || true)
+	fi
+
+	if [[ "$exit_code" -eq 0 && "$permissions" == "600" ]] &&
+		[[ $(grep -c '^export FIRST_KEY=' "$credentials_file") -eq 1 ]] &&
+		grep -qx 'export FIRST_KEY="first-value"' "$credentials_file" &&
+		[[ ! -d "${credentials_file}.lock" ]]; then
+		print_result "fallback set creates credentials store" 0
+	else
+		print_result "fallback set creates credentials store" 1 "writer=$exit_code mode=$permissions"
+	fi
+
+	return 0
+}
+
 test_concurrent_fallback_sets_preserve_all_credentials() {
 	setup
 	trap 'teardown' RETURN
@@ -306,8 +335,8 @@ EOF
 		name=$(printf 'BASELINE_%02d' "$index")
 		expected_line=$(printf 'export %s="baseline-%02d"' "$name" "$index")
 		if [[ $(grep -c "^export ${name}=" "$credentials_file") -ne 1 ]] || ! grep -qx "$expected_line" "$credentials_file"; then
-		print_result "concurrent fallback sets preserve all credentials" 1 "Missing or duplicate baseline entry: $name"
-		return 0
+			print_result "concurrent fallback sets preserve all credentials" 1 "Missing or duplicate baseline entry: $name"
+			return 0
 		fi
 	done
 
@@ -315,15 +344,16 @@ EOF
 		name=$(printf 'NEW_KEY_%02d' "$index")
 		expected_line=$(printf 'export %s="value-%02d"' "$name" "$index")
 		if [[ $(grep -c "^export ${name}=" "$credentials_file") -ne 1 ]] || ! grep -qx "$expected_line" "$credentials_file"; then
-		print_result "concurrent fallback sets preserve all credentials" 1 "Missing or duplicate concurrent entry: $name"
-		return 0
+			print_result "concurrent fallback sets preserve all credentials" 1 "Missing or duplicate concurrent entry: $name"
+			return 0
 		fi
 	done
 
 	local permissions=""
 	permissions=$(stat -f '%Lp' "$credentials_file" 2>/dev/null || stat -c '%a' "$credentials_file" 2>/dev/null || true)
 	if [[ "$exit_code" -eq 0 && $(grep -c '^export UPDATED_KEY=' "$credentials_file") -eq 1 &&
-		$(grep -c '^export ' "$credentials_file") -eq 25 && "$permissions" == "600" ]]; then
+	$(grep -c '^export ' "$credentials_file") -eq 25 && "$permissions" == "600" ]] &&
+		grep -qx 'export UPDATED_KEY="after"' "$credentials_file"; then
 		print_result "concurrent fallback sets preserve all credentials" 0
 	else
 		print_result "concurrent fallback sets preserve all credentials" 1 "writers=$exit_code entries=$(grep -c '^export ' "$credentials_file") mode=$permissions"
@@ -382,6 +412,7 @@ main() {
 	test_set_uses_provided_stdin_value
 	test_credentials_read_unescapes_special_chars
 	test_set_rejects_command_literal_input
+	test_fallback_set_creates_credentials_store
 	test_concurrent_fallback_sets_preserve_all_credentials
 	test_run_redacts_sed_significant_literal_values
 	test_run_fails_closed_when_redactor_cannot_start

--- a/.agents/scripts/tests/test-secret-helper.sh
+++ b/.agents/scripts/tests/test-secret-helper.sh
@@ -267,6 +267,71 @@ test_set_rejects_command_literal_input() {
 	return 0
 }
 
+test_concurrent_fallback_sets_preserve_all_credentials() {
+	setup
+	trap 'teardown' RETURN
+	cat >"$TEST_DIR/bin/gopass" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+	chmod +x "$TEST_DIR/bin/gopass"
+	mkdir -p "$TEST_DIR/home/.config/aidevops"
+	local credentials_file="$TEST_DIR/home/.config/aidevops/credentials.sh"
+	local name=""
+	local index=0
+	local -a pids=()
+
+	for index in $(seq 1 12); do
+		printf 'export BASELINE_%02d="baseline-%02d"\n' "$index" "$index" >>"$credentials_file"
+	done
+	printf '%s\n' 'export UPDATED_KEY="before"' >>"$credentials_file"
+	chmod 600 "$credentials_file"
+
+	for index in $(seq 1 12); do
+		name=$(printf 'NEW_KEY_%02d' "$index")
+		printf 'value-%02d\n' "$index" | HOME="$TEST_DIR/home" bash "$HELPER" set "$name" >/dev/null 2>&1 &
+		pids+=("$!")
+	done
+	printf '%s\n' 'after' | HOME="$TEST_DIR/home" bash "$HELPER" set UPDATED_KEY >/dev/null 2>&1 &
+	pids+=("$!")
+
+	local pid=""
+	local exit_code=0
+	for pid in "${pids[@]}"; do
+		wait "$pid" || exit_code=$?
+	done
+
+	local expected_line=""
+	for index in $(seq 1 12); do
+		name=$(printf 'BASELINE_%02d' "$index")
+		expected_line=$(printf 'export %s="baseline-%02d"' "$name" "$index")
+		if [[ $(grep -c "^export ${name}=" "$credentials_file") -ne 1 ]] || ! grep -qx "$expected_line" "$credentials_file"; then
+		print_result "concurrent fallback sets preserve all credentials" 1 "Missing or duplicate baseline entry: $name"
+		return 0
+		fi
+	done
+
+	for index in $(seq 1 12); do
+		name=$(printf 'NEW_KEY_%02d' "$index")
+		expected_line=$(printf 'export %s="value-%02d"' "$name" "$index")
+		if [[ $(grep -c "^export ${name}=" "$credentials_file") -ne 1 ]] || ! grep -qx "$expected_line" "$credentials_file"; then
+		print_result "concurrent fallback sets preserve all credentials" 1 "Missing or duplicate concurrent entry: $name"
+		return 0
+		fi
+	done
+
+	local permissions=""
+	permissions=$(stat -f '%Lp' "$credentials_file" 2>/dev/null || stat -c '%a' "$credentials_file" 2>/dev/null || true)
+	if [[ "$exit_code" -eq 0 && $(grep -c '^export UPDATED_KEY=' "$credentials_file") -eq 1 &&
+		$(grep -c '^export ' "$credentials_file") -eq 25 && "$permissions" == "600" ]]; then
+		print_result "concurrent fallback sets preserve all credentials" 0
+	else
+		print_result "concurrent fallback sets preserve all credentials" 1 "writers=$exit_code entries=$(grep -c '^export ' "$credentials_file") mode=$permissions"
+	fi
+
+	return 0
+}
+
 test_run_redacts_sed_significant_literal_values() {
 	setup
 	trap 'teardown' RETURN
@@ -317,6 +382,7 @@ main() {
 	test_set_uses_provided_stdin_value
 	test_credentials_read_unescapes_special_chars
 	test_set_rejects_command_literal_input
+	test_concurrent_fallback_sets_preserve_all_credentials
 	test_run_redacts_sed_significant_literal_values
 	test_run_fails_closed_when_redactor_cannot_start
 	test_multiline_gopass_injection_preserves_embedded_newlines


### PR DESCRIPTION
Resolves #30987 — Serializes plaintext fallback credential mutations using a portable directory lock, unique owner-only same-directory temporary files, and atomic replacement so unrelated exports are retained. Files: .agents/scripts/secret-helper.sh; .agents/scripts/tests/test-secret-helper.sh. Verification: ShellCheck passed; the focused secret-helper suite passed 10 checks including concurrent writers preserving 25 owner-only entries.
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 8m and 93,070 tokens on this as a headless worker.