### PR TITLE
GH#31038: ignore signature footer URLs in issue path extraction

### DIFF
--- a/.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh
+++ b/.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh
@@ -45,6 +45,18 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
 	205)
 		printf '## Implementation target\nUpdate `.agents/scripts/target.sh`; evidence is at `https://example.com/unrelated/gh`.\n'
 		;;
+	206)
+		printf 'No repository files are cited.\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) automated scan.\n'
+		;;
+	207)
+		printf 'Evidence: [remote.sh](https://example.com/path/remote.sh) and https://example.com/raw.sh.\n'
+		;;
+	208 | 209)
+		printf '## Implementation target\nUpdate `.agents/scripts/target.sh`.\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) automated scan.\n'
+		;;
+	210)
+		printf '<!-- aidevops:sig -->\nUntrusted marker before `.agents/scripts/target.sh` must not hide the target.\n'
+		;;
 	*)
 		exit 1
 		;;
@@ -68,6 +80,12 @@ if [[ "${1:-}" == "api" ]]; then
 		;;
 	repos/owner/repo/pulls/105/files?per_page=100 | repos/owner/repo/pulls/106/files?per_page=100)
 		printf 'unrelated/gh\n'
+		;;
+	repos/owner/repo/pulls/107/files?per_page=100)
+		printf '.agents/scripts/target.sh\n'
+		;;
+	repos/owner/repo/pulls/108/files?per_page=100)
+		printf 'aidevops.sh\n'
 		;;
 	*)
 		exit 1
@@ -122,6 +140,40 @@ assert_check_rejects() {
 	return 0
 }
 
+assert_extract_excludes() {
+	local label="$1"
+	local issue_number="$2"
+	local unexpected_path="$3"
+
+	local output
+	output=$(bash "$HELPER_PATH" extract-paths "$issue_number" owner/repo 2>&1)
+	if printf '%s' "$output" | grep -qF "$unexpected_path"; then
+		FAIL=$((FAIL + 1))
+		printf 'FAIL: %s — extracted metadata path %s\n%s\n' "$label" "$unexpected_path" "$output"
+	else
+		PASS=$((PASS + 1))
+		printf 'PASS: %s\n' "$label"
+	fi
+	return 0
+}
+
+assert_check_skips_no_paths() {
+	local label="$1"
+	local issue_number="$2"
+	local pr_number="$3"
+
+	local output
+	if output=$(bash "$HELPER_PATH" check "$issue_number" "$pr_number" owner/repo 2>&1) &&
+		printf '%s' "$output" | grep -q 'WARN: no file paths found'; then
+		PASS=$((PASS + 1))
+		printf 'PASS: %s\n' "$label"
+	else
+		FAIL=$((FAIL + 1))
+		printf 'FAIL: %s — metadata created a file-overlap requirement\n%s\n' "$label" "$output"
+	fi
+	return 0
+}
+
 assert_check_passes "merged PR files come from the REST pull files endpoint" 100
 assert_check_passes "standard PR files come from the REST pull files endpoint" 101
 assert_check_passes "independent general target survives a supporting specific path" 102 201
@@ -129,6 +181,13 @@ assert_check_rejects "specific target cannot be satisfied by an unrelated same-b
 assert_check_passes "extensionless repository path matches the exact PR file" 104 203
 assert_check_rejects "extensionless repository path rejects an unrelated same-basename file" 204 105
 assert_check_rejects "backtick URL cannot supply an extensionless repository path" 205 106
+assert_extract_excludes "signature footer basename is not extracted" 206 "aidevops.sh"
+assert_extract_excludes "Markdown URL basename is not extracted" 207 "remote.sh"
+assert_extract_excludes "raw URL basename is not extracted" 207 "raw.sh"
+assert_check_skips_no_paths "footer-only issue stays on the manual-review path" 206 109
+assert_check_passes "repository path survives signature filtering" 107 208
+assert_check_rejects "footer basename cannot replace an absent repository path" 209 108
+assert_check_passes "signature-like marker cannot hide a later repository path" 107 210
 
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then

--- a/.agents/scripts/verify-issue-close-helper.sh
+++ b/.agents/scripts/verify-issue-close-helper.sh
@@ -44,6 +44,25 @@ readonly MIN_FILE_OVERLAP=1
 # =============================================================================
 
 #######################################
+# Remove generated provenance and URL metadata before path extraction.
+#
+# Args: $1 = issue body text
+# Outputs: issue content that may contain repository-relative references
+# Returns: 0 always
+#######################################
+_strip_non_repository_path_metadata() {
+	local text="$1"
+
+	# Remove metadata tokens rather than truncating at the marker: issue text is
+	# untrusted, so a signature-like comment must not hide later file references.
+	printf '%s' "$text" | sed -E \
+		-e '/^[[:space:]]*<!--[[:space:]]*aidevops:sig[[:space:]]*-->[[:space:]]*$/d' \
+		-e 's#\[[^]]*\]\(https?://[^)]*\)##g' \
+		-e 's#https?://[^[:space:])>]+##g'
+	return 0
+}
+
+#######################################
 # Extract file paths from an issue body.
 #
 # Looks for common file-path patterns in the issue text:
@@ -57,6 +76,7 @@ readonly MIN_FILE_OVERLAP=1
 #######################################
 extract_file_paths_from_text() {
 	local text="$1"
+	text=$(_strip_non_repository_path_metadata "$text")
 
 	# Extract paths that look like file references:
 	# - Must contain a dot (extension) or a slash (directory)
@@ -122,7 +142,7 @@ get_pr_changed_files() {
 	# native GraphQL `files` projection, which cannot report its exact cost.
 	pr_files=$(AIDEVOPS_GH_ROUTE_DECISION="verify-close-pr-files-rest" \
 		gh api --paginate "repos/${repo_slug}/pulls/${pr_number}/files?per_page=100" \
-			--jq '.[].filename' 2>/dev/null) || {
+		--jq '.[].filename' 2>/dev/null) || {
 		log_error "Failed to fetch PR #${pr_number} file list via REST"
 		return 1
 	}


### PR DESCRIPTION
## Summary

Filter generated signature markers, Markdown links, and raw URLs before deriving repository file references for issue-close overlap checks.

## Files Changed

.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh, .agents/scripts/verify-issue-close-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 14 focused overlap tests pass; ShellCheck is clean; linters-local.sh --changed passes; closeout bundle 2d4600c6781e152869fbf84afb0f56cda3f716b38a6990df7fbcf1381939b0c5 is clean.

Resolves #31038


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 50m and 182,865 tokens on this with the user in an interactive session.