### PR TITLE
GH#31018: fix zsh body-file normalization

### DIFF
--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -601,11 +601,14 @@ _GH_EDIT_REJECTION_REASON=""
 _GH_WRAPPER_BODY_FILE_ARGS=()
 _gh_wrapper_normalize_stdin_body_file() {
 	_GH_WRAPPER_BODY_FILE_ARGS=("$@")
-	local i=0 needs_stdin=0
+	local i=0 needs_stdin=0 array_index_offset=0
+	# Bash arrays are zero-based while zsh arrays are one-based by default.
+	# Keep the loop zero-based and translate only array subscripts for zsh.
+	[[ -n "${ZSH_VERSION:-}" ]] && array_index_offset=1
 	while [[ $i -lt ${#_GH_WRAPPER_BODY_FILE_ARGS[@]} ]]; do
-		case "${_GH_WRAPPER_BODY_FILE_ARGS[i]}" in
+		case "${_GH_WRAPPER_BODY_FILE_ARGS[$((i + array_index_offset))]}" in
 		--body-file)
-			[[ "${_GH_WRAPPER_BODY_FILE_ARGS[i + 1]:-}" == "-" ]] && needs_stdin=1
+			[[ "${_GH_WRAPPER_BODY_FILE_ARGS[$((i + array_index_offset + 1))]:-}" == "-" ]] && needs_stdin=1
 			i=$((i + 1))
 			;;
 		--body-file=-) needs_stdin=1 ;;
@@ -639,19 +642,29 @@ _gh_wrapper_normalize_stdin_body_file() {
 		return 1
 	fi
 
+	local -a normalized_args=()
+	local current_arg
 	i=0
 	while [[ $i -lt ${#_GH_WRAPPER_BODY_FILE_ARGS[@]} ]]; do
-		case "${_GH_WRAPPER_BODY_FILE_ARGS[i]}" in
+		current_arg="${_GH_WRAPPER_BODY_FILE_ARGS[$((i + array_index_offset))]}"
+		case "$current_arg" in
 		--body-file)
-			if [[ "${_GH_WRAPPER_BODY_FILE_ARGS[i + 1]:-}" == "-" ]]; then
-				_GH_WRAPPER_BODY_FILE_ARGS[i + 1]="$stdin_body_file"
+			normalized_args+=("$current_arg")
+			if [[ $((i + 1)) -lt ${#_GH_WRAPPER_BODY_FILE_ARGS[@]} ]]; then
+				if [[ "${_GH_WRAPPER_BODY_FILE_ARGS[$((i + array_index_offset + 1))]}" == "-" ]]; then
+					normalized_args+=("$stdin_body_file")
+				else
+					normalized_args+=("${_GH_WRAPPER_BODY_FILE_ARGS[$((i + array_index_offset + 1))]}")
+				fi
+				i=$((i + 1))
 			fi
-			i=$((i + 1))
 			;;
-		--body-file=-) _GH_WRAPPER_BODY_FILE_ARGS[i]="--body-file=${stdin_body_file}" ;;
+		--body-file=-) normalized_args+=("--body-file=${stdin_body_file}") ;;
+		*) normalized_args+=("$current_arg") ;;
 		esac
 		i=$((i + 1))
 	done
+	_GH_WRAPPER_BODY_FILE_ARGS=("${normalized_args[@]}")
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gh-wrapper-shell-compat.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-shell-compat.sh
@@ -309,6 +309,7 @@ gh() {
 source '${WRAPPERS_FILE}'
 _ensure_origin_labels_for_args() { return 0; }
 _gh_validate_edit_args() { return 0; }
+_gh_guard_public_write_args() { return 0; }
 _rest_should_fallback() { return 1; }
 session_origin_label() { printf 'origin:worker'; return 0; }
 detect_session_origin() { printf 'worker'; return 0; }
@@ -324,6 +325,62 @@ gh_create_pr --repo owner/repo --title 'zsh smoke' --body 'body'
 		fail "9: gh_create_pr sourced under zsh has quiet cleanup setup" \
 			"output: $(printf '%q' "$zsh_pr_out")"
 	fi
+fi
+
+# =============================================================================
+# Test 10: _gh_wrapper_normalize_stdin_body_file preserves argument order and
+# replaces only stdin body files under both bash and zsh.
+# =============================================================================
+test_stdin_body_normalization() {
+	local shell_path="$1"
+	local shell_name="$2"
+	local ordinary_body_file="${TMP}/ordinary-body.md"
+	local normalization_out
+
+	printf 'ordinary body\n' >"$ordinary_body_file"
+	normalization_out=$(printf 'stdin body\n' | AIDEVOPS_TEMP_DIR="$TMP" "$shell_path" -c "
+source '${WRAPPERS_FILE}'
+push_cleanup() { return 0; }
+
+_gh_wrapper_normalize_stdin_body_file --repo owner/repo --body-file - --label managed
+stdin_args=\"\$(printf '%s|' \"\${_GH_WRAPPER_BODY_FILE_ARGS[@]}\")\"
+stdin_file=''
+expect_file=0
+for arg in \"\${_GH_WRAPPER_BODY_FILE_ARGS[@]}\"; do
+    if [[ \"\$expect_file\" -eq 1 ]]; then stdin_file=\"\$arg\"; break; fi
+    [[ \"\$arg\" == '--body-file' ]] && expect_file=1
+done
+[[ \"\$stdin_args\" == \"--repo|owner/repo|--body-file|\${stdin_file}|--label|managed|\" ]] || exit 1
+[[ \"\$(cat \"\$stdin_file\")\" == 'stdin body' ]] || exit 1
+
+_gh_wrapper_normalize_stdin_body_file --title 'stdin equals' --body-file=- --repo owner/repo
+equals_args=\"\$(printf '%s|' \"\${_GH_WRAPPER_BODY_FILE_ARGS[@]}\")\"
+equals_file=''
+for arg in \"\${_GH_WRAPPER_BODY_FILE_ARGS[@]}\"; do
+    case \"\$arg\" in --body-file=*) equals_file=\"\${arg#--body-file=}\" ;; esac
+done
+[[ \"\$equals_args\" == \"--title|stdin equals|--body-file=\${equals_file}|--repo|owner/repo|\" ]] || exit 1
+[[ \"\$(cat \"\$equals_file\")\" == '' ]] || exit 1
+
+_gh_wrapper_normalize_stdin_body_file --body-file '${ordinary_body_file}' --repo owner/repo --label managed
+ordinary_args=\"\$(printf '%s|' \"\${_GH_WRAPPER_BODY_FILE_ARGS[@]}\")\"
+[[ \"\$ordinary_args\" == \"--body-file|${ordinary_body_file}|--repo|owner/repo|--label|managed|\" ]] || exit 1
+printf 'OK\n'
+" 2>&1)
+	if [[ "$normalization_out" == "OK" ]]; then
+		pass "10: stdin body-file normalization preserves argv under ${shell_name}"
+	else
+		fail "10: stdin body-file normalization preserves argv under ${shell_name}" \
+			"output: $(printf '%q' "$normalization_out")"
+	fi
+	return 0
+}
+
+test_stdin_body_normalization /bin/bash "bash"
+if command -v zsh >/dev/null 2>&1; then
+	test_stdin_body_normalization "$(command -v zsh)" "zsh"
+else
+	skip "10: stdin body-file normalization preserves argv under zsh" "zsh not installed"
 fi
 
 # =============================================================================


### PR DESCRIPTION
Resolves #31018\n\nDraft checkpoint: normalize managed stdin body-file arguments safely in Bash and zsh.
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra
