### PR TITLE
GH#31006: reclaim safe recovery caches within deadline

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -168,9 +168,10 @@ closed linked task, no open pull request, no live Git
 worktree/registry/claim/process reference, and exact readable sizing. Ignored,
 untracked directories with recognised regenerable-cache identities
 (`node_modules`, `.pnpm-store`, `.yarn/cache`, `.next/cache`, `.nuxt/cache`,
-`.turbo`, `.parcel-cache`, and `.vite`) do not make an otherwise clean archive
-dirty; new archives omit only those directory roots after proving they contain
-no tracked files. Other ignored content remains protected. Positive live or
+`.turbo`, `.parcel-cache`, `.vite`, `__pycache__`, and `.pytest_cache` at any
+depth, plus `.codegraph` only at the repository root) do not make an otherwise
+clean archive dirty; new archives omit only those directory roots after proving
+they contain no tracked files. Other ignored content remains protected. Positive live or
 unfinished evidence is `protected`. Missing APIs, process visibility, identity,
 validation, or sizing is `unknown`. Identity and allocated bytes are read again
 immediately before an entry is emitted, so concurrent drift downgrades only
@@ -239,7 +240,9 @@ evidence remain mandatory before deletion. One pass cheaply enumerates paths,
 then validates and classifies at most 50 rotating inventory entries inside a
 120-second deadline, and applies at most 20 candidates or 5 GiB. Expensive
 per-archive Git validation is limited to that cursor window and bounded by the
-same deadline. A persistent cursor advances after a deadline stop so large
+same deadline. Both the initial size probe and its mandatory drift-detection
+remeasurement use the remaining pass budget rather than the shorter global
+reporting timeout. A persistent cursor advances after a deadline stop so large
 inventories cannot starve later entries. Operators may tune these soft limits
 with:
 

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -277,6 +277,70 @@ test_git_state_detects_recovery_data() {
 	return 0
 }
 
+test_cache_policy_recognises_python_and_root_codegraph_only() {
+	local archive_path="${TEST_DIR}/cache-status-archive"
+	local status_path="${TEST_DIR}/cache-status.bin"
+	local symlink_target="${TEST_DIR}/cache-status-symlink-target"
+	local policy_status=0
+	local rc=0
+
+	"$GIT_BIN" init -q -b main "$archive_path" || rc=1
+	mkdir -p "${archive_path}/backend/__pycache__" \
+		"${archive_path}/backend/.pytest_cache" "${archive_path}/.codegraph" \
+		"${archive_path}/nested/.codegraph" "$symlink_target" || rc=1
+	printf '!! backend/__pycache__/module.pyc\0!! backend/.pytest_cache/state\0!! .codegraph/codegraph.db\0' \
+		>"$status_path" || rc=1
+	policy_status=0
+	_worktree_recovery_status_has_user_data "$status_path" "$archive_path" || policy_status=$?
+	[[ "$policy_status" -eq 1 ]] || rc=1
+	policy_status=0
+	_worktree_recovery_cache_policy "status" "$status_path" "$archive_path" \
+		"${TEST_DIR}/missing-git" || policy_status=$?
+	[[ "$policy_status" -eq 2 ]] || rc=1
+	printf '!! nested/.codegraph/codegraph.db\0' >"$status_path" || rc=1
+	policy_status=0
+	_worktree_recovery_status_has_user_data "$status_path" "$archive_path" || policy_status=$?
+	[[ "$policy_status" -eq 0 ]] || rc=1
+	rm -rf "${archive_path}/.codegraph" || rc=1
+	ln -s "$symlink_target" "${archive_path}/.codegraph" || rc=1
+	printf '!! .codegraph/codegraph.db\0' >"$status_path" || rc=1
+	policy_status=0
+	_worktree_recovery_status_has_user_data "$status_path" "$archive_path" || policy_status=$?
+	[[ "$policy_status" -eq 0 ]] || rc=1
+	printf '!! logs/diagnostic.log\0' >"$status_path" || rc=1
+	policy_status=0
+	_worktree_recovery_status_has_user_data "$status_path" "$archive_path" || policy_status=$?
+	[[ "$policy_status" -eq 0 ]] || rc=1
+	print_result "cache_policy_recognises_python_and_root_codegraph_only" "$rc" \
+		"Expected Python and root CodeGraph caches to be regenerable while nested CodeGraph, symlinks, and logs remain protected"
+	return 0
+}
+
+test_git_state_protects_tracked_regenerable_cache_roots() {
+	local cache_path="" repo_path="" identity="" state=""
+	local rc=0
+
+	for cache_path in ".codegraph" "backend/__pycache__" "backend/.pytest_cache"; do
+		repo_path="${TEST_DIR}/tracked-status-${cache_path//\//-}"
+		"$GIT_BIN" init -q -b main "$repo_path" || rc=1
+		"$GIT_BIN" -C "$repo_path" config user.email test@example.invalid || rc=1
+		"$GIT_BIN" -C "$repo_path" config user.name 'Aidevops Test' || rc=1
+		"$GIT_BIN" -C "$repo_path" config commit.gpgsign false || rc=1
+		printf '%s/\n' "$cache_path" >>"${repo_path}/.git/info/exclude" || rc=1
+		mkdir -p "${repo_path}/${cache_path}" || rc=1
+		printf 'tracked configuration\n' >"${repo_path}/${cache_path}/config.json" || rc=1
+		"$GIT_BIN" -C "$repo_path" add -f "${cache_path}/config.json" || rc=1
+		"$GIT_BIN" -C "$repo_path" commit -q -m init || rc=1
+		printf 'generated cache\n' >"${repo_path}/${cache_path}/generated.bin" || rc=1
+		identity=$(jq -cn --arg archive_path "$repo_path" '{archive_path:$archive_path}') || rc=1
+		state=$(_worktree_recovery_plan_git_state "$identity") || rc=1
+		[[ "$state" == "dirty" ]] || rc=1
+	done
+	print_result "git_state_protects_tracked_regenerable_cache_roots" "$rc" \
+		"Expected tracked content to keep every newly recognised cache identity protected"
+	return 0
+}
+
 test_archive_prunes_only_regenerable_ignored_caches() {
 	local repo_path="${TEST_DIR}/cache-policy-repo"
 	local worktree_path="${TEST_DIR}/cache-policy-worktree"
@@ -287,25 +351,62 @@ test_archive_prunes_only_regenerable_ignored_caches() {
 	mkdir -p "$recovery_root" || rc=1
 	create_unarchived_fixture "$repo_path" "$worktree_path" \
 		"bugfix/gh30931-cache-policy" || rc=1
-	printf 'node_modules/\nprivate-artifact/\n' >>"${repo_path}/.git/info/exclude" || rc=1
-	mkdir -p "${worktree_path}/node_modules/package" "${worktree_path}/private-artifact" || rc=1
+	printf 'node_modules/\n__pycache__/\n.pytest_cache/\n/.codegraph/\nnested/.codegraph/\nprivate-artifact/\n' \
+		>>"${repo_path}/.git/info/exclude" || rc=1
+	mkdir -p "${worktree_path}/node_modules/package" \
+		"${worktree_path}/backend/__pycache__" "${worktree_path}/backend/.pytest_cache" \
+		"${worktree_path}/.codegraph" "${worktree_path}/nested/.codegraph" \
+		"${worktree_path}/private-artifact" || rc=1
 	python3 - "${worktree_path}/node_modules/package/large-cache.bin" <<'PY' || rc=1
 from pathlib import Path
 import sys
 
 Path(sys.argv[1]).write_bytes(b"x" * 2 * 1024 * 1024)
 PY
+	printf 'bytecode\n' >"${worktree_path}/backend/__pycache__/module.pyc" || rc=1
+	printf 'pytest\n' >"${worktree_path}/backend/.pytest_cache/state" || rc=1
+	printf 'graph\n' >"${worktree_path}/.codegraph/codegraph.db" || rc=1
+	printf 'nested graph\n' >"${worktree_path}/nested/.codegraph/codegraph.db" || rc=1
 	printf 'user-evidence\n' >"${worktree_path}/private-artifact/user.bin" || rc=1
 	AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
 		archive_worktree_path_recoverably "$worktree_path" "test.sh" "cache-policy" || rc=1
 	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
 	[[ ! -e "${archive_path}/node_modules" ]] || rc=1
+	[[ ! -e "${archive_path}/backend/__pycache__" ]] || rc=1
+	[[ ! -e "${archive_path}/backend/.pytest_cache" ]] || rc=1
+	[[ ! -e "${archive_path}/.codegraph" ]] || rc=1
+	[[ -f "${archive_path}/nested/.codegraph/codegraph.db" ]] || rc=1
 	[[ -f "${archive_path}/private-artifact/user.bin" ]] || rc=1
 	identity=$(_worktree_recovery_plan_identity_json "${archive_path%/*}") || rc=1
 	state=$(_worktree_recovery_plan_git_state "$identity") || rc=1
 	[[ "$state" == "dirty" ]] || rc=1
 	print_result "archive_prunes_only_regenerable_ignored_caches" "$rc" \
 		"Expected large dependency caches to be omitted while ignored user evidence remains protected"
+	return 0
+}
+
+test_archive_pruning_preserves_tracked_codegraph_root() {
+	local source_path="${TEST_DIR}/tracked-codegraph-source"
+	local archive_path="${TEST_DIR}/tracked-codegraph-archive"
+	local rc=0
+
+	"$GIT_BIN" init -q -b main "$source_path" || rc=1
+	"$GIT_BIN" -C "$source_path" config user.email test@example.invalid || rc=1
+	"$GIT_BIN" -C "$source_path" config user.name 'Aidevops Test' || rc=1
+	"$GIT_BIN" -C "$source_path" config commit.gpgsign false || rc=1
+	printf '/.codegraph/\n' >>"${source_path}/.git/info/exclude" || rc=1
+	mkdir -p "${source_path}/.codegraph" || rc=1
+	printf 'tracked configuration\n' >"${source_path}/.codegraph/config.json" || rc=1
+	"$GIT_BIN" -C "$source_path" add -f .codegraph/config.json || rc=1
+	"$GIT_BIN" -C "$source_path" commit -q -m init || rc=1
+	printf 'generated graph\n' >"${source_path}/.codegraph/codegraph.db" || rc=1
+	cp -R "$source_path" "$archive_path" || rc=1
+	_worktree_prune_regenerable_archive_caches \
+		"$source_path" "$archive_path" "$GIT_BIN" || rc=1
+	[[ -f "${archive_path}/.codegraph/config.json" &&
+		-f "${archive_path}/.codegraph/codegraph.db" ]] || rc=1
+	print_result "archive_pruning_preserves_tracked_codegraph_root" "$rc" \
+		"Expected any tracked file to veto pruning the repository-root CodeGraph cache"
 	return 0
 }
 
@@ -476,6 +577,66 @@ test_size_drift_downgrades_only_entry() {
 	[[ "$(printf '%s\n' "$entry" | jq -r '.reasons[0]')" == "identity-or-size-changed" ]] || rc=1
 	print_result "size_drift_downgrades_only_entry" "$rc" \
 		"Expected a late byte change to downgrade the affected entry"
+	return 0
+}
+
+test_attributed_remeasurement_uses_explicit_budget() {
+	local bucket_path="${TEST_DIR}/remeasure-budget-bucket"
+	local du_script="${TEST_DIR}/remeasure-budget-du.sh"
+	local reasons_path="${TEST_DIR}/remeasure-budget-reasons"
+	local entry="" timed_out="" counts=""
+	local rc=0
+
+	mkdir -p "$bucket_path" || rc=1
+	cat >"$du_script" <<'SH'
+#!/usr/bin/env bash
+sleep 0.3
+printf '1\t%s\n' "$2"
+SH
+	chmod 700 "$du_script" || rc=1
+	entry=$(
+		_worktree_recovery_plan_identity_json() {
+			jq -cn --arg bucket "$bucket_path" \
+				'{bucket_path:$bucket,archive_path:($bucket + "/archive"),
+				source_removal_outcome:"removed",branch:"refs/heads/bugfix/gh31009"}'
+			return $?
+		}
+		_worktree_recovery_plan_evidence_json() {
+			jq -cn '{git:"clear",worktree:"clear",registry:"clear",claim:"clear",process:"clear",
+				external:{commit:"merged",open_pr:"clear",task:"closed"}}'
+			return $?
+		}
+		AIDEVOPS_WORKTREE_RECOVERY_DU_COMMAND="$du_script" \
+			AIDEVOPS_WORKTREE_RECOVERY_SIZE_TIMEOUT_TENTHS=2 \
+			_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" 1024 10
+	) || rc=1
+	[[ "$(printf '%s\n' "$entry" | jq -r '.disposition')" == "candidate" ]] || rc=1
+	timed_out=$(
+		_worktree_recovery_plan_identity_json() {
+			jq -cn --arg bucket "$bucket_path" \
+				'{bucket_path:$bucket,archive_path:($bucket + "/archive"),
+				source_removal_outcome:"removed",branch:"refs/heads/bugfix/gh31009"}'
+			return $?
+		}
+		_worktree_recovery_plan_evidence_json() {
+			jq -cn '{git:"clear",worktree:"clear",registry:"clear",claim:"clear",process:"clear",
+				external:{commit:"merged",open_pr:"clear",task:"closed"}}'
+			return $?
+		}
+		AIDEVOPS_WORKTREE_RECOVERY_DU_COMMAND="$du_script" \
+			AIDEVOPS_WORKTREE_RECOVERY_SIZE_TIMEOUT_TENTHS=2 \
+			_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" 1024
+	) || rc=1
+	[[ "$(printf '%s\n' "$timed_out" | jq -r '.reasons[0]')" == "sizing-timeout" ]] || rc=1
+	: >"$reasons_path" || rc=1
+	_worktree_recovery_maintenance_record_reason "$reasons_path" \
+		"$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" "sizing-timeout" || rc=1
+	counts=$(_worktree_recovery_maintenance_reason_counts_json "$reasons_path") || rc=1
+	printf '%s\n' "$counts" | jq -e \
+		'.sizing_timeout == 1 and .sizing_unavailable == 0 and .classification_unavailable == 0' \
+		>/dev/null || rc=1
+	print_result "attributed_remeasurement_uses_explicit_budget" "$rc" \
+		"Expected a slow exact remeasurement to use its supplied budget and distinguish timeout from overall deadline exhaustion"
 	return 0
 }
 
@@ -1730,13 +1891,17 @@ source "${SCRIPTS_DIR}/worktree-helper-cmds.sh"
 setup
 printf '=== test-worktree-recovery-lifecycle.sh ===\n'
 test_git_state_detects_recovery_data
+test_cache_policy_recognises_python_and_root_codegraph_only
+test_git_state_protects_tracked_regenerable_cache_roots
 test_archive_prunes_only_regenerable_ignored_caches
+test_archive_pruning_preserves_tracked_codegraph_root
 test_claim_state_uses_archive_repository
 test_exact_plan_writes_candidate_without_mutation
 test_plan_output_refuses_unsafe_targets
 test_classification_fails_closed
 test_plan_records_malformed_bucket_unknown
 test_size_drift_downgrades_only_entry
+test_attributed_remeasurement_uses_explicit_budget
 test_global_inventory_failure_is_explicit
 test_entry_sizing_failure_is_localized
 test_manual_plan_classification_is_bounded_and_resumable

--- a/.agents/scripts/worktree-recovery-cache-policy.py
+++ b/.agents/scripts/worktree-recovery-cache-policy.py
@@ -10,8 +10,17 @@ import subprocess
 import sys
 from typing import List, Optional, Set, Tuple
 
-SAFE_COMPONENTS = {"node_modules", ".pnpm-store", ".turbo", ".parcel-cache", ".vite"}
+SAFE_COMPONENTS = {
+    "node_modules",
+    ".pnpm-store",
+    ".turbo",
+    ".parcel-cache",
+    ".vite",
+    "__pycache__",
+    ".pytest_cache",
+}
 SAFE_CHAINS = {(".yarn", "cache"), (".next", "cache"), (".nuxt", "cache")}
+SAFE_REPOSITORY_ROOTS = {".codegraph"}
 
 
 def safe_root(raw_path: str) -> Optional[Tuple[str, ...]]:
@@ -19,6 +28,8 @@ def safe_root(raw_path: str) -> Optional[Tuple[str, ...]]:
     parts = PurePosixPath(raw_path.rstrip("/")).parts
     if not parts or parts[0] in {"/", ".", ".."} or ".." in parts:
         return None
+    if parts[0] in SAFE_REPOSITORY_ROOTS:
+        return parts[:1]
     for index, part in enumerate(parts):
         if part in SAFE_COMPONENTS:
             return parts[: index + 1]
@@ -49,16 +60,27 @@ def status_records(raw: bytes):
         yield record[:2], os.fsdecode(record[3:])
 
 
-def status_has_user_data(status_path: Path, archive_root: Path) -> int:
+def status_has_user_data(status_path: Path, archive_root: Path, git_bin: str) -> int:
     """Return 0 for protected data, 1 for recognised caches only, 2 on uncertainty."""
     try:
         raw_status = status_path.read_bytes()
     except OSError:
         return 2
+    checked: Set[Tuple[str, ...]] = set()
     for state, relative_path in status_records(raw_status):
         root_parts = safe_root(relative_path) if state == b"!!" else None
         if root_parts is None or ordinary_directory(archive_root, root_parts) is None:
             return 0
+        if root_parts in checked:
+            continue
+        tracked_rc, tracked = git_output(
+            git_bin, archive_root, ["ls-files", "-z", "--", "/".join(root_parts)]
+        )
+        if tracked_rc != 0:
+            return 2
+        if tracked:
+            return 0
+        checked.add(root_parts)
     return 1
 
 
@@ -66,12 +88,15 @@ def git_output(
     git_bin: str, source_root: Path, arguments: List[str]
 ) -> Tuple[int, bytes]:
     """Run one read-only Git query with bounded captured output."""
-    result = subprocess.run(
-        [git_bin, "-C", str(source_root), *arguments],
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-    )
+    try:
+        result = subprocess.run(
+            [git_bin, "-C", str(source_root), *arguments],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return 2, b""
     return result.returncode, result.stdout
 
 
@@ -117,7 +142,7 @@ def main() -> int:
     if not archive_root.is_dir() or archive_root.is_symlink():
         return 2
     if mode == "status":
-        return status_has_user_data(Path(source_raw), archive_root)
+        return status_has_user_data(Path(source_raw), archive_root, git_bin)
     source_root = Path(source_raw)
     if mode != "prune" or not source_root.is_dir() or source_root.is_symlink():
         return 2

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -790,19 +790,26 @@ _worktree_recovery_plan_attributed_entry_json() {
 	local role="$1"
 	local bucket_path="$2"
 	local expected_bytes="$3"
+	local measurement_timeout_tenths="${4:-}"
 	local identity_before="" identity_after="" evidence_json="" measured_after=""
 	local bytes_after="" confidence_after="" measure_error_after="" stable=false
-	local classification_json=""
+	local classification_json="" sizing_reason="sizing-unavailable"
 
 	identity_before=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
 	evidence_json=$(_worktree_recovery_plan_evidence_json "$identity_before") || return 1
 	identity_after=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
-	measured_after=$(_worktree_recovery_measure_path "$bucket_path") || return 1
+	if [[ -n "$measurement_timeout_tenths" ]]; then
+		measured_after=$(_worktree_recovery_measure_path \
+			"$bucket_path" "$measurement_timeout_tenths") || return 1
+	else
+		measured_after=$(_worktree_recovery_measure_path "$bucket_path") || return 1
+	fi
 	IFS='|' read -r bytes_after confidence_after measure_error_after <<<"$measured_after"
 	if [[ "$confidence_after" != "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" ||
 		! "$bytes_after" =~ ^[0-9]+$ ]]; then
+		[[ "$measure_error_after" != "sizing-timeout" ]] || sizing_reason="sizing-timeout"
 		_worktree_recovery_plan_unknown_entry_json \
-			"$role" "$bucket_path" "$WORKTREE_RECOVERY_PLAN_JSON_NULL" "sizing-unavailable"
+			"$role" "$bucket_path" "$WORKTREE_RECOVERY_PLAN_JSON_NULL" "$sizing_reason"
 		return $?
 	fi
 	if [[ "$expected_bytes" == "$WORKTREE_RECOVERY_PLAN_JSON_NULL" ]]; then

--- a/.agents/scripts/worktree-recovery-maintenance-helper.sh
+++ b/.agents/scripts/worktree-recovery-maintenance-helper.sh
@@ -259,7 +259,7 @@ _worktree_recovery_maintenance_order_inventory() {
 }
 
 _worktree_recovery_maintenance_zero_reason_counts_json() {
-	jq -cn '{unknown_archive:0,sizing_unavailable:0,classification_unavailable:0,
+	jq -cn '{unknown_archive:0,sizing_unavailable:0,sizing_timeout:0,classification_unavailable:0,
 		identity_or_size_changed:0,required_evidence_unavailable:0,
 		unrecognised_evidence_state:0,age_unavailable:0,archive_worktree_dirty:0,
 		active_git_worktree_reference:0,active_registry_owner:0,active_session_claim:0,
@@ -278,6 +278,7 @@ _worktree_recovery_maintenance_record_reason() {
 	case "$reason" in
 	unknown-archive) safe_reason="unknown_archive" ;;
 	sizing-unavailable) safe_reason="sizing_unavailable" ;;
+	sizing-timeout) safe_reason="sizing_timeout" ;;
 	classification-unavailable) safe_reason="classification_unavailable" ;;
 	identity-or-size-changed) safe_reason="identity_or_size_changed" ;;
 	required-evidence-unavailable) safe_reason="required_evidence_unavailable" ;;
@@ -597,6 +598,22 @@ _worktree_recovery_maintenance_mark_unknown_classification() {
 	return $?
 }
 
+_worktree_recovery_maintenance_attributed_entry_before_epoch() {
+	local deadline_epoch="$1"
+	local bucket_path="$2"
+	local bytes="$3"
+	local current_epoch=0
+	local remaining_seconds=0
+
+	current_epoch=$(date +%s) || return 1
+	remaining_seconds=$((deadline_epoch - current_epoch))
+	[[ "$remaining_seconds" -gt 0 ]] || return 124
+	_worktree_recovery_maintenance_run_function_before_epoch "$deadline_epoch" \
+		_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" "$bytes" \
+		"$((remaining_seconds * 10))"
+	return $?
+}
+
 _worktree_recovery_maintenance_scan() {
 	local ordered_path="$1"
 	local selected_path="$2"
@@ -656,8 +673,8 @@ _worktree_recovery_maintenance_scan() {
 			continue
 		fi
 		entry_status=0
-		entry_json=$(_worktree_recovery_maintenance_run_function_before_epoch "$deadline_epoch" \
-			_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" "$bytes") || entry_status=$?
+		entry_json=$(_worktree_recovery_maintenance_attributed_entry_before_epoch \
+			"$deadline_epoch" "$bucket_path" "$bytes") || entry_status=$?
 		if [[ "$entry_status" -eq 124 ]]; then
 			WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=true
 			_worktree_recovery_maintenance_mark_unknown_classification "$reasons_path" || return 1
@@ -676,7 +693,8 @@ _worktree_recovery_maintenance_scan() {
 		if [[ "$disposition" == "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" ]]; then
 			WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN + 1))
 			primary_reason=$(printf '%s\n' "$entry_json" | jq -r '.reasons[0] // empty') || return 1
-			if [[ "$primary_reason" == "$WORKTREE_RECOVERY_MAINTENANCE_REASON_SIZING_UNAVAILABLE" ]]; then
+			if [[ "$primary_reason" == "$WORKTREE_RECOVERY_MAINTENANCE_REASON_SIZING_UNAVAILABLE" ||
+				"$primary_reason" == "sizing-timeout" ]]; then
 				WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_SIZING + 1))
 			else
 				WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION=$((WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN_CLASSIFICATION + 1))


### PR DESCRIPTION
## Summary

- Recognize ignored, untracked `__pycache__` and `.pytest_cache` directories at any depth, plus `.codegraph` only at the repository root, as regenerable recovery caches.
- Let mandatory exact remeasurement use the remaining automatic-maintenance deadline instead of the shorter default sizing timeout.
- Preserve fail-closed protection for tracked content, symlinks, nested `.codegraph`, arbitrary ignored data, failed Git queries, identity drift, and deadline exhaustion.

## Root cause

Recovery archive classification did not include the approved Python and CodeGraph cache identities. Separately, the second exact size measurement inherited the short global reporting timeout even when the automatic maintenance pass still had budget, so valid candidates could remain indefinitely unavailable.

## Safety decisions

- Repository-root-only cache identities use a dedicated allowlist rather than the any-depth component allowlist.
- Both status classification and archive pruning query tracked files before treating a recognized root as disposable.
- Git process-launch or query failures classify the archive as unavailable, never clear.
- The outer process-group deadline remains authoritative while the inner measurement receives only the calculated remaining budget.

## Verification

- `test-worktree-recovery-lifecycle.sh`: 36/36 passed.
- `test-cleanup-worktrees-async.sh`: 14/14 passed.
- `test-worktree-removal-audit.sh`: 50/50 passed.
- `linters-local.sh --changed`: all required changed-file gates passed with no regressions.
- Independent destructive-safety review: PASS with no blocking findings at head `4352ee05e`.
- Review evidence digest: `954f482e15dc63c3fe1d7e66771a8b60bc7265d9e36438933b818bd6b23ae145` (prompt-injection scan clean).

Resolves #31006
Resolves #31009

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 48m and 477,072 tokens on this with the user in an interactive session.