### PR TITLE
GH#31035: preserve source approvals across verified edits

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
@@ -4,7 +4,7 @@
 import { execFileSync } from "child_process";
 import { existsSync } from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { join, resolve } from "path";
 import { classifyFullLoopCommitAndPr } from "./quality-hooks-full-loop-trust.mjs";
 
 export { bindActiveScriptsDir } from "./quality-hooks-full-loop-trust.mjs";
@@ -50,13 +50,65 @@ function normaliseToolName(tool) {
 }
 
 export function isDirectFileMutationTool(tool) {
-  return [
-    "write", "write_file", "edit", "edit_file", "apply_patch", "applypatch",
-  ].includes(normaliseToolName(tool));
+  return Boolean(directFileMutationKind(tool));
 }
 
 export function isApplyPatchMutationTool(tool) {
-  return ["apply_patch", "applypatch"].includes(normaliseToolName(tool));
+  return directFileMutationKind(tool) === "apply_patch";
+}
+
+export function directFileMutationKind(tool) {
+  const normalized = normaliseToolName(tool);
+  if (["write", "write_file"].includes(normalized)) return "write";
+  if (["edit", "edit_file"].includes(normalized)) return "edit";
+  if (["apply_patch", "applypatch"].includes(normalized)) return "apply_patch";
+  return "";
+}
+
+export function directFileMutations(tool, args = {}, repositoryDir = "") {
+  const cwd = args.workdir || args.cwd || repositoryDir || process.cwd();
+  const kind = directFileMutationKind(tool);
+  if (kind !== "apply_patch") {
+    const filePath = args.filePath || args.file_path || args.path || "";
+    if (!filePath) return [];
+    return [{
+      filePath: resolve(cwd, filePath),
+      kind,
+      content: args.content,
+      oldString: args.oldString ?? args.old_string,
+      newString: args.newString ?? args.new_string,
+      replaceAll: args.replaceAll === true || args.replace_all === true,
+    }];
+  }
+  const patchText = typeof args.patchText === "string" ? args.patchText : args.patch_text || "";
+  const headers = [...patchText.matchAll(/^\*\*\* (Update|Delete) File: (.+)$/gm)];
+  return headers.map((match, index) => ({
+    filePath: resolve(cwd, match[2].trim()),
+    kind: match[1] === "Update" ? kind : "delete",
+    patchText: patchText.slice(match.index + match[0].length, headers[index + 1]?.index),
+  }));
+}
+
+function replaceExactOnce(content, oldString, newString) {
+  const first = content.indexOf(oldString);
+  if (first < 0 || content.indexOf(oldString, first + oldString.length) >= 0) return false;
+  return content.slice(0, first) + newString + content.slice(first + oldString.length);
+}
+
+export function expectedSimpleMutationContent(state, mutation) {
+  const content = state.content.toString("utf8");
+  let updated;
+  if (mutation.kind === "write") {
+    updated = typeof mutation.content === "string" ? mutation.content : false;
+  } else if (mutation.kind === "edit") {
+    const validEdit = typeof mutation.oldString === "string" && mutation.oldString &&
+      typeof mutation.newString === "string" && content.includes(mutation.oldString);
+    if (!validEdit) return false;
+    updated = mutation.replaceAll
+      ? content.replaceAll(mutation.oldString, mutation.newString)
+      : replaceExactOnce(content, mutation.oldString, mutation.newString);
+  }
+  return updated === undefined || updated === false ? updated : Buffer.from(updated);
 }
 
 function parsePolicyPayload(raw) {

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -7,7 +7,7 @@
 import { existsSync } from "fs";
 import { execFileSync, execFile } from "child_process";
 import { join } from "path";
-import { recordToolCall } from "./observability.mjs";
+import { recordToolCall, toolCallSucceeded } from "./observability.mjs";
 import {
   consumeIntentRecord,
   peekIntentSource,
@@ -21,7 +21,15 @@ import {
   isReadTool,
   secretReadBlockReason,
 } from "./quality-hooks-secret-read.mjs";
-import { checkSecretReadWithApproval } from "./source-access-approval.mjs";
+import {
+  SOURCE_ACCESS_REASON,
+  checkSecretReadWithApproval,
+  createSourceAccessMutationProvenance,
+} from "./source-access-approval.mjs";
+import {
+  beginObservedSourceMutation,
+  finishObservedSourceAccess,
+} from "./source-access-request.mjs";
 import { checkResearchStagingAccess } from "./research-staging-guard.mjs";
 import {
   bindActiveScriptsDir,
@@ -268,20 +276,66 @@ function enforceDirectFileMutationSafety(ctx, input, output) {
   checkCanonicalWriteSafetyGate(filePath, ctx.scriptsDir, writeCwd, patchText);
 }
 
+function prepareToolIntent(log, input, output) {
+  const callID = input.callID || "";
+  if (!callID) return { callID, intent: "" };
+  const prepared = prepareIntent(callID, output.args, input.tool);
+  output.args = prepared.args;
+  const intent = prepared.intent || "";
+  if (intent) {
+    log("INFO", `Intent [${input.tool}] callID=${callID} source=${peekIntentSource(callID)}: ${intent}`);
+  }
+  return { callID, intent };
+}
+
+function enforceBashToolSafety(ctx, log, input, output, sessionId) {
+  if (!isBashTool(input.tool)) return;
+  const bashArgs = output.args ?? {};
+  const bashCwd = bashArgs.workdir || bashArgs.cwd || process.cwd();
+  bashArgs.command = checkCanonicalGitSafetyGate(
+    bashArgs.command || "",
+    ctx.scriptsDir,
+    bashCwd,
+    {
+      activeScriptsDir: ctx.activeScriptsDir,
+      activeScriptsDirBinding: ctx.activeScriptsDirBinding,
+    },
+  );
+  const signatureModel = ctx.resolveSessionModel(sessionId);
+  checkSignatureFooterGate(bashArgs.command || "", log, ctx.scriptsDir, output, {
+    model: signatureModel,
+    useProcessModelFallback: false,
+  });
+}
+
+function enforceReadAndFileQuality(ctx, log, input, output, sessionId) {
+  checkSecretReadWithApproval({
+    tool: input.tool,
+    args: output.args || {},
+    sessionId,
+    scriptsDir: ctx.scriptsDir,
+    repositoryDir: ctx.repositoryDir,
+    callId: input.callID || "",
+    provenance: ctx.sourceAccessProvenance,
+    isReadTool,
+    secretReadBlockReason,
+    checkSecretReadGate,
+    log,
+    verify: ctx.verifySourceAccessReceipt,
+    brokerMatches: ctx.sourceAccessBrokerMatches,
+    requestRun: ctx.sourceAccessRequestRun,
+  });
+  checkResearchStagingAccess(input.tool, output.args || {});
+  if (!isWriteOrEditTool(input.tool)) return;
+  const filePath = output.args?.filePath || output.args?.file_path || "";
+  if (filePath) runFileQualityGate(ctx, filePath, output.args);
+}
+
 function handleToolBefore(ctx, log, input, output) {
   ctx.continuationGuard?.beforeTool(input, output);
   enforceDirectFileMutationSafety(ctx, input, output);
 
-  const callID = input.callID || "";
-  let intent = "";
-  if (callID) {
-    const prepared = prepareIntent(callID, output.args, input.tool);
-    output.args = prepared.args;
-    intent = prepared.intent || "";
-    if (intent) {
-      log("INFO", `Intent [${input.tool}] callID=${callID} source=${peekIntentSource(callID)}: ${intent}`);
-    }
-  }
+  const { callID, intent } = prepareToolIntent(log, input, output);
 
   // t2184: pair with tool.execute.after to compute duration_ms for the
   // tool_calls INSERT. recordToolStart no-ops on empty callID.
@@ -300,46 +354,34 @@ function handleToolBefore(ctx, log, input, output) {
   }).catch(() => {});
 
   const sessionId = input.sessionID || input.sessionId || input.session?.id || "";
-  if (isBashTool(input.tool)) {
-    const bashArgs = output.args ?? {};
-    const bashCwd = bashArgs.workdir || bashArgs.cwd || process.cwd();
-    bashArgs.command = checkCanonicalGitSafetyGate(
-      bashArgs.command || "",
-      ctx.scriptsDir,
-      bashCwd,
-      {
-        activeScriptsDir: ctx.activeScriptsDir,
-        activeScriptsDirBinding: ctx.activeScriptsDirBinding,
-      },
-    );
-    // t2685: pass scriptsDir + output so the hook can repair (mutate
-    // output.args.command) or block (throw) as appropriate.
-    const signatureModel = ctx.resolveSessionModel(sessionId);
-    checkSignatureFooterGate(bashArgs.command || "", log, ctx.scriptsDir, output, {
-      model: signatureModel,
-      useProcessModelFallback: false,
-    });
-  }
-
-  checkSecretReadWithApproval({
-    tool: input.tool,
-    args: output.args || {},
-    sessionId,
-    scriptsDir: ctx.scriptsDir,
+  beginObservedSourceMutation({
     repositoryDir: ctx.repositoryDir,
-    isReadTool,
-    secretReadBlockReason,
-    checkSecretReadGate,
-    log,
-  });
-  checkResearchStagingAccess(input.tool, output.args || {});
+    sessionId,
+    sourceAccessProvenance: ctx.sourceAccessProvenance,
+    sourceAccessReason: ctx.sourceAccessReason,
+  }, input, output);
+  enforceBashToolSafety(ctx, log, input, output, sessionId);
+  enforceReadAndFileQuality(ctx, log, input, output, sessionId);
+}
 
-  if (!isWriteOrEditTool(input.tool)) return;
+function scrubObservedToolOutput(log, toolName, output) {
+  const rawOutput = output.output;
+  if (rawOutput === undefined) return;
+  const { output: scrubbedOutput, redacted } = scrubToolOutput(rawOutput);
+  if (!redacted) return;
+  output.output = scrubbedOutput;
+  log("WARN", `[credential-scrub] redacted credential token(s) from ${toolName} output`);
+}
 
-  const filePath = output.args?.filePath || output.args?.file_path || "";
-  if (filePath) {
-    runFileQualityGate(ctx, filePath, output.args);
+function trackObservedToolEffects(ctx, log, toolName, input, output) {
+  const continuationResult = ctx.continuationGuard?.afterTool(input, output);
+  if (continuationResult?.replan) {
+    log("WARN", `[session-continuation] repeated ${toolName} failure requires replanning`);
   }
+  if (isBashTool(toolName)) trackBashOperation(ctx, output.title || "", output.output || "");
+  if (!isWriteOrEditTool(toolName)) return;
+  const filePath = output.metadata?.filePath || "";
+  if (filePath) log("INFO", `File modified: ${filePath} via ${toolName}`);
 }
 
 /**
@@ -352,35 +394,20 @@ function handleToolBefore(ctx, log, input, output) {
  */
 function handleToolAfter(ctx, log, scriptsDir, input, output) {
   const toolName = input.tool || "";
+  const sessionId = input.sessionID || input.sessionId || input.session?.id || "";
+
+  finishObservedSourceAccess({
+    sessionId,
+    sourceAccessProvenance: ctx.sourceAccessProvenance,
+    sourceAccessReason: ctx.sourceAccessReason,
+  }, input, output, toolCallSucceeded);
 
   // GH#20207 (t2458 Layer 4): scrub credentials from tool output before
   // persisting to the SQLite transcript store or sending to the model.
   // Applies to all tools — credentials can arrive via user scripts, third-party
   // CLIs, or runtime error backtraces, not just framework helpers.
-  const rawOutput = output.output;
-  if (rawOutput !== undefined) {
-    const { output: scrubbedOutput, redacted } = scrubToolOutput(rawOutput);
-    if (redacted) {
-      output.output = scrubbedOutput;
-      log("WARN", `[credential-scrub] redacted credential token(s) from ${toolName} output`);
-    }
-  }
-
-  const continuationResult = ctx.continuationGuard?.afterTool(input, output);
-  if (continuationResult?.replan) {
-    log("WARN", `[session-continuation] repeated ${toolName} failure requires replanning`);
-  }
-
-  if (isBashTool(toolName)) {
-    trackBashOperation(ctx, output.title || "", output.output || "");
-  }
-
-  if (isWriteOrEditTool(toolName)) {
-    const filePath = output.metadata?.filePath || "";
-    if (filePath) {
-      log("INFO", `File modified: ${filePath} via ${toolName}`);
-    }
-  }
+  scrubObservedToolOutput(log, toolName, output);
+  trackObservedToolEffects(ctx, log, toolName, input, output);
 
   const intentRecord = consumeIntentRecord(input.callID || "");
   // t2184: consumeToolDuration returns null when the callID wasn't paired
@@ -398,6 +425,13 @@ export function createQualityHooks(deps) {
   const activeScriptsDir = deps.activeScriptsDir ?? scriptsDir;
   const activeScriptsDirBinding = bindActiveScriptsDir(activeScriptsDir, scriptsDir);
   const qualityLogPath = join(logsDir, "quality-hooks.log");
+  const sourceAccessProvenance = createSourceAccessMutationProvenance({
+    repositoryDir: deps.repositoryDir,
+    verify: deps.verifySourceAccessReceipt,
+    git: deps.git,
+    gitRun: deps.gitRun,
+    now: deps.now,
+  });
   // t2120: qualityDetailLog (in quality-logging.mjs) reads ctx.detailLogPath
   // and ctx.detailMaxBytes. Previously these were never populated here, so
   // every call to logQualityGateResult → qualityDetailLog threw
@@ -419,6 +453,11 @@ export function createQualityHooks(deps) {
     detailMaxBytes,
     repositoryDir: deps.repositoryDir,
     continuationGuard,
+    sourceAccessProvenance,
+    sourceAccessReason: SOURCE_ACCESS_REASON,
+    verifySourceAccessReceipt: deps.verifySourceAccessReceipt,
+    sourceAccessBrokerMatches: deps.sourceAccessBrokerMatches,
+    sourceAccessRequestRun: deps.sourceAccessRequestRun,
     resolveSessionModel: typeof deps.resolveSessionModel === "function"
       ? deps.resolveSessionModel
       : () => "",

--- a/.agents/plugins/opencode-aidevops/source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/source-access-approval.mjs
@@ -27,6 +27,7 @@ import {
   applyApprovedRead,
   brokerMatchesCurrentRelease,
   checkGateWithApprovalInstructions,
+  createMutationProvenance,
   requestApprovalId,
 } from "./source-access-request.mjs";
 
@@ -219,6 +220,43 @@ function sourceDigestMatches(filePath, expectedDigest) {
   }
 }
 
+function trustedSourceSnapshot(filePath, git = "/usr/bin/git", run = execFileSync) {
+  let descriptor = -1;
+  let result = false;
+  try {
+    requireValidReceipt(isAbsolute(filePath));
+    requireValidReceipt(!hasSymlinkComponent(filePath));
+    const canonicalPath = realpathSync(filePath);
+    requireValidReceipt(canonicalPath === resolve(filePath));
+    descriptor = openSync(canonicalPath, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+    const opened = fstatSync(descriptor);
+    requireValidReceipt(opened.isFile());
+    requireValidReceipt(opened.nlink === 1);
+    requireValidReceipt(opened.size <= MAX_SOURCE_BYTES);
+    const content = readFileSync(descriptor);
+    const current = lstatSync(canonicalPath);
+    requireValidReceipt(content.length <= MAX_SOURCE_BYTES);
+    requireValidReceipt(current.isFile());
+    requireValidReceipt(!current.isSymbolicLink());
+    requireValidReceipt(current.nlink === 1);
+    requireValidReceipt(current.dev === opened.dev);
+    requireValidReceipt(current.ino === opened.ino);
+    const identity = trackedFileIdentity(canonicalPath, git, run);
+    requireValidReceipt(identity);
+    result = {
+      canonicalPath,
+      content,
+      contentSha256: createHash("sha256").update(content).digest("hex"),
+      ...identity,
+    };
+  } catch {
+    result = false;
+  } finally {
+    if (descriptor >= 0) closeSync(descriptor);
+  }
+  return result;
+}
+
 function requireValidReceipt(condition) {
   if (!condition) throw new Error("source-access receipt is invalid");
 }
@@ -237,6 +275,7 @@ function validatedSingleReceipt(options) {
     git = "/usr/bin/git",
     gitRun = execFileSync,
     run = execFileSync,
+    authorizedApprovalId = "",
   } = options;
   requireValidReceipt(/^[A-Za-z0-9._:-]{6,256}$/.test(sessionId));
   requireValidReceipt(reason === SOURCE_ACCESS_REASON);
@@ -245,8 +284,10 @@ function validatedSingleReceipt(options) {
   requireValidReceipt(!hasSymlinkComponent(filePath));
   const canonicalPath = realpathSync(filePath);
   requireValidReceipt(statSync(canonicalPath).isFile());
-  requireValidReceipt(isGitTrackedFile(canonicalPath, git, gitRun));
+  const identity = trackedFileIdentity(canonicalPath, git, gitRun);
+  requireValidReceipt(identity);
   const approvalId = approvalScopeId(sessionId, uid, canonicalPath, reason);
+  if (authorizedApprovalId) requireValidReceipt(authorizedApprovalId === approvalId);
   const receiptPath = join(stateDir, "approvals", String(uid), `${approvalId}.json`);
   requireValidReceipt(trustedDirectory(dirname(receiptPath), trustUid));
   requireValidReceipt(trustedDirectory(dirname(publicKeyPath), trustUid));
@@ -263,7 +304,9 @@ function validatedSingleReceipt(options) {
   requireValidReceipt(payload.path === canonicalPath);
   requireValidReceipt(payload.reason === reason);
   requireValidReceipt(/^[a-f0-9]{64}$/.test(payload.content_sha256 || ""));
-  requireValidReceipt(sourceDigestMatches(canonicalPath, payload.content_sha256));
+  if (!authorizedApprovalId) {
+    requireValidReceipt(sourceDigestMatches(canonicalPath, payload.content_sha256));
+  }
   const snapshotPath = join(stateDir, "snapshots", String(uid), `${approvalId}.source`);
   requireValidReceipt(payload.snapshot_path === snapshotPath);
   requireValidReceipt(trustedDirectory(dirname(snapshotPath), trustUid));
@@ -278,7 +321,20 @@ function validatedSingleReceipt(options) {
   requireValidReceipt(payload.expires_at - payload.issued_at <= MAX_TTL_SECONDS);
   requireValidReceipt(typeof receipt.signature === "string");
   requireValidReceipt(receipt.signature.includes("SSH SIGNATURE"));
-  return {payload, publicKeyPath, receipt, run, snapshotPath, sshKeygen};
+  return {
+    approvalId,
+    canonicalPath,
+    contentSha256: payload.content_sha256,
+    expiresAt: payload.expires_at,
+    payload,
+    publicKeyPath,
+    receipt,
+    repoRoot: identity.repoRoot,
+    relativePath: identity.relativePath,
+    run,
+    snapshotPath,
+    sshKeygen,
+  };
 }
 
 function validatedReceipt(options) {
@@ -302,7 +358,8 @@ function validatedReceipt(options) {
   }
 }
 
-function verifyReceiptSignature({payload, publicKeyPath, receipt, run, snapshotPath, sshKeygen}) {
+function verifyReceiptSignature(receiptData) {
+  const {payload, publicKeyPath, receipt, run, snapshotPath, sshKeygen} = receiptData;
   const tempRoot = verificationTempRoot();
   mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
   const tempDir = mkdtempSync(join(tempRoot, "source-access-verify-"));
@@ -338,7 +395,15 @@ function verifyReceiptSignature({payload, publicKeyPath, receipt, run, snapshotP
         timeout: 15000,
       },
     );
-    return { approvedPath: snapshotPath };
+    return {
+      approvalId: receiptData.approvalId,
+      approvedPath: snapshotPath,
+      canonicalPath: receiptData.canonicalPath,
+      contentSha256: receiptData.contentSha256,
+      expiresAt: receiptData.expiresAt,
+      repoRoot: receiptData.repoRoot,
+      relativePath: receiptData.relativePath,
+    };
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
@@ -351,6 +416,24 @@ export function verifySourceAccessReceipt(options) {
   } catch {
     return false;
   }
+}
+
+export function createSourceAccessMutationProvenance({
+  repositoryDir = "",
+  verify = verifySourceAccessReceipt,
+  git = "/usr/bin/git",
+  gitRun = execFileSync,
+  now = () => Math.floor(Date.now() / 1000),
+} = {}) {
+  return createMutationProvenance({
+    git,
+    gitRun,
+    now,
+    reason: SOURCE_ACCESS_REASON,
+    repositoryDir,
+    snapshot: trustedSourceSnapshot,
+    verify,
+  });
 }
 
 /**
@@ -370,6 +453,8 @@ export function checkSecretReadWithApproval({
   verify = verifySourceAccessReceipt,
   brokerMatches = sourceAccessBrokerMatches,
   requestRun = execFileSync,
+  callId = "",
+  provenance,
 }) {
   const filePath = readPath(args);
   // Fail closed before tool-name classification. OpenCode hook identities can
@@ -391,10 +476,16 @@ export function checkSecretReadWithApproval({
   }
 
   const brokerCurrent = brokerMatchesCurrentRelease(brokerMatches, scriptsDir);
-  const approval = brokerCurrent
-    ? verify({ sessionId, filePath, reason, repositoryDir })
+  const continuedApproval = brokerCurrent
+    ? provenance?.authorizeRead({ sessionId, callId, filePath, reason, args })
     : false;
-  if (applyApprovedRead(args, approval, filePath, log)) return;
+  const approval = continuedApproval || (brokerCurrent
+    ? verify({ sessionId, filePath, reason, repositoryDir })
+    : false);
+  if (applyApprovedRead(args, approval, filePath, log)) {
+    if (!continuedApproval) provenance?.rememberApproval({ sessionId, filePath, approval });
+    return;
+  }
 
   const requestId = requestApprovalId({ brokerCurrent, filePath, reason, requestRun, sessionId });
   checkGateWithApprovalInstructions({
@@ -404,6 +495,7 @@ export function checkSecretReadWithApproval({
     filePath,
     log,
     requestId,
+    denialReason: provenance?.denialReason(sessionId, filePath) || "missing",
     tool,
   });
 }

--- a/.agents/plugins/opencode-aidevops/source-access-manifest-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/source-access-manifest-approval.mjs
@@ -14,6 +14,74 @@ const MAX_MANIFEST_ENTRIES = 32;
 const DEFAULT_STATE_DIR = "/var/run/aidevops/source-access";
 const DEFAULT_PUBLIC_KEY = "/etc/aidevops/source-access/source-access.pub";
 
+export function renderApprovedSourceContent(content, args, template) {
+  const offset = Number.isInteger(args?.offset) && args.offset > 0 ? args.offset : 1;
+  const limit = Number.isInteger(args?.limit) && args.limit >= 0 ? args.limit : 2000;
+  const text = content.toString("utf8");
+  const hasTrailingNewline = text.endsWith("\n");
+  const lines = text.split("\n");
+  if (hasTrailingNewline) lines.pop();
+  const selected = lines.slice(offset - 1, offset - 1 + limit);
+  const raw = selected.join("\n") + (hasTrailingNewline && offset - 1 + limit >= lines.length ? "\n" : "");
+  const templateLines = String(template || "").split("\n");
+  const numbered = templateLines
+    .map((line, index) => ({ index, match: line.match(/^(\s*)(\d+)(:\s|\|\s?)/) }))
+    .filter(({ match }) => match);
+  if (numbered.length === 0) return raw;
+  const first = numbered[0];
+  const last = numbered.at(-1);
+  const width = first.match[2].length;
+  const rendered = selected.map((line, index) =>
+    `${first.match[1]}${String(offset + index).padStart(width, "0")}${first.match[3]}${line}`,
+  );
+  return [
+    ...templateLines.slice(0, first.index),
+    ...rendered,
+    ...templateLines.slice(last.index + 1),
+  ].join("\n");
+}
+
+function replaceExactOnce(content, oldString, newString) {
+  const first = content.indexOf(oldString);
+  if (first < 0 || content.indexOf(oldString, first + oldString.length) >= 0) return false;
+  return content.slice(0, first) + newString + content.slice(first + oldString.length);
+}
+
+function applyObservedPatch(content, patchText) {
+  let result = content;
+  const chunks = String(patchText).split(/^@@.*$/m).slice(1);
+  if (chunks.length === 0) return false;
+  for (const chunk of chunks) {
+    const lines = chunk.replace(/^\n/, "").split("\n");
+    while (lines.at(-1) === "" || lines.at(-1)?.startsWith("*** ")) lines.pop();
+    const oldLines = [];
+    const newLines = [];
+    for (const line of lines) {
+      if (line.startsWith(" ")) {
+        oldLines.push(line.slice(1));
+        newLines.push(line.slice(1));
+      } else if (line.startsWith("-")) {
+        oldLines.push(line.slice(1));
+      } else if (line.startsWith("+")) {
+        newLines.push(line.slice(1));
+      } else if (line !== "\\ No newline at end of file") {
+        return false;
+      }
+    }
+    const oldBlock = oldLines.join("\n");
+    if (!oldBlock) return false;
+    result = replaceExactOnce(result, oldBlock, newLines.join("\n"));
+    if (result === false) return false;
+  }
+  return result;
+}
+
+export function applyApprovedMutationPatch(state, mutation) {
+  const content = state.content.toString("utf8");
+  const updated = applyObservedPatch(content, mutation.patchText);
+  return updated === false ? false : Buffer.from(updated);
+}
+
 function repositoryId(repoRoot) {
   return createHash("sha256").update(repoRoot, "utf8").digest("hex");
 }
@@ -39,7 +107,9 @@ function normalizedEntries(payload, context) {
     context.requireValidReceipt(/^[a-f0-9]{64}$/.test(entry.content_sha256 || ""));
     totalBytes += statSync(path).size;
     context.requireValidReceipt(totalBytes <= MAX_SOURCE_BYTES);
-    context.requireValidReceipt(context.sourceDigestMatches(path, entry.content_sha256));
+    if (!context.authorizedApprovalId) {
+      context.requireValidReceipt(context.sourceDigestMatches(path, entry.content_sha256));
+    }
     return { entry, path, relativePath: identity.relativePath };
   });
 }
@@ -99,6 +169,9 @@ function validateManifestReceipt(receiptName, context) {
     context.reason,
     paths,
   );
+  if (context.authorizedApprovalId) {
+    context.requireValidReceipt(context.authorizedApprovalId === approvalId);
+  }
   context.requireValidReceipt(payload.approval_id === approvalId);
   context.requireValidReceipt(payload.request_id === approvalId);
   context.requireValidReceipt(receiptName === `${approvalId}.json`);
@@ -112,10 +185,18 @@ function validateManifestReceipt(receiptName, context) {
   context.requireValidReceipt(payload.expires_at - payload.issued_at <= MAX_TTL_SECONDS);
   context.requireValidReceipt(typeof receipt.signature === "string");
   context.requireValidReceipt(receipt.signature.includes("SSH SIGNATURE"));
+  const requestedEntry = entries.find(({ path }) => path === context.canonicalPath);
+  context.requireValidReceipt(requestedEntry);
   return {
+    approvalId,
+    canonicalPath: context.canonicalPath,
+    contentSha256: requestedEntry.entry.content_sha256,
+    expiresAt: payload.expires_at,
     payload,
     publicKeyPath: context.publicKeyPath,
     receipt,
+    repoRoot: context.requestedIdentity.repoRoot,
+    relativePath: context.requestedIdentity.relativePath,
     run: context.run,
     snapshotPath,
     sshKeygen: context.sshKeygen,
@@ -137,6 +218,7 @@ export function validatedManifestReceipt(options, dependencies) {
     git = "/usr/bin/git",
     gitRun = execFileSync,
     run = execFileSync,
+    authorizedApprovalId = "",
   } = options;
   const { requireValidReceipt } = dependencies;
   requireValidReceipt(/^[A-Za-z0-9._:-]{6,256}$/.test(sessionId));
@@ -155,6 +237,7 @@ export function validatedManifestReceipt(options, dependencies) {
   const context = {
     ...dependencies,
     approvalsDir,
+    authorizedApprovalId,
     canonicalPath,
     git,
     gitRun,

--- a/.agents/plugins/opencode-aidevops/source-access-request.mjs
+++ b/.agents/plugins/opencode-aidevops/source-access-request.mjs
@@ -1,8 +1,209 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  directFileMutations,
+  expectedSimpleMutationContent,
+  isDirectFileMutationTool,
+} from "./quality-hooks-git-safety.mjs";
+import {
+  applyApprovedMutationPatch,
+  renderApprovedSourceContent,
+} from "./source-access-manifest-approval.mjs";
+
 export const ROOT_BROKER = "/etc/aidevops/source-access/source-access-helper.py";
 const REQUEST_ID_PATTERN = /^[a-f0-9]{32,64}$/;
+
+function provenanceKey(sessionId, filePath) {
+  return `${sessionId}\0${resolve(filePath)}`;
+}
+
+function operationKey(sessionId, callId) {
+  return `${sessionId}\0${callId}`;
+}
+
+function sameIdentity(candidate, state) {
+  return Boolean(candidate) && candidate.repoRoot === state.repoRoot &&
+    candidate.relativePath === state.relativePath;
+}
+
+function completeMutationMatches(approval, snapshot, state, entry) {
+  return sameIdentity(approval, state) && sameIdentity(snapshot, state) &&
+    snapshot.contentSha256 === entry.expectedSha256 && snapshot.content.equals(entry.expectedContent);
+}
+
+function expectedApprovedMutationContent(state, mutation) {
+  const simple = expectedSimpleMutationContent(state, mutation);
+  return simple === undefined ? applyApprovedMutationPatch(state, mutation) : simple;
+}
+
+class MutationProvenance {
+  constructor(options) {
+    Object.assign(this, options);
+    this.approvals = new Map();
+    this.pendingMutations = new Map();
+    this.pendingReads = new Map();
+    this.denialReasons = new Map();
+  }
+
+  invalidate(key, reason) {
+    this.approvals.delete(key);
+    this.denialReasons.set(key, reason);
+  }
+
+  revalidate(state, sessionId, filePath, reason) {
+    if (this.now() >= state.expiresAt) return { denial: "expired" };
+    let approval = false;
+    try {
+      approval = this.verify({
+        sessionId, filePath, reason, repositoryDir: this.repositoryDir,
+        authorizedApprovalId: state.approvalId,
+      });
+    } catch {
+      return { denial: "invalid" };
+    }
+    if (!sameIdentity(approval, state)) return { denial: "invalid" };
+    const snapshot = this.snapshot(filePath, this.git, this.gitRun);
+    if (!sameIdentity(snapshot, state) || snapshot.contentSha256 !== state.contentSha256) {
+      return { denial: "drift" };
+    }
+    return { approval, snapshot };
+  }
+
+  rememberApproval({ sessionId, filePath, approval }) {
+    const fields = ["approvalId", "canonicalPath", "contentSha256", "expiresAt", "repoRoot", "relativePath"];
+    if (!fields.every((field) => approval?.[field])) return;
+    try {
+      const content = readFileSync(approval.approvedPath);
+      if (createHash("sha256").update(content).digest("hex") !== approval.contentSha256) return;
+      this.approvals.set(provenanceKey(sessionId, filePath), { ...approval, content });
+      this.denialReasons.delete(provenanceKey(sessionId, filePath));
+    } catch {
+      // The initial root-owned snapshot remains mandatory; never cache an unreadable path.
+    }
+  }
+
+  authorizeRead({ sessionId, callId, filePath, reason, args }) {
+    const key = provenanceKey(sessionId, filePath);
+    const state = this.approvals.get(key);
+    if (!state || !callId) return false;
+    const result = this.revalidate(state, sessionId, filePath, reason);
+    if (!result.approval) {
+      this.invalidate(key, result.denial);
+      return false;
+    }
+    this.pendingReads.set(operationKey(sessionId, callId), {
+      args: { ...args }, content: Buffer.from(state.content),
+    });
+    return { ...result.approval, approvedPath: state.approvedPath };
+  }
+
+  finishRead(sessionId, callId, output, succeeded) {
+    const key = operationKey(sessionId, callId);
+    const pending = this.pendingReads.get(key);
+    this.pendingReads.delete(key);
+    if (!pending || !succeeded) return;
+    output.output = renderApprovedSourceContent(pending.content, pending.args, output.output);
+    output.metadata = { ...(output.metadata || {}), sourceAccessContinuation: true };
+  }
+
+  beginMutation({ sessionId, callId, mutations, reason = this.reason }) {
+    if (!callId || !Array.isArray(mutations)) return;
+    const entries = [];
+    for (const mutation of mutations) {
+      const key = provenanceKey(sessionId, mutation.filePath);
+      const state = this.approvals.get(key);
+      if (!state) continue;
+      const result = this.revalidate(state, sessionId, mutation.filePath, reason);
+      const expectedContent = result.approval && expectedApprovedMutationContent(state, mutation);
+      if (!expectedContent) {
+        this.invalidate(key, result.denial || "drift");
+        continue;
+      }
+      entries.push({
+        expectedContent,
+        expectedSha256: createHash("sha256").update(expectedContent).digest("hex"),
+        filePath: mutation.filePath,
+        key,
+        state,
+      });
+    }
+    if (entries.length > 0) this.pendingMutations.set(operationKey(sessionId, callId), entries);
+  }
+
+  finishMutation({ sessionId, callId, succeeded, reason = this.reason }) {
+    const pendingKey = operationKey(sessionId, callId);
+    const entries = this.pendingMutations.get(pendingKey) || [];
+    this.pendingMutations.delete(pendingKey);
+    for (const entry of entries) this.finishMutationEntry(entry, sessionId, reason, succeeded);
+  }
+
+  finishMutationEntry(entry, sessionId, reason, succeeded) {
+    if (!succeeded) {
+      this.invalidate(entry.key, "drift");
+      return;
+    }
+    let approval = false;
+    try {
+      approval = this.verify({
+        sessionId, filePath: entry.filePath, reason, repositoryDir: this.repositoryDir,
+        authorizedApprovalId: entry.state.approvalId,
+      });
+    } catch {
+      this.invalidate(entry.key, "invalid");
+      return;
+    }
+    const snapshot = this.snapshot(entry.filePath, this.git, this.gitRun);
+    if (!completeMutationMatches(approval, snapshot, entry.state, entry)) {
+      this.invalidate(entry.key, "drift");
+      return;
+    }
+    this.approvals.set(entry.key, {
+      ...entry.state, content: Buffer.from(snapshot.content), contentSha256: snapshot.contentSha256,
+    });
+    this.denialReasons.delete(entry.key);
+  }
+
+  denialReason(sessionId, filePath) {
+    return this.denialReasons.get(provenanceKey(sessionId, filePath)) || "missing";
+  }
+}
+
+export function createMutationProvenance(options) {
+  return new MutationProvenance(options);
+}
+
+export function observedToolSucceeded(output, classify) {
+  if (!output || typeof output !== "object") return false;
+  const hasOutcome = typeof output.output === "string" || (output.metadata && typeof output.metadata === "object");
+  return hasOutcome && classify(output);
+}
+
+export function beginObservedSourceMutation(context, input, output) {
+  if (!isDirectFileMutationTool(input.tool)) return;
+  context.sourceAccessProvenance.beginMutation({
+    sessionId: context.sessionId,
+    callId: input.callID || "",
+    mutations: directFileMutations(input.tool, output.args, context.repositoryDir),
+    reason: context.sourceAccessReason,
+  });
+}
+
+export function finishObservedSourceAccess(context, input, output, classify) {
+  const callId = input.callID || "";
+  const succeeded = observedToolSucceeded(output, classify);
+  context.sourceAccessProvenance.finishRead(context.sessionId, callId, output, succeeded);
+  if (!isDirectFileMutationTool(input.tool)) return;
+  context.sourceAccessProvenance.finishMutation({
+    sessionId: context.sessionId,
+    callId,
+    succeeded,
+    reason: context.sourceAccessReason,
+  });
+}
 
 function runSourceAccessHelper(helperArgs, run) {
   return String(
@@ -51,6 +252,7 @@ export function checkGateWithApprovalInstructions({
   filePath,
   log,
   requestId,
+  denialReason = "missing",
   tool,
 }) {
   try {
@@ -64,8 +266,14 @@ export function checkGateWithApprovalInstructions({
       );
     }
     if (!requestId) throw error;
+    const explanation = {
+      drift: "The prior approval was invalidated by an unobserved content transition.",
+      expired: "The prior approval has expired.",
+      invalid: "The prior approval was revoked or its repository/worktree identity is no longer valid.",
+      missing: "No source-access approval exists for this exact path and session.",
+    }[denialReason] || "No valid source-access approval exists for this exact path and session.";
     throw new Error(
-      `${originalMessage}\n\nTo approve only this tracked source path for this session, run:\n` +
+      `${originalMessage}\n\n${explanation}\n\nTo approve only this tracked source path for this session, run:\n` +
         `sudo -k /usr/bin/python3 -I -B ${ROOT_BROKER} approve ${requestId} --ttl 12h\n\n` +
         "For one approval covering several exact tracked paths, create one request with " +
         "`aidevops source-access request --session <session> --reason 'secret-bearing basename' " +

--- a/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
@@ -7,9 +7,12 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   mkdirSync,
+  linkSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -20,6 +23,7 @@ import {
   SOURCE_ACCESS_REASON,
   canonicalReceiptPayload,
   checkSecretReadWithApproval,
+  createSourceAccessMutationProvenance,
   sourceAccessBrokerMatches,
   verifySourceAccessReceipt,
 } from "../source-access-approval.mjs";
@@ -38,6 +42,59 @@ const BASE = {
     throw new Error("[secret-read-guard] blocked read: secret-bearing basename");
   },
 };
+
+function mutationFixture() {
+  const tempParent = join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+  mkdirSync(tempParent, { recursive: true });
+  const root = mkdtempSync(join(tempParent, "source-access-mutation-test-"));
+  const repo = join(root, "repo");
+  const source = join(repo, "secret-helper.sh");
+  const snapshot = join(root, "approved.source");
+  const sessionId = "ses_mutation_123456";
+  mkdirSync(repo);
+  execFileSync("git", ["-C", repo, "init", "--quiet"]);
+  writeFileSync(source, "one\n");
+  writeFileSync(snapshot, "one\n");
+  execFileSync("git", ["-C", repo, "add", "secret-helper.sh"]);
+  const approval = {
+    approvalId: "a".repeat(64),
+    approvedPath: snapshot,
+    canonicalPath: realpathSync(source),
+    contentSha256: createHash("sha256").update("one\n").digest("hex"),
+    expiresAt: 2_000_000_000,
+    repoRoot: realpathSync(repo),
+    relativePath: "secret-helper.sh",
+  };
+  const verify = ({ sessionId: requestedSession, filePath, authorizedApprovalId }) => {
+    if (requestedSession !== sessionId || realpathSync(filePath) !== approval.canonicalPath) return false;
+    if (authorizedApprovalId && authorizedApprovalId !== approval.approvalId) return false;
+    if (!authorizedApprovalId && readFileSync(filePath, "utf8") !== "one\n") return false;
+    return approval;
+  };
+  const provenance = createSourceAccessMutationProvenance({
+    repositoryDir: repo,
+    verify,
+    now: () => 1_900_000_000,
+  });
+  provenance.rememberApproval({ sessionId, filePath: source, approval });
+  return { approval, provenance, repo, root, sessionId, snapshot, source, verify };
+}
+
+function approvedMutationRead(fixture, callId, expected) {
+  const args = { filePath: fixture.source };
+  const approval = fixture.provenance.authorizeRead({
+    sessionId: fixture.sessionId,
+    callId,
+    filePath: fixture.source,
+    reason: SOURCE_ACCESS_REASON,
+    args,
+  });
+  assert.ok(approval);
+  const output = { output: "immutable approval snapshot" };
+  fixture.provenance.finishRead(fixture.sessionId, callId, output, true);
+  assert.equal(output.output, expected);
+  assert.equal(output.metadata.sourceAccessContinuation, true);
+}
 
 test("a valid verifier result bypasses only the exact basename reason", () => {
   let gateCalls = 0;
@@ -508,5 +565,242 @@ test("one signed manifest authorizes only three exact repository-bound paths", (
     assert.equal(verifySourceAccessReceipt({ ...baseArgs, filePath: paths[0] }), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("one approval survives verified Write, Edit, and apply_patch cycles", () => {
+  const fixture = mutationFixture();
+  try {
+    fixture.provenance.beginMutation({
+      sessionId: fixture.sessionId,
+      callId: "write-1",
+      mutations: [{ filePath: fixture.source, kind: "write", content: "two\n" }],
+    });
+    writeFileSync(fixture.source, "two\n");
+    fixture.provenance.finishMutation({
+      sessionId: fixture.sessionId,
+      callId: "write-1",
+      succeeded: true,
+    });
+    approvedMutationRead(fixture, "read-2", "two\n");
+
+    fixture.provenance.beginMutation({
+      sessionId: fixture.sessionId,
+      callId: "edit-2",
+      mutations: [{
+        filePath: fixture.source,
+        kind: "edit",
+        oldString: "two",
+        newString: "three",
+        replaceAll: false,
+      }],
+    });
+    writeFileSync(fixture.source, "three\n");
+    fixture.provenance.finishMutation({
+      sessionId: fixture.sessionId,
+      callId: "edit-2",
+      succeeded: true,
+    });
+    approvedMutationRead(fixture, "read-3", "three\n");
+
+    fixture.provenance.beginMutation({
+      sessionId: fixture.sessionId,
+      callId: "patch-3",
+      mutations: [{
+        filePath: fixture.source,
+        kind: "apply_patch",
+        patchText: "\n@@\n-three\n+four\n",
+      }],
+    });
+    writeFileSync(fixture.source, "four\n");
+    fixture.provenance.finishMutation({
+      sessionId: fixture.sessionId,
+      callId: "patch-3",
+      succeeded: true,
+    });
+    approvedMutationRead(fixture, "read-4", "four\n");
+
+    const approval = fixture.provenance.authorizeRead({
+      sessionId: fixture.sessionId,
+      callId: "read-race",
+      filePath: fixture.source,
+      reason: SOURCE_ACCESS_REASON,
+      args: { filePath: fixture.source },
+    });
+    assert.ok(approval);
+    writeFileSync(fixture.source, "unobserved-after-verification\n");
+    const output = { output: "stale snapshot" };
+    fixture.provenance.finishRead(fixture.sessionId, "read-race", output, true);
+    assert.equal(output.output, "four\n", "the returned bytes cannot race the live path");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("failed, ambiguous, or mismatched mutations never advance authority", () => {
+  for (const scenario of ["failed", "ambiguous", "mismatch"]) {
+    const fixture = mutationFixture();
+    try {
+      fixture.provenance.beginMutation({
+        sessionId: fixture.sessionId,
+        callId: scenario,
+        mutations: [{ filePath: fixture.source, kind: "write", content: "expected\n" }],
+      });
+      writeFileSync(fixture.source, scenario === "mismatch" ? "concurrent\n" : "expected\n");
+      fixture.provenance.finishMutation({
+        sessionId: fixture.sessionId,
+        callId: scenario,
+        succeeded: scenario === "mismatch",
+      });
+      assert.equal(
+        fixture.provenance.authorizeRead({
+          sessionId: fixture.sessionId,
+          callId: `read-${scenario}`,
+          filePath: fixture.source,
+          reason: SOURCE_ACCESS_REASON,
+          args: { filePath: fixture.source },
+        }),
+        false,
+      );
+      assert.equal(fixture.provenance.denialReason(fixture.sessionId, fixture.source), "drift");
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("unobserved filesystem and identity transitions fail closed", () => {
+  for (const scenario of ["external", "untracked", "hardlink", "symlink"]) {
+    const fixture = mutationFixture();
+    try {
+      if (scenario === "external") writeFileSync(fixture.source, "external\n");
+      if (scenario === "untracked") {
+        execFileSync("git", ["-C", fixture.repo, "rm", "--cached", "--quiet", "secret-helper.sh"]);
+      }
+      if (scenario === "hardlink") linkSync(fixture.source, join(fixture.root, "linked.source"));
+      if (scenario === "symlink") {
+        rmSync(fixture.source);
+        symlinkSync(fixture.snapshot, fixture.source);
+      }
+      assert.equal(
+        fixture.provenance.authorizeRead({
+          sessionId: fixture.sessionId,
+          callId: `read-${scenario}`,
+          filePath: fixture.source,
+          reason: SOURCE_ACCESS_REASON,
+          args: { filePath: fixture.source },
+        }),
+        false,
+      );
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("expiry, session changes, and plugin restart do not preserve mutation authority", () => {
+  const fixture = mutationFixture();
+  try {
+    assert.equal(
+      fixture.provenance.authorizeRead({
+        sessionId: "ses_other_123456",
+        callId: "wrong-session",
+        filePath: fixture.source,
+        reason: SOURCE_ACCESS_REASON,
+        args: { filePath: fixture.source },
+      }),
+      false,
+    );
+    const restarted = createSourceAccessMutationProvenance({
+      repositoryDir: fixture.repo,
+      verify: fixture.verify,
+      now: () => 1_900_000_000,
+    });
+    assert.equal(
+      restarted.authorizeRead({
+        sessionId: fixture.sessionId,
+        callId: "restart",
+        filePath: fixture.source,
+        reason: SOURCE_ACCESS_REASON,
+        args: { filePath: fixture.source },
+      }),
+      false,
+    );
+    const expired = createSourceAccessMutationProvenance({
+      repositoryDir: fixture.repo,
+      verify: fixture.verify,
+      now: () => fixture.approval.expiresAt,
+    });
+    expired.rememberApproval({
+      sessionId: fixture.sessionId,
+      filePath: fixture.source,
+      approval: fixture.approval,
+    });
+    assert.equal(
+      expired.authorizeRead({
+        sessionId: fixture.sessionId,
+        callId: "expired",
+        filePath: fixture.source,
+        reason: SOURCE_ACCESS_REASON,
+        args: { filePath: fixture.source },
+      }),
+      false,
+    );
+    assert.equal(expired.denialReason(fixture.sessionId, fixture.source), "expired");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("denial guidance distinguishes missing approval from unobserved drift", () => {
+  assert.throws(
+    () => checkSecretReadWithApproval({
+      ...BASE,
+      verify: () => false,
+      requestRun: () => "0123456789abcdef0123456789abcdef",
+    }),
+    /No source-access approval exists for this exact path and session/,
+  );
+  assert.throws(
+    () => checkSecretReadWithApproval({
+      ...BASE,
+      verify: () => false,
+      provenance: { authorizeRead: () => false, denialReason: () => "drift" },
+      requestRun: () => "0123456789abcdef0123456789abcdef",
+    }),
+    /invalidated by an unobserved content transition/,
+  );
+});
+
+test("pending reads are session-bound, success-bound, and preserve numbered output", () => {
+  const fixture = mutationFixture();
+  try {
+    const args = { filePath: fixture.source, offset: 1, limit: 1 };
+    assert.ok(fixture.provenance.authorizeRead({
+      sessionId: fixture.sessionId,
+      callId: "shared-call",
+      filePath: fixture.source,
+      reason: SOURCE_ACCESS_REASON,
+      args,
+    }));
+    const wrongSession = { output: "<content>\n1: wrong\n</content>" };
+    fixture.provenance.finishRead("ses_other_123456", "shared-call", wrongSession, true);
+    assert.equal(wrongSession.output, "<content>\n1: wrong\n</content>");
+    const failedRead = { output: "failed to read snapshot" };
+    fixture.provenance.finishRead(fixture.sessionId, "shared-call", failedRead, false);
+    assert.equal(failedRead.output, "failed to read snapshot");
+
+    assert.ok(fixture.provenance.authorizeRead({
+      sessionId: fixture.sessionId,
+      callId: "numbered-call",
+      filePath: fixture.source,
+      reason: SOURCE_ACCESS_REASON,
+      args,
+    }));
+    const numbered = { output: "<content>\n1: stale\n</content>" };
+    fixture.provenance.finishRead(fixture.sessionId, "numbered-call", numbered, true);
+    assert.equal(numbered.output, "<content>\n1: one\n</content>");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

Preserve exact-path source access approval across runtime-observed same-session Write, Edit, and apply_patch mutations while retaining fail-closed receipt, digest, identity, session, repository, and link validation.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs, .agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/source-access-approval.mjs, .agents/plugins/opencode-aidevops/source-access-manifest-approval.mjs, .agents/plugins/opencode-aidevops/source-access-request.mjs, .agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified through the composed OpenCode hook path; 50 focused Node tests pass across source-access continuity, mutation failure, TOCTOU, expiry, session, tracking, link substitution, git safety, and intent integration. Local linters pass and Qlty regression is zero.

Resolves #31035


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol spent 49m and 464,795 tokens on this as a headless worker.