### PR TITLE
GH#31004: fix: trust Courier Prime Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -28,6 +28,7 @@ elysia
 @fontsource/ibm-plex-sans
 @fontsource/ibm-plex-serif
 @fontsource/inter
+@fontsource/courier-prime
 @fontsource/source-serif-4
 @fontsource/tilt-neon
 @fontsource/ubuntu

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aidevops/gui-shared": "workspace:*",
-        "@fontsource/courier-prime": "5.2.8",
+        "@fontsource/courier-prime": "5.3.0",
         "@fontsource/dm-mono": "5.3.0",
         "@fontsource/dm-sans": "5.3.0",
         "@fontsource/fredoka": "5.2.10",
@@ -92,7 +92,7 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.1.1", "", {}, "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA=="],
 
-    "@fontsource/courier-prime": ["@fontsource/courier-prime@5.2.8", "", {}, "sha512-M3xOCcXnGuFi9TcGCrz4hm5yeWg4Sn35MALRLPnqNoHhawTFvhyi2KSI2+5RyFtDNJrb58bPh8LLipgiI9KA0w=="],
+    "@fontsource/courier-prime": ["@fontsource/courier-prime@5.3.0", "", {}, "sha512-KIi1k4VG1Wv+/CGpb1AUpLkUuOAQA6zmvthqxOZGN0AV8BEgQgbK7qAtquv14zsBJAY1bb5BHIEbWVFLgENh0w=="],
 
     "@fontsource/dm-mono": ["@fontsource/dm-mono@5.3.0", "", {}, "sha512-OINjI8C1S/wpchhQxl7njZdMn4+hnDCpQ4YtvvOpKNARo+0J8O1x1IcrChxNjHOhfVv1by8C/FQoy3hXK+C1Ug=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@aidevops/gui-shared": "workspace:*",
-    "@fontsource/courier-prime": "5.2.8",
+    "@fontsource/courier-prime": "5.3.0",
     "@fontsource/dm-mono": "5.3.0",
     "@fontsource/dm-sans": "5.3.0",
     "@fontsource/fredoka": "5.2.10",


### PR DESCRIPTION
## Summary

Replaced Dependabot PR #30993 with the validated Courier Prime 5.3.0 manifest and lockfile update, and added its exact package name to the narrow trusted Dependabot allowlist after exact-head bot, same-repository, file-boundary, and security-check evidence.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, bun.lock, packages/gui-web/package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile; bun --cwd packages/gui-web test; bun audit; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

Resolves #31004


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 3m and 64,694 tokens on this as a headless worker.