### PR TITLE
fix: reconcile stale worktree ownership leases

### DIFF
--- a/.agents/scripts/cleanup-worktrees-async-helper.sh
+++ b/.agents/scripts/cleanup-worktrees-async-helper.sh
@@ -200,6 +200,18 @@ _update_last_run() {
 	return 0
 }
 
+_reconcile_worktree_registry() {
+	if ! declare -F prune_worktree_registry >/dev/null 2>&1; then
+		echo "[cleanup-worktrees-async] registry prune unavailable; skipping reconciliation" >>"$LOGFILE"
+		return 0
+	fi
+	if ! prune_worktree_registry >>"$LOGFILE" 2>&1; then
+		echo "[cleanup-worktrees-async] registry reconciliation failed closed; continuing guarded cleanup" >>"$LOGFILE"
+		return 0
+	fi
+	return 0
+}
+
 _prune_dirty_worktree_backups() {
 	local helper_path="${SCRIPT_DIR}/dirty-worktree-backup-helper.sh"
 	local retention_days="${DIRTY_WORKTREE_BACKUP_RETENTION_DAYS:-30}"
@@ -249,6 +261,7 @@ main() {
 	fi
 
 	echo "[cleanup-worktrees-async] Starting cleanup_worktrees (cadence OK)" >>"$LOGFILE"
+	_reconcile_worktree_registry
 
 	local rc=0
 	local outcome="success"

--- a/.agents/scripts/interactive-session-helper-stamp.sh
+++ b/.agents/scripts/interactive-session-helper-stamp.sh
@@ -91,6 +91,9 @@ _isc_write_stamp() {
 		_isc_warn "failed to write stamp: $stamp_file"
 		return 0
 	}
+	if [[ -n "$worktree_path" ]] && declare -F renew_worktree_ownership >/dev/null 2>&1; then
+		renew_worktree_ownership "$worktree_path" --owner-pid "$owner_pid" >/dev/null 2>&1 || true
+	fi
 	return 0
 }
 
@@ -101,6 +104,31 @@ _isc_delete_stamp() {
 	local stamp_file
 	stamp_file=$(_isc_stamp_path "$issue" "$slug")
 	rm -f "$stamp_file" 2>/dev/null || true
+	return 0
+}
+
+# Cross-host PIDs cannot be verified locally, so remote authority is bounded by
+# a renewable stamp age. Return 0 while fresh, 1 when conclusively expired, and
+# 2 when timestamp parsing is unavailable or malformed (callers fail closed).
+_isc_cross_host_claim_freshness() {
+	local claimed_at="$1"
+	local ttl_hours="${AIDEVOPS_CROSS_HOST_CLAIM_TTL_HOURS:-168}"
+	[[ "$ttl_hours" =~ ^[1-9][0-9]*$ ]] || ttl_hours=168
+	[[ -n "$claimed_at" ]] || return 2
+
+	local claimed_epoch=""
+	claimed_epoch=$(date -u -d "$claimed_at" '+%s' 2>/dev/null || true)
+	if [[ -z "$claimed_epoch" ]]; then
+		claimed_epoch=$(TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' "$claimed_at" '+%s' 2>/dev/null || true)
+	fi
+	[[ "$claimed_epoch" =~ ^[0-9]+$ ]] || return 2
+
+	local now_epoch=""
+	now_epoch=$(date +%s 2>/dev/null || true)
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || return 2
+	if [[ $((now_epoch - claimed_epoch)) -gt $((ttl_hours * 3600)) ]]; then
+		return 1
+	fi
 	return 0
 }
 
@@ -305,19 +333,21 @@ _isc_branch_has_active_claim() {
 	[[ -f "$stamp_file" ]] || return 1
 
 	# Read stamp fields. Treat any jq error as "no claim" (fail-open).
-	local pid hostname stored_hash
+	local pid hostname stored_hash claimed_at
 	pid=$(jq -r '.pid // empty' "$stamp_file" 2>/dev/null || echo "")
 	hostname=$(jq -r '.hostname // empty' "$stamp_file" 2>/dev/null || echo "")
 	stored_hash=$(jq -r '.owner_argv_hash // empty' "$stamp_file" 2>/dev/null || echo "")
+	claimed_at=$(jq -r '.claimed_at // empty' "$stamp_file" 2>/dev/null || echo "")
 
-	# Cross-host stamps cannot have their PID verified. Other hosts are
-	# assumed to be the authority for their own claims — if a remote
-	# session is alive on a different machine, we still want to skip
-	# cleanup of its worktree; if it's dead, scan-stale on that host
-	# will reap it. Trust the stamp existence.
+	# Cross-host stamps cannot have their PID verified. Trust remote authority
+	# only within a bounded renewable lease. Malformed timestamps remain active
+	# (fail closed); only a conclusively expired timestamp releases this gate.
 	local local_host
 	local_host=$(_isc_hostname_or_fallback)
 	if [[ -n "$hostname" && "$hostname" != "$local_host" ]]; then
+		local freshness_rc=0
+		_isc_cross_host_claim_freshness "$claimed_at" || freshness_rc=$?
+		[[ "$freshness_rc" -eq 1 ]] && return 1
 		return 0
 	fi
 

--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -115,6 +115,42 @@ _wt_process_start_token_for_pid() {
 	return 0
 }
 
+# Return a stable identity for the current operating-system boot. Linux exposes
+# a UUID directly; macOS/BSD expose the boot timestamp. An unavailable identity
+# remains empty so legacy/portable environments fail closed on PID evidence.
+_wt_current_boot_id() {
+	local boot_id=""
+	if [[ -r "/proc/sys/kernel/random/boot_id" ]]; then
+		boot_id=$(<"/proc/sys/kernel/random/boot_id") || boot_id=""
+	elif command -v sysctl >/dev/null 2>&1; then
+		boot_id=$(sysctl -n kern.boottime 2>/dev/null || true)
+	fi
+	[[ -n "$boot_id" ]] || return 1
+	printf '%s' "$boot_id"
+	return 0
+}
+
+_wt_default_lease_kind() {
+	local session_id="$1"
+	local batch_id="$2"
+	local task_id="$3"
+	case "$session_id" in
+	cleanup:*) printf '%s' "cleanup" ;;
+	dispatch-precreate-*) printf '%s' "dispatch-precreate" ;;
+	ses_*) printf '%s' "interactive" ;;
+	*)
+		if [[ -n "$batch_id" ]]; then
+			printf '%s' "worker"
+		elif [[ -n "$task_id" ]]; then
+			printf '%s' "task"
+		else
+			printf '%s' "owner"
+		fi
+		;;
+	esac
+	return 0
+}
+
 # Get the parent PID for a given PID.
 # Returns empty string if the PID does not exist or info is unavailable.
 # Arguments:
@@ -380,6 +416,9 @@ _init_registry_db() {
             task_id       TEXT DEFAULT '',
             owner_comm    TEXT DEFAULT '',
             owner_process_start TEXT DEFAULT '',
+            owner_boot_id TEXT DEFAULT '',
+            lease_kind TEXT DEFAULT 'owner',
+            heartbeat_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
             owner_dead_seen_at TEXT DEFAULT '',
             created_at    TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
         );
@@ -425,6 +464,37 @@ _init_registry_db() {
         WHERE name = 'owner_process_start';
     " 2>/dev/null) || return 1
 	[[ "$has_owner_process_start_column" == "1" ]] || return 1
+
+	local column_name=""
+	local column_default=""
+	for column_name in owner_boot_id lease_kind heartbeat_at; do
+		column_default=""
+		[[ "$column_name" == "lease_kind" ]] && column_default="owner"
+		local has_column=""
+		has_column=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+            SELECT 1 FROM pragma_table_info('worktree_owners')
+            WHERE name = '$column_name';
+        " 2>/dev/null || echo "")
+		if [[ -z "$has_column" ]]; then
+			sqlite3 "$WORKTREE_REGISTRY_DB" "
+                ALTER TABLE worktree_owners
+                ADD COLUMN $column_name TEXT DEFAULT '$column_default';
+            " 2>/dev/null || return 1
+		fi
+	done
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+        UPDATE worktree_owners
+		SET lease_kind = CASE
+				WHEN COALESCE(lease_kind, '') NOT IN ('', 'owner') THEN lease_kind
+				WHEN COALESCE(owner_session, '') GLOB 'cleanup:*' THEN 'cleanup'
+				WHEN COALESCE(owner_session, '') GLOB 'dispatch-precreate-*' THEN 'dispatch-precreate'
+				WHEN COALESCE(owner_session, '') GLOB 'ses_*' THEN 'interactive'
+				WHEN COALESCE(owner_batch, '') != '' THEN 'worker'
+				WHEN COALESCE(task_id, '') != '' THEN 'task'
+				ELSE 'owner'
+			END,
+            heartbeat_at = CASE WHEN COALESCE(heartbeat_at, '') = '' THEN COALESCE(created_at, '') ELSE heartbeat_at END;
+    " 2>/dev/null || return 1
 	return 0
 }
 
@@ -442,38 +512,55 @@ remove_canonical_worktree_owner() {
 # Arguments:
 #   $1 - worktree path (required)
 #   $2 - branch name (required)
-#   Flags: --task <id>, --batch <id>, --session <id>
+#   Flags: --task <id>, --batch <id>, --session <id>, --lease-kind <kind>
 register_worktree() {
 	local wt_path="$1"
 	local branch="$2"
 	shift 2
 
-	local task_id="" batch_id="" session_id="" owner_pid_override=""
+	local task_id="" batch_id="" session_id="" owner_pid_override="" lease_kind=""
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
+		local option="$1"
+		shift
+		case "$option" in
 		--task)
-			task_id="${2:-}"
-			shift 2
+			[[ $# -ge 1 ]] || return 1
+			local option_value="$1"
+			task_id="$option_value"
+			shift
 			;;
 		--batch)
-			batch_id="${2:-}"
-			shift 2
+			[[ $# -ge 1 ]] || return 1
+			local option_value="$1"
+			batch_id="$option_value"
+			shift
 			;;
 		--session)
-			session_id="${2:-}"
-			shift 2
+			[[ $# -ge 1 ]] || return 1
+			local option_value="$1"
+			session_id="$option_value"
+			shift
 			;;
 		--owner-pid)
-			owner_pid_override="${2:-}"
-			shift 2
+			[[ $# -ge 1 ]] || return 1
+			local option_value="$1"
+			owner_pid_override="$option_value"
+			shift
 			;;
-		*) shift ;;
+		--lease-kind)
+			[[ $# -ge 1 ]] || return 1
+			local option_value="$1"
+			lease_kind="$option_value"
+			shift
+			;;
+		*) ;;
 		esac
 	done
 
 	if [[ -z "$session_id" ]]; then
 		session_id="${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
 	fi
+	[[ -n "$lease_kind" ]] || lease_kind=$(_wt_default_lease_kind "$session_id" "$batch_id" "$task_id")
 
 	local owner_pid
 	owner_pid=$(_resolve_worktree_owner_pid "$owner_pid_override")
@@ -481,6 +568,8 @@ register_worktree() {
 	owner_comm=$(_get_proc_comm "$owner_pid")
 	local owner_process_start=""
 	owner_process_start=$(_wt_process_start_token_for_pid "$owner_pid") || return 1
+	local owner_boot_id=""
+	owner_boot_id=$(_wt_current_boot_id 2>/dev/null || true)
 
 	_init_registry_db || return 1
 	wt_path=$(_wt_registry_lookup_path "$wt_path")
@@ -493,7 +582,7 @@ register_worktree() {
 		_wt_sqlite_set_owner_pid_param "$owner_pid"
 		printf '%s\n' "
         INSERT OR REPLACE INTO worktree_owners
-			(worktree_path, branch, owner_pid, owner_session, owner_batch, task_id, owner_comm, owner_process_start, owner_dead_seen_at)
+			(worktree_path, branch, owner_pid, owner_session, owner_batch, task_id, owner_comm, owner_process_start, owner_boot_id, lease_kind, heartbeat_at, owner_dead_seen_at)
         VALUES
 		 ('$(_wt_sql_escape "$wt_path")',
 		  '$(_wt_sql_escape "$branch")',
@@ -503,6 +592,9 @@ register_worktree() {
 		  '$(_wt_sql_escape "$task_id")',
 		  '$(_wt_sql_escape "$owner_comm")',
 		  '$(_wt_sql_escape "$owner_process_start")',
+		  '$(_wt_sql_escape "$owner_boot_id")',
+		  '$(_wt_sql_escape "$lease_kind")',
+		  strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
 		  '');
     "
 	} | sqlite3 "$WORKTREE_REGISTRY_DB" 2>/dev/null || return 1
@@ -524,10 +616,12 @@ _wt_claim_owner_record() {
 	local session_id="$4"
 	local batch_id="$5"
 	local task_id="$6"
-	local owner_comm="$7" owner_process_start="$8" trusted_opencode_session="$9"
+	local owner_comm="$7" owner_process_start="$8" owner_boot_id="$9"
+	local lease_kind="${10}" trusted_opencode_session="${11}"
 
 	python3 - "$WORKTREE_REGISTRY_DB" "$wt_path" "$branch" "$owner_pid" "$session_id" \
-		"$batch_id" "$task_id" "$owner_comm" "$owner_process_start" "$trusted_opencode_session" <<'PY' || return 1
+		"$batch_id" "$task_id" "$owner_comm" "$owner_process_start" "$owner_boot_id" \
+		"$lease_kind" "$trusted_opencode_session" <<'PY' || return 1
 import os
 import sqlite3
 import sys
@@ -542,6 +636,8 @@ import sys
     task_id,
     owner_comm,
     owner_process_start,
+    owner_boot_id,
+    lease_kind,
     trusted_session_text,
 ) = sys.argv[1:]
 owner_pid = int(owner_pid_text)
@@ -575,7 +671,9 @@ try:
     connection.execute(
         """UPDATE worktree_owners
            SET branch = ?, owner_pid = ?, owner_session = ?, owner_batch = ?,
-               task_id = ?, owner_comm = ?, owner_process_start = ?, owner_dead_seen_at = ''
+               task_id = ?, owner_comm = ?, owner_process_start = ?, owner_boot_id = ?,
+               lease_kind = ?, heartbeat_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
+               owner_dead_seen_at = ''
            WHERE worktree_path = ?
              AND (owner_pid = ? OR (? AND owner_session = ?))""",
         (
@@ -586,6 +684,8 @@ try:
             task_id,
             owner_comm,
             owner_process_start,
+            owner_boot_id,
+            lease_kind,
             worktree_path,
             owner_pid,
             trusted_session,
@@ -595,9 +695,11 @@ try:
     connection.execute(
         """INSERT OR IGNORE INTO worktree_owners
            (worktree_path, branch, owner_pid, owner_session, owner_batch,
-            task_id, owner_comm, owner_process_start, owner_dead_seen_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, '')""",
-        (worktree_path, branch, owner_pid, session_id, batch_id, task_id, owner_comm, owner_process_start),
+             task_id, owner_comm, owner_process_start, owner_boot_id, lease_kind,
+             heartbeat_at, owner_dead_seen_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), '')""",
+        (worktree_path, branch, owner_pid, session_id, batch_id, task_id, owner_comm,
+         owner_process_start, owner_boot_id, lease_kind),
     )
     final_owner = connection.execute(
         """SELECT owner_pid, COALESCE(owner_session, '')
@@ -622,7 +724,8 @@ PY
 # Arguments:
 #   $1 - worktree path (required)
 #   $2 - branch name (required)
-#   Flags: --task <id>, --batch <id>, --session <id>, --owner-pid <pid>
+#   Flags: --task <id>, --batch <id>, --session <id>, --owner-pid <pid>,
+#          --lease-kind <kind>
 # Returns:
 #   0 - ownership acquired or already held by this owner_pid or OpenCode session
 #   1 - another live owner currently holds the worktree
@@ -631,32 +734,49 @@ claim_worktree_ownership() {
 	local branch="$2"
 	shift 2
 
-	local task_id="" batch_id="" session_id="" owner_pid_override=""
+	local task_id="" batch_id="" session_id="" owner_pid_override="" lease_kind=""
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
+		local option="$1"
+		shift
+		case "$option" in
 		--task)
-			task_id="${2:-}"
-			shift 2
+			[[ $# -ge 1 ]] || return 1
+			local option_value="$1"
+			task_id="$option_value"
+			shift
 			;;
 		--batch)
-			batch_id="${2:-}"
-			shift 2
+			[[ $# -ge 1 ]] || return 1
+			local option_value="$1"
+			batch_id="$option_value"
+			shift
 			;;
 		--session)
-			session_id="${2:-}"
-			shift 2
+			[[ $# -ge 1 ]] || return 1
+			local option_value="$1"
+			session_id="$option_value"
+			shift
 			;;
 		--owner-pid)
-			owner_pid_override="${2:-}"
-			shift 2
+			[[ $# -ge 1 ]] || return 1
+			local option_value="$1"
+			owner_pid_override="$option_value"
+			shift
 			;;
-		*) shift ;;
+		--lease-kind)
+			[[ $# -ge 1 ]] || return 1
+			local option_value="$1"
+			lease_kind="$option_value"
+			shift
+			;;
+		*) ;;
 		esac
 	done
 
 	if [[ -z "$session_id" ]]; then
 		session_id="${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
 	fi
+	[[ -n "$lease_kind" ]] || lease_kind=$(_wt_default_lease_kind "$session_id" "$batch_id" "$task_id")
 
 	local owner_pid
 	owner_pid=$(_resolve_worktree_owner_pid "$owner_pid_override")
@@ -664,6 +784,8 @@ claim_worktree_ownership() {
 	owner_comm=$(_get_proc_comm "$owner_pid")
 	local owner_process_start=""
 	owner_process_start=$(_wt_process_start_token_for_pid "$owner_pid") || return 1
+	local owner_boot_id=""
+	owner_boot_id=$(_wt_current_boot_id 2>/dev/null || true)
 	local trusted_opencode_session=0
 	_wt_is_trusted_opencode_session "$session_id" && trusted_opencode_session=1
 
@@ -676,7 +798,8 @@ claim_worktree_ownership() {
 
 	local final_owner_info=""
 	final_owner_info=$(_wt_claim_owner_record "$wt_path" "$branch" "$owner_pid" "$session_id" \
-		"$batch_id" "$task_id" "$owner_comm" "$owner_process_start" "$trusted_opencode_session") || return 1
+		"$batch_id" "$task_id" "$owner_comm" "$owner_process_start" "$owner_boot_id" \
+		"$lease_kind" "$trusted_opencode_session") || return 1
 
 	if [[ "${final_owner_info%%|*}" == "$owner_pid" ]]; then
 		return 0
@@ -702,6 +825,10 @@ _wt_compare_and_swap_owner_record() {
 	shift
 	local owner_process_start="$1"
 	shift
+	local owner_boot_id="$1"
+	shift
+	local lease_kind="$1"
+	shift
 	local expected_owner_pid="$1"
 	shift
 	local expected_session_id="$1"
@@ -716,6 +843,7 @@ _wt_compare_and_swap_owner_record() {
 
 	python3 - "$WORKTREE_REGISTRY_DB" "$wt_path" "$branch" "$owner_pid" \
 		"$session_id" "$batch_id" "$task_id" "$owner_comm" "$owner_process_start" \
+		"$owner_boot_id" "$lease_kind" \
 		"$expected_owner_pid" "$expected_session_id" "$expected_batch_id" \
 		"$expected_task_id" "$expected_created_at" "$expected_process_start" <<'PY' || return 1
 import sqlite3
@@ -731,6 +859,8 @@ import sys
     task_id,
     owner_comm,
     owner_process_start,
+    owner_boot_id,
+    lease_kind,
     expected_owner_pid_text,
     expected_session_id,
     expected_batch_id,
@@ -745,8 +875,9 @@ try:
     cursor = connection.execute(
         """UPDATE worktree_owners
            SET branch = ?, owner_pid = ?, owner_session = ?, owner_batch = ?,
-               task_id = ?, owner_comm = ?, owner_process_start = ?, owner_dead_seen_at = '',
-               created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+               task_id = ?, owner_comm = ?, owner_process_start = ?, owner_boot_id = ?,
+               lease_kind = ?, heartbeat_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
+               owner_dead_seen_at = '', created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
            WHERE worktree_path = ?
              AND owner_pid = ?
              AND COALESCE(owner_session, '') = ?
@@ -762,6 +893,8 @@ try:
             task_id,
             owner_comm,
             owner_process_start,
+            owner_boot_id,
+            lease_kind,
             worktree_path,
             int(expected_owner_pid_text),
             expected_session_id,
@@ -792,6 +925,7 @@ PY
 #   $1 - worktree path (required)
 #   $2 - branch name (required)
 #   Flags: --task <id>, --batch <id>, --session <id>, --owner-pid <pid>,
+#          --lease-kind <kind>,
 #          --expected-task <id>, --expected-batch <id>,
 #          --expected-session <id>, --expected-owner-pid <pid>,
 #          --expected-created-at <timestamp>, --expected-process-start <token>
@@ -808,6 +942,7 @@ transfer_worktree_ownership_if_expected() {
 	local batch_id=""
 	local session_id=""
 	local owner_pid_override=""
+	local lease_kind=""
 	local expected_task_id=""
 	local expected_batch_id=""
 	local expected_session_id=""
@@ -816,22 +951,25 @@ transfer_worktree_ownership_if_expected() {
 	local expected_process_start=""
 	while [[ $# -gt 0 ]]; do
 		local option="$1"
+		shift
 		case "$option" in
-		--task | --batch | --session | --owner-pid | --expected-task | --expected-batch | --expected-session | --expected-owner-pid | --expected-created-at | --expected-process-start)
-			[[ $# -ge 2 ]] || return 1
+		--task | --batch | --session | --owner-pid | --lease-kind | --expected-task | --expected-batch | --expected-session | --expected-owner-pid | --expected-created-at | --expected-process-start)
+			[[ $# -ge 1 ]] || return 1
 			;;
 		esac
+		local option_value="${1:-}"
 		case "$option" in
-		--task) task_id="$2"; shift 2 ;;
-		--batch) batch_id="$2"; shift 2 ;;
-		--session) session_id="$2"; shift 2 ;;
-		--owner-pid) owner_pid_override="$2"; shift 2 ;;
-		--expected-task) expected_task_id="$2"; shift 2 ;;
-		--expected-batch) expected_batch_id="$2"; shift 2 ;;
-		--expected-session) expected_session_id="$2"; shift 2 ;;
-		--expected-owner-pid) expected_owner_pid="$2"; shift 2 ;;
-		--expected-created-at) expected_created_at="$2"; shift 2 ;;
-		--expected-process-start) expected_process_start="$2"; shift 2 ;;
+		--task) task_id="$option_value"; shift ;;
+		--batch) batch_id="$option_value"; shift ;;
+		--session) session_id="$option_value"; shift ;;
+		--owner-pid) owner_pid_override="$option_value"; shift ;;
+		--lease-kind) lease_kind="$option_value"; shift ;;
+		--expected-task) expected_task_id="$option_value"; shift ;;
+		--expected-batch) expected_batch_id="$option_value"; shift ;;
+		--expected-session) expected_session_id="$option_value"; shift ;;
+		--expected-owner-pid) expected_owner_pid="$option_value"; shift ;;
+		--expected-created-at) expected_created_at="$option_value"; shift ;;
+		--expected-process-start) expected_process_start="$option_value"; shift ;;
 		*) return 1 ;;
 		esac
 	done
@@ -841,6 +979,7 @@ transfer_worktree_ownership_if_expected() {
 	if [[ -z "$session_id" ]]; then
 		session_id="${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
 	fi
+	[[ -n "$lease_kind" ]] || lease_kind=$(_wt_default_lease_kind "$session_id" "$batch_id" "$task_id")
 
 	local owner_pid=""
 	owner_pid=$(_resolve_worktree_owner_pid "$owner_pid_override")
@@ -849,6 +988,8 @@ transfer_worktree_ownership_if_expected() {
 	owner_comm=$(_get_proc_comm "$owner_pid")
 	local owner_process_start=""
 	owner_process_start=$(_wt_process_start_token_for_pid "$owner_pid") || return 1
+	local owner_boot_id=""
+	owner_boot_id=$(_wt_current_boot_id 2>/dev/null || true)
 
 	_init_registry_db || return 1
 	wt_path=$(_wt_registry_lookup_path "$wt_path")
@@ -858,8 +999,53 @@ transfer_worktree_ownership_if_expected() {
 	fi
 	_wt_compare_and_swap_owner_record "$wt_path" "$branch" "$owner_pid" \
 		"$session_id" "$batch_id" "$task_id" "$owner_comm" "$owner_process_start" \
+		"$owner_boot_id" "$lease_kind" \
 		"$expected_owner_pid" "$expected_session_id" "$expected_batch_id" \
 		"$expected_task_id" "$expected_created_at" "$expected_process_start" || return 1
+	return 0
+}
+
+# Refresh liveness only for the exact current owner generation and session.
+# This never acquires or transfers ownership.
+renew_worktree_ownership() {
+	[[ $# -ge 1 ]] || return 1
+	local wt_path="$1"
+	shift
+	local owner_pid_override=""
+	local session_id=""
+	while [[ $# -gt 0 ]]; do
+		local option="$1"
+		shift
+		[[ $# -ge 1 ]] || return 1
+		local option_value="$1"
+		case "$option" in
+		--owner-pid) owner_pid_override="$option_value"; shift ;;
+		--session) session_id="$option_value"; shift ;;
+		*) return 1 ;;
+		esac
+	done
+	[[ -n "$session_id" ]] || session_id="${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+	local owner_pid=""
+	owner_pid=$(_resolve_worktree_owner_pid "$owner_pid_override")
+	[[ "$owner_pid" =~ ^[0-9]+$ ]] || return 1
+	local owner_process_start=""
+	owner_process_start=$(_wt_process_start_token_for_pid "$owner_pid") || return 1
+	local owner_boot_id=""
+	owner_boot_id=$(_wt_current_boot_id 2>/dev/null || true)
+	_init_registry_db || return 1
+	wt_path=$(_wt_registry_lookup_path "$wt_path") || return 1
+	local changed="0"
+	changed=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+        UPDATE worktree_owners
+        SET heartbeat_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), owner_dead_seen_at = ''
+        WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
+          AND owner_pid = ${owner_pid}
+          AND COALESCE(owner_session, '') = '$(_wt_sql_escape "$session_id")'
+          AND COALESCE(owner_process_start, '') = '$(_wt_sql_escape "$owner_process_start")'
+          AND COALESCE(owner_boot_id, '') = '$(_wt_sql_escape "$owner_boot_id")';
+        SELECT changes();
+    " 2>/dev/null) || return 1
+	[[ "$changed" == "1" ]] || return 1
 	return 0
 }
 
@@ -1139,14 +1325,16 @@ _wt_owner_comm_for_path() {
 	return 0
 }
 
-# Return the PID, process-generation token, and creation timestamp from one
+# Return the PID, process-generation token, boot identity, and creation timestamp
+# from one
 # registry snapshot. Read failures are ownership-unknown and fail closed.
 _wt_owner_generation_contract_for_path() {
 	local wt_path="$1"
 	local separator=$'\x1f'
 	local owner_contract=""
 	owner_contract=$(sqlite3 -separator "$separator" "$WORKTREE_REGISTRY_DB" "
-        SELECT owner_pid, COALESCE(owner_process_start, ''), COALESCE(created_at, '')
+        SELECT owner_pid, COALESCE(owner_process_start, ''),
+               COALESCE(owner_boot_id, ''), COALESCE(created_at, '')
         FROM worktree_owners
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
 	" 2>/dev/null) || return 1
@@ -1157,18 +1345,35 @@ _wt_owner_generation_contract_for_path() {
 # Delete only the exact owner generation that was inspected. A concurrent
 # registration or transfer changes the token or timestamp and remains intact.
 _wt_unregister_owner_if_generation_matches() {
+	[[ $# -eq 4 || $# -eq 5 ]] || return 1
 	local wt_path="$1"
 	local expected_owner_pid="$2"
 	local expected_process_start="$3"
-	local expected_created_at="$4"
+	local expected_boot_id=""
+	local expected_created_at=""
+	[[ "$expected_owner_pid" =~ ^[0-9]+$ ]] || return 1
+	if [[ $# -eq 5 ]]; then
+		expected_boot_id="$4"
+		expected_created_at="$5"
+	else
+		expected_created_at="$4"
+		expected_boot_id=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+			SELECT COALESCE(owner_boot_id, '') FROM worktree_owners
+			WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
+			  AND owner_pid = ${expected_owner_pid}
+			  AND COALESCE(owner_process_start, '') = '$(_wt_sql_escape "$expected_process_start")'
+			  AND COALESCE(created_at, '') = '$(_wt_sql_escape "$expected_created_at")';
+		" 2>/dev/null) || return 1
+	fi
 	local changed="0"
 
-	[[ "$expected_owner_pid" =~ ^[0-9]+$ && -n "$expected_created_at" ]] || return 1
+	[[ -n "$expected_created_at" ]] || return 1
 	changed=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
         DELETE FROM worktree_owners
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
           AND owner_pid = ${expected_owner_pid}
           AND COALESCE(owner_process_start, '') = '$(_wt_sql_escape "$expected_process_start")'
+          AND COALESCE(owner_boot_id, '') = '$(_wt_sql_escape "$expected_boot_id")'
           AND COALESCE(created_at, '') = '$(_wt_sql_escape "$expected_created_at")';
         SELECT changes();
 	" 2>/dev/null) || return 1
@@ -1207,10 +1412,16 @@ PY
 _wt_owner_live_pid_reused_or_untrusted() {
 	local owner_pid="$1"
 	local registered_process_start="$2"
-	local registered_created_at="$3"
+	local registered_boot_id="$3"
+	local registered_created_at="$4"
 	local current_process_start=""
+	local current_boot_id=""
 
 	current_process_start=$(_wt_process_start_token_for_pid "$owner_pid") || return 1
+	current_boot_id=$(_wt_current_boot_id 2>/dev/null || true)
+	if [[ -n "$registered_boot_id" && -n "$current_boot_id" && "$registered_boot_id" != "$current_boot_id" ]]; then
+		return 0
+	fi
 	if [[ -n "$registered_process_start" ]]; then
 		[[ "$registered_process_start" != "$current_process_start" ]]
 		return $?
@@ -1265,17 +1476,21 @@ _wt_is_worktree_owned_by_others_for_resolved_pid() {
 	local owner_contract=""
 	local owner_pid=""
 	local registered_process_start=""
+	local registered_boot_id=""
 	local registered_created_at=""
 	owner_contract=$(_wt_owner_generation_contract_for_path "$wt_path") || return 0
-	IFS=$'\x1f' read -r owner_pid registered_process_start registered_created_at <<<"$owner_contract"
+	IFS=$'\x1f' read -r owner_pid registered_process_start registered_boot_id registered_created_at <<<"$owner_contract"
 
 	# No owner registered
 	[[ -z "$owner_pid" ]] && return 1
 
 	if [[ "$owner_pid" == "$my_pid" ]]; then
 		local current_process_start=""
+		local current_boot_id=""
 		current_process_start=$(_wt_process_start_token_for_pid "$my_pid") || return 0
-		if [[ -n "$registered_process_start" && "$registered_process_start" == "$current_process_start" ]]; then
+		current_boot_id=$(_wt_current_boot_id 2>/dev/null || true)
+		if [[ -n "$registered_process_start" && "$registered_process_start" == "$current_process_start" ]] &&
+			{ [[ -z "$registered_boot_id" ]] || [[ -z "$current_boot_id" ]] || [[ "$registered_boot_id" == "$current_boot_id" ]]; }; then
 			return 1
 		fi
 	fi
@@ -1287,7 +1502,7 @@ _wt_is_worktree_owned_by_others_for_resolved_pid() {
 		_wt_mark_owner_dead_seen "$wt_path"
 		if _wt_owner_dead_cooldown_expired "$wt_path"; then
 			if _wt_unregister_owner_if_generation_matches "$wt_path" "$owner_pid" \
-				"$registered_process_start" "$registered_created_at"; then
+				"$registered_process_start" "$registered_boot_id" "$registered_created_at"; then
 				return 1
 			fi
 		fi
@@ -1300,7 +1515,7 @@ _wt_is_worktree_owned_by_others_for_resolved_pid() {
 	if [[ -z "$registered_process_start" ]] &&
 		_wt_legacy_dispatch_precreate_systemd_owner_expired "$wt_path" "$owner_pid"; then
 		if _wt_unregister_owner_if_generation_matches "$wt_path" "$owner_pid" \
-			"$registered_process_start" "$registered_created_at"; then
+			"$registered_process_start" "$registered_boot_id" "$registered_created_at"; then
 			return 1
 		fi
 		return 0
@@ -1309,9 +1524,9 @@ _wt_is_worktree_owned_by_others_for_resolved_pid() {
 	# Owner recovered or PID was reused while still registered; clear any stale
 	# marker so a later dead observation gets a fresh cooldown window.
 	if _wt_owner_live_pid_reused_or_untrusted "$owner_pid" "$registered_process_start" \
-		"$registered_created_at"; then
+		"$registered_boot_id" "$registered_created_at"; then
 		if _wt_unregister_owner_if_generation_matches "$wt_path" "$owner_pid" \
-			"$registered_process_start" "$registered_created_at"; then
+			"$registered_process_start" "$registered_boot_id" "$registered_created_at"; then
 			return 1
 		fi
 		return 0
@@ -1323,6 +1538,7 @@ _wt_is_worktree_owned_by_others_for_resolved_pid() {
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
           AND owner_pid = ${owner_pid}
           AND COALESCE(owner_process_start, '') = '$(_wt_sql_escape "$registered_process_start")'
+          AND COALESCE(owner_boot_id, '') = '$(_wt_sql_escape "$registered_boot_id")'
           AND COALESCE(created_at, '') = '$(_wt_sql_escape "$registered_created_at")'
           AND COALESCE(owner_dead_seen_at, '') != '';
     " 2>/dev/null || true
@@ -1423,9 +1639,40 @@ _wt_registry_entry_count() {
 	return 0
 }
 
-# Prune stale registry entries (dead PIDs, missing directories, corrupted paths)
+# Reconcile ownership rows whose worktree directories still exist. Missing
+# directories are handled by the batch path below; surviving worktrees need the
+# generation-aware owner checks so dead runtimes and recycled PIDs do not leave
+# permanent registry locks. This updates ownership metadata only and never
+# removes a worktree directory or bypasses downstream cleanup gates.
+_wt_registry_reconcile_existing_owners() {
+	local reconcile_limit="${WORKTREE_REGISTRY_RECONCILE_LIMIT:-500}"
+	[[ "$reconcile_limit" =~ ^[1-9][0-9]*$ ]] || reconcile_limit=500
+
+	local entries=""
+	entries=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
+        SELECT worktree_path, owner_pid
+        FROM worktree_owners
+        ORDER BY CASE WHEN COALESCE(owner_dead_seen_at, '') = '' THEN 1 ELSE 0 END,
+                 owner_dead_seen_at, created_at
+        LIMIT ${reconcile_limit};
+    " 2>/dev/null || true)
+	[[ -z "$entries" ]] && return 0
+
+	local my_pid="$$"
+	local wt_path=""
+	local _owner_pid=""
+	while IFS='|' read -r wt_path _owner_pid; do
+		[[ -n "$wt_path" && -d "$wt_path" ]] || continue
+		_wt_is_worktree_owned_by_others_for_resolved_pid "$wt_path" "$my_pid" \
+			>/dev/null 2>&1 || true
+	done <<<"$entries"
+	return 0
+}
+
+# Prune stale registry entries and reconcile dead or recycled owners.
 # (t197) Enhanced to handle:
-#   - Dead PIDs with missing directories
+#   - Dead or recycled owner processes for surviving worktree directories
+#   - Missing worktree directories
 #   - Paths with ANSI escape codes (corrupted entries)
 #   - Test artifacts in /tmp or /var/folders
 prune_worktree_registry() {
@@ -1475,6 +1722,11 @@ prune_worktree_registry() {
 			[[ -n "${VERBOSE:-}" ]] && _wt_registry_print_pruned_entries "$stale_entries"
 		fi
 	fi
+
+	# Existing directories may still have abandoned ownership after runtime
+	# crashes. Reconcile those rows independently; deletion remains the normal
+	# guarded cleanup pipeline's responsibility.
+	_wt_registry_reconcile_existing_owners || return 1
 
 	[[ -n "${VERBOSE:-}" ]] && echo "Pruned $pruned_count entries total"
 	return 0

--- a/.agents/scripts/tests/test-cleanup-worktrees-async.sh
+++ b/.agents/scripts/tests/test-cleanup-worktrees-async.sh
@@ -88,6 +88,7 @@ STUB
 	# Use literal return 0 / return 1 (not a variable) so the pre-commit
 	# return-statement ratchet doesn't flag the heredoc-embedded function.
 	local mock_ran_file="${TEST_DIR}/mock-ran"
+	local registry_reconcile_file="${TEST_DIR}/registry-reconcile-ran"
 	local maintenance_ran_file="${TEST_DIR}/maintenance-ran"
 	local maintenance_result="${MOCK_MAINTENANCE_RESULT:-{\"schema\":\"test\",\"outcome\":\"no-candidates\"}}"
 	if [[ "${MOCK_CLEANUP_SKIPPED:-0}" -eq 1 ]]; then
@@ -122,6 +123,10 @@ STUB
 CLEANUP_WORKTREES_REMOVED_COUNT="${MOCK_REMOVED_COUNT:-0}"
 CLEANUP_WORKTREES_ARCHIVED_COUNT="${MOCK_ARCHIVED_COUNT:-0}"
 CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT="${MOCK_ARCHIVE_FAILED_COUNT:-0}"
+prune_worktree_registry() {
+	printf 'REGISTRY_RECONCILE_RAN\n' >>"${registry_reconcile_file}"
+	return 0
+}
 STUB
 
 	# Copy the helper into stub_dir so that when it runs, BASH_SOURCE[0] points
@@ -156,7 +161,9 @@ STUB
 # ============================================================
 test_cold_start() {
 	local mock_ran="${TEST_DIR}/mock-ran"
+	local registry_reconcile_ran="${TEST_DIR}/registry-reconcile-ran"
 	rm -f "$mock_ran"
+	rm -f "$registry_reconcile_ran"
 
 	MOCK_CLEANUP_EXIT=0 run_helper_in_isolation || true
 
@@ -165,6 +172,12 @@ test_cold_start() {
 	else
 		print_result "cold-start: cleanup_worktrees runs on first invocation" 1 \
 			"mock-ran marker not created; cleanup_worktrees was not called"
+	fi
+	if [[ -f "$registry_reconcile_ran" ]] && grep -q "REGISTRY_RECONCILE_RAN" "$registry_reconcile_ran"; then
+		print_result "cold-start: registry ownership reconciles before cleanup" 0
+	else
+		print_result "cold-start: registry ownership reconciles before cleanup" 1 \
+			"registry reconciliation marker not created"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-worktree-cleanup-claim-guard.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-claim-guard.sh
@@ -254,11 +254,13 @@ test_no_stamp
 test_cross_host_active() {
 	local issue=99004
 	local stamp="${CLAIM_DIR}/testowner-testrepo-${issue}.json"
-	jq -n '{
+	local claimed_at
+	claimed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	jq -n --arg claimed_at "$claimed_at" '{
 		issue: 99004,
 		slug: "testowner/testrepo",
 		worktree_path: "/tmp/wt-claim-99004",
-		claimed_at: "2026-04-29T00:00:00Z",
+		claimed_at: $claimed_at,
 		pid: 999998,
 		hostname: "different-host-machine-xyz",
 		user: "testuser"
@@ -274,6 +276,31 @@ test_cross_host_active() {
 	fi
 }
 test_cross_host_active
+
+test_cross_host_expired() {
+	local issue=99005
+	local stamp="${CLAIM_DIR}/testowner-testrepo-${issue}.json"
+	jq -n '{
+		issue: 99005,
+		slug: "testowner/testrepo",
+		worktree_path: "/tmp/wt-claim-99005",
+		claimed_at: "2020-01-01T00:00:00Z",
+		pid: 999997,
+		hostname: "different-host-machine-xyz",
+		user: "testuser"
+	}' >"$stamp"
+
+	AIDEVOPS_CROSS_HOST_CLAIM_TTL_HOURS=24 \
+		_isc_branch_has_active_claim "feature/gh-${issue}-test" --worktree "$FAKE_REPO" >/dev/null 2>&1
+	local rc=$?
+	rm -f "$stamp"
+	if [[ $rc -eq 1 ]]; then
+		print_result "expired cross-host stamp → no claim (exit 1)" 0
+	else
+		print_result "expired cross-host stamp → no claim (exit 1)" 1 "(rc=$rc)"
+	fi
+}
+test_cross_host_expired
 
 # =============================================================================
 # Test 6 — unparseable branch (no issue derivable) → no claim

--- a/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
+++ b/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
@@ -156,6 +156,28 @@ test_dead_owner_after_cooldown_unregisters() {
 	return 0
 }
 
+test_registry_prune_reconciles_expired_existing_owner() {
+	local wt_path
+	wt_path=$(make_worktree_dir "prune-expired-existing-owner")
+	register_dead_owner_fixture "$wt_path" "feature/prune-expired-existing-owner"
+	is_worktree_owned_by_others "$wt_path" >/dev/null 2>&1
+	local registry_path
+	registry_path=$(_wt_registry_lookup_path "$wt_path")
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+        UPDATE worktree_owners
+        SET owner_dead_seen_at = '2020-01-01T00:00:00Z'
+        WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
+    "
+	export WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES=1
+
+	local rc=0
+	prune_worktree_registry >/dev/null 2>&1 || rc=1
+	assert_owner_missing "$wt_path" || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	print_result "registry prune reconciles expired owner without deleting worktree" "$rc"
+	return 0
+}
+
 test_owner_pid_override_rejects_sql_payload() {
 	local wt_path
 	wt_path=$(make_worktree_dir "owner-pid-sql-payload")
@@ -234,10 +256,11 @@ test_reused_owner_delete_preserves_concurrent_replacement() {
 	register_worktree "$wt_path" "feature/reused-owner-delete-race" --owner-pid "$owner_pid"
 	local registry_path=""
 	local original_process_start=""
+	local original_boot_id=""
 	local original_created_at=""
 	registry_path=$(_wt_registry_lookup_path "$wt_path")
-	IFS='|' read -r original_process_start original_created_at <<<"$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
-        SELECT COALESCE(owner_process_start, ''), COALESCE(created_at, '')
+	IFS='|' read -r original_process_start original_boot_id original_created_at <<<"$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
+		SELECT COALESCE(owner_process_start, ''), COALESCE(owner_boot_id, ''), COALESCE(created_at, '')
         FROM worktree_owners WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
     ")"
 	sqlite3 "$WORKTREE_REGISTRY_DB" "
@@ -247,7 +270,7 @@ test_reused_owner_delete_preserves_concurrent_replacement() {
 
 	local rc=0
 	if _wt_unregister_owner_if_generation_matches "$registry_path" "$owner_pid" \
-		"$original_process_start" "$original_created_at"; then
+		"$original_process_start" "$original_boot_id" "$original_created_at"; then
 		rc=1
 	fi
 	local replacement_process_start=""
@@ -398,6 +421,12 @@ test_explicit_cleanup_lease_identity() {
 		"worktree-removal"; then
 		rc=1
 	fi
+	local lease_kind=""
+	lease_kind=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+		SELECT lease_kind FROM worktree_owners
+		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
+	")
+	[[ "$lease_kind" == "cleanup" ]] || rc=1
 	if worktree_has_exact_owner_contract "$wt_path" "$$" "cleanup-replaced" \
 		"worktree-removal"; then
 		rc=1
@@ -473,9 +502,79 @@ test_legacy_registry_schema_migrates_on_owner_check() {
 	has_owner_comm=$(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT 1 FROM pragma_table_info('worktree_owners') WHERE name = 'owner_comm';" 2>/dev/null || true)
 	local has_owner_process_start=""
 	has_owner_process_start=$(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT 1 FROM pragma_table_info('worktree_owners') WHERE name = 'owner_process_start';" 2>/dev/null || true)
+	local has_owner_boot_id=""
+	has_owner_boot_id=$(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT 1 FROM pragma_table_info('worktree_owners') WHERE name = 'owner_boot_id';" 2>/dev/null || true)
+	local has_lease_kind=""
+	has_lease_kind=$(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT 1 FROM pragma_table_info('worktree_owners') WHERE name = 'lease_kind';" 2>/dev/null || true)
+	local has_heartbeat_at=""
+	has_heartbeat_at=$(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT 1 FROM pragma_table_info('worktree_owners') WHERE name = 'heartbeat_at';" 2>/dev/null || true)
 	[[ "$has_owner_comm" == "1" ]] || rc=1
 	[[ "$has_owner_process_start" == "1" ]] || rc=1
+	[[ "$has_owner_boot_id" == "1" ]] || rc=1
+	[[ "$has_lease_kind" == "1" ]] || rc=1
+	[[ "$has_heartbeat_at" == "1" ]] || rc=1
 	print_result "legacy registry schema migrates during owner check" "$rc"
+	return 0
+}
+
+test_registration_metadata_and_exact_heartbeat_renewal() {
+	local wt_path
+	wt_path=$(make_worktree_dir "registry-heartbeat-metadata")
+	register_worktree "$wt_path" "feature/registry-heartbeat-metadata" \
+		--owner-pid "$$" --session "test-session-identity" --lease-kind "interactive"
+	local registry_path=""
+	registry_path=$(_wt_registry_lookup_path "$wt_path")
+	local metadata=""
+	metadata=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
+		SELECT owner_session, lease_kind, COALESCE(owner_boot_id, ''), COALESCE(heartbeat_at, '')
+		FROM worktree_owners WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
+	")
+	local owner_session="" lease_kind="" owner_boot_id="" heartbeat_at=""
+	IFS='|' read -r owner_session lease_kind owner_boot_id heartbeat_at <<<"$metadata"
+	local rc=0
+	[[ "$owner_session" == "test-session-identity" ]] || rc=1
+	[[ "$lease_kind" == "interactive" ]] || rc=1
+	[[ -n "$owner_boot_id" && -n "$heartbeat_at" ]] || rc=1
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+		UPDATE worktree_owners SET heartbeat_at = '2020-01-01T00:00:00Z'
+		WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
+	"
+	renew_worktree_ownership "$wt_path" --owner-pid "$$" --session "test-session-identity" || rc=1
+	heartbeat_at=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+		SELECT heartbeat_at FROM worktree_owners WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
+	")
+	[[ "$heartbeat_at" != "2020-01-01T00:00:00Z" ]] || rc=1
+	if renew_worktree_ownership "$wt_path" --owner-pid "$$" --session "wrong-session"; then
+		rc=1
+	fi
+	print_result "registration stores identity metadata and renews exact heartbeat" "$rc"
+	return 0
+}
+
+test_boot_identity_mismatch_unregisters_recycled_owner() {
+	local current_boot_id=""
+	current_boot_id=$(_wt_current_boot_id 2>/dev/null || true)
+	if [[ -z "$current_boot_id" ]]; then
+		print_result "boot identity mismatch unregisters recycled owner" 0 "(boot identity unavailable)"
+		return 0
+	fi
+	local wt_path
+	wt_path=$(make_worktree_dir "boot-identity-mismatch")
+	local owner_pid
+	owner_pid=$(live_other_pid)
+	register_worktree "$wt_path" "feature/boot-identity-mismatch" --owner-pid "$owner_pid"
+	local registry_path=""
+	registry_path=$(_wt_registry_lookup_path "$wt_path")
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+		UPDATE worktree_owners SET owner_boot_id = 'different-boot-identity'
+		WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
+	"
+	local rc=0
+	if is_worktree_owned_by_others "$wt_path" >/dev/null 2>&1; then
+		rc=1
+	fi
+	assert_owner_missing "$wt_path" || rc=1
+	print_result "boot identity mismatch unregisters recycled owner" "$rc"
 	return 0
 }
 
@@ -550,6 +649,7 @@ main() {
 	test_dead_owner_first_pass_quarantines
 	test_dead_owner_within_cooldown_keeps_skip
 	test_dead_owner_after_cooldown_unregisters
+	test_registry_prune_reconciles_expired_existing_owner
 	test_owner_pid_override_rejects_sql_payload
 	test_recycled_live_pid_with_same_command_unregisters
 	test_matching_live_process_generation_still_blocks
@@ -561,6 +661,8 @@ main() {
 	test_explicit_cleanup_lease_identity
 	test_matching_pid_requires_matching_process_generation
 	test_legacy_registry_schema_migrates_on_owner_check
+	test_registration_metadata_and_exact_heartbeat_renewal
+	test_boot_identity_mismatch_unregisters_recycled_owner
 	test_inconclusive_dead_pid_probe_fails_closed
 	test_unavailable_process_generation_fails_closed
 	test_should_skip_cleanup_branch_merged_within_grace

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -581,18 +581,21 @@ cmd_registry() {
 			echo "No registry entries"
 			return 0
 		}
+		_init_registry_db || return 1
 		echo -e "${BOLD}Worktree Ownership Registry:${NC}"
 		echo ""
 		local entries
 		entries=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
-                SELECT worktree_path, branch, owner_pid, owner_session, owner_batch, task_id, created_at
+				SELECT worktree_path, branch, owner_pid, owner_session, owner_batch, task_id,
+				       COALESCE(lease_kind, ''), COALESCE(heartbeat_at, ''),
+				       COALESCE(owner_boot_id, ''), created_at
                 FROM worktree_owners ORDER BY created_at DESC;
             " 2>/dev/null || echo "")
 		if [[ -z "$entries" ]]; then
 			echo "  (empty)"
 			return 0
 		fi
-		while IFS='|' read -r wt_path branch pid session batch task created; do
+		while IFS='|' read -r wt_path branch pid session batch task lease_kind heartbeat boot_id created; do
 			local alive_status="${RED}dead${NC}"
 			if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
 				alive_status="${GREEN}alive${NC}"
@@ -603,6 +606,9 @@ cmd_registry() {
 			[[ -n "$session" ]] && echo -e "    Session: $session"
 			[[ -n "$batch" ]] && echo -e "    Batch:   $batch"
 			[[ -n "$task" ]] && echo -e "    Task:    $task"
+			[[ -n "$lease_kind" ]] && echo -e "    Lease:   $lease_kind"
+			[[ -n "$heartbeat" ]] && echo -e "    Heartbeat: $heartbeat"
+			[[ -n "$boot_id" ]] && echo -e "    Boot:    $boot_id"
 			echo -e "    Created: $created"
 			echo ""
 		done <<<"$entries"
@@ -695,11 +701,12 @@ COMMANDS
                          Apply only exact candidates from a supported plan after
                          locked revalidation, staging, and receipt publication.
 
-  registry [list|prune]  View or prune the ownership registry (t189, t197)
-                         list: Show all registered worktrees with ownership info
-                         prune [-v|--verbose]: Clean dead/corrupted entries:
-                           - Dead PIDs with missing directories
-                           - Paths with ANSI escape codes
+	registry [list|prune]  View or prune the ownership registry (t189, t197)
+	                         list: Show all registered worktrees with ownership info
+	                         prune [-v|--verbose]: Clean dead/corrupted entries:
+	                           - Dead/recycled owners after a safety cooldown
+	                           - Missing worktree directories
+	                           - Paths with ANSI escape codes
                            - Test artifacts in /tmp or /var/folders
 
   help                   Show this help


### PR DESCRIPTION
## Summary

- reconcile dead or recycled registry owners for worktrees that still exist
- add typed lease, heartbeat, session, process-generation, and boot identity metadata
- bound cross-host interactive claims with renewable timestamps while preserving fail-closed malformed-stamp handling
- expose lease metadata in `worktree-helper.sh registry list`

## Implementation

- `.agents/scripts/shared-worktree-registry.sh` migrates legacy databases in place, refreshes exact-owner heartbeats, detects cross-boot PID reuse, and keeps generation-aware deletion contracts backward compatible.
- `.agents/scripts/cleanup-worktrees-async-helper.sh` runs bounded registry reconciliation before guarded cleanup without deleting worktree directories.
- `.agents/scripts/interactive-session-helper-stamp.sh` renews matching registry ownership and expires only conclusively stale cross-host claims.
- Existing test scripts cover migrations, renewal, boot mismatch, reconciliation, cross-host expiry, ownership transfer, and removal safeguards.

## Verification

- ShellCheck on all seven changed shell files
- `git diff --check`
- `test-worktree-registry-dead-owner.sh`: 20/20
- `test-worktree-registry-session-claim.sh`: 15/15
- `test-cleanup-worktrees-async.sh`: 15/15
- `test-worktree-cleanup-claim-guard.sh`: 11/11
- `test-worktree-removal-audit.sh`: 50/50
- `test-worktree-registry-prune-batch.sh`: 5/5
- pre-commit and pre-push quality hooks passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.297 plugin for [OpenCode](https://opencode.ai) v1.18.26 with gpt-5.6-sol
