### PR TITLE
GH#30989: add non-publishing release candidate verification

### DIFF
--- a/.agents/scripts/release-candidate-helper.sh
+++ b/.agents/scripts/release-candidate-helper.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+_RELEASE_CANDIDATE_TMP_DIR=""
+_RELEASE_CANDIDATE_REPO_ROOT=""
+_RELEASE_CANDIDATE_COMMIT=""
+_RELEASE_CANDIDATE_PACK_JSON=""
+_RELEASE_CANDIDATE_ARCHIVE=""
+
+_release_candidate_error() {
+	local message="$1"
+	printf 'release-candidate: %s\n' "$message" >&2
+	return 1
+}
+
+_release_candidate_usage() {
+	cat <<'USAGE'
+Usage:
+  release-candidate-helper.sh verify --repo PATH --expected-commit SHA \
+    --expected-version VERSION [--manifest PATH] [--archive PATH]
+
+Builds the exact npm distributable without lifecycle scripts, verifies its
+identity and archive contents, and emits a machine-readable manifest. The
+command never creates commits, tags, releases, workflow dispatches, or uploads.
+USAGE
+	return 0
+}
+
+_release_candidate_cleanup() {
+	if [[ -n "$_RELEASE_CANDIDATE_TMP_DIR" && -d "$_RELEASE_CANDIDATE_TMP_DIR" ]]; then
+		rm -f -- \
+			"${_RELEASE_CANDIDATE_TMP_DIR}/npm-pack.json" \
+			"${_RELEASE_CANDIDATE_TMP_DIR}/expected-files.txt" \
+			"${_RELEASE_CANDIDATE_TMP_DIR}/archive-files.txt" \
+			"${_RELEASE_CANDIDATE_TMP_DIR}/manifest.json" \
+			"${_RELEASE_CANDIDATE_TMP_DIR}"/*.tgz 2>/dev/null || true
+		rmdir "$_RELEASE_CANDIDATE_TMP_DIR" 2>/dev/null || true
+	fi
+	return 0
+}
+
+_release_candidate_require_command() {
+	local command_name="$1"
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		_release_candidate_error "required command is unavailable: ${command_name}"
+		return 1
+	fi
+	return 0
+}
+
+_release_candidate_sha256() {
+	local file_path="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$file_path" | cut -d' ' -f1
+		return "${PIPESTATUS[0]}"
+	fi
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$file_path" | cut -d' ' -f1
+		return "${PIPESTATUS[0]}"
+	fi
+	_release_candidate_error "sha256sum or shasum is required"
+	return 1
+}
+
+_release_candidate_validate_destination() {
+	local destination="$1"
+	local description="$2"
+	local parent=""
+	[[ -n "$destination" ]] || return 0
+	if [[ -e "$destination" || -L "$destination" ]]; then
+		_release_candidate_error "refusing to overwrite ${description}: ${destination}"
+		return 1
+	fi
+	parent=$(dirname "$destination")
+	if [[ ! -d "$parent" || -L "$parent" ]]; then
+		_release_candidate_error "${description} parent is unavailable: ${parent}"
+		return 1
+	fi
+	return 0
+}
+
+_release_candidate_validate_source() {
+	local repo_path="$1"
+	local expected_commit="$2"
+	local expected_version="$3"
+	local package_version=""
+	local version_file=""
+
+	[[ "$expected_commit" =~ ^[0-9a-f]{40}$ ]] || {
+		_release_candidate_error "expected commit must be one full lowercase SHA"
+		return 1
+	}
+	[[ "$expected_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+		_release_candidate_error "expected version must be an exact semantic version"
+		return 1
+	}
+	if [[ ! -d "$repo_path" || -L "$repo_path" ]]; then
+		_release_candidate_error "repository worktree is unavailable: ${repo_path}"
+		return 1
+	fi
+	_RELEASE_CANDIDATE_REPO_ROOT=$(cd "$repo_path" && pwd -P) || return 1
+	_RELEASE_CANDIDATE_COMMIT=$(git -C "$_RELEASE_CANDIDATE_REPO_ROOT" rev-parse HEAD 2>/dev/null) || {
+		_release_candidate_error "repository commit cannot be resolved"
+		return 1
+	}
+	if [[ "$_RELEASE_CANDIDATE_COMMIT" != "$expected_commit" ]]; then
+		_release_candidate_error "worktree commit ${_RELEASE_CANDIDATE_COMMIT} does not match ${expected_commit}"
+		return 1
+	fi
+	if [[ -n "$(git -C "$_RELEASE_CANDIDATE_REPO_ROOT" status --porcelain --untracked-files=all)" ]]; then
+		_release_candidate_error "repository worktree must be clean"
+		return 1
+	fi
+	if [[ ! -f "${_RELEASE_CANDIDATE_REPO_ROOT}/package.json" ||
+		! -f "${_RELEASE_CANDIDATE_REPO_ROOT}/VERSION" ]]; then
+		_release_candidate_error "repository is missing package.json or VERSION"
+		return 1
+	fi
+	package_version=$(jq -er '.version' "${_RELEASE_CANDIDATE_REPO_ROOT}/package.json" 2>/dev/null) || {
+		_release_candidate_error "package.json version is unavailable"
+		return 1
+	}
+	version_file=$(<"${_RELEASE_CANDIDATE_REPO_ROOT}/VERSION")
+	if [[ "$package_version" != "$expected_version" || "$version_file" != "$expected_version" ]]; then
+		_release_candidate_error "package.json and VERSION must match ${expected_version}"
+		return 1
+	fi
+	return 0
+}
+
+_release_candidate_prepare_temp() {
+	local manifest_destination="$1"
+	local archive_destination="$2"
+	local temp_base=""
+	_release_candidate_validate_destination "$manifest_destination" "manifest" || return 1
+	_release_candidate_validate_destination "$archive_destination" "archive" || return 1
+	temp_base="${AIDEVOPS_TEMP_DIR:-${RUNNER_TEMP:-${HOME}/.aidevops/.agent-workspace/tmp}}"
+	if [[ ! -d "$temp_base" || -L "$temp_base" ]]; then
+		_release_candidate_error "private temporary directory is unavailable: ${temp_base}"
+		return 1
+	fi
+	_RELEASE_CANDIDATE_TMP_DIR=$(mktemp -d "${temp_base%/}/release-candidate.XXXXXX") || return 1
+	chmod 700 "$_RELEASE_CANDIDATE_TMP_DIR"
+	trap _release_candidate_cleanup EXIT
+	trap '_release_candidate_cleanup; exit 130' HUP INT TERM
+	return 0
+}
+
+_release_candidate_build_archive() {
+	local expected_version="$1"
+	local archive_name=""
+	_RELEASE_CANDIDATE_PACK_JSON="${_RELEASE_CANDIDATE_TMP_DIR}/npm-pack.json"
+	if ! (cd "$_RELEASE_CANDIDATE_REPO_ROOT" && npm pack --ignore-scripts --json \
+		--pack-destination "$_RELEASE_CANDIDATE_TMP_DIR") >"$_RELEASE_CANDIDATE_PACK_JSON"; then
+		_release_candidate_error "npm package build failed"
+		return 1
+	fi
+	if ! jq -e --arg version "$expected_version" '
+		type == "array" and length == 1
+		and .[0].name == "aidevops"
+		and .[0].version == $version
+		and (.[0].integrity | test("^sha512-[A-Za-z0-9+/]+={0,2}$"))
+		and (.[0].shasum | test("^[0-9a-f]{40}$"))
+		and (.[0].entryCount == (.[0].files | length))
+		and (.[0].files | type == "array" and length > 0)
+	' "$_RELEASE_CANDIDATE_PACK_JSON" >/dev/null; then
+		_release_candidate_error "npm package identity is malformed"
+		return 1
+	fi
+	archive_name=$(jq -er '.[0].filename' "$_RELEASE_CANDIDATE_PACK_JSON") || return 1
+	if [[ "$archive_name" != "$(basename "$archive_name")" || "$archive_name" != *.tgz ]]; then
+		_release_candidate_error "npm returned an unsafe archive filename"
+		return 1
+	fi
+	_RELEASE_CANDIDATE_ARCHIVE="${_RELEASE_CANDIDATE_TMP_DIR}/${archive_name}"
+	[[ -f "$_RELEASE_CANDIDATE_ARCHIVE" && ! -L "$_RELEASE_CANDIDATE_ARCHIVE" ]] || {
+		_release_candidate_error "npm package archive was not created"
+		return 1
+	}
+	return 0
+}
+
+_release_candidate_verify_archive() {
+	local expected_files=""
+	local archive_files=""
+	expected_files="${_RELEASE_CANDIDATE_TMP_DIR}/expected-files.txt"
+	archive_files="${_RELEASE_CANDIDATE_TMP_DIR}/archive-files.txt"
+	jq -er '.[0].files[] | "package/" + .path' "$_RELEASE_CANDIDATE_PACK_JSON" >"$expected_files"
+	tar -tzf "$_RELEASE_CANDIDATE_ARCHIVE" >"$archive_files"
+	if grep -qE '(^/|(^|/)\.\.(/|$))' "$archive_files"; then
+		_release_candidate_error "package archive contains an unsafe path"
+		return 1
+	fi
+	LC_ALL=C sort "$expected_files" -o "$expected_files"
+	LC_ALL=C sort "$archive_files" -o "$archive_files"
+	if ! cmp -s "$expected_files" "$archive_files"; then
+		_release_candidate_error "package archive contents do not match npm's manifest"
+		return 1
+	fi
+	return 0
+}
+
+_release_candidate_emit_outputs() {
+	local manifest_destination="$1"
+	local archive_destination="$2"
+	local archive_sha256=""
+	local manifest_path=""
+	archive_sha256=$(_release_candidate_sha256 "$_RELEASE_CANDIDATE_ARCHIVE") || return 1
+	[[ "$archive_sha256" =~ ^[0-9a-f]{64}$ ]] || return 1
+	manifest_path="${_RELEASE_CANDIDATE_TMP_DIR}/manifest.json"
+	jq -S --arg schema "aidevops.release-candidate/v1" \
+		--arg commit "$_RELEASE_CANDIDATE_COMMIT" --arg archive_sha256 "$archive_sha256" '
+		.[0] | {
+			schema: $schema,
+			commit: $commit,
+			name,
+			version,
+			filename,
+			size,
+			unpackedSize,
+			entryCount,
+			integrity,
+			shasum,
+			archive_sha256: $archive_sha256,
+			files: (.files | sort_by(.path))
+		}
+	' "$_RELEASE_CANDIDATE_PACK_JSON" >"$manifest_path"
+
+	if [[ -n "$manifest_destination" ]]; then
+		cp "$manifest_path" "$manifest_destination"
+		chmod 600 "$manifest_destination"
+		printf 'MANIFEST_FILE=%s\n' "$manifest_destination"
+	else
+		jq -c . "$manifest_path"
+	fi
+	if [[ -n "$archive_destination" ]]; then
+		cp "$_RELEASE_CANDIDATE_ARCHIVE" "$archive_destination"
+		chmod 600 "$archive_destination"
+		printf 'ARCHIVE_FILE=%s\n' "$archive_destination"
+	fi
+	return 0
+}
+
+_release_candidate_verify() {
+	local repo_path="$1"
+	local expected_commit="$2"
+	local expected_version="$3"
+	local manifest_destination="$4"
+	local archive_destination="$5"
+	_release_candidate_validate_source "$repo_path" "$expected_commit" "$expected_version" || return 1
+	_release_candidate_prepare_temp "$manifest_destination" "$archive_destination" || return 1
+	_release_candidate_build_archive "$expected_version" || return 1
+	_release_candidate_verify_archive || return 1
+	_release_candidate_emit_outputs "$manifest_destination" "$archive_destination"
+	return $?
+}
+
+main() {
+	local action="${1:-}"
+	local repo_path=""
+	local expected_commit=""
+	local expected_version=""
+	local manifest_destination=""
+	local archive_destination=""
+	[[ $# -gt 0 ]] && shift
+
+	if [[ "$action" == "--help" || "$action" == "-h" ]]; then
+		_release_candidate_usage
+		return 0
+	fi
+	if [[ "$action" != "verify" ]]; then
+		_release_candidate_usage >&2
+		return 2
+	fi
+	while [[ $# -gt 0 ]]; do
+		local argument="$1"
+		case "$argument" in
+		--repo | --expected-commit | --expected-version | --manifest | --archive)
+			if [[ $# -lt 2 ]]; then
+				_release_candidate_error "missing value for ${argument}"
+				return 2
+			fi
+			;;
+		*)
+			_release_candidate_error "unknown argument: $argument"
+			return 2
+			;;
+		esac
+		local argument_value="$2"
+		case "$argument" in
+		--repo)
+			repo_path="$argument_value"
+			shift 2
+			;;
+		--expected-commit)
+			expected_commit="$argument_value"
+			shift 2
+			;;
+		--expected-version)
+			expected_version="$argument_value"
+			shift 2
+			;;
+		--manifest)
+			manifest_destination="$argument_value"
+			shift 2
+			;;
+		--archive)
+			archive_destination="$argument_value"
+			shift 2
+			;;
+		esac
+	done
+	if [[ -z "$repo_path" || -z "$expected_commit" || -z "$expected_version" ]]; then
+		_release_candidate_usage >&2
+		return 2
+	fi
+	for command_name in git jq npm tar cmp sort; do
+		_release_candidate_require_command "$command_name" || return 1
+	done
+	_release_candidate_verify "$repo_path" "$expected_commit" "$expected_version" \
+		"$manifest_destination" "$archive_destination"
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-release-candidate-helper.sh
+++ b/.agents/scripts/tests/test-release-candidate-helper.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)" || exit 1
+HELPER="${REPO_ROOT}/.agents/scripts/release-candidate-helper.sh"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL %s\n' "$message"
+	exit 1
+}
+
+pass() {
+	local message="$1"
+	printf 'PASS %s\n' "$message"
+	return 0
+}
+
+FIXTURE_REPO="${TEST_ROOT}/repo"
+mkdir -p "$FIXTURE_REPO"
+git -C "$FIXTURE_REPO" init -q
+git -C "$FIXTURE_REPO" config user.name Test
+git -C "$FIXTURE_REPO" config user.email test@example.invalid
+git -C "$FIXTURE_REPO" config commit.gpgsign false
+git -C "$FIXTURE_REPO" config core.hooksPath /dev/null
+printf '1.2.3\n' >"${FIXTURE_REPO}/VERSION"
+cat >"${FIXTURE_REPO}/package.json" <<'JSON'
+{
+  "name": "aidevops",
+  "version": "1.2.3",
+  "files": ["VERSION", "payload.txt"]
+}
+JSON
+printf 'candidate payload\n' >"${FIXTURE_REPO}/payload.txt"
+git -C "$FIXTURE_REPO" add VERSION package.json payload.txt
+git -C "$FIXTURE_REPO" commit -q -m 'test: candidate fixture'
+FIXTURE_COMMIT=$(git -C "$FIXTURE_REPO" rev-parse HEAD)
+
+MANIFEST="${TEST_ROOT}/candidate.json"
+ARCHIVE="${TEST_ROOT}/aidevops-1.2.3.tgz"
+AIDEVOPS_TEMP_DIR="$TEST_ROOT" bash "$HELPER" verify \
+	--repo "$FIXTURE_REPO" \
+	--expected-commit "$FIXTURE_COMMIT" \
+	--expected-version 1.2.3 \
+	--manifest "$MANIFEST" \
+	--archive "$ARCHIVE" >/dev/null
+
+if ! jq -e --arg commit "$FIXTURE_COMMIT" '
+	.schema == "aidevops.release-candidate/v1"
+	and .commit == $commit
+	and .name == "aidevops"
+	and .version == "1.2.3"
+	and .entryCount == (.files | length)
+	and (.archive_sha256 | test("^[0-9a-f]{64}$"))
+	and ([.files[].path] | index("payload.txt")) != null
+' "$MANIFEST" >/dev/null; then
+	fail "candidate manifest binds the exact commit, version, and archive"
+fi
+if [[ ! -s "$ARCHIVE" ]] || ! tar -tzf "$ARCHIVE" | grep -qx 'package/payload.txt'; then
+	fail "candidate archive contains the declared payload"
+fi
+pass "candidate helper builds and verifies an exact distributable"
+
+if AIDEVOPS_TEMP_DIR="$TEST_ROOT" bash "$HELPER" verify \
+	--repo "$FIXTURE_REPO" \
+	--expected-commit 0000000000000000000000000000000000000000 \
+	--expected-version 1.2.3 >/dev/null 2>&1; then
+	fail "candidate helper accepted a mismatched commit"
+fi
+pass "candidate helper rejects a mismatched commit before packaging"
+
+printf 'dirty\n' >>"${FIXTURE_REPO}/payload.txt"
+if AIDEVOPS_TEMP_DIR="$TEST_ROOT" bash "$HELPER" verify \
+	--repo "$FIXTURE_REPO" \
+	--expected-commit "$FIXTURE_COMMIT" \
+	--expected-version 1.2.3 >/dev/null 2>&1; then
+	fail "candidate helper accepted a dirty worktree"
+fi
+pass "candidate helper rejects a dirty worktree before packaging"
+
+exit 0

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)" || exit 1
 PACKAGE_WORKFLOW="${REPO_ROOT}/.github/workflows/publish-packages.yml"
+CANDIDATE_WORKFLOW="${REPO_ROOT}/.github/workflows/release-candidate.yml"
 POSTFLIGHT_WORKFLOW="${REPO_ROOT}/.github/workflows/postflight.yml"
 SETTINGS_HELPER="${REPO_ROOT}/.agents/scripts/release-publication-settings-helper.sh"
 readonly SNAPSHOT_MODE="snapshot-empty"
@@ -119,6 +120,11 @@ assert_contains "npm publication skips an existing exact version" \
 	"if: steps.npm-state.outputs.published != 'true'" "$PACKAGE_WORKFLOW"
 assert_contains "npm state binds the locally packed artifact integrity" \
 	"Existing npm package does not match the verified tag artifact" "$PACKAGE_WORKFLOW"
+assert_contains "publication reuses the non-publishing package verifier" \
+	"release-candidate-helper.sh verify" "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match the literal workflow shell variable.
+assert_contains "publication publishes the exact verified archive" \
+	'npm publish "$NPM_PACKAGE_ARCHIVE" --ignore-scripts' "$PACKAGE_WORKFLOW"
 assert_contains "npm provenance signatures are cryptographically audited" \
 	"audit signatures --json --include-attestations" "$PACKAGE_WORKFLOW"
 assert_contains "npm provenance binds the canonical workflow path" \
@@ -175,10 +181,27 @@ assert_order "postflight verifies reviewed main before exposing the PAT fallback
 assert_order "release provenance precedes release creation" \
 	'bash "$VERIFIER" verify' "github-release-helper.sh create" "$PACKAGE_WORKFLOW"
 assert_order "GitHub release precedes npm publication" \
-	"github-release-helper.sh create" "npm publish --provenance" "$PACKAGE_WORKFLOW"
+	"github-release-helper.sh create" "npm publish \"\$NPM_PACKAGE_ARCHIVE\"" "$PACKAGE_WORKFLOW"
 # shellcheck disable=SC2016 # Match the literal verifier command.
 assert_order "package provenance precedes npm publication" \
-	'bash "$VERIFIER" verify' "npm publish --provenance" "$PACKAGE_WORKFLOW"
+	'bash "$VERIFIER" verify' "npm publish \"\$NPM_PACKAGE_ARCHIVE\"" "$PACKAGE_WORKFLOW"
+assert_order "package build precedes the first release side effect" \
+	"release-candidate-helper.sh verify" "github-release-helper.sh create" "$PACKAGE_WORKFLOW"
+assert_contains "candidate workflow is manually dispatched" "workflow_dispatch:" "$CANDIDATE_WORKFLOW"
+assert_contains "candidate workflow has read-only repository permission" \
+	"contents: read" "$CANDIDATE_WORKFLOW"
+assert_contains "candidate workflow requires reviewed main" \
+	"[[ \"\$GITHUB_REF\" == \"refs/heads/main\" ]]" "$CANDIDATE_WORKFLOW"
+assert_contains "candidate workflow pins an exact commit" \
+	"Candidate commit must be one full lowercase SHA" "$CANDIDATE_WORKFLOW"
+assert_contains "candidate workflow uses the reviewed verifier checkout" \
+	"bash verifier/.agents/scripts/release-candidate-helper.sh verify" "$CANDIDATE_WORKFLOW"
+assert_contains "candidate workflow emits a short-lived artifact" \
+	"retention-days: 7" "$CANDIDATE_WORKFLOW"
+assert_absent "candidate workflow cannot publish npm packages" "npm publish" "$CANDIDATE_WORKFLOW"
+assert_absent "candidate workflow cannot create GitHub releases" "gh release" "$CANDIDATE_WORKFLOW"
+assert_absent "candidate workflow cannot create tags" "git tag" "$CANDIDATE_WORKFLOW"
+assert_absent "candidate workflow cannot push refs" "git push" "$CANDIDATE_WORKFLOW"
 
 package_environment_count=$(grep -cE \
 	'^[[:space:]]*environment:[[:space:]]*release[[:space:]]*$' "$PACKAGE_WORKFLOW" || true)
@@ -220,7 +243,7 @@ mkdir -p "$TEST_BIN"
 NOTES_SCRIPT="${TEST_ROOT}/extract-release-notes.sh"
 awk '
 	$0 == "      - name: Extract CHANGELOG section" { inside_step = 1; next }
-	inside_step && $0 == "      - name: Create or reconcile GitHub release" { exit }
+	inside_step && $0 == "      - name: Setup Node.js" { exit }
 	inside_step && $0 == "        run: |" { inside_script = 1; next }
 	inside_script { sub(/^          /, ""); print }
 ' "$PACKAGE_WORKFLOW" >"$NOTES_SCRIPT"

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -164,6 +164,32 @@ or `release:superseded`; other terminal receipts remain immutable.
 
 **Related**: `workflows/version-bump.md` · `workflows/changelog.md` · `workflows/postflight.md` · `reference/release-artifact-provenance.md` · `.agents/scripts/validate-version-consistency.sh`
 
+## Non-publishing release candidate
+
+Use the read-only candidate verifier when package contents need validation before
+release authorization. It builds the exact npm archive with lifecycle scripts
+disabled, verifies the archive against npm's file manifest, and emits commit,
+version, integrity, shasum, SHA-256, size, and sorted file evidence. It never
+creates commits, tags, releases, workflow dispatches, or uploads by itself.
+
+```bash
+.agents/scripts/release-candidate-helper.sh verify \
+  --repo "$PWD" \
+  --expected-commit "$(git rev-parse HEAD)" \
+  --expected-version "$(<VERSION)" \
+  --manifest "${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}/release-candidate.json" \
+  --archive "${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}/aidevops-candidate.tgz"
+```
+
+For auditable remote verification, dispatch `.github/workflows/release-candidate.yml`
+from reviewed `main` with one full candidate commit SHA and the exact expected
+version. Its job has only `contents: read`, checks out the reviewed verifier
+separately from the candidate, and uploads the package plus manifest as a
+short-lived workflow artifact. The production publication workflow invokes the
+same verifier before its first release side effect and publishes that exact
+verified archive. Candidate verification is evidence only; it grants no release
+or publication authority.
+
 ## Manual Release (Non-aidevops Repos)
 
 Reuse terminal-success CI and lint evidence for the exact release SHA. Do not

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -127,26 +127,6 @@ jobs:
           fi
           printf '%s\n' "$BODY" > "$RUNNER_TEMP/release-notes.md"
 
-      - name: Create or reconcile GitHub release
-        id: github-release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          RELEASE_RC=0
-          bash .agents/scripts/github-release-helper.sh create "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --tag "$RELEASE_TAG" \
-            --title "$RELEASE_TAG" \
-            --notes-file "$RUNNER_TEMP/release-notes.md" \
-            --reconcile-existing || RELEASE_RC=$?
-          if [[ "$RELEASE_RC" -eq 75 ]]; then
-            echo "deferred=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::GitHub release creation is deferred until the installation API rate limit resets; re-run this workflow with the same verified tag and correlation"
-            exit 0
-          fi
-          [[ "$RELEASE_RC" -eq 0 ]] || exit "$RELEASE_RC"
-          echo "deferred=false" >> "$GITHUB_OUTPUT"
-
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -174,24 +154,44 @@ jobs:
           }
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Build expected npm package identity
+      - name: Build and verify npm package
         id: npm-package
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          PACKAGE_JSON=$(npm pack --dry-run --json)
-          EXPECTED_VERSION=$(jq -er 'if type == "array" and length == 1 then .[0].version else empty end' \
-            <<<"$PACKAGE_JSON")
-          EXPECTED_INTEGRITY=$(jq -er 'if type == "array" and length == 1 then .[0].integrity else empty end' \
-            <<<"$PACKAGE_JSON")
-          EXPECTED_SHASUM=$(jq -er 'if type == "array" and length == 1 then .[0].shasum else empty end' \
-            <<<"$PACKAGE_JSON")
-          [[ "$EXPECTED_VERSION" == "${{ steps.version.outputs.version }}" \
-            && "$EXPECTED_INTEGRITY" =~ ^sha512-[A-Za-z0-9+/]+={0,2}$ \
-            && "$EXPECTED_SHASUM" =~ ^[0-9a-f]{40}$ ]] || {
-            echo "::error::Unable to derive the exact npm package identity"
-            exit 1
-          }
+          PACKAGE_MANIFEST="$RUNNER_TEMP/npm-package-manifest.json"
+          PACKAGE_ARCHIVE="$RUNNER_TEMP/aidevops-${RELEASE_VERSION}.tgz"
+          bash .agents/scripts/release-candidate-helper.sh verify \
+            --repo "$GITHUB_WORKSPACE" \
+            --expected-commit "$(git rev-parse HEAD)" \
+            --expected-version "$RELEASE_VERSION" \
+            --manifest "$PACKAGE_MANIFEST" \
+            --archive "$PACKAGE_ARCHIVE"
+          EXPECTED_INTEGRITY=$(jq -er '.integrity' "$PACKAGE_MANIFEST")
+          EXPECTED_SHASUM=$(jq -er '.shasum' "$PACKAGE_MANIFEST")
           echo "integrity=$EXPECTED_INTEGRITY" >> "$GITHUB_OUTPUT"
           echo "shasum=$EXPECTED_SHASUM" >> "$GITHUB_OUTPUT"
+          echo "archive=$PACKAGE_ARCHIVE" >> "$GITHUB_OUTPUT"
+
+      - name: Create or reconcile GitHub release
+        id: github-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_RC=0
+          bash .agents/scripts/github-release-helper.sh create "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --title "$RELEASE_TAG" \
+            --notes-file "$RUNNER_TEMP/release-notes.md" \
+            --reconcile-existing || RELEASE_RC=$?
+          if [[ "$RELEASE_RC" -eq 75 ]]; then
+            echo "deferred=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::GitHub release creation is deferred until the installation API rate limit resets; re-run this workflow with the same verified tag and correlation"
+            exit 0
+          fi
+          [[ "$RELEASE_RC" -eq 0 ]] || exit "$RELEASE_RC"
+          echo "deferred=false" >> "$GITHUB_OUTPUT"
 
       - name: Check npm publication state
         id: npm-state
@@ -223,7 +223,9 @@ jobs:
       # No token needed: npm verifies this workflow and environment through OIDC.
       - name: Publish to npm
         if: steps.npm-state.outputs.published != 'true'
-        run: npm publish --provenance --access public
+        env:
+          NPM_PACKAGE_ARCHIVE: ${{ steps.npm-package.outputs.archive }}
+        run: npm publish "$NPM_PACKAGE_ARCHIVE" --ignore-scripts --provenance --access public
 
       - name: Verify npm publication
         env:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,85 @@
+name: Verify Release Candidate
+run-name: Verify candidate ${{ inputs.candidate_commit }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_commit:
+        description: Exact reviewed commit to package
+        required: true
+        type: string
+      expected_version:
+        description: Exact VERSION and package.json version
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Build and verify npm candidate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout reviewed verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          path: verifier
+          persist-credentials: false
+
+      - name: Require reviewed workflow and exact candidate commit
+        env:
+          CANDIDATE_COMMIT: ${{ inputs.candidate_commit }}
+        run: |
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+            echo "::error::Release-candidate verification must run from reviewed main"
+            exit 1
+          }
+          [[ "$CANDIDATE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::Candidate commit must be one full lowercase SHA"
+            exit 1
+          }
+
+      - name: Checkout exact candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.candidate_commit }}
+          path: candidate
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Build and verify candidate package
+        env:
+          CANDIDATE_COMMIT: ${{ inputs.candidate_commit }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+        run: |
+          ACTUAL_COMMIT=$(git -C candidate rev-parse HEAD)
+          [[ "$ACTUAL_COMMIT" == "$CANDIDATE_COMMIT" ]] || {
+            echo "::error::Candidate checkout does not match the requested commit"
+            exit 1
+          }
+          bash verifier/.agents/scripts/release-candidate-helper.sh verify \
+            --repo "$GITHUB_WORKSPACE/candidate" \
+            --expected-commit "$CANDIDATE_COMMIT" \
+            --expected-version "$EXPECTED_VERSION" \
+            --manifest "$RUNNER_TEMP/release-candidate-manifest.json" \
+            --archive "$RUNNER_TEMP/aidevops-${EXPECTED_VERSION}.tgz"
+
+      - name: Upload verified candidate
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-candidate-${{ inputs.candidate_commit }}
+          path: |
+            ${{ runner.temp }}/release-candidate-manifest.json
+            ${{ runner.temp }}/aidevops-${{ inputs.expected_version }}.tgz
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
## Summary

- add a read-only helper that builds and validates the exact npm distributable
- add a manual candidate workflow with `contents: read` and separate reviewed-verifier checkout
- reuse the verifier before publication's first external side effect and publish its exact archive
- document local and remote non-publishing candidate verification

## Safety

- candidate packaging disables lifecycle scripts
- candidate execution contains no tag, release, push, dispatch, or package-publication command
- release/publication authorization remains unchanged and separately required

## Verification

- `bash .agents/scripts/tests/test-release-candidate-helper.sh`
- `bash .agents/scripts/tests/test-release-publication-workflows.sh`
- `actionlint .github/workflows/release-candidate.yml .github/workflows/publish-packages.yml`
- `shellcheck .agents/scripts/release-candidate-helper.sh .agents/scripts/tests/test-release-candidate-helper.sh .agents/scripts/tests/test-release-publication-workflows.sh`
- `.agents/scripts/linters-local.sh --changed`
- production-path candidate build against exact clean commit `a303882a12ea784e4408d624f126738743337340`

Resolves #30989

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 2h 15m and 766,831 tokens on this with the user in an interactive session.