### PR TITLE
GH#30999: add executable managed comment subcommands

### DIFF
--- a/.agents/reference/gh-command-discipline.md
+++ b/.agents/reference/gh-command-discipline.md
@@ -74,9 +74,10 @@ their existing behavior.
   securely buffer stdin once, and reuse that body for validation and fallback.
 - Executable managed-write pattern: run `gh-write-helper.sh issue create`,
   `gh-write-helper.sh pr create`, `gh-write-helper.sh issue edit`, or
-  `gh-write-helper.sh pr edit`. Use `--body-file -` for streamed bodies; the
-  executable loads the audited create/edit wrappers internally without
-  caller-side `source`.
+  `gh-write-helper.sh pr edit`. Managed comments use `gh-write-helper.sh issue
+  comment` or `gh-write-helper.sh pr comment`. Use `--body-file -` for streamed
+  bodies; the executable loads the audited create/edit/comment wrappers
+  internally without caller-side `source`.
 - ANTI-PATTERN (blocked by t2893 enforcement): same-command heredoc, process
   substitution, command substitution, or shell-variable body construction such
   as passing a heredoc through command substitution to `--body`, passing

--- a/.agents/scripts/gh-write-helper.sh
+++ b/.agents/scripts/gh-write-helper.sh
@@ -13,6 +13,7 @@ trap '_run_cleanups; exit 130' HUP INT TERM
 usage() {
 	printf 'Usage: gh-write-helper.sh {issue|pr} create [gh create options]\n'
 	printf '       gh-write-helper.sh {issue|pr} edit <number-or-url> [gh edit options]\n'
+	printf '       gh-write-helper.sh {issue|pr} comment <number-or-url> [gh comment options]\n'
 	printf 'Bodies may use --body-file - to read stdin once through the safe wrapper.\n'
 	return 0
 }
@@ -24,7 +25,7 @@ main() {
 		usage
 		return 0
 	fi
-	if [[ "$action" != "create" && "$action" != "edit" ]]; then
+	if [[ "$action" != "create" && "$action" != "edit" && "$action" != "comment" ]]; then
 		usage >&2
 		return 2
 	fi
@@ -32,8 +33,10 @@ main() {
 	case "${resource}:${action}" in
 	issue:create) gh_create_issue "$@" ;;
 	issue:edit) gh_issue_edit_safe "$@" ;;
+	issue:comment) gh_issue_comment "$@" ;;
 	pr:create) gh_create_pr "$@" ;;
 	pr:edit) gh_pr_edit_safe "$@" ;;
+	pr:comment) gh_pr_comment "$@" ;;
 	*)
 		usage >&2
 		return 2

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -1145,6 +1145,15 @@ _gh_recover_pr_if_exists() {
 # are not double-signed.
 gh_issue_comment() {
 	_gh_wrapper_enter_cleanup_scope
+	if ! _gh_wrapper_normalize_stdin_body_file "$@"; then
+		_gh_edit_audit_rejection "gh issue comment" "$_GH_EDIT_REJECTION_REASON" "$@"
+		return 1
+	fi
+	set -- "${_GH_WRAPPER_BODY_FILE_ARGS[@]}"
+	if ! _gh_validate_edit_args "$@"; then
+		_gh_edit_audit_rejection "gh issue comment" "$_GH_EDIT_REJECTION_REASON" "$@"
+		return 1
+	fi
 	local ephemeral_body_file="${AIDEVOPS_GH_EPHEMERAL_BODY_FILE:-}"
 	local gh_command="gh"
 	if [[ -n "$ephemeral_body_file" ]]; then
@@ -1182,6 +1191,15 @@ gh_issue_comment() {
 
 gh_pr_comment() {
 	_gh_wrapper_enter_cleanup_scope
+	if ! _gh_wrapper_normalize_stdin_body_file "$@"; then
+		_gh_edit_audit_rejection "gh pr comment" "$_GH_EDIT_REJECTION_REASON" "$@"
+		return 1
+	fi
+	set -- "${_GH_WRAPPER_BODY_FILE_ARGS[@]}"
+	if ! _gh_validate_edit_args "$@"; then
+		_gh_edit_audit_rejection "gh pr comment" "$_GH_EDIT_REJECTION_REASON" "$@"
+		return 1
+	fi
 	gh_record_call graphql gh_pr_comment 2>/dev/null || true
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"

--- a/.agents/scripts/tests/test-gh-wrapper-stdin.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-stdin.sh
@@ -30,6 +30,7 @@ fail() {
 }
 
 export AIDEVOPS_TEMP_DIR="${TMP}/bodies"
+export AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE=1
 mkdir -p "$AIDEVOPS_TEMP_DIR"
 CAPTURED_BODY="${TMP}/captured-body.md"
 CAPTURED_MODE="${TMP}/captured-mode.txt"
@@ -71,6 +72,10 @@ gh() {
 		return 0
 	fi
 	if [[ "${STUB_CREATE_FAIL:-0}" == "1" && "${1:-} ${2:-}" == "issue create" ]]; then
+		cp "$CAPTURED_BODY" "$NATIVE_BODY"
+		return 1
+	fi
+	if [[ "${STUB_COMMENT_FAIL:-0}" == "1" && "${1:-} ${2:-}" == "pr comment" ]]; then
 		cp "$CAPTURED_BODY" "$NATIVE_BODY"
 		return 1
 	fi
@@ -145,6 +150,42 @@ else
 	fail "native and REST fallback reuse the same once-signed stdin body" "rc=${fallback_rc}"
 fi
 
+_rest_pr_comment() {
+	local previous=""
+	local argument body_file=""
+	for argument in "$@"; do
+		if [[ "$previous" == "--body-file" ]]; then
+			body_file="$argument"
+			break
+		fi
+		case "$argument" in
+		--body-file=*)
+			body_file="${argument#--body-file=}"
+			break
+			;;
+		esac
+		previous="$argument"
+	done
+	cp "$body_file" "$REST_BODY"
+	printf 'https://github.com/test/repo/pull/1001#issuecomment-3\n'
+	return 0
+}
+: >"$NATIVE_BODY"
+: >"$REST_BODY"
+export STUB_COMMENT_FAIL=1
+printf 'Comment fallback body\n' | gh_pr_comment 456 --repo test/repo \
+	--body-file - >/dev/null 2>&1
+comment_fallback_rc=$?
+unset STUB_COMMENT_FAIL
+if [[ $comment_fallback_rc -eq 0 && -s "$NATIVE_BODY" && -s "$REST_BODY" ]] &&
+	cmp -s "$NATIVE_BODY" "$REST_BODY" &&
+	[[ "$(grep -c '<!-- aidevops:sig -->' "$REST_BODY")" -eq 1 ]]; then
+	pass "native and REST comment fallback reuse the same once-signed stdin body"
+else
+	fail "native and REST comment fallback reuse the same once-signed stdin body" \
+		"rc=${comment_fallback_rc}"
+fi
+
 : >"$GH_CALLS"
 printf 'Pull request body\n' |
 	gh_create_pr --repo test/repo --title "A substantive PR" --body-file=- >/dev/null 2>&1
@@ -185,7 +226,9 @@ case "${1:-} ${2:-}" in
 "api repos/test/repo" | "api graphql") printf '%s\n' 'false' ;;
 "api /repos/test/repo/issues/999") printf '%s\n' 'origin:interactive' ;;
 "issue create") printf '%s\n' 'https://github.com/test/repo/issues/999' ;;
+"issue comment") printf '%s\n' 'https://github.com/test/repo/issues/999#issuecomment-1' ;;
 "pr create") printf '%s\n' 'https://github.com/test/repo/pull/999' ;;
+"pr comment") printf '%s\n' 'https://github.com/test/repo/pull/999#issuecomment-2' ;;
 esac
 exit 0
 STUB
@@ -213,6 +256,56 @@ if [[ $pr_create_helper_rc -eq 0 ]] && [[ "$(grep -c '^pr create ' "$GH_CALLS")"
 	pass "standalone helper routes streamed PR creation exactly once"
 else
 	fail "standalone helper routes streamed PR creation exactly once" "rc=${pr_create_helper_rc}"
+fi
+
+EXECUTABLE_COMMENT_BODY="${TMP}/executable-comment-body.md"
+printf 'Executable path-backed issue comment\n' >"$EXECUTABLE_COMMENT_BODY"
+: >"$GH_CALLS"
+PATH="${STUB_BIN}:$PATH" "${SCRIPTS_DIR}/gh-write-helper.sh" issue comment 123 \
+	--repo test/repo --body-file "$EXECUTABLE_COMMENT_BODY" >/dev/null 2>&1
+issue_comment_rc=$?
+if [[ $issue_comment_rc -eq 0 ]] && [[ "$(grep -c '^issue comment 123 ' "$GH_CALLS")" -eq 1 ]] &&
+	grep -q 'Executable path-backed issue comment' "$CAPTURED_BODY" &&
+	[[ "$(grep -c '<!-- aidevops:sig -->' "$CAPTURED_BODY")" -eq 1 ]]; then
+	pass "standalone helper routes a path-backed issue comment with one signature"
+else
+	fail "standalone helper routes a path-backed issue comment with one signature" \
+		"rc=${issue_comment_rc}"
+fi
+
+: >"$GH_CALLS"
+printf 'Executable streamed PR comment\n' | PATH="${STUB_BIN}:$PATH" \
+	"${SCRIPTS_DIR}/gh-write-helper.sh" pr comment 456 --repo test/repo \
+	--body-file - >/dev/null 2>&1
+pr_comment_rc=$?
+if [[ $pr_comment_rc -eq 0 ]] && [[ "$(grep -c '^pr comment 456 ' "$GH_CALLS")" -eq 1 ]] &&
+	grep -q 'Executable streamed PR comment' "$CAPTURED_BODY" &&
+	[[ "$(grep -c '<!-- aidevops:sig -->' "$CAPTURED_BODY")" -eq 1 ]]; then
+	pass "standalone helper routes a streamed PR comment with one signature"
+else
+	fail "standalone helper routes a streamed PR comment with one signature" "rc=${pr_comment_rc}"
+fi
+
+: >"$GH_CALLS"
+printf '' | PATH="${STUB_BIN}:$PATH" "${SCRIPTS_DIR}/gh-write-helper.sh" issue comment 123 \
+	--repo test/repo --body-file - >/dev/null 2>&1
+empty_comment_rc=$?
+if [[ $empty_comment_rc -eq 1 && ! -s "$GH_CALLS" ]]; then
+	pass "standalone helper rejects an empty comment before a GitHub write"
+else
+	fail "standalone helper rejects an empty comment before a GitHub write" "rc=${empty_comment_rc}"
+fi
+
+: >"$GH_CALLS"
+printf '%s\n' '<!-- aidevops:sig -->' | PATH="${STUB_BIN}:$PATH" \
+	"${SCRIPTS_DIR}/gh-write-helper.sh" pr comment 456 --repo test/repo \
+	--body-file - >/dev/null 2>&1
+signature_only_comment_rc=$?
+if [[ $signature_only_comment_rc -eq 1 && ! -s "$GH_CALLS" ]]; then
+	pass "standalone helper rejects a signature-only comment before a GitHub write"
+else
+	fail "standalone helper rejects a signature-only comment before a GitHub write" \
+		"rc=${signature_only_comment_rc}"
 fi
 
 : >"$GH_CALLS"


### PR DESCRIPTION
## Summary

- add executable managed `issue comment` and `pr comment` routes
- normalize streamed comment bodies once before signing and fallback
- reject empty or signature-only comments before GitHub writes
- document the executable managed-comment pattern

## Verification

- `bash .agents/scripts/tests/test-gh-wrapper-stdin.sh` (19/19 passed)
- `shellcheck .agents/scripts/gh-write-helper.sh .agents/scripts/shared-gh-wrappers-create.sh .agents/scripts/tests/test-gh-wrapper-stdin.sh`
- `.agents/scripts/linters-local.sh --changed`
- `bash .agents/scripts/tests/test-canonical-git-command-guard.sh`

Resolves #30999

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 42m and 546,788 tokens on this with the user in an interactive session.