### PR TITLE
GH#31032: avoid objective disposition argv limits

### DIFF
--- a/.agents/scripts/objective-reconciliation-helper.sh
+++ b/.agents/scripts/objective-reconciliation-helper.sh
@@ -221,7 +221,8 @@ _objective_disposition() {
 		state_json=$(jq -c '.' "$state_file" 2>/dev/null) || state_json="$OBJECTIVE_EMPTY_STATE"
 	fi
 	jq -nc --arg repo "$repo" --argjson issue "$issue_number" --arg aid "$attempt_id" \
-		--argjson evidence "$evidence_json" --argjson state "$state_json" \
+		--slurpfile evidence_file <(printf '%s\n' "$evidence_json") \
+		--slurpfile state_file <(printf '%s\n' "$state_json") \
 		--arg record_type "$OBJECTIVE_RECORD_ATTEMPT_OUTCOME" \
 		--arg event_completed "$OBJECTIVE_EVENT_COMPLETED" --arg event_failed "$OBJECTIVE_EVENT_FAILED" --arg event_deferred "$OBJECTIVE_EVENT_DEFERRED" \
 		--arg outcome_success "$OBJECTIVE_OUTCOME_SUCCESS" --arg outcome_failed "$OBJECTIVE_OUTCOME_FAILED" --arg outcome_deferred "$OBJECTIVE_OUTCOME_DEFERRED" \
@@ -229,6 +230,8 @@ _objective_disposition() {
 		--arg source_lifecycle "$OBJECTIVE_SOURCE_LIFECYCLE" --arg source_state "$OBJECTIVE_SOURCE_STATE" --arg source_none "$OBJECTIVE_SOURCE_NONE" \
 		--arg state_completed "$OBJECTIVE_STATE_COMPLETED" --arg state_cancelled "$OBJECTIVE_STATE_CANCELLED" \
 		--arg state_impossible "$OBJECTIVE_STATE_IMPOSSIBLE" --arg state_review "$OBJECTIVE_STATE_REVIEW" '
+		($evidence_file[0] // []) as $evidence |
+		($state_file[0] // {objectives:[]}) as $state |
 		def timestamp: ((.evidence_timestamp // .timestamp // .ts // 0) | tonumber? // 0);
 		def epoch_key:
 			((.attempt_started_at // timestamp) | tostring) as $raw |
@@ -525,7 +528,7 @@ main() {
 		--next-action) [[ $# -gt 0 ]] || return 2; next_action="$1"; shift ;;
 		--timestamp) [[ $# -gt 0 ]] || return 2; outcome_timestamp="$1"; shift ;;
 		--attempt-started-at) [[ $# -gt 0 ]] || return 2; attempt_started_at="$1"; shift ;;
-		--help|-h) _objective_usage; return 0 ;;
+		--help | -h) _objective_usage; return 0 ;;
 		*) printf 'ERROR: unknown option: %s\n' "$arg" >&2; return 2 ;;
 		esac
 	done

--- a/.agents/scripts/tests/test-objective-reconciliation.sh
+++ b/.agents/scripts/tests/test-objective-reconciliation.sh
@@ -189,4 +189,22 @@ jq -e '.source == "objective_state" and .effective_outcome == "success" and
 	.suppress_retry == true and .suppress_failure_mining == true' \
 	"$disposition" >/dev/null || fail "legacy objective state remains readable"
 
+large_evidence_file="$TMP_DIR/large-evidence.jsonl"
+large_payload=$(printf '%0200000d' 0)
+for large_index in 1 2 3 4 5 6 7 8 9 10; do
+	printf '{"repo":"owner/repo","issue_number":%s,"event_type":"worker.failed","payload":"%s"}\n' \
+		"$large_index" "$large_payload" >>"$large_evidence_file"
+done
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$large_evidence_file" \
+	"$HELPER" record-outcome --repo owner/repo --issue 88 \
+	--attempt-id attempt-large --run-id run-large --raw-result recovered \
+	--outcome success --status recovered --classification stale_cleanup \
+	--next-action monitor_pr --timestamp 10400
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$large_evidence_file" \
+	"$HELPER" disposition --repo owner/repo --issue 88 --attempt-id attempt-large \
+	--state-file "$state_file" >"$disposition"
+jq -e '.source == "attempt_outcome" and .effective_outcome == "success" and
+	.raw_result == "recovered"' "$disposition" >/dev/null ||
+	fail "large evidence disposition must avoid argv limits"
+
 printf 'PASS objective-reconciliation\n'


### PR DESCRIPTION
## Summary
- avoid passing large objective evidence arrays through `jq --argjson` argv
- load bounded evidence/state JSON through `--slurpfile` in disposition
- add regression coverage for large evidence logs

Resolves #31032

## Verification
- `bash .agents/scripts/tests/test-objective-reconciliation.sh`
- `bash -n .agents/scripts/objective-reconciliation-helper.sh .agents/scripts/tests/test-objective-reconciliation.sh`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.5 spent 2d 2h and 1,780,301 tokens on this with the user in an interactive session.