### PR TITLE
GH#31026: fix: bound verbose successful output

### DIFF
--- a/.agents/scripts/output-sandbox-helper.sh
+++ b/.agents/scripts/output-sandbox-helper.sh
@@ -18,6 +18,8 @@ RAW_DIR="${AIDEVOPS_OUTPUT_SANDBOX_RAW_DIR:-${SANDBOX_ROOT}/raw}"
 DEFAULT_SUMMARY_LINES="${AIDEVOPS_OUTPUT_SANDBOX_SUMMARY_LINES:-20}"
 DEFAULT_DIAGNOSTIC_LINES="${AIDEVOPS_OUTPUT_SANDBOX_DIAGNOSTIC_LINES:-20}"
 DEFAULT_RETENTION_DAYS="${AIDEVOPS_OUTPUT_SANDBOX_RETENTION_DAYS:-14}"
+DEFAULT_COMPACT_BYTES="${AIDEVOPS_OUTPUT_SANDBOX_COMPACT_BYTES:-8192}"
+DEFAULT_COMPACT_LINES="${AIDEVOPS_OUTPUT_SANDBOX_COMPACT_LINES:-80}"
 
 usage() {
 	cat <<'EOF'
@@ -34,7 +36,7 @@ auditable pointer. Exact/verbatim/security-sensitive commands are bypassed.
 
 Run options:
   --tag TAG                    Evidence category (default: run)
-  --success-mode MODE          receipt|summary|full (default: receipt)
+  --success-mode MODE          auto|receipt|summary|full (default: auto)
   --failure-mode MODE          diagnostic|summary|full (default: diagnostic)
   --summary-lines N            Maximum summary lines (default: 20)
   --diagnostic-lines N         Maximum failure diagnostic lines (default: 20)
@@ -244,7 +246,7 @@ redact_capture_files() {
 validate_mode() {
 	local mode="$1"
 	case "$mode" in
-	receipt | summary | diagnostic | full) return 0 ;;
+	auto | receipt | summary | diagnostic | full) return 0 ;;
 	*) return 1 ;;
 	esac
 }
@@ -383,6 +385,67 @@ print_presentation() {
 	return 0
 }
 
+is_verbose_success() {
+	local byte_count="$1"
+	local line_count="$2"
+	[[ "$byte_count" -ge "$DEFAULT_COMPACT_BYTES" || "$line_count" -ge "$DEFAULT_COMPACT_LINES" ]]
+	return $?
+}
+
+print_verbose_success_summary() {
+	local output_id="$1"
+	local command_text="$2"
+	local exit_code="$3"
+	local duration_seconds="$4"
+	local byte_count="$5"
+	local line_count="$6"
+	local sensitive="$7"
+	local raw_path="$8"
+	if [[ "$sensitive" == "1" ]]; then
+		printf 'command: %s\n' "$command_text"
+		printf 'exit_status: %s\n' "$exit_code"
+		printf 'duration_seconds: %s\n' "$duration_seconds"
+		printf 'output: %s bytes across %s lines; sensitive content redacted\n' "$byte_count" "$line_count"
+		printf 'full_log: output-sandbox-helper.sh show %s\n' "$output_id"
+		return 0
+	fi
+	python3 - "$raw_path" "$command_text" "$exit_code" "$duration_seconds" "$byte_count" "$line_count" "$output_id" <<'PY'
+import re
+import sys
+
+path, command, exit_code, duration, byte_count, line_count, output_id = sys.argv[1:]
+with open(path, "r", encoding="utf-8", errors="replace") as handle:
+    lines = handle.read().splitlines()
+warning_pattern = re.compile(r"(?i)(warning|deprecated|deprecation|lint|compiler)")
+warnings = [line for line in lines if warning_pattern.search(line)]
+test_patterns = (
+    re.compile(r"(?i)\btests?\s*[:=]\s*(.+)$"),
+    re.compile(r"(?i)\b(\d+)\s+(?:tests?\s+)?passed\b(?:.*?\b(\d+)\s+failed\b)?"),
+    re.compile(r"(?i)^#\s*(pass|fail)\s+(\d+)\b"),
+)
+test_lines = []
+for line in lines:
+    if any(pattern.search(line) for pattern in test_patterns):
+        test_lines.append(line.strip())
+
+print(f"command: {command}")
+print(f"exit_status: {exit_code}")
+print(f"duration_seconds: {duration}")
+print(f"output: {byte_count} bytes across {line_count} lines")
+print(f"warnings: {len(warnings)}")
+for line in warnings[:4]:
+    print(f"  warning: {line}")
+if len(warnings) > 4:
+    print(f"  ... {len(warnings) - 4} additional warning line(s) retained")
+if test_lines:
+    print("test_totals:")
+    for line in test_lines[:4]:
+        print(f"  {line}")
+print(f"full_log: output-sandbox-helper.sh show {output_id}")
+PY
+	return 0
+}
+
 cmd_store() {
 	local command_text="stdin"
 	local exit_code="0"
@@ -426,7 +489,7 @@ cmd_store() {
 
 cmd_run() {
 	local tag="run" summary_lines="$DEFAULT_SUMMARY_LINES" diagnostic_lines="$DEFAULT_DIAGNOSTIC_LINES"
-	local success_mode="receipt" failure_mode="diagnostic"
+	local success_mode="auto" failure_mode="diagnostic"
 	local expected_text="" format="text"
 	while [[ $# -gt 0 ]]; do
 		local opt="$1"
@@ -474,7 +537,8 @@ cmd_run() {
 		return $?
 	fi
 	local output_id raw_path stdout_path stderr_path summary_file diagnostic_file
-	local process_exit exit_code byte_count line_count sensitive outcome basis mode
+	local process_exit exit_code byte_count line_count sensitive outcome basis mode start_seconds duration_seconds
+	start_seconds=$SECONDS
 	output_id=$(make_output_id)
 	raw_path="${RAW_DIR}/${output_id}.txt"
 	stdout_path="${raw_path}.stdout"
@@ -506,6 +570,7 @@ cmd_run() {
 	fi
 	byte_count=$(wc -c <"$raw_path" | tr -d ' ')
 	line_count=$(wc -l <"$raw_path" | tr -d ' ')
+	duration_seconds=$((SECONDS - start_seconds))
 	if ! summarize_file "$raw_path" "$summary_lines" "$sensitive" >"$summary_file" || \
 		! diagnose_file "$raw_path" "$diagnostic_lines" "$sensitive" >"$diagnostic_file" || \
 		! record_output "$output_id" "$command_text" "$PWD" "$exit_code" "$tag" "$raw_path" "$byte_count" "$line_count" "$sensitive" "$summary_file"; then
@@ -518,6 +583,18 @@ cmd_run() {
 	if [[ "$exit_code" -ne 0 ]]; then
 		outcome="failed"
 		mode="$failure_mode"
+	fi
+	if [[ "$outcome" == "succeeded" && "$mode" == "auto" && "$format" == "text" ]]; then
+		if is_verbose_success "$byte_count" "$line_count"; then
+			print_verbose_success_summary "$output_id" "$command_text" "$exit_code" "$duration_seconds" \
+				"$byte_count" "$line_count" "$sensitive" "$raw_path"
+		else
+			emit_native_capture "$stdout_path" "$stderr_path"
+		fi
+		return "$exit_code"
+	fi
+	if [[ "$mode" == "auto" ]]; then
+		mode="receipt"
 	fi
 	print_presentation "$format" "$mode" "$output_id" "$outcome" "$exit_code" "$process_exit" \
 		"$byte_count" "$line_count" "$sensitive" "$basis" "$raw_path" "$summary_file" "$diagnostic_file"

--- a/.agents/scripts/output-sandbox-helper.sh
+++ b/.agents/scripts/output-sandbox-helper.sh
@@ -446,6 +446,37 @@ PY
 	return 0
 }
 
+present_run_result() {
+	local format="$1"
+	local mode="$2"
+	local output_id="$3"
+	local outcome="$4"
+	local exit_code="$5"
+	local process_exit="$6"
+	local byte_count="$7"
+	local line_count="$8"
+	local sensitive="$9"
+	local basis="${10}"
+	local raw_path="${11}"
+	local summary_file="${12}"
+	local diagnostic_file="${13}"
+	local duration_seconds="${14}"
+	local command_text="${15}"
+	if [[ "$outcome" == "succeeded" && "$mode" == "auto" && "$format" == "text" ]]; then
+		if is_verbose_success "$byte_count" "$line_count"; then
+			print_verbose_success_summary "$output_id" "$command_text" "$exit_code" "$duration_seconds" \
+				"$byte_count" "$line_count" "$sensitive" "$raw_path"
+		else
+			emit_native_capture "$raw_path.stdout" "$raw_path.stderr"
+		fi
+		return "$exit_code"
+	fi
+	[[ "$mode" == "auto" ]] && mode="receipt"
+	print_presentation "$format" "$mode" "$output_id" "$outcome" "$exit_code" "$process_exit" \
+		"$byte_count" "$line_count" "$sensitive" "$basis" "$raw_path" "$summary_file" "$diagnostic_file"
+	return "$exit_code"
+}
+
 cmd_store() {
 	local command_text="stdin"
 	local exit_code="0"
@@ -537,7 +568,7 @@ cmd_run() {
 		return $?
 	fi
 	local output_id raw_path stdout_path stderr_path summary_file diagnostic_file
-	local process_exit exit_code byte_count line_count sensitive outcome basis mode start_seconds duration_seconds
+	local process_exit exit_code byte_count line_count sensitive outcome="succeeded" basis mode="$success_mode" start_seconds duration_seconds
 	start_seconds=$SECONDS
 	output_id=$(make_output_id)
 	raw_path="${RAW_DIR}/${output_id}.txt"
@@ -578,26 +609,13 @@ cmd_run() {
 		emit_native_capture "$stdout_path" "$stderr_path"
 		return "$exit_code"
 	fi
-	outcome="succeeded"
-	mode="$success_mode"
 	if [[ "$exit_code" -ne 0 ]]; then
 		outcome="failed"
 		mode="$failure_mode"
 	fi
-	if [[ "$outcome" == "succeeded" && "$mode" == "auto" && "$format" == "text" ]]; then
-		if is_verbose_success "$byte_count" "$line_count"; then
-			print_verbose_success_summary "$output_id" "$command_text" "$exit_code" "$duration_seconds" \
-				"$byte_count" "$line_count" "$sensitive" "$raw_path"
-		else
-			emit_native_capture "$stdout_path" "$stderr_path"
-		fi
-		return "$exit_code"
-	fi
-	if [[ "$mode" == "auto" ]]; then
-		mode="receipt"
-	fi
-	print_presentation "$format" "$mode" "$output_id" "$outcome" "$exit_code" "$process_exit" \
-		"$byte_count" "$line_count" "$sensitive" "$basis" "$raw_path" "$summary_file" "$diagnostic_file"
+	present_run_result "$format" "$mode" "$output_id" "$outcome" "$exit_code" "$process_exit" \
+		"$byte_count" "$line_count" "$sensitive" "$basis" "$raw_path" "$summary_file" "$diagnostic_file" \
+		"$duration_seconds" "$command_text" || return $?
 	return "$exit_code"
 }
 

--- a/.agents/scripts/tests/test-output-sandbox-helper.sh
+++ b/.agents/scripts/tests/test-output-sandbox-helper.sh
@@ -60,7 +60,7 @@ file_mode() {
 }
 
 # shellcheck disable=SC2016 # Inner bash expands $i, not this test harness.
-run_output=$("$HELPER" run --summary-lines 4 -- bash -c 'for i in 1 2 3 4 5 6; do printf "line%s\n" "$i"; done')
+run_output=$("$HELPER" run --success-mode receipt --summary-lines 4 -- bash -c 'for i in 1 2 3 4 5 6; do printf "line%s\n" "$i"; done')
 assert_contains "run prints output id" "output_id: out_" "$run_output"
 assert_contains "successful run reports outcome" "outcome: succeeded" "$run_output"
 assert_not_contains "success receipt hides raw path" "raw_path:" "$run_output"
@@ -74,6 +74,20 @@ assert_contains "show respects limit" "3: line3" "$show_output"
 # shellcheck disable=SC2016 # Inner bash expands $i, not this test harness.
 summary_output=$("$HELPER" run --success-mode summary --summary-lines 4 -- bash -c 'for i in 1 2 3 4 5 6; do printf "line%s\n" "$i"; done')
 assert_contains "explicit success summary reports omission" "omitted" "$summary_output"
+
+short_output=$("$HELPER" run -- bash -c 'printf "short successful output\n"')
+[[ "$short_output" == "short successful output" ]] && \
+	pass "ordinary short successful output remains unchanged" || \
+	fail "ordinary short successful output remains unchanged" "got ${short_output}"
+
+# shellcheck disable=SC2016 # Inner bash expands $i, not this test harness.
+verbose_output=$("$HELPER" run -- bash -c 'for i in $(seq 1 100); do printf "asset %s\n" "$i"; done; printf "warning: fixture deprecation\n"; printf "Tests: 100 passed, 0 failed\n"')
+assert_contains "verbose success reports command identity" "command: bash" "$verbose_output"
+assert_contains "verbose success reports exit status" "exit_status: 0" "$verbose_output"
+assert_contains "verbose success preserves warning evidence" "warning: fixture deprecation" "$verbose_output"
+assert_contains "verbose success preserves test totals" "Tests: 100 passed, 0 failed" "$verbose_output"
+assert_contains "verbose success retains retrievable full log" "full_log: output-sandbox-helper.sh show out_" "$verbose_output"
+assert_not_contains "verbose success bounds raw asset listing" "asset 50" "$verbose_output"
 
 set +e
 failure_output=$("$HELPER" run --diagnostic-lines 4 -- bash -c 'printf "routine line\n"; printf "fatal: fixture failed\n" >&2; exit 7')


### PR DESCRIPTION
## Summary

Adds threshold-based automatic summaries for verbose successful output-sandbox commands while preserving short output and retained diagnostics.

## Files Changed

.agents/scripts/output-sandbox-helper.sh, .agents/scripts/tests/test-output-sandbox-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck .agents/scripts/output-sandbox-helper.sh .agents/scripts/tests/test-output-sandbox-helper.sh; bash .agents/scripts/tests/test-output-sandbox-helper.sh

Resolves #31026


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-terra spent 8m and 122,708 tokens on this as a headless worker.