### PR TITLE
chore(deps): update IBM Plex Sans to 5.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "@fontsource/dm-sans": "5.3.0",
         "@fontsource/fredoka": "5.2.10",
         "@fontsource/ibm-plex-mono": "5.2.7",
-        "@fontsource/ibm-plex-sans": "5.2.8",
+        "@fontsource/ibm-plex-sans": "5.3.0",
         "@fontsource/ibm-plex-serif": "5.3.0",
         "@fontsource/inter": "5.3.0",
         "@fontsource/mohave": "5.3.0",
@@ -102,7 +102,7 @@
 
     "@fontsource/ibm-plex-mono": ["@fontsource/ibm-plex-mono@5.2.7", "", {}, "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w=="],
 
-    "@fontsource/ibm-plex-sans": ["@fontsource/ibm-plex-sans@5.2.8", "", {}, "sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ=="],
+    "@fontsource/ibm-plex-sans": ["@fontsource/ibm-plex-sans@5.3.0", "", {}, "sha512-CbE4CbbEEZJX860XyUiRpsksXIQR8Rp2XDva2VO53NJox9tVNtusrysd2x5YkUEY3ErQ66W1IiiQL8/wihhw5w=="],
 
     "@fontsource/ibm-plex-serif": ["@fontsource/ibm-plex-serif@5.3.0", "", {}, "sha512-zwPfHB7EJbS5B8qnitPigJYzNdnt6PUeaoOA1gAAt//1pjpTVZN5sOU14NIAZ+C1xypL6GWsUG2VMYJW9bhJqQ=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -10,7 +10,7 @@
     "@fontsource/dm-sans": "5.3.0",
     "@fontsource/fredoka": "5.2.10",
     "@fontsource/ibm-plex-mono": "5.2.7",
-    "@fontsource/ibm-plex-sans": "5.2.8",
+    "@fontsource/ibm-plex-sans": "5.3.0",
     "@fontsource/ibm-plex-serif": "5.3.0",
     "@fontsource/inter": "5.3.0",
     "@fontsource/mohave": "5.3.0",


### PR DESCRIPTION
## Summary

Supersedes PR #30968 with the same reviewed dependency patch on an internal branch. The source PR's head was updated after exact-snapshot approval, invalidating that approval, and its Dependabot trust classifier then rejected the maintainer-authored merge commit.

## Changes

- Update `@fontsource/ibm-plex-sans` from 5.2.8 to 5.3.0.
- Preserve the exact manifest and Bun lock resolution previously reviewed on #30968.

## Verification

- `bun install --frozen-lockfile --ignore-scripts`: passed.
- `bun run gui:typecheck`: passed.
- `bun run gui:build`: passed and emitted the IBM Plex Sans assets.
- `.agents/scripts/linters-local.sh`: all local checks passed.

Ref #30968

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 20m and 551,813 tokens on this with the user in an interactive session.