### PR TITLE
GH#31035: preserve source approvals across verified edits

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
@@ -50,13 +50,19 @@ function normaliseToolName(tool) {
 }
 
 export function isDirectFileMutationTool(tool) {
-  return [
-    "write", "write_file", "edit", "edit_file", "apply_patch", "applypatch",
-  ].includes(normaliseToolName(tool));
+  return Boolean(directFileMutationKind(tool));
 }
 
 export function isApplyPatchMutationTool(tool) {
-  return ["apply_patch", "applypatch"].includes(normaliseToolName(tool));
+  return directFileMutationKind(tool) === "apply_patch";
+}
+
+export function directFileMutationKind(tool) {
+  const normalized = normaliseToolName(tool);
+  if (["write", "write_file"].includes(normalized)) return "write";
+  if (["edit", "edit_file"].includes(normalized)) return "edit";
+  if (["apply_patch", "applypatch"].includes(normalized)) return "apply_patch";
+  return "";
 }
 
 function parsePolicyPayload(raw) {

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -6,8 +6,8 @@
 
 import { existsSync } from "fs";
 import { execFileSync, execFile } from "child_process";
-import { join } from "path";
-import { recordToolCall } from "./observability.mjs";
+import { join, resolve } from "path";
+import { recordToolCall, toolCallSucceeded } from "./observability.mjs";
 import { extractAndStoreIntent, consumeIntent } from "./intent-tracing.mjs";
 import { recordToolStart, consumeToolDuration } from "./timing-tracing.mjs";
 import { qualityLog, runFileQualityGate } from "./quality-logging.mjs";
@@ -17,12 +17,17 @@ import {
   isReadTool,
   secretReadBlockReason,
 } from "./quality-hooks-secret-read.mjs";
-import { checkSecretReadWithApproval } from "./source-access-approval.mjs";
+import {
+  SOURCE_ACCESS_REASON,
+  checkSecretReadWithApproval,
+  createSourceAccessMutationProvenance,
+} from "./source-access-approval.mjs";
 import { checkResearchStagingAccess } from "./research-staging-guard.mjs";
 import {
   bindActiveScriptsDir,
   checkCanonicalGitSafetyGate,
   checkCanonicalWriteSafetyGate,
+  directFileMutationKind,
   isApplyPatchMutationTool,
   isDirectFileMutationTool,
 } from "./quality-hooks-git-safety.mjs";
@@ -264,6 +269,37 @@ function enforceDirectFileMutationSafety(ctx, input, output) {
   checkCanonicalWriteSafetyGate(filePath, ctx.scriptsDir, writeCwd, patchText);
 }
 
+function directMutations(ctx, input, output) {
+  const args = output.args || {};
+  const cwd = args.workdir || args.cwd || ctx.repositoryDir || process.cwd();
+  const kind = directFileMutationKind(input.tool);
+  if (kind !== "apply_patch") {
+    const filePath = args.filePath || args.file_path || args.path || "";
+    if (!filePath) return [];
+    return [{
+      filePath: resolve(cwd, filePath),
+      kind,
+      content: args.content,
+      oldString: args.oldString ?? args.old_string,
+      newString: args.newString ?? args.new_string,
+      replaceAll: args.replaceAll === true || args.replace_all === true,
+    }];
+  }
+  const patchText = typeof args.patchText === "string" ? args.patchText : args.patch_text || "";
+  const headers = [...patchText.matchAll(/^\*\*\* (Update|Delete) File: (.+)$/gm)];
+  return headers.map((match, index) => ({
+    filePath: resolve(cwd, match[2].trim()),
+    kind: match[1] === "Update" ? kind : "delete",
+    patchText: patchText.slice(match.index + match[0].length, headers[index + 1]?.index),
+  }));
+}
+
+function mutationSucceeded(output) {
+  if (!output || typeof output !== "object") return false;
+  const hasOutcome = typeof output.output === "string" || (output.metadata && typeof output.metadata === "object");
+  return hasOutcome && toolCallSucceeded(output);
+}
+
 function handleToolBefore(ctx, log, input, output) {
   ctx.continuationGuard?.beforeTool(input, output);
   enforceDirectFileMutationSafety(ctx, input, output);
@@ -294,6 +330,14 @@ function handleToolBefore(ctx, log, input, output) {
   }).catch(() => {});
 
   const sessionId = input.sessionID || input.sessionId || input.session?.id || "";
+  if (isDirectFileMutationTool(input.tool)) {
+    ctx.sourceAccessProvenance.beginMutation({
+      sessionId,
+      callId: input.callID || "",
+      mutations: directMutations(ctx, input, output),
+      reason: SOURCE_ACCESS_REASON,
+    });
+  }
   if (isBashTool(input.tool)) {
     const bashArgs = output.args ?? {};
     const bashCwd = bashArgs.workdir || bashArgs.cwd || process.cwd();
@@ -321,10 +365,15 @@ function handleToolBefore(ctx, log, input, output) {
     sessionId,
     scriptsDir: ctx.scriptsDir,
     repositoryDir: ctx.repositoryDir,
+    callId: input.callID || "",
+    provenance: ctx.sourceAccessProvenance,
     isReadTool,
     secretReadBlockReason,
     checkSecretReadGate,
     log,
+    verify: ctx.verifySourceAccessReceipt,
+    brokerMatches: ctx.sourceAccessBrokerMatches,
+    requestRun: ctx.sourceAccessRequestRun,
   });
   checkResearchStagingAccess(input.tool, output.args || {});
 
@@ -346,6 +395,16 @@ function handleToolBefore(ctx, log, input, output) {
  */
 function handleToolAfter(ctx, log, scriptsDir, input, output) {
   const toolName = input.tool || "";
+
+  ctx.sourceAccessProvenance.finishRead(input.callID || "", output);
+  if (isDirectFileMutationTool(toolName)) {
+    ctx.sourceAccessProvenance.finishMutation({
+      sessionId: input.sessionID || input.sessionId || input.session?.id || "",
+      callId: input.callID || "",
+      succeeded: mutationSucceeded(output),
+      reason: SOURCE_ACCESS_REASON,
+    });
+  }
 
   // GH#20207 (t2458 Layer 4): scrub credentials from tool output before
   // persisting to the SQLite transcript store or sending to the model.
@@ -392,6 +451,13 @@ export function createQualityHooks(deps) {
   const activeScriptsDir = deps.activeScriptsDir ?? scriptsDir;
   const activeScriptsDirBinding = bindActiveScriptsDir(activeScriptsDir, scriptsDir);
   const qualityLogPath = join(logsDir, "quality-hooks.log");
+  const sourceAccessProvenance = createSourceAccessMutationProvenance({
+    repositoryDir: deps.repositoryDir,
+    verify: deps.verifySourceAccessReceipt,
+    git: deps.git,
+    gitRun: deps.gitRun,
+    now: deps.now,
+  });
   // t2120: qualityDetailLog (in quality-logging.mjs) reads ctx.detailLogPath
   // and ctx.detailMaxBytes. Previously these were never populated here, so
   // every call to logQualityGateResult → qualityDetailLog threw
@@ -413,6 +479,10 @@ export function createQualityHooks(deps) {
     detailMaxBytes,
     repositoryDir: deps.repositoryDir,
     continuationGuard,
+    sourceAccessProvenance,
+    verifySourceAccessReceipt: deps.verifySourceAccessReceipt,
+    sourceAccessBrokerMatches: deps.sourceAccessBrokerMatches,
+    sourceAccessRequestRun: deps.sourceAccessRequestRun,
     resolveSessionModel: typeof deps.resolveSessionModel === "function"
       ? deps.resolveSessionModel
       : () => "",

--- a/.agents/plugins/opencode-aidevops/source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/source-access-approval.mjs
@@ -219,6 +219,42 @@ function sourceDigestMatches(filePath, expectedDigest) {
   }
 }
 
+function trustedSourceSnapshot(filePath, git = "/usr/bin/git", run = execFileSync) {
+  let descriptor = -1;
+  try {
+    if (!isAbsolute(filePath) || hasSymlinkComponent(filePath)) return false;
+    const canonicalPath = realpathSync(filePath);
+    if (canonicalPath !== resolve(filePath)) return false;
+    descriptor = openSync(canonicalPath, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+    const opened = fstatSync(descriptor);
+    if (!opened.isFile() || opened.nlink !== 1 || opened.size > MAX_SOURCE_BYTES) return false;
+    const content = readFileSync(descriptor);
+    const current = lstatSync(canonicalPath);
+    if (
+      content.length > MAX_SOURCE_BYTES ||
+      !current.isFile() ||
+      current.isSymbolicLink() ||
+      current.nlink !== 1 ||
+      current.dev !== opened.dev ||
+      current.ino !== opened.ino
+    ) {
+      return false;
+    }
+    const identity = trackedFileIdentity(canonicalPath, git, run);
+    if (!identity) return false;
+    return {
+      canonicalPath,
+      content,
+      contentSha256: createHash("sha256").update(content).digest("hex"),
+      ...identity,
+    };
+  } catch {
+    return false;
+  } finally {
+    if (descriptor >= 0) closeSync(descriptor);
+  }
+}
+
 function requireValidReceipt(condition) {
   if (!condition) throw new Error("source-access receipt is invalid");
 }
@@ -237,6 +273,7 @@ function validatedSingleReceipt(options) {
     git = "/usr/bin/git",
     gitRun = execFileSync,
     run = execFileSync,
+    authorizedApprovalId = "",
   } = options;
   requireValidReceipt(/^[A-Za-z0-9._:-]{6,256}$/.test(sessionId));
   requireValidReceipt(reason === SOURCE_ACCESS_REASON);
@@ -245,8 +282,10 @@ function validatedSingleReceipt(options) {
   requireValidReceipt(!hasSymlinkComponent(filePath));
   const canonicalPath = realpathSync(filePath);
   requireValidReceipt(statSync(canonicalPath).isFile());
-  requireValidReceipt(isGitTrackedFile(canonicalPath, git, gitRun));
+  const identity = trackedFileIdentity(canonicalPath, git, gitRun);
+  requireValidReceipt(identity);
   const approvalId = approvalScopeId(sessionId, uid, canonicalPath, reason);
+  if (authorizedApprovalId) requireValidReceipt(authorizedApprovalId === approvalId);
   const receiptPath = join(stateDir, "approvals", String(uid), `${approvalId}.json`);
   requireValidReceipt(trustedDirectory(dirname(receiptPath), trustUid));
   requireValidReceipt(trustedDirectory(dirname(publicKeyPath), trustUid));
@@ -263,7 +302,9 @@ function validatedSingleReceipt(options) {
   requireValidReceipt(payload.path === canonicalPath);
   requireValidReceipt(payload.reason === reason);
   requireValidReceipt(/^[a-f0-9]{64}$/.test(payload.content_sha256 || ""));
-  requireValidReceipt(sourceDigestMatches(canonicalPath, payload.content_sha256));
+  if (!authorizedApprovalId) {
+    requireValidReceipt(sourceDigestMatches(canonicalPath, payload.content_sha256));
+  }
   const snapshotPath = join(stateDir, "snapshots", String(uid), `${approvalId}.source`);
   requireValidReceipt(payload.snapshot_path === snapshotPath);
   requireValidReceipt(trustedDirectory(dirname(snapshotPath), trustUid));
@@ -278,7 +319,20 @@ function validatedSingleReceipt(options) {
   requireValidReceipt(payload.expires_at - payload.issued_at <= MAX_TTL_SECONDS);
   requireValidReceipt(typeof receipt.signature === "string");
   requireValidReceipt(receipt.signature.includes("SSH SIGNATURE"));
-  return {payload, publicKeyPath, receipt, run, snapshotPath, sshKeygen};
+  return {
+    approvalId,
+    canonicalPath,
+    contentSha256: payload.content_sha256,
+    expiresAt: payload.expires_at,
+    payload,
+    publicKeyPath,
+    receipt,
+    repoRoot: identity.repoRoot,
+    relativePath: identity.relativePath,
+    run,
+    snapshotPath,
+    sshKeygen,
+  };
 }
 
 function validatedReceipt(options) {
@@ -302,7 +356,8 @@ function validatedReceipt(options) {
   }
 }
 
-function verifyReceiptSignature({payload, publicKeyPath, receipt, run, snapshotPath, sshKeygen}) {
+function verifyReceiptSignature(receiptData) {
+  const {payload, publicKeyPath, receipt, run, snapshotPath, sshKeygen} = receiptData;
   const tempRoot = verificationTempRoot();
   mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
   const tempDir = mkdtempSync(join(tempRoot, "source-access-verify-"));
@@ -338,7 +393,15 @@ function verifyReceiptSignature({payload, publicKeyPath, receipt, run, snapshotP
         timeout: 15000,
       },
     );
-    return { approvedPath: snapshotPath };
+    return {
+      approvalId: receiptData.approvalId,
+      approvedPath: snapshotPath,
+      canonicalPath: receiptData.canonicalPath,
+      contentSha256: receiptData.contentSha256,
+      expiresAt: receiptData.expiresAt,
+      repoRoot: receiptData.repoRoot,
+      relativePath: receiptData.relativePath,
+    };
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
@@ -351,6 +414,232 @@ export function verifySourceAccessReceipt(options) {
   } catch {
     return false;
   }
+}
+
+function provenanceKey(sessionId, filePath) {
+  return `${sessionId}\0${resolve(filePath)}`;
+}
+
+function renderAuthorizedContent(content, args) {
+  const offset = Number.isInteger(args?.offset) && args.offset > 0 ? args.offset : 1;
+  const limit = Number.isInteger(args?.limit) && args.limit >= 0 ? args.limit : undefined;
+  const lines = content.toString("utf8").split("\n");
+  const selected = lines.slice(offset - 1, limit === undefined ? undefined : offset - 1 + limit);
+  return selected.join("\n");
+}
+
+function replaceExactOnce(content, oldString, newString) {
+  const first = content.indexOf(oldString);
+  if (first < 0 || content.indexOf(oldString, first + oldString.length) >= 0) return false;
+  return content.slice(0, first) + newString + content.slice(first + oldString.length);
+}
+
+function applyObservedPatch(content, patchText) {
+  let result = content;
+  const chunks = String(patchText).split(/^@@.*$/m).slice(1);
+  if (chunks.length === 0) return false;
+  for (const chunk of chunks) {
+    const lines = chunk.replace(/^\n/, "").split("\n");
+    while (lines.at(-1) === "" || lines.at(-1)?.startsWith("*** ")) lines.pop();
+    const oldLines = [];
+    const newLines = [];
+    for (const line of lines) {
+      if (line.startsWith(" ")) {
+        oldLines.push(line.slice(1));
+        newLines.push(line.slice(1));
+      } else if (line.startsWith("-")) {
+        oldLines.push(line.slice(1));
+      } else if (line.startsWith("+")) {
+        newLines.push(line.slice(1));
+      } else if (line !== "\\ No newline at end of file") {
+        return false;
+      }
+    }
+    const oldBlock = oldLines.join("\n");
+    if (!oldBlock) return false;
+    result = replaceExactOnce(result, oldBlock, newLines.join("\n"));
+    if (result === false) return false;
+  }
+  return result;
+}
+
+function expectedMutationContent(state, mutation) {
+  const content = state.content.toString("utf8");
+  if (mutation.kind === "write") {
+    return typeof mutation.content === "string" ? Buffer.from(mutation.content) : false;
+  }
+  if (mutation.kind === "edit") {
+    if (typeof mutation.oldString !== "string" || !mutation.oldString) return false;
+    if (typeof mutation.newString !== "string") return false;
+    if (!content.includes(mutation.oldString)) return false;
+    const updated = mutation.replaceAll
+      ? content.replaceAll(mutation.oldString, mutation.newString)
+      : replaceExactOnce(content, mutation.oldString, mutation.newString);
+    return updated === false ? false : Buffer.from(updated);
+  }
+  if (mutation.kind === "apply_patch") {
+    const updated = applyObservedPatch(content, mutation.patchText);
+    return updated === false ? false : Buffer.from(updated);
+  }
+  return false;
+}
+
+/** Keep verified post-mutation bytes and receipt authority inside one plugin instance. */
+export function createSourceAccessMutationProvenance({
+  repositoryDir = "",
+  verify = verifySourceAccessReceipt,
+  git = "/usr/bin/git",
+  gitRun = execFileSync,
+  now = () => Math.floor(Date.now() / 1000),
+} = {}) {
+  const approvals = new Map();
+  const pendingMutations = new Map();
+  const pendingReads = new Map();
+  const denialReasons = new Map();
+
+  function invalidate(key, reason) {
+    approvals.delete(key);
+    denialReasons.set(key, reason);
+  }
+
+  function revalidate(state, sessionId, filePath, reason) {
+    if (now() >= state.expiresAt) return { denial: "expired" };
+    const approval = verify({
+      sessionId,
+      filePath,
+      reason,
+      repositoryDir,
+      authorizedApprovalId: state.approvalId,
+    });
+    if (!approval || approval.repoRoot !== state.repoRoot || approval.relativePath !== state.relativePath) {
+      return { denial: "invalid" };
+    }
+    const snapshot = trustedSourceSnapshot(filePath, git, gitRun);
+    if (
+      !snapshot ||
+      snapshot.repoRoot !== state.repoRoot ||
+      snapshot.relativePath !== state.relativePath ||
+      snapshot.contentSha256 !== state.contentSha256
+    ) {
+      return { denial: "drift" };
+    }
+    return { approval, snapshot };
+  }
+
+  return {
+    rememberApproval({ sessionId, filePath, approval }) {
+      if (
+        !approval?.approvalId ||
+        !approval?.canonicalPath ||
+        !approval?.contentSha256 ||
+        !approval?.expiresAt ||
+        !approval?.repoRoot ||
+        !approval?.relativePath
+      ) {
+        return;
+      }
+      try {
+        const content = readFileSync(approval.approvedPath);
+        if (createHash("sha256").update(content).digest("hex") !== approval.contentSha256) return;
+        approvals.set(provenanceKey(sessionId, filePath), { ...approval, content });
+        denialReasons.delete(provenanceKey(sessionId, filePath));
+      } catch {
+        // The initial root-owned snapshot remains mandatory; never cache an unreadable path.
+      }
+    },
+
+    authorizeRead({ sessionId, callId, filePath, reason, args }) {
+      const key = provenanceKey(sessionId, filePath);
+      const state = approvals.get(key);
+      if (!state || !callId) return false;
+      const result = revalidate(state, sessionId, filePath, reason);
+      if (!result.approval) {
+        invalidate(key, result.denial);
+        return false;
+      }
+      pendingReads.set(callId, { args: { ...args }, content: Buffer.from(state.content) });
+      return { ...result.approval, approvedPath: state.approvedPath };
+    },
+
+    finishRead(callId, output) {
+      const pending = pendingReads.get(callId);
+      pendingReads.delete(callId);
+      if (!pending) return;
+      output.output = renderAuthorizedContent(pending.content, pending.args);
+      output.metadata = { ...(output.metadata || {}), sourceAccessContinuation: true };
+    },
+
+    beginMutation({ sessionId, callId, mutations, reason = SOURCE_ACCESS_REASON }) {
+      if (!callId || !Array.isArray(mutations)) return;
+      const entries = [];
+      for (const mutation of mutations) {
+        const { filePath } = mutation;
+        const key = provenanceKey(sessionId, filePath);
+        const state = approvals.get(key);
+        if (!state) continue;
+        const result = revalidate(state, sessionId, filePath, reason);
+        if (!result.approval) {
+          invalidate(key, result.denial);
+          continue;
+        }
+        const expectedContent = expectedMutationContent(state, mutation);
+        if (!expectedContent) {
+          invalidate(key, "drift");
+          continue;
+        }
+        entries.push({
+          expectedContent,
+          expectedSha256: createHash("sha256").update(expectedContent).digest("hex"),
+          filePath,
+          key,
+          state,
+        });
+      }
+      if (entries.length > 0) pendingMutations.set(callId, entries);
+    },
+
+    finishMutation({ sessionId, callId, succeeded, reason = SOURCE_ACCESS_REASON }) {
+      const entries = pendingMutations.get(callId) || [];
+      pendingMutations.delete(callId);
+      for (const { expectedContent, expectedSha256, filePath, key, state } of entries) {
+        if (!succeeded) {
+          invalidate(key, "drift");
+          continue;
+        }
+        const approval = verify({
+          sessionId,
+          filePath,
+          reason,
+          repositoryDir,
+          authorizedApprovalId: state.approvalId,
+        });
+        const snapshot = trustedSourceSnapshot(filePath, git, gitRun);
+        if (
+          !approval ||
+          !snapshot ||
+          approval.repoRoot !== state.repoRoot ||
+          approval.relativePath !== state.relativePath ||
+          snapshot.repoRoot !== state.repoRoot ||
+          snapshot.relativePath !== state.relativePath ||
+          snapshot.contentSha256 !== expectedSha256 ||
+          !snapshot.content.equals(expectedContent)
+        ) {
+          invalidate(key, "drift");
+          continue;
+        }
+        approvals.set(key, {
+          ...state,
+          content: Buffer.from(snapshot.content),
+          contentSha256: snapshot.contentSha256,
+        });
+        denialReasons.delete(key);
+      }
+    },
+
+    denialReason(sessionId, filePath) {
+      return denialReasons.get(provenanceKey(sessionId, filePath)) || "missing";
+    },
+  };
 }
 
 /**
@@ -370,6 +659,8 @@ export function checkSecretReadWithApproval({
   verify = verifySourceAccessReceipt,
   brokerMatches = sourceAccessBrokerMatches,
   requestRun = execFileSync,
+  callId = "",
+  provenance,
 }) {
   const filePath = readPath(args);
   // Fail closed before tool-name classification. OpenCode hook identities can
@@ -391,10 +682,16 @@ export function checkSecretReadWithApproval({
   }
 
   const brokerCurrent = brokerMatchesCurrentRelease(brokerMatches, scriptsDir);
-  const approval = brokerCurrent
-    ? verify({ sessionId, filePath, reason, repositoryDir })
+  const continuedApproval = brokerCurrent
+    ? provenance?.authorizeRead({ sessionId, callId, filePath, reason, args })
     : false;
-  if (applyApprovedRead(args, approval, filePath, log)) return;
+  const approval = continuedApproval || (brokerCurrent
+    ? verify({ sessionId, filePath, reason, repositoryDir })
+    : false);
+  if (applyApprovedRead(args, approval, filePath, log)) {
+    if (!continuedApproval) provenance?.rememberApproval({ sessionId, filePath, approval });
+    return;
+  }
 
   const requestId = requestApprovalId({ brokerCurrent, filePath, reason, requestRun, sessionId });
   checkGateWithApprovalInstructions({
@@ -404,6 +701,7 @@ export function checkSecretReadWithApproval({
     filePath,
     log,
     requestId,
+    denialReason: provenance?.denialReason(sessionId, filePath) || "missing",
     tool,
   });
 }

--- a/.agents/plugins/opencode-aidevops/source-access-manifest-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/source-access-manifest-approval.mjs
@@ -39,7 +39,9 @@ function normalizedEntries(payload, context) {
     context.requireValidReceipt(/^[a-f0-9]{64}$/.test(entry.content_sha256 || ""));
     totalBytes += statSync(path).size;
     context.requireValidReceipt(totalBytes <= MAX_SOURCE_BYTES);
-    context.requireValidReceipt(context.sourceDigestMatches(path, entry.content_sha256));
+    if (!context.authorizedApprovalId) {
+      context.requireValidReceipt(context.sourceDigestMatches(path, entry.content_sha256));
+    }
     return { entry, path, relativePath: identity.relativePath };
   });
 }
@@ -99,6 +101,9 @@ function validateManifestReceipt(receiptName, context) {
     context.reason,
     paths,
   );
+  if (context.authorizedApprovalId) {
+    context.requireValidReceipt(context.authorizedApprovalId === approvalId);
+  }
   context.requireValidReceipt(payload.approval_id === approvalId);
   context.requireValidReceipt(payload.request_id === approvalId);
   context.requireValidReceipt(receiptName === `${approvalId}.json`);
@@ -112,10 +117,18 @@ function validateManifestReceipt(receiptName, context) {
   context.requireValidReceipt(payload.expires_at - payload.issued_at <= MAX_TTL_SECONDS);
   context.requireValidReceipt(typeof receipt.signature === "string");
   context.requireValidReceipt(receipt.signature.includes("SSH SIGNATURE"));
+  const requestedEntry = entries.find(({ path }) => path === context.canonicalPath);
+  context.requireValidReceipt(requestedEntry);
   return {
+    approvalId,
+    canonicalPath: context.canonicalPath,
+    contentSha256: requestedEntry.entry.content_sha256,
+    expiresAt: payload.expires_at,
     payload,
     publicKeyPath: context.publicKeyPath,
     receipt,
+    repoRoot: context.requestedIdentity.repoRoot,
+    relativePath: context.requestedIdentity.relativePath,
     run: context.run,
     snapshotPath,
     sshKeygen: context.sshKeygen,
@@ -137,6 +150,7 @@ export function validatedManifestReceipt(options, dependencies) {
     git = "/usr/bin/git",
     gitRun = execFileSync,
     run = execFileSync,
+    authorizedApprovalId = "",
   } = options;
   const { requireValidReceipt } = dependencies;
   requireValidReceipt(/^[A-Za-z0-9._:-]{6,256}$/.test(sessionId));
@@ -155,6 +169,7 @@ export function validatedManifestReceipt(options, dependencies) {
   const context = {
     ...dependencies,
     approvalsDir,
+    authorizedApprovalId,
     canonicalPath,
     git,
     gitRun,

--- a/.agents/plugins/opencode-aidevops/source-access-request.mjs
+++ b/.agents/plugins/opencode-aidevops/source-access-request.mjs
@@ -51,6 +51,7 @@ export function checkGateWithApprovalInstructions({
   filePath,
   log,
   requestId,
+  denialReason = "missing",
   tool,
 }) {
   try {
@@ -64,8 +65,14 @@ export function checkGateWithApprovalInstructions({
       );
     }
     if (!requestId) throw error;
+    const explanation = {
+      drift: "The prior approval was invalidated by an unobserved content transition.",
+      expired: "The prior approval has expired.",
+      invalid: "The prior approval was revoked or its repository/worktree identity is no longer valid.",
+      missing: "No source-access approval exists for this exact path and session.",
+    }[denialReason] || "No valid source-access approval exists for this exact path and session.";
     throw new Error(
-      `${originalMessage}\n\nTo approve only this tracked source path for this session, run:\n` +
+      `${originalMessage}\n\n${explanation}\n\nTo approve only this tracked source path for this session, run:\n` +
         `sudo -k /usr/bin/python3 -I -B ${ROOT_BROKER} approve ${requestId} --ttl 12h\n\n` +
         "For one approval covering several exact tracked paths, create one request with " +
         "`aidevops source-access request --session <session> --reason 'secret-bearing basename' " +

--- a/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
@@ -7,9 +7,12 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   mkdirSync,
+  linkSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -20,6 +23,7 @@ import {
   SOURCE_ACCESS_REASON,
   canonicalReceiptPayload,
   checkSecretReadWithApproval,
+  createSourceAccessMutationProvenance,
   sourceAccessBrokerMatches,
   verifySourceAccessReceipt,
 } from "../source-access-approval.mjs";
@@ -38,6 +42,59 @@ const BASE = {
     throw new Error("[secret-read-guard] blocked read: secret-bearing basename");
   },
 };
+
+function mutationFixture() {
+  const tempParent = join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+  mkdirSync(tempParent, { recursive: true });
+  const root = mkdtempSync(join(tempParent, "source-access-mutation-test-"));
+  const repo = join(root, "repo");
+  const source = join(repo, "secret-helper.sh");
+  const snapshot = join(root, "approved.source");
+  const sessionId = "ses_mutation_123456";
+  mkdirSync(repo);
+  execFileSync("git", ["-C", repo, "init", "--quiet"]);
+  writeFileSync(source, "one\n");
+  writeFileSync(snapshot, "one\n");
+  execFileSync("git", ["-C", repo, "add", "secret-helper.sh"]);
+  const approval = {
+    approvalId: "a".repeat(64),
+    approvedPath: snapshot,
+    canonicalPath: realpathSync(source),
+    contentSha256: createHash("sha256").update("one\n").digest("hex"),
+    expiresAt: 2_000_000_000,
+    repoRoot: realpathSync(repo),
+    relativePath: "secret-helper.sh",
+  };
+  const verify = ({ sessionId: requestedSession, filePath, authorizedApprovalId }) => {
+    if (requestedSession !== sessionId || realpathSync(filePath) !== approval.canonicalPath) return false;
+    if (authorizedApprovalId && authorizedApprovalId !== approval.approvalId) return false;
+    if (!authorizedApprovalId && readFileSync(filePath, "utf8") !== "one\n") return false;
+    return approval;
+  };
+  const provenance = createSourceAccessMutationProvenance({
+    repositoryDir: repo,
+    verify,
+    now: () => 1_900_000_000,
+  });
+  provenance.rememberApproval({ sessionId, filePath: source, approval });
+  return { approval, provenance, repo, root, sessionId, snapshot, source, verify };
+}
+
+function approvedMutationRead(fixture, callId, expected) {
+  const args = { filePath: fixture.source };
+  const approval = fixture.provenance.authorizeRead({
+    sessionId: fixture.sessionId,
+    callId,
+    filePath: fixture.source,
+    reason: SOURCE_ACCESS_REASON,
+    args,
+  });
+  assert.ok(approval);
+  const output = { output: "immutable approval snapshot" };
+  fixture.provenance.finishRead(callId, output);
+  assert.equal(output.output, expected);
+  assert.equal(output.metadata.sourceAccessContinuation, true);
+}
 
 test("a valid verifier result bypasses only the exact basename reason", () => {
   let gateCalls = 0;
@@ -509,4 +566,208 @@ test("one signed manifest authorizes only three exact repository-bound paths", (
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("one approval survives verified Write, Edit, and apply_patch cycles", () => {
+  const fixture = mutationFixture();
+  try {
+    fixture.provenance.beginMutation({
+      sessionId: fixture.sessionId,
+      callId: "write-1",
+      mutations: [{ filePath: fixture.source, kind: "write", content: "two\n" }],
+    });
+    writeFileSync(fixture.source, "two\n");
+    fixture.provenance.finishMutation({
+      sessionId: fixture.sessionId,
+      callId: "write-1",
+      succeeded: true,
+    });
+    approvedMutationRead(fixture, "read-2", "two\n");
+
+    fixture.provenance.beginMutation({
+      sessionId: fixture.sessionId,
+      callId: "edit-2",
+      mutations: [{
+        filePath: fixture.source,
+        kind: "edit",
+        oldString: "two",
+        newString: "three",
+        replaceAll: false,
+      }],
+    });
+    writeFileSync(fixture.source, "three\n");
+    fixture.provenance.finishMutation({
+      sessionId: fixture.sessionId,
+      callId: "edit-2",
+      succeeded: true,
+    });
+    approvedMutationRead(fixture, "read-3", "three\n");
+
+    fixture.provenance.beginMutation({
+      sessionId: fixture.sessionId,
+      callId: "patch-3",
+      mutations: [{
+        filePath: fixture.source,
+        kind: "apply_patch",
+        patchText: "\n@@\n-three\n+four\n",
+      }],
+    });
+    writeFileSync(fixture.source, "four\n");
+    fixture.provenance.finishMutation({
+      sessionId: fixture.sessionId,
+      callId: "patch-3",
+      succeeded: true,
+    });
+    approvedMutationRead(fixture, "read-4", "four\n");
+
+    const approval = fixture.provenance.authorizeRead({
+      sessionId: fixture.sessionId,
+      callId: "read-race",
+      filePath: fixture.source,
+      reason: SOURCE_ACCESS_REASON,
+      args: { filePath: fixture.source },
+    });
+    assert.ok(approval);
+    writeFileSync(fixture.source, "unobserved-after-verification\n");
+    const output = { output: "stale snapshot" };
+    fixture.provenance.finishRead("read-race", output);
+    assert.equal(output.output, "four\n", "the returned bytes cannot race the live path");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("failed, ambiguous, or mismatched mutations never advance authority", () => {
+  for (const scenario of ["failed", "ambiguous", "mismatch"]) {
+    const fixture = mutationFixture();
+    try {
+      fixture.provenance.beginMutation({
+        sessionId: fixture.sessionId,
+        callId: scenario,
+        mutations: [{ filePath: fixture.source, kind: "write", content: "expected\n" }],
+      });
+      writeFileSync(fixture.source, scenario === "mismatch" ? "concurrent\n" : "expected\n");
+      fixture.provenance.finishMutation({
+        sessionId: fixture.sessionId,
+        callId: scenario,
+        succeeded: scenario === "mismatch",
+      });
+      assert.equal(
+        fixture.provenance.authorizeRead({
+          sessionId: fixture.sessionId,
+          callId: `read-${scenario}`,
+          filePath: fixture.source,
+          reason: SOURCE_ACCESS_REASON,
+          args: { filePath: fixture.source },
+        }),
+        false,
+      );
+      assert.equal(fixture.provenance.denialReason(fixture.sessionId, fixture.source), "drift");
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("unobserved filesystem and identity transitions fail closed", () => {
+  for (const scenario of ["external", "untracked", "hardlink", "symlink"]) {
+    const fixture = mutationFixture();
+    try {
+      if (scenario === "external") writeFileSync(fixture.source, "external\n");
+      if (scenario === "untracked") {
+        execFileSync("git", ["-C", fixture.repo, "rm", "--cached", "--quiet", "secret-helper.sh"]);
+      }
+      if (scenario === "hardlink") linkSync(fixture.source, join(fixture.root, "linked.source"));
+      if (scenario === "symlink") {
+        rmSync(fixture.source);
+        symlinkSync(fixture.snapshot, fixture.source);
+      }
+      assert.equal(
+        fixture.provenance.authorizeRead({
+          sessionId: fixture.sessionId,
+          callId: `read-${scenario}`,
+          filePath: fixture.source,
+          reason: SOURCE_ACCESS_REASON,
+          args: { filePath: fixture.source },
+        }),
+        false,
+      );
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("expiry, session changes, and plugin restart do not preserve mutation authority", () => {
+  const fixture = mutationFixture();
+  try {
+    assert.equal(
+      fixture.provenance.authorizeRead({
+        sessionId: "ses_other_123456",
+        callId: "wrong-session",
+        filePath: fixture.source,
+        reason: SOURCE_ACCESS_REASON,
+        args: { filePath: fixture.source },
+      }),
+      false,
+    );
+    const restarted = createSourceAccessMutationProvenance({
+      repositoryDir: fixture.repo,
+      verify: fixture.verify,
+      now: () => 1_900_000_000,
+    });
+    assert.equal(
+      restarted.authorizeRead({
+        sessionId: fixture.sessionId,
+        callId: "restart",
+        filePath: fixture.source,
+        reason: SOURCE_ACCESS_REASON,
+        args: { filePath: fixture.source },
+      }),
+      false,
+    );
+    const expired = createSourceAccessMutationProvenance({
+      repositoryDir: fixture.repo,
+      verify: fixture.verify,
+      now: () => fixture.approval.expiresAt,
+    });
+    expired.rememberApproval({
+      sessionId: fixture.sessionId,
+      filePath: fixture.source,
+      approval: fixture.approval,
+    });
+    assert.equal(
+      expired.authorizeRead({
+        sessionId: fixture.sessionId,
+        callId: "expired",
+        filePath: fixture.source,
+        reason: SOURCE_ACCESS_REASON,
+        args: { filePath: fixture.source },
+      }),
+      false,
+    );
+    assert.equal(expired.denialReason(fixture.sessionId, fixture.source), "expired");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("denial guidance distinguishes missing approval from unobserved drift", () => {
+  assert.throws(
+    () => checkSecretReadWithApproval({
+      ...BASE,
+      verify: () => false,
+      requestRun: () => "0123456789abcdef0123456789abcdef",
+    }),
+    /No source-access approval exists for this exact path and session/,
+  );
+  assert.throws(
+    () => checkSecretReadWithApproval({
+      ...BASE,
+      verify: () => false,
+      provenance: { authorizeRead: () => false, denialReason: () => "drift" },
+      requestRun: () => "0123456789abcdef0123456789abcdef",
+    }),
+    /invalidated by an unobserved content transition/,
+  );
 });


### PR DESCRIPTION
## Summary

Add fail-closed in-memory mutation provenance so approved source reads survive exact runtime-observed direct edits without weakening the root-signed snapshot trust anchor.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs, .agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/source-access-approval.mjs, .agents/plugins/opencode-aidevops/source-access-manifest-approval.mjs, .agents/plugins/opencode-aidevops/source-access-request.mjs, .agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with the composed OpenCode hook path and focused Node suites: 40 tests pass across continuity, TOCTOU, drift, failure, expiry, session, tracking, and link-substitution cases; broader plugin gates pending.

Resolves #31035


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol spent 13m and 121,139 tokens on this as a headless worker.