### PR TITLE
chore(deps): update Hono to 4.13.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@vitejs/plugin-react": "6.0.5",
         "elysia": "1.4.29",
         "file-type": "21.3.4",
-        "hono": "4.13.3",
+        "hono": "4.13.5",
         "vite": "8.2.1",
       },
       "devDependencies": {
@@ -322,7 +322,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.13.3", "", {}, "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw=="],
+    "hono": ["hono@4.13.5", "", {}, "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw=="],
 
     "hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@vitejs/plugin-react": "6.0.5",
         "elysia": "1.4.29",
         "file-type": "21.3.4",
-        "hono": "4.13.0",
+        "hono": "4.13.3",
         "vite": "8.2.1",
       },
       "devDependencies": {
@@ -322,7 +322,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
+    "hono": ["hono@4.13.3", "", {}, "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw=="],
 
     "hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@vitejs/plugin-react": "6.0.5",
     "elysia": "1.4.29",
     "file-type": "21.3.4",
-    "hono": "4.13.0",
+    "hono": "4.13.3",
     "vite": "8.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@vitejs/plugin-react": "6.0.5",
     "elysia": "1.4.29",
     "file-type": "21.3.4",
-    "hono": "4.13.3",
+    "hono": "4.13.5",
     "vite": "8.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Supersedes stale dependency PR #30720 with the current verified Hono release.

## Changes

- Update the root Hono dependency from 4.13.0 to 4.13.5 rather than stopping at 4.13.3.
- Regenerate the Bun lock entry with the 4.13.5 package integrity.

## Verification

- `bun install --frozen-lockfile --ignore-scripts`: passed with no changes.
- `bun run gui:typecheck`: passed.
- `bun test packages/gui-api/tests`: 36 passed, 0 failed.
- `.agents/scripts/linters-local.sh`: all local checks passed.

Ref #30720

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 16m and 527,933 tokens on this with the user in an interactive session.