### PR TITLE
GH#31030: verify managed Pulse restarts by active runtime PID

### DIFF
--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -265,13 +265,8 @@ _pulse_start_managed() {
 		_pl_err "launchd accepted the Pulse restart but no new activated-bundle process appeared"
 		return 1
 	fi
-	_start || return $?
-	if active_pid=$(_pulse_find_active_runtime_pid_since ""); then
-		_pl_ok "Pulse is running from the activated bundle (PID ${active_pid})"
-		return 0
-	fi
-	_pl_err "Pulse started but its activated runtime bundle could not be verified"
-	return 1
+	_start_activated_runtime
+	return $?
 }
 
 # _pulse_pids_raw: print ALL matching pulse PIDs including subshells of the
@@ -715,18 +710,8 @@ _stop_reconciliation_processes() {
 	return 0
 }
 
-# _start: launch pulse in background via nohup. No-op if already running.
-_start() {
-	if _is_running; then
-		_pl_info "Pulse already running (PIDs: $(_pulse_pids | tr '\n' ' '))"
-		return 0
-	fi
-
-	if [[ ! -x "$_PULSE_SCRIPT" ]]; then
-		_pl_err "pulse-wrapper.sh not found or not executable: $_PULSE_SCRIPT"
-		return 2
-	fi
-
+# _pulse_launch_unmanaged: launch pulse in background via nohup.
+_pulse_launch_unmanaged() {
 	mkdir -p "${_PULSE_LOG%/*}"
 
 	# t2994: cache priming moved into pulse-wrapper.sh::main() with a
@@ -744,12 +729,48 @@ _start() {
 
 	# Give nohup a moment to fork and let pulse-wrapper emit its startup banner.
 	sleep 1
+	return 0
+}
+
+_pulse_require_script() {
+	if [[ ! -x "$_PULSE_SCRIPT" ]]; then
+		_pl_err "pulse-wrapper.sh not found or not executable: $_PULSE_SCRIPT"
+		return 2
+	fi
+	return 0
+}
+
+# _start: launch pulse in background via nohup. No-op if already running.
+_start() {
+	if _is_running; then
+		_pl_info "Pulse already running (PIDs: $(_pulse_pids | tr '\n' ' '))"
+		return 0
+	fi
+
+	_pulse_require_script || return $?
+	_pulse_launch_unmanaged
 
 	if _is_running; then
 		_pl_ok "Pulse started (PID: $(_pulse_pids | head -1))"
 		return 0
 	fi
 	_pl_err "Pulse failed to start — check $_PULSE_LOG"
+	return 1
+}
+
+_start_activated_runtime() {
+	local active_pid=""
+	if active_pid=$(_pulse_find_active_runtime_pid_since ""); then
+		_pl_info "Pulse already running from the activated bundle (PID ${active_pid})"
+		return 0
+	fi
+	_pulse_require_script || return $?
+	_pulse_launch_unmanaged
+	if active_pid=$(_pulse_find_active_runtime_pid_since ""); then
+		_pl_ok "Pulse is running from the activated bundle (PID ${active_pid})"
+		return 0
+	fi
+	_pl_err "Pulse started but its activated runtime bundle could not be verified"
 	return 1
 }
 

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -657,6 +657,55 @@ test_managed_replacement_requires_new_active_bundle_lease() {
 	return 0
 }
 
+test_managed_start_ignores_non_active_running_pids() {
+	local find_count_file="${TEST_ROOT}/managed-start-find-count"
+	local launch_count_file="${TEST_ROOT}/managed-start-launch-count"
+	local result=""
+	local rc=0
+	printf '0\n' >"$find_count_file"
+	printf '0\n' >"$launch_count_file"
+	result=$(
+		# shellcheck source=../pulse-lifecycle-helper.sh
+		source "$HELPER"
+		_is_running() {
+			return 0
+		}
+		_pulse_require_script() {
+			return 0
+		}
+		_pulse_launch_unmanaged() {
+			local launch_calls=""
+			IFS= read -r launch_calls <"$launch_count_file" || launch_calls=0
+			launch_calls=$((launch_calls + 1))
+			printf '%s\n' "$launch_calls" >"$launch_count_file"
+			return 0
+		}
+		_pulse_find_active_runtime_pid_since() {
+			local baseline_pids="$1"
+			local find_calls=""
+			: "$baseline_pids"
+			IFS= read -r find_calls <"$find_count_file" || find_calls=0
+			find_calls=$((find_calls + 1))
+			printf '%s\n' "$find_calls" >"$find_count_file"
+			if [[ "$find_calls" -lt 2 ]]; then
+				return 1
+			fi
+			printf '303\n'
+			return 0
+		}
+		_start_activated_runtime
+		local launch_calls=""
+		IFS= read -r launch_calls <"$launch_count_file" || launch_calls=0
+		printf 'launch-calls=%s\n' "$launch_calls"
+	) || rc=$?
+	if [[ "$rc" -eq 0 && "$result" == *"Pulse is running from the activated bundle (PID 303)"* && "$result" == *"launch-calls=1"* ]]; then
+		_print_result "managed start ignores non-active running PIDs" 1
+	else
+		_print_result "managed start failed to bypass non-active running PIDs (rc=$rc result=$result)" 0
+	fi
+	return 0
+}
+
 test_launchd_runtime_wait_accepts_prompt_start() {
 	local result=""
 	local rc=0
@@ -1331,6 +1380,7 @@ main() {
 	test_reconciliation_fails_closed_on_unkillable_snapshot
 	test_reconciliation_skips_reused_snapshot_pid
 	test_managed_replacement_requires_new_active_bundle_lease
+	test_managed_start_ignores_non_active_running_pids
 	test_launchd_runtime_wait_accepts_prompt_start
 	test_launchd_runtime_wait_accepts_delayed_start
 	test_launchd_runtime_wait_rejects_wrong_runtime


### PR DESCRIPTION
## Summary
- require managed Pulse startup to prove a PID from the activated runtime bundle
- keep normal `start` idempotent by extracting unmanaged launch and script validation helpers
- add regression coverage for non-active running PIDs during managed activation

Resolves #31030

## Verification
- `bash .agents/scripts/tests/test-pulse-lifecycle-helper.sh`
- `bash -n .agents/scripts/pulse-lifecycle-helper.sh .agents/scripts/tests/test-pulse-lifecycle-helper.sh`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.5 spent 1d 23h and 1,529,937 tokens on this with the user in an interactive session.