### PR TITLE
GH#31025: add privacy-safe intent fallback provenance

### DIFF
--- a/.agents/plugins/opencode-aidevops/intent-tracing.mjs
+++ b/.agents/plugins/opencode-aidevops/intent-tracing.mjs
@@ -16,10 +16,100 @@ export const INTENT_FIELD = "agent__intent";
 
 /**
  * Per-callID intent store. Bridges tool.execute.before → tool.execute.after.
- * Maps callID → intent string.
- * @type {Map<string, string>}
+ * Maps callID → bounded intent record.
+ * @type {Map<string, {intent: string, source: "explicit" | "fallback"}>}
  */
 const intentByCallId = new Map();
+
+const FALLBACK_INTENT_BY_OPERATION = new Map([
+  ["read", "Reading requested context"],
+  ["search", "Searching requested context"],
+  ["execute", "Running the requested operation"],
+  ["write", "Updating requested files"],
+  ["research", "Researching requested context"],
+  ["fetch", "Fetching the requested reference"],
+  ["track", "Tracking requested work"],
+  ["load", "Loading requested guidance"],
+  ["use", "Using the requested tool"],
+]);
+
+function operationClass(toolName) {
+  const normalized = typeof toolName === "string"
+    ? toolName.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").slice(0, 64)
+    : "";
+  if (["read"].includes(normalized)) return "read";
+  if (["grep", "glob", "osgrep"].includes(normalized)) return "search";
+  if (["bash"].includes(normalized)) return "execute";
+  if (["apply_patch", "edit", "write"].includes(normalized)) return "write";
+  if (["task", "ai_research"].includes(normalized)) return "research";
+  if (["webfetch"].includes(normalized)) return "fetch";
+  if (["todowrite"].includes(normalized)) return "track";
+  if (["skill"].includes(normalized)) return "load";
+  return normalized ? "use" : "";
+}
+
+/** Derive a privacy-safe fallback from tool identity alone. */
+export function deriveFallbackIntent(toolName) {
+  const operation = operationClass(toolName);
+  return operation ? FALLBACK_INTENT_BY_OPERATION.get(operation) : undefined;
+}
+
+function storeIntentRecord(callID, record) {
+  if (!callID || !record) return;
+  intentByCallId.set(callID, record);
+
+  // Prune old entries to prevent unbounded memory growth.
+  if (intentByCallId.size > 5000) {
+    const keys = Array.from(intentByCallId.keys());
+    for (const k of keys.slice(0, 2500)) {
+      intentByCallId.delete(k);
+    }
+  }
+}
+
+function cloneArgsWithoutIntent(args) {
+  const clone = {};
+  const descriptors = Object.getOwnPropertyDescriptors(args);
+  for (const [key, descriptor] of Object.entries(descriptors)) {
+    if (key === INTENT_FIELD || !descriptor.enumerable || !("value" in descriptor)) continue;
+    clone[key] = descriptor.value;
+  }
+  return clone;
+}
+
+/**
+ * Prepare tool args and intent metadata as one fail-closed boundary operation.
+ * A non-configurable intent field is removed through a replacement plain object.
+ */
+export function prepareIntent(callID, args, toolName = "") {
+  let raw;
+  let sanitizedArgs = args;
+  if (args && typeof args === "object") {
+    let descriptor;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(args, INTENT_FIELD);
+    } catch {
+      descriptor = undefined;
+    }
+    if (descriptor && "value" in descriptor) raw = descriptor.value;
+    if (descriptor) {
+      try {
+        delete args[INTENT_FIELD];
+      } catch {
+        // Fall through to a replacement object below.
+      }
+      if (Object.prototype.hasOwnProperty.call(args, INTENT_FIELD)) {
+        sanitizedArgs = cloneArgsWithoutIntent(args);
+      }
+    }
+  }
+
+  const explicitIntent = typeof raw === "string" ? raw.trim() : "";
+  const intent = explicitIntent || deriveFallbackIntent(toolName);
+  const source = intent ? (explicitIntent ? "explicit" : "fallback") : undefined;
+  if (intent) storeIntentRecord(callID, { intent, source });
+  return { args: sanitizedArgs, intent, source };
+}
 
 /**
  * Extract, store, and strip the intent field from tool call args.
@@ -30,38 +120,23 @@ const intentByCallId = new Map();
  *
  * @param {string} callID - Unique tool call identifier
  * @param {object} args - Tool call arguments (may contain agent__intent)
- * @returns {string | undefined} Extracted intent string, or undefined
+ * @param {string} [toolName] - Host tool identity; never tool arguments
+ * @returns {string | undefined} Explicit or fallback intent string
  */
-export function extractAndStoreIntent(callID, args) {
-  if (!args || typeof args !== "object") return undefined;
+export function extractAndStoreIntent(callID, args, toolName = "") {
+  return prepareIntent(callID, args, toolName).intent;
+}
 
-  const hasIntent = Object.prototype.hasOwnProperty.call(args, INTENT_FIELD);
-  const raw = args[INTENT_FIELD];
-  if (hasIntent) {
-    try {
-      delete args[INTENT_FIELD];
-    } catch {
-      // Tool args can come from host/runtime objects with frozen or
-      // non-configurable properties; extraction must not crash execution.
-    }
-  }
+/** Return intent provenance without consuming the current call record. */
+export function peekIntentSource(callID) {
+  return intentByCallId.get(callID)?.source;
+}
 
-  if (typeof raw !== "string") return undefined;
-
-  const intent = raw.trim();
-  if (!intent) return undefined;
-
-  intentByCallId.set(callID, intent);
-
-  // Prune old entries to prevent unbounded memory growth
-  if (intentByCallId.size > 5000) {
-    const keys = Array.from(intentByCallId.keys());
-    for (const k of keys.slice(0, 2500)) {
-      intentByCallId.delete(k);
-    }
-  }
-
-  return intent;
+/** Retrieve and remove the complete intent record for one call. */
+export function consumeIntentRecord(callID) {
+  const record = intentByCallId.get(callID);
+  if (record !== undefined) intentByCallId.delete(callID);
+  return record;
 }
 
 /**
@@ -72,9 +147,5 @@ export function extractAndStoreIntent(callID, args) {
  * @returns {string | undefined}
  */
 export function consumeIntent(callID) {
-  const intent = intentByCallId.get(callID);
-  if (intent !== undefined) {
-    intentByCallId.delete(callID);
-  }
-  return intent;
+  return consumeIntentRecord(callID)?.intent;
 }

--- a/.agents/plugins/opencode-aidevops/intent-tracing.mjs
+++ b/.agents/plugins/opencode-aidevops/intent-tracing.mjs
@@ -70,9 +70,10 @@ function storeIntentRecord(callID, record) {
 function cloneArgsWithoutIntent(args) {
   const clone = {};
   const descriptors = Object.getOwnPropertyDescriptors(args);
-  for (const [key, descriptor] of Object.entries(descriptors)) {
-    if (key === INTENT_FIELD || !descriptor.enumerable || !("value" in descriptor)) continue;
-    clone[key] = descriptor.value;
+  for (const key of Reflect.ownKeys(descriptors)) {
+    const descriptor = descriptors[key];
+    if (key === INTENT_FIELD || !descriptor.enumerable) continue;
+    Object.defineProperty(clone, key, descriptor);
   }
   return clone;
 }

--- a/.agents/plugins/opencode-aidevops/intent-tracing.mjs
+++ b/.agents/plugins/opencode-aidevops/intent-tracing.mjs
@@ -33,19 +33,27 @@ const FALLBACK_INTENT_BY_OPERATION = new Map([
   ["use", "Using the requested tool"],
 ]);
 
+const TOOL_OPERATION_BY_NAME = new Map([
+  ["read", "read"],
+  ["grep", "search"],
+  ["glob", "search"],
+  ["osgrep", "search"],
+  ["bash", "execute"],
+  ["apply_patch", "write"],
+  ["edit", "write"],
+  ["write", "write"],
+  ["task", "research"],
+  ["ai_research", "research"],
+  ["webfetch", "fetch"],
+  ["todowrite", "track"],
+  ["skill", "load"],
+]);
+
 function operationClass(toolName) {
   const normalized = typeof toolName === "string"
     ? toolName.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").slice(0, 64)
     : "";
-  if (["read"].includes(normalized)) return "read";
-  if (["grep", "glob", "osgrep"].includes(normalized)) return "search";
-  if (["bash"].includes(normalized)) return "execute";
-  if (["apply_patch", "edit", "write"].includes(normalized)) return "write";
-  if (["task", "ai_research"].includes(normalized)) return "research";
-  if (["webfetch"].includes(normalized)) return "fetch";
-  if (["todowrite"].includes(normalized)) return "track";
-  if (["skill"].includes(normalized)) return "load";
-  return normalized ? "use" : "";
+  return normalized ? (TOOL_OPERATION_BY_NAME.get(normalized) || "use") : "";
 }
 
 /** Derive a privacy-safe fallback from tool identity alone. */
@@ -78,33 +86,41 @@ function cloneArgsWithoutIntent(args) {
   return clone;
 }
 
-/**
- * Prepare tool args and intent metadata as one fail-closed boundary operation.
- * A non-configurable intent field is removed through a replacement plain object.
- */
-export function prepareIntent(callID, args, toolName = "") {
-  let raw;
-  let sanitizedArgs = args;
+function ownIntentDescriptor(args) {
+  let descriptor;
   if (args && typeof args === "object") {
-    let descriptor;
     try {
       descriptor = Object.getOwnPropertyDescriptor(args, INTENT_FIELD);
     } catch {
       descriptor = undefined;
     }
-    if (descriptor && "value" in descriptor) raw = descriptor.value;
-    if (descriptor) {
-      try {
-        delete args[INTENT_FIELD];
-      } catch {
-        // Fall through to a replacement object below.
-      }
-      if (Object.prototype.hasOwnProperty.call(args, INTENT_FIELD)) {
-        sanitizedArgs = cloneArgsWithoutIntent(args);
-      }
+  }
+  return descriptor;
+}
+
+function stripOwnIntent(args, descriptor) {
+  let sanitizedArgs = args;
+  if (descriptor) {
+    try {
+      delete args[INTENT_FIELD];
+    } catch {
+      // Fall through to a replacement object below.
+    }
+    if (Object.prototype.hasOwnProperty.call(args, INTENT_FIELD)) {
+      sanitizedArgs = cloneArgsWithoutIntent(args);
     }
   }
+  return sanitizedArgs;
+}
 
+/**
+ * Prepare tool args and intent metadata as one fail-closed boundary operation.
+ * A non-configurable intent field is removed through a replacement plain object.
+ */
+export function prepareIntent(callID, args, toolName = "") {
+  const descriptor = ownIntentDescriptor(args);
+  const raw = descriptor && "value" in descriptor ? descriptor.value : undefined;
+  const sanitizedArgs = stripOwnIntent(args, descriptor);
   const explicitIntent = typeof raw === "string" ? raw.trim() : "";
   const intent = explicitIntent || deriveFallbackIntent(toolName);
   const source = intent ? (explicitIntent ? "explicit" : "fallback") : undefined;

--- a/.agents/plugins/opencode-aidevops/observability-retention.mjs
+++ b/.agents/plugins/opencode-aidevops/observability-retention.mjs
@@ -49,8 +49,11 @@ function firstTruthy(values, fallback) {
  * Replace raw host-tool metadata with a small outcome envelope. Raw values,
  * paths, output fragments, and unknown keys never cross the storage boundary.
  */
-export function summarizeToolMetadata(metadata) {
-  if (metadata === null || metadata === undefined) return null;
+export function summarizeToolMetadata(metadata, { intentSource } = {}) {
+  const retainedIntentSource = ["explicit", "fallback"].includes(intentSource)
+    ? intentSource
+    : undefined;
+  if ((metadata === null || metadata === undefined) && !retainedIntentSource) return null;
   const source = metadata && typeof metadata === "object" && !Array.isArray(metadata)
     ? metadata
     : {};
@@ -73,6 +76,7 @@ export function summarizeToolMetadata(metadata) {
   if (typeof truncated === "boolean") summary.truncated = truncated;
   if (typeof timedOut === "boolean") summary.timed_out = timedOut;
   if (source.error !== undefined) summary.has_error = Boolean(source.error);
+  if (retainedIntentSource) summary.intent_source = retainedIntentSource;
 
   const retainedSourceKeys = [
     "status", "state", "outcome", "exit", "exitCode", "exit_code", "outputBytes",

--- a/.agents/plugins/opencode-aidevops/observability-tool-calls.mjs
+++ b/.agents/plugins/opencode-aidevops/observability-tool-calls.mjs
@@ -26,16 +26,17 @@ export function toolCallSucceeded(output) {
  * @param {0 | 1} args.isSuccess
  * @param {number | null | undefined} args.durationMs - Elapsed ms, or null/undefined to store SQL NULL
  * @param {object | null | undefined} args.metadata - Raw metadata object; summarized before persistence
+ * @param {"explicit" | "fallback" | undefined} args.intentSource - Intent provenance
  * @param {string | null | undefined} args.outcomeCategory - Bounded outcome classification
  * @returns {string} INSERT statement ready for sqliteExec
  */
 export function buildToolCallInsertSql({
-  sessionID, callID, toolName, intent, isSuccess, durationMs, metadata, outcomeCategory,
+  sessionID, callID, toolName, intent, isSuccess, durationMs, metadata, intentSource, outcomeCategory,
 }) {
   const durationSql = (durationMs !== null && durationMs !== undefined)
     ? String(durationMs)
     : "NULL";
-  const metadataSummary = summarizeToolMetadata(metadata);
+  const metadataSummary = summarizeToolMetadata(metadata, { intentSource });
   const metadataValue = metadataSummary === null ? null : JSON.stringify(metadataSummary);
 
   return `INSERT INTO tool_calls (

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -471,8 +471,9 @@ ON CONFLICT(session_id) DO UPDATE SET
  * @param {object} output - { title, output, metadata }
  * @param {string | undefined} intent - LLM-provided intent string (from agent__intent field)
  * @param {number | null | undefined} [durationMs] - Elapsed milliseconds from tool.execute.before (t2184)
+ * @param {"explicit" | "fallback" | undefined} [intentSource] - Intent provenance
  */
-export function recordToolCall(input, output, intent, durationMs) {
+export function recordToolCall(input, output, intent, durationMs, intentSource) {
   if (!dbReady) return;
 
   const toolName = input.tool || "";
@@ -508,6 +509,7 @@ export function recordToolCall(input, output, intent, durationMs) {
     isSuccess,
     durationMs,
     metadata: output?.metadata,
+    intentSource,
     outcomeCategory,
   });
 

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -8,7 +8,11 @@ import { existsSync } from "fs";
 import { execFileSync, execFile } from "child_process";
 import { join } from "path";
 import { recordToolCall } from "./observability.mjs";
-import { extractAndStoreIntent, consumeIntent } from "./intent-tracing.mjs";
+import {
+  consumeIntentRecord,
+  peekIntentSource,
+  prepareIntent,
+} from "./intent-tracing.mjs";
 import { recordToolStart, consumeToolDuration } from "./timing-tracing.mjs";
 import { qualityLog, runFileQualityGate } from "./quality-logging.mjs";
 import { enrichActiveSpan, detectTaskId, detectSessionOrigin } from "./otel-enrichment.mjs";
@@ -270,10 +274,12 @@ function handleToolBefore(ctx, log, input, output) {
 
   const callID = input.callID || "";
   let intent = "";
-  if (callID && output.args) {
-    intent = extractAndStoreIntent(callID, output.args) || "";
+  if (callID) {
+    const prepared = prepareIntent(callID, output.args, input.tool);
+    output.args = prepared.args;
+    intent = prepared.intent || "";
     if (intent) {
-      log("INFO", `Intent [${input.tool}] callID=${callID}: ${intent}`);
+      log("INFO", `Intent [${input.tool}] callID=${callID} source=${peekIntentSource(callID)}: ${intent}`);
     }
   }
 
@@ -376,11 +382,11 @@ function handleToolAfter(ctx, log, scriptsDir, input, output) {
     }
   }
 
-  const intent = consumeIntent(input.callID || "");
+  const intentRecord = consumeIntentRecord(input.callID || "");
   // t2184: consumeToolDuration returns null when the callID wasn't paired
   // (e.g., hook race on plugin reload) — recordToolCall emits SQL NULL.
   const durationMs = consumeToolDuration(input.callID || "");
-  recordToolCall(input, output, intent, durationMs);
+  recordToolCall(input, output, intentRecord?.intent, durationMs, intentRecord?.source);
 
   if (toolName === "mcp_task" || toolName === "task") {
     recordChildSubagent(output?.metadata?.task_id || "", scriptsDir, log);

--- a/.agents/plugins/opencode-aidevops/tests/test-intent-args-strip.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-intent-args-strip.mjs
@@ -8,7 +8,13 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
-import { extractAndStoreIntent, consumeIntent } from "../intent-tracing.mjs";
+import {
+  consumeIntent,
+  consumeIntentRecord,
+  deriveFallbackIntent,
+  extractAndStoreIntent,
+  prepareIntent,
+} from "../intent-tracing.mjs";
 
 describe("extractAndStoreIntent", () => {
   test("stores and strips agent__intent while preserving Bash workdir", () => {
@@ -54,7 +60,7 @@ describe("extractAndStoreIntent", () => {
     assert.deepEqual(args, { target: "custom-tool" });
   });
 
-  test("stores intent without throwing for non-configurable args", () => {
+  test("replaces non-configurable args so intent cannot reach execution", () => {
     const callID = "call-gh-25992-nonconfigurable";
     const args = { target: "custom-tool" };
     Object.defineProperty(args, "agent__intent", {
@@ -63,10 +69,77 @@ describe("extractAndStoreIntent", () => {
       enumerable: true,
     });
 
-    const intent = extractAndStoreIntent(callID, args);
+    const prepared = prepareIntent(callID, args, "custom-tool");
 
-    assert.equal(intent, "Recording intent from immutable host args");
+    assert.equal(prepared.intent, "Recording intent from immutable host args");
     assert.equal(consumeIntent(callID), "Recording intent from immutable host args");
     assert.equal(args.agent__intent, "Recording intent from immutable host args");
+    assert.deepEqual(prepared.args, { target: "custom-tool" });
+    assert.ok(!Object.prototype.hasOwnProperty.call(prepared.args, "agent__intent"));
+  });
+
+  test("records explicit provenance without changing the intent text", () => {
+    const callID = "call-gh-31025-explicit";
+    const args = { agent__intent: "Reading explicit context" };
+
+    extractAndStoreIntent(callID, args, "read");
+
+    assert.deepEqual(consumeIntentRecord(callID), {
+      intent: "Reading explicit context",
+      source: "explicit",
+    });
+  });
+
+  test("derives fallback only from normalized tool identity", () => {
+    const callID = "call-gh-31025-fallback";
+    const args = {
+      command: "secret-command-canary",
+      filePath: "/private/path-canary",
+      prompt: "private-prompt-canary",
+    };
+
+    const intent = extractAndStoreIntent(callID, args, "Bash");
+    const record = consumeIntentRecord(callID);
+
+    assert.equal(intent, "Running the requested operation");
+    assert.deepEqual(record, { intent, source: "fallback" });
+    assert.doesNotMatch(intent, /secret-command|private|canary/i);
+    assert.deepEqual(args, {
+      command: "secret-command-canary",
+      filePath: "/private/path-canary",
+      prompt: "private-prompt-canary",
+    });
+  });
+
+  test("strips blank metadata and uses fallback provenance", () => {
+    const callID = "call-gh-31025-blank";
+    const args = { agent__intent: "   ", filePath: "/private/canary" };
+
+    extractAndStoreIntent(callID, args, "READ");
+
+    assert.deepEqual(consumeIntentRecord(callID), {
+      intent: "Reading requested context",
+      source: "fallback",
+    });
+    assert.deepEqual(args, { filePath: "/private/canary" });
+  });
+
+  test("uses a generic fallback for bounded unknown tool identities", () => {
+    assert.equal(deriveFallbackIntent("custom.vendor/tool"), "Using the requested tool");
+    assert.equal(deriveFallbackIntent(""), undefined);
+  });
+
+  test("ignores inherited intent and records fallback provenance", () => {
+    const callID = "call-gh-31025-prototype";
+    const args = Object.create({ agent__intent: "Inherited private canary" });
+    args.target = "safe-value";
+
+    const prepared = prepareIntent(callID, args, "read");
+
+    assert.equal(prepared.args, args);
+    assert.deepEqual(consumeIntentRecord(callID), {
+      intent: "Reading requested context",
+      source: "fallback",
+    });
   });
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-retention.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-retention.mjs
@@ -30,6 +30,16 @@ describe("tool metadata retention", () => {
     assert.equal(summary.omitted_keys, 2);
     assert.doesNotMatch(encoded, /sensitive-value|private|project|raw/);
   });
+
+  test("stores only bounded intent provenance when host metadata is absent", () => {
+    assert.deepEqual(summarizeToolMetadata(undefined, { intentSource: "fallback" }), {
+      schema_version: 1,
+      original_bytes: 0,
+      omitted_keys: 0,
+      intent_source: "fallback",
+    });
+    assert.equal(summarizeToolMetadata(undefined, { intentSource: "untrusted" }), null);
+  });
 });
 
 describe("part-stream retention", () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs
@@ -290,6 +290,22 @@ describe("buildToolCallInsertSql — metadata rendering", () => {
     assert.equal(vals[6], "NULL");
   });
 
+  test("fallback intent provenance is retained without host metadata", () => {
+    const sql = buildToolCallInsertSql({
+      sessionID: "s1",
+      callID: "c1",
+      toolName: "Read",
+      intent: "Reading requested context",
+      intentSource: "fallback",
+      isSuccess: 1,
+      durationMs: 5,
+      metadata: null,
+    });
+    const vals = extractValues(sql);
+    const inner = vals[6].slice(1, -1).replace(/''/g, "'");
+    assert.equal(JSON.parse(inner).intent_source, "fallback");
+  });
+
   test("metadata=undefined renders as SQL NULL keyword", () => {
     const sql = buildToolCallInsertSql({
       sessionID: "s1",

--- a/.agents/plugins/opencode-aidevops/tests/test-tui-console-routing.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-tui-console-routing.mjs
@@ -123,7 +123,13 @@ test("pre-tool bash handling tolerates a missing args payload", async () => {
 
 test("pre-tool handling replaces args when intent cannot be deleted in place", async () => {
   const tempDir = mkdtempSync(join(tmpdir(), "aidevops-immutable-tool-args-"));
-  const args = { todos: [] };
+  const todos = [];
+  const getTodos = () => todos;
+  const args = {};
+  Object.defineProperty(args, "todos", {
+    enumerable: true,
+    get: getTodos,
+  });
   Object.defineProperty(args, "agent__intent", {
     configurable: false,
     enumerable: true,
@@ -139,7 +145,8 @@ test("pre-tool handling replaces args when intent cannot be deleted in place", a
     );
 
     assert.notEqual(output.args, args);
-    assert.deepEqual(output.args, { todos: [] });
+    assert.equal(Object.getOwnPropertyDescriptor(output.args, "todos").get, getTodos);
+    assert.equal(output.args.todos, todos);
     assert.ok(!Object.prototype.hasOwnProperty.call(output.args, "agent__intent"));
   } finally {
     rmSync(tempDir, { recursive: true, force: true });

--- a/.agents/plugins/opencode-aidevops/tests/test-tui-console-routing.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-tui-console-routing.mjs
@@ -120,3 +120,28 @@ test("pre-tool bash handling tolerates a missing args payload", async () => {
     rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("pre-tool handling replaces args when intent cannot be deleted in place", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "aidevops-immutable-tool-args-"));
+  const args = { todos: [] };
+  Object.defineProperty(args, "agent__intent", {
+    configurable: false,
+    enumerable: true,
+    value: "Inspecting repository status",
+  });
+  const output = { args };
+
+  try {
+    const hooks = createQualityHooks({ scriptsDir: tempDir, logsDir: tempDir });
+    await hooks.toolExecuteBefore(
+      { tool: "todowrite", callID: "call-immutable-intent" },
+      output,
+    );
+
+    assert.notEqual(output.args, args);
+    assert.deepEqual(output.args, { todos: [] });
+    assert.ok(!Object.prototype.hasOwnProperty.call(output.args, "agent__intent"));
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/.agents/scripts/session-introspect-helper.sh
+++ b/.agents/scripts/session-introspect-helper.sh
@@ -219,6 +219,35 @@ _recent_json() {
 	return 0
 }
 
+_pattern_stats() {
+	local db="$1"
+	local sid_esc="$2"
+	local since="$3"
+	sqlite3 -separator '|' "$db" "
+		SELECT
+			COUNT(*) AS total,
+			SUM(CASE WHEN success=0 THEN 1 ELSE 0 END) AS errors,
+			MIN(timestamp) AS first_ts,
+			MAX(timestamp) AS last_ts,
+			COALESCE(AVG(duration_ms),0) AS avg_dur,
+			SUM(CASE WHEN intent IS NOT NULL AND LENGTH(TRIM(intent)) > 0 THEN 1 ELSE 0 END) AS intent_present,
+			SUM(CASE WHEN intent IS NULL OR LENGTH(TRIM(intent)) = 0 THEN 1 ELSE 0 END) AS intent_missing,
+			printf('%.1f', 100.0 * SUM(CASE WHEN intent IS NOT NULL AND LENGTH(TRIM(intent)) > 0 THEN 1 ELSE 0 END) / MAX(1, COUNT(*))) AS intent_coverage,
+			SUM(CASE WHEN intent IS NOT NULL AND LENGTH(TRIM(intent)) > 0 AND
+				COALESCE(CASE WHEN json_valid(metadata) THEN json_extract(metadata,'\$.intent_source') END,'explicit') <> 'fallback'
+				THEN 1 ELSE 0 END) AS intent_explicit,
+			SUM(CASE WHEN intent IS NOT NULL AND LENGTH(TRIM(intent)) > 0 AND
+				COALESCE(CASE WHEN json_valid(metadata) THEN json_extract(metadata,'\$.intent_source') END,'') = 'fallback'
+				THEN 1 ELSE 0 END) AS intent_fallback,
+			printf('%.1f', 100.0 * SUM(CASE WHEN intent IS NOT NULL AND LENGTH(TRIM(intent)) > 0 AND
+				COALESCE(CASE WHEN json_valid(metadata) THEN json_extract(metadata,'\$.intent_source') END,'explicit') <> 'fallback'
+				THEN 1 ELSE 0 END) / MAX(1, COUNT(*))) AS intent_explicit_coverage
+		FROM tool_calls
+		WHERE session_id='${sid_esc}' ${since};
+	"
+	return $?
+}
+
 cmd_patterns() {
 	local parsed; parsed=$(_parse_common_flags "$@")
 	local session_id db_override json_flag since_min
@@ -237,26 +266,19 @@ cmd_patterns() {
 
 	# Aggregate stats for the session.
 	local stats
-	stats=$(sqlite3 -separator '|' "$db" "
-		SELECT
-			COUNT(*) AS total,
-			SUM(CASE WHEN success=0 THEN 1 ELSE 0 END) AS errors,
-			MIN(timestamp) AS first_ts,
-			MAX(timestamp) AS last_ts,
-			COALESCE(AVG(duration_ms),0) AS avg_dur,
-			SUM(CASE WHEN intent IS NOT NULL AND LENGTH(TRIM(intent)) > 0 THEN 1 ELSE 0 END) AS intent_present,
-			SUM(CASE WHEN intent IS NULL OR LENGTH(TRIM(intent)) = 0 THEN 1 ELSE 0 END) AS intent_missing,
-			printf('%.1f', 100.0 * SUM(CASE WHEN intent IS NOT NULL AND LENGTH(TRIM(intent)) > 0 THEN 1 ELSE 0 END) / MAX(1, COUNT(*))) AS intent_coverage
-		FROM tool_calls
-		WHERE session_id='${sid_esc}' ${since};
-	")
+	stats=$(_pattern_stats "$db" "$sid_esc" "$since") || return 1
 	local total errors first_ts last_ts avg_dur intent_present intent_missing intent_coverage
-	IFS='|' read -r total errors first_ts last_ts avg_dur intent_present intent_missing intent_coverage <<<"$stats"
+	local intent_explicit intent_fallback intent_explicit_coverage
+	IFS='|' read -r total errors first_ts last_ts avg_dur intent_present intent_missing intent_coverage \
+		intent_explicit intent_fallback intent_explicit_coverage <<<"$stats"
 	total="${total:-0}"
 	errors="${errors:-0}"
 	intent_present="${intent_present:-0}"
 	intent_missing="${intent_missing:-0}"
 	intent_coverage="${intent_coverage:-0.0}"
+	intent_explicit="${intent_explicit:-0}"
+	intent_fallback="${intent_fallback:-0}"
+	intent_explicit_coverage="${intent_explicit_coverage:-0.0}"
 
 	# Per-tool counts.
 	local by_tool
@@ -310,11 +332,13 @@ cmd_patterns() {
 	if [[ "$json_flag" == "true" ]]; then
 		_patterns_json "$sid" "$total" "$errors" "$first_ts" "$last_ts" \
 			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes" \
-			"$intent_present" "$intent_missing" "$intent_coverage"
+			"$intent_present" "$intent_missing" "$intent_coverage" \
+			"$intent_explicit" "$intent_fallback" "$intent_explicit_coverage"
 	else
 		_patterns_table "$sid" "$total" "$errors" "$first_ts" "$last_ts" \
 			"$avg_dur" "$rate_per_min" "$by_tool" "$rereads" "$outcomes" \
-			"$intent_present" "$intent_missing" "$intent_coverage"
+			"$intent_present" "$intent_missing" "$intent_coverage" \
+			"$intent_explicit" "$intent_fallback" "$intent_explicit_coverage"
 	fi
 	return 0
 }
@@ -324,12 +348,15 @@ _patterns_table() {
 	local avg_dur="$6" rate="$7" by_tool="$8" rereads="$9"
 	local outcomes="${10}"
 	local intent_present="${11}" intent_missing="${12}" intent_coverage="${13}"
+	local intent_explicit="${14}" intent_fallback="${15}" intent_explicit_coverage="${16}"
 	printf 'Session: %s\n' "$sid"
 	printf 'Window:  %s → %s\n' "${first_ts:-?}" "${last_ts:-?}"
 	printf 'Calls:   %s total, %s error(s), %s calls/min, avg %sms\n' \
 		"$total" "$errors" "$rate" "${avg_dur%.*}"
 	printf 'Intent:  %s populated, %s missing (%s%% coverage)\n' \
 		"$intent_present" "$intent_missing" "$intent_coverage"
+	printf 'Source:  %s explicit, %s fallback (%s%% explicit coverage)\n' \
+		"$intent_explicit" "$intent_fallback" "$intent_explicit_coverage"
 	if [[ "$intent_missing" -gt 0 ]]; then
 		printf 'Notice: missing intents limit reliable root-cause clustering.\n'
 	fi
@@ -373,6 +400,7 @@ _patterns_json() {
 	local avg_dur="$6" rate="$7" by_tool="$8" rereads="$9"
 	local outcomes="${10}"
 	local intent_present="${11}" intent_missing="${12}" intent_coverage="${13}"
+	local intent_explicit="${14}" intent_fallback="${15}" intent_explicit_coverage="${16}"
 	command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
 	local by_tool_json
 	by_tool_json=$(printf '%s' "$by_tool" | jq -R -s '
@@ -403,7 +431,8 @@ _patterns_json() {
 		--argjson by_tool "$by_tool_json" --argjson outcomes "$outcomes_json" \
 		--argjson rereads "$rereads_json" \
 		--argjson intent_present "$intent_present" --argjson intent_missing "$intent_missing" \
-		--arg intent_coverage "$intent_coverage" \
+		--arg intent_coverage "$intent_coverage" --argjson intent_explicit "$intent_explicit" \
+		--argjson intent_fallback "$intent_fallback" --arg intent_explicit_coverage "$intent_explicit_coverage" \
 		--argjson minimum_repeat_count "$REPEATED_PATH_MIN_COUNT" '
 		{
 			session: $sid,
@@ -417,7 +446,10 @@ _patterns_json() {
 				intent_coverage: {
 					populated: $intent_present,
 					missing: $intent_missing,
-					percentage: ($intent_coverage | tonumber)
+					percentage: ($intent_coverage | tonumber),
+					explicit: $intent_explicit,
+					fallback: $intent_fallback,
+					explicit_percentage: ($intent_explicit_coverage | tonumber)
 				}
 			},
 			by_tool: $by_tool,

--- a/.agents/scripts/tests/test-session-introspect.sh
+++ b/.agents/scripts/tests/test-session-introspect.sh
@@ -83,7 +83,7 @@ INSERT INTO tool_calls (timestamp, session_id, tool_name, intent, success, durat
  ('2026-04-18T04:00:25Z', 'sess-A', 'Edit',   'patching auth handler',         1, 240, '{"args":{"filePath":"/repo/b.sh"}}', 'success'),
  ('2026-04-18T04:00:30Z', 'sess-A', 'Bash',   'running shellcheck',            0, 850, '{}', 'command_failure'),
  ('2026-04-18T04:00:35Z', 'sess-A', 'Bash',   NULL,                            0, 910, '{}', 'policy_block'),
- ('2026-04-18T04:00:40Z', 'sess-A', 'Bash',   'running shellcheck final',      1, 780, '{}', 'success'),
+ ('2026-04-18T04:00:40Z', 'sess-A', 'Bash',   'running shellcheck final',      1, 780, '{"intent_source":"fallback"}', 'success'),
  ('2026-04-18T04:00:45Z', 'sess-A', 'Task',   '',                              0,  50, '{}', 'tool_error');
 
 INSERT INTO session_summaries (session_id, first_seen, last_seen, request_count, total_tool_calls, total_errors, total_cost, models_used)
@@ -146,6 +146,7 @@ assert_contains "patterns: preserves unknown legacy outcomes" "$out" "legacy_unk
 assert_contains "patterns: reports repeated-path evidence" "$out" "/repo/b.sh"
 assert_contains "patterns: requires contextual interpretation" "$out" "Interpret in context"
 assert_contains "patterns: reports mixed intent coverage" "$out" "8 populated, 2 missing (80.0% coverage)"
+assert_contains "patterns: distinguishes intent provenance" "$out" "7 explicit, 1 fallback (70.0% explicit coverage)"
 assert_contains "patterns: warns when intent is missing" "$out" "missing intents limit reliable root-cause clustering"
 
 out=$($HELPER patterns --session sess-B 2>&1) || true
@@ -197,7 +198,10 @@ if command -v jq >/dev/null 2>&1; then
 		.calls.outcomes.legacy_unknown == 1 and
 		.calls.intent_coverage.populated == 8 and
 		.calls.intent_coverage.missing == 2 and
-		.calls.intent_coverage.percentage == 80
+		.calls.intent_coverage.percentage == 80 and
+		.calls.intent_coverage.explicit == 7 and
+		.calls.intent_coverage.fallback == 1 and
+		.calls.intent_coverage.explicit_percentage == 70
 	' >/dev/null 2>&1; then
 		pass "patterns --json: separates outcomes and reports intent coverage"
 	else


### PR DESCRIPTION
## Summary

Derive missing tool intent from normalized tool identity only, strip metadata before execution, preserve bounded explicit/fallback provenance, and report coverage.

## Files Changed

.agents/plugins/opencode-aidevops/intent-tracing.mjs, .agents/plugins/opencode-aidevops/observability-retention.mjs, .agents/plugins/opencode-aidevops/observability-tool-calls.mjs, .agents/plugins/opencode-aidevops/observability.mjs, .agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/tests/test-intent-args-strip.mjs, .agents/plugins/opencode-aidevops/tests/test-observability-retention.mjs, .agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs, .agents/plugins/opencode-aidevops/tests/test-tui-console-routing.mjs, .agents/scripts/session-introspect-helper.sh, .agents/scripts/tests/test-session-introspect.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: npm test passed 706/706; focused intent and observability tests passed 41/41; session introspection tests passed 34/34; changed-file linters and complexity gates passed; independent exact-diff review b8c476688842b19c50ab98d1748df2be7d90f8c1f68c32ebd3d05c970b05f2f5 found no concrete defects before a conflict-free rebase onto origin/main.

Resolves #31025


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 38m and 970,276 tokens on this with the user in an interactive session.