### PR TITLE
GH#31026: complete live output compaction adoption

### DIFF
--- a/.agents/plugins/opencode-aidevops/output-compaction.mjs
+++ b/.agents/plugins/opencode-aidevops/output-compaction.mjs
@@ -1,0 +1,66 @@
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+import { toolCallSucceeded } from "./observability-tool-calls.mjs";
+
+const DEFAULT_COMPACT_BYTES = 8192;
+const DEFAULT_COMPACT_LINES = 80;
+const outputPolicyByCallId = new Map();
+
+function positiveThreshold(name, fallback) {
+  const value = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function requiresExactOutput(command) {
+  if (typeof command !== "string") return false;
+  return /^(?:cat|head|tail|less|more)\s|^git\s+diff\b|\s--json(?:\s|$)|\ssecurity\s|secret|credential/i.test(command.trim());
+}
+
+function pruneOutputPolicies() {
+  if (outputPolicyByCallId.size <= 2000) return;
+  for (const callID of Array.from(outputPolicyByCallId.keys()).slice(0, 1000)) {
+    outputPolicyByCallId.delete(callID);
+  }
+}
+
+export function rememberBashOutputPolicy(callID, args) {
+  if (!callID) return;
+  outputPolicyByCallId.set(callID, {
+    exact: requiresExactOutput(args?.command),
+  });
+  pruneOutputPolicies();
+}
+
+function isVerboseOutput(text) {
+  const byteCount = Buffer.byteLength(text, "utf8");
+  const lineCount = (text.match(/\n/g) || []).length;
+  return byteCount >= positiveThreshold("AIDEVOPS_OUTPUT_SANDBOX_COMPACT_BYTES", DEFAULT_COMPACT_BYTES)
+    || lineCount >= positiveThreshold("AIDEVOPS_OUTPUT_SANDBOX_COMPACT_LINES", DEFAULT_COMPACT_LINES);
+}
+
+export function compactSuccessfulBashOutput({ callID, output, scriptsDir, durationMs, log }) {
+  const policy = outputPolicyByCallId.get(callID);
+  outputPolicyByCallId.delete(callID);
+  const text = output?.output;
+  if (policy?.exact || typeof text !== "string" || !toolCallSucceeded(output) || !isVerboseOutput(text)) {
+    return false;
+  }
+
+  const helper = join(scriptsDir, "output-sandbox-helper.sh");
+  if (!existsSync(helper)) return false;
+  try {
+    const summary = execFileSync(
+      helper,
+      ["compact", "--command", "bash", "--duration-ms", String(durationMs ?? 0), "--tag", "opencode-tool"],
+      { input: text, encoding: "utf8", maxBuffer: 64 * 1024 },
+    );
+    if (!summary.trim()) return false;
+    output.output = summary.trimEnd();
+    log("INFO", `[output-sandbox] retained verbose Bash output as a bounded receipt`);
+    return true;
+  } catch {
+    log("WARN", `[output-sandbox] retention unavailable; returning native Bash output`);
+    return false;
+  }
+}

--- a/.agents/plugins/opencode-aidevops/output-compaction.mjs
+++ b/.agents/plugins/opencode-aidevops/output-compaction.mjs
@@ -12,9 +12,11 @@ function positiveThreshold(name, fallback) {
   return Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
-function requiresExactOutput(command) {
+function commandIsEligible(command) {
   if (typeof command !== "string") return false;
-  return /^(?:cat|head|tail|less|more)\s|^git\s+diff\b|\s--json(?:\s|$)|\ssecurity\s|secret|credential/i.test(command.trim());
+  const normalized = command.trim();
+  if (/secret|credential|password|authorization|token|--json/i.test(normalized)) return false;
+  return /^(?:(?:npm|pnpm|yarn|bun)\s+(?:test|run|exec|build|lint|check|typecheck|ci)\b|(?:python3?\s+-m\s+)?pytest\b|go\s+test\b|cargo\s+(?:test|build|check|clippy)\b|make(?:\s|$)|cmake\s+--build\b|(?:gradle|\.\/gradlew|mvn)\b|dotnet\s+(?:test|build)\b|shellcheck\b|bash\s+\S*(?:test|lint)[^\s]*\.sh\b)/i.test(normalized);
 }
 
 function pruneOutputPolicies() {
@@ -27,7 +29,7 @@ function pruneOutputPolicies() {
 export function rememberBashOutputPolicy(callID, args) {
   if (!callID) return;
   outputPolicyByCallId.set(callID, {
-    exact: requiresExactOutput(args?.command),
+    compact: commandIsEligible(args?.command),
   });
   pruneOutputPolicies();
 }
@@ -43,7 +45,7 @@ export function compactSuccessfulBashOutput({ callID, output, scriptsDir, durati
   const policy = outputPolicyByCallId.get(callID);
   outputPolicyByCallId.delete(callID);
   const text = output?.output;
-  if (policy?.exact || typeof text !== "string" || !toolCallSucceeded(output) || !isVerboseOutput(text)) {
+  if (policy?.compact !== true || typeof text !== "string" || !toolCallSucceeded(output) || !isVerboseOutput(text)) {
     return false;
   }
 

--- a/.agents/plugins/opencode-aidevops/output-compaction.mjs
+++ b/.agents/plugins/opencode-aidevops/output-compaction.mjs
@@ -6,6 +6,9 @@ import { toolCallSucceeded } from "./observability-tool-calls.mjs";
 const DEFAULT_COMPACT_BYTES = 8192;
 const DEFAULT_COMPACT_LINES = 80;
 const outputPolicyByCallId = new Map();
+const COMMAND_CONTROL_PATTERN = /[;&|`<>]|\$\(|\r|\n/;
+const SENSITIVE_COMMAND_PATTERN = /secret|credential|password|authorization|token|--json/i;
+const ELIGIBLE_COMMAND_PATTERN = /^(?:(?:npm|pnpm|yarn|bun)\s+(?:test|build|lint|check|typecheck|ci)\b|(?:npm|pnpm|yarn|bun)\s+run\s+(?:test|build|lint|check|typecheck)(?:[:_.-][\w.-]+)?\b|(?:python3?\s+-m\s+)?pytest\b|go\s+test\b|cargo\s+(?:test|build|check|clippy)\b|make(?:\s+(?:test|check|build|lint)(?:[:_.-][\w.-]+)?)?(?:\s|$)|cmake\s+--build\b|(?:gradle|\.\/gradlew)\s+(?:test|build|check|lint)\b|mvn\s+(?:test|verify|package|install|compile)\b|dotnet\s+(?:test|build)\b|shellcheck\b|(?:\S*\/)?linters-local\.sh\b|bash\s+\S*(?:test|lint)[^\s]*\.sh\b)/i;
 
 function positiveThreshold(name, fallback) {
   const value = Number.parseInt(process.env[name] || "", 10);
@@ -15,8 +18,8 @@ function positiveThreshold(name, fallback) {
 function commandIsEligible(command) {
   if (typeof command !== "string") return false;
   const normalized = command.trim();
-  if (/secret|credential|password|authorization|token|--json/i.test(normalized)) return false;
-  return /^(?:(?:npm|pnpm|yarn|bun)\s+(?:test|run|exec|build|lint|check|typecheck|ci)\b|(?:python3?\s+-m\s+)?pytest\b|go\s+test\b|cargo\s+(?:test|build|check|clippy)\b|make(?:\s|$)|cmake\s+--build\b|(?:gradle|\.\/gradlew|mvn)\b|dotnet\s+(?:test|build)\b|shellcheck\b|bash\s+\S*(?:test|lint)[^\s]*\.sh\b)/i.test(normalized);
+  if (COMMAND_CONTROL_PATTERN.test(normalized) || SENSITIVE_COMMAND_PATTERN.test(normalized)) return false;
+  return ELIGIBLE_COMMAND_PATTERN.test(normalized);
 }
 
 function pruneOutputPolicies() {
@@ -34,18 +37,20 @@ export function rememberBashOutputPolicy(callID, args) {
   pruneOutputPolicies();
 }
 
-function isVerboseOutput(text) {
+export function isVerboseBashOutput(text) {
+  if (typeof text !== "string") return false;
   const byteCount = Buffer.byteLength(text, "utf8");
   const lineCount = (text.match(/\n/g) || []).length;
   return byteCount >= positiveThreshold("AIDEVOPS_OUTPUT_SANDBOX_COMPACT_BYTES", DEFAULT_COMPACT_BYTES)
     || lineCount >= positiveThreshold("AIDEVOPS_OUTPUT_SANDBOX_COMPACT_LINES", DEFAULT_COMPACT_LINES);
 }
 
-export function compactSuccessfulBashOutput({ callID, output, scriptsDir, durationMs, log }) {
+export function compactSuccessfulBashOutput({ callID, output, scriptsDir, durationMs, wasVerbose, log }) {
   const policy = outputPolicyByCallId.get(callID);
   outputPolicyByCallId.delete(callID);
   const text = output?.output;
-  if (policy?.compact !== true || typeof text !== "string" || !toolCallSucceeded(output) || !isVerboseOutput(text)) {
+  if (policy?.compact !== true || typeof text !== "string" || !toolCallSucceeded(output)
+    || !(wasVerbose ?? isVerboseBashOutput(text))) {
     return false;
   }
 

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -14,6 +14,7 @@ import {
   prepareIntent,
 } from "./intent-tracing.mjs";
 import { recordToolStart, consumeToolDuration } from "./timing-tracing.mjs";
+import { compactSuccessfulBashOutput, rememberBashOutputPolicy } from "./output-compaction.mjs";
 import { qualityLog, runFileQualityGate } from "./quality-logging.mjs";
 import { enrichActiveSpan, detectTaskId, detectSessionOrigin } from "./otel-enrichment.mjs";
 import {
@@ -333,6 +334,7 @@ function handleToolBefore(ctx, log, input, output) {
     log,
   });
   checkResearchStagingAccess(input.tool, output.args || {});
+  if (isBashTool(input.tool)) rememberBashOutputPolicy(callID, output.args);
 
   if (!isWriteOrEditTool(input.tool)) return;
 
@@ -375,6 +377,18 @@ function handleToolAfter(ctx, log, scriptsDir, input, output) {
     trackBashOperation(ctx, output.title || "", output.output || "");
   }
 
+  // Consume timing before output compaction so the receipt can report runtime.
+  const durationMs = consumeToolDuration(input.callID || "");
+  if (isBashTool(toolName)) {
+    compactSuccessfulBashOutput({
+      callID: input.callID || "",
+      output,
+      scriptsDir,
+      durationMs,
+      log,
+    });
+  }
+
   if (isWriteOrEditTool(toolName)) {
     const filePath = output.metadata?.filePath || "";
     if (filePath) {
@@ -383,9 +397,8 @@ function handleToolAfter(ctx, log, scriptsDir, input, output) {
   }
 
   const intentRecord = consumeIntentRecord(input.callID || "");
-  // t2184: consumeToolDuration returns null when the callID wasn't paired
-  // (e.g., hook race on plugin reload) — recordToolCall emits SQL NULL.
-  const durationMs = consumeToolDuration(input.callID || "");
+  // t2184: durationMs is null when the callID wasn't paired (for example,
+  // a hook race on plugin reload); recordToolCall emits SQL NULL.
   recordToolCall(input, output, intentRecord?.intent, durationMs, intentRecord?.source);
 
   if (toolName === "mcp_task" || toolName === "task") {

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -14,7 +14,11 @@ import {
   prepareIntent,
 } from "./intent-tracing.mjs";
 import { recordToolStart, consumeToolDuration } from "./timing-tracing.mjs";
-import { compactSuccessfulBashOutput, rememberBashOutputPolicy } from "./output-compaction.mjs";
+import {
+  compactSuccessfulBashOutput,
+  isVerboseBashOutput,
+  rememberBashOutputPolicy,
+} from "./output-compaction.mjs";
 import { qualityLog, runFileQualityGate } from "./quality-logging.mjs";
 import { enrichActiveSpan, detectTaskId, detectSessionOrigin } from "./otel-enrichment.mjs";
 import {
@@ -360,6 +364,7 @@ function handleToolAfter(ctx, log, scriptsDir, input, output) {
   // Applies to all tools — credentials can arrive via user scripts, third-party
   // CLIs, or runtime error backtraces, not just framework helpers.
   const rawOutput = output.output;
+  const bashOutputWasVerbose = isBashTool(toolName) && isVerboseBashOutput(rawOutput);
   if (rawOutput !== undefined) {
     const { output: scrubbedOutput, redacted } = scrubToolOutput(rawOutput);
     if (redacted) {
@@ -385,6 +390,7 @@ function handleToolAfter(ctx, log, scriptsDir, input, output) {
       output,
       scriptsDir,
       durationMs,
+      wasVerbose: bashOutputWasVerbose,
       log,
     });
   }

--- a/.agents/plugins/opencode-aidevops/tests/test-output-compaction.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-output-compaction.mjs
@@ -10,7 +10,9 @@ function fixture() {
   const root = mkdtempSync(join(tmpdir(), "aidevops-output-compaction-"));
   const capture = join(root, "captured.txt");
   const helper = join(root, "output-sandbox-helper.sh");
+  const commandPolicy = join(root, "command-policy-helper.py");
   writeFileSync(helper, `#!/usr/bin/env bash\ncat > "${capture}"\nprintf 'bounded receipt\\nfull_log: output-sandbox-helper.sh show out_fixture\\n'\n`);
+  writeFileSync(commandPolicy, 'import json\nprint(json.dumps({"decision": "allow"}))\n');
   chmodSync(helper, 0o700);
   return { root, capture };
 }
@@ -20,10 +22,28 @@ test("live Bash after-hook replaces verbose success with retained receipt", asyn
   const output = { output: "asset line\n".repeat(1000), metadata: { exitCode: 0 }, title: "build" };
   try {
     const hooks = createQualityHooks({ scriptsDir: root, logsDir: root });
-    rememberBashOutputPolicy("call-verbose", { command: "npm test" });
+    await hooks.toolExecuteBefore(
+      { tool: "bash", callID: "call-verbose" },
+      { args: { command: "npm test", workdir: root } },
+    );
     await hooks.toolExecuteAfter({ tool: "bash", callID: "call-verbose" }, output);
     assert.match(output.output, /^bounded receipt/);
     assert.equal(readFileSync(capture, "utf8"), "asset line\n".repeat(1000));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("pre-scrub verbosity still produces a redacted compact receipt", async () => {
+  const { root, capture } = fixture();
+  const credential = `ghp_${"x".repeat(10000)}`;
+  const output = { output: credential, metadata: { exitCode: 0 }, title: "test" };
+  try {
+    const hooks = createQualityHooks({ scriptsDir: root, logsDir: root });
+    rememberBashOutputPolicy("call-redacted", { command: "npm test" });
+    await hooks.toolExecuteAfter({ tool: "bash", callID: "call-redacted" }, output);
+    assert.match(output.output, /^bounded receipt/);
+    assert.equal(readFileSync(capture, "utf8"), "[redacted-credential]");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -46,6 +66,16 @@ test("live hook preserves failures, short output, and exact-output calls", async
     rememberBashOutputPolicy("call-exact", { command: "git diff --stat" });
     await hooks.toolExecuteAfter({ tool: "bash", callID: "call-exact" }, exact);
     assert.match(exact.output, /^diff line/);
+
+    const arbitraryScript = { output: "deploy line\n".repeat(1000), metadata: { exitCode: 0 } };
+    rememberBashOutputPolicy("call-arbitrary-script", { command: "npm run deploy" });
+    await hooks.toolExecuteAfter({ tool: "bash", callID: "call-arbitrary-script" }, arbitraryScript);
+    assert.match(arbitraryScript.output, /^deploy line/);
+
+    const composed = { output: "composed line\n".repeat(1000), metadata: { exitCode: 0 } };
+    rememberBashOutputPolicy("call-composed", { command: "npm test && git diff" });
+    await hooks.toolExecuteAfter({ tool: "bash", callID: "call-composed" }, composed);
+    assert.match(composed.output, /^composed line/);
 
     const unpaired = { output: "unpaired line\n".repeat(1000), metadata: { exitCode: 0 } };
     await hooks.toolExecuteAfter({ tool: "bash", callID: "call-unpaired" }, unpaired);

--- a/.agents/plugins/opencode-aidevops/tests/test-output-compaction.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-output-compaction.mjs
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createQualityHooks } from "../quality-hooks.mjs";
+import { rememberBashOutputPolicy } from "../output-compaction.mjs";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-output-compaction-"));
+  const capture = join(root, "captured.txt");
+  const helper = join(root, "output-sandbox-helper.sh");
+  writeFileSync(helper, `#!/usr/bin/env bash\ncat > "${capture}"\nprintf 'bounded receipt\\nfull_log: output-sandbox-helper.sh show out_fixture\\n'\n`);
+  chmodSync(helper, 0o700);
+  return { root, capture };
+}
+
+test("live Bash after-hook replaces verbose success with retained receipt", async () => {
+  const { root, capture } = fixture();
+  const output = { output: "asset line\n".repeat(1000), metadata: { exitCode: 0 }, title: "build" };
+  try {
+    const hooks = createQualityHooks({ scriptsDir: root, logsDir: root });
+    await hooks.toolExecuteAfter({ tool: "bash", callID: "call-verbose" }, output);
+    assert.match(output.output, /^bounded receipt/);
+    assert.equal(readFileSync(capture, "utf8"), "asset line\n".repeat(1000));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("live hook preserves failures, short output, and exact-output calls", async () => {
+  const { root } = fixture();
+  const hooks = createQualityHooks({ scriptsDir: root, logsDir: root });
+  try {
+    const failure = { output: "fatal: failed\n".repeat(1000), metadata: { exitCode: 7 } };
+    await hooks.toolExecuteAfter({ tool: "bash", callID: "call-failure" }, failure);
+    assert.match(failure.output, /^fatal: failed/);
+
+    const short = { output: "short output", metadata: { exitCode: 0 } };
+    await hooks.toolExecuteAfter({ tool: "bash", callID: "call-short" }, short);
+    assert.equal(short.output, "short output");
+
+    const exact = { output: "diff line\n".repeat(1000), metadata: { exitCode: 0 } };
+    rememberBashOutputPolicy("call-exact", { command: "git diff --stat" });
+    await hooks.toolExecuteAfter({ tool: "bash", callID: "call-exact" }, exact);
+    assert.match(exact.output, /^diff line/);
+
+    const structured = { output: { result: "x".repeat(10000) }, metadata: { exitCode: 0 } };
+    await hooks.toolExecuteAfter({ tool: "bash", callID: "call-structured" }, structured);
+    assert.equal(typeof structured.output, "object");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("live hook returns native output when retention fails", async () => {
+  const { root } = fixture();
+  const helper = join(root, "output-sandbox-helper.sh");
+  writeFileSync(helper, "#!/usr/bin/env bash\nexit 1\n");
+  chmodSync(helper, 0o700);
+  const native = "native output\n".repeat(1000);
+  const output = { output: native, metadata: { exitCode: 0 } };
+  try {
+    const hooks = createQualityHooks({ scriptsDir: root, logsDir: root });
+    await hooks.toolExecuteAfter({ tool: "bash", callID: "call-retention-failure" }, output);
+    assert.equal(output.output, native);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-output-compaction.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-output-compaction.mjs
@@ -20,6 +20,7 @@ test("live Bash after-hook replaces verbose success with retained receipt", asyn
   const output = { output: "asset line\n".repeat(1000), metadata: { exitCode: 0 }, title: "build" };
   try {
     const hooks = createQualityHooks({ scriptsDir: root, logsDir: root });
+    rememberBashOutputPolicy("call-verbose", { command: "npm test" });
     await hooks.toolExecuteAfter({ tool: "bash", callID: "call-verbose" }, output);
     assert.match(output.output, /^bounded receipt/);
     assert.equal(readFileSync(capture, "utf8"), "asset line\n".repeat(1000));
@@ -37,6 +38,7 @@ test("live hook preserves failures, short output, and exact-output calls", async
     assert.match(failure.output, /^fatal: failed/);
 
     const short = { output: "short output", metadata: { exitCode: 0 } };
+    rememberBashOutputPolicy("call-short", { command: "npm test" });
     await hooks.toolExecuteAfter({ tool: "bash", callID: "call-short" }, short);
     assert.equal(short.output, "short output");
 
@@ -44,6 +46,10 @@ test("live hook preserves failures, short output, and exact-output calls", async
     rememberBashOutputPolicy("call-exact", { command: "git diff --stat" });
     await hooks.toolExecuteAfter({ tool: "bash", callID: "call-exact" }, exact);
     assert.match(exact.output, /^diff line/);
+
+    const unpaired = { output: "unpaired line\n".repeat(1000), metadata: { exitCode: 0 } };
+    await hooks.toolExecuteAfter({ tool: "bash", callID: "call-unpaired" }, unpaired);
+    assert.match(unpaired.output, /^unpaired line/);
 
     const structured = { output: { result: "x".repeat(10000) }, metadata: { exitCode: 0 } };
     await hooks.toolExecuteAfter({ tool: "bash", callID: "call-structured" }, structured);
@@ -62,6 +68,7 @@ test("live hook returns native output when retention fails", async () => {
   const output = { output: native, metadata: { exitCode: 0 } };
   try {
     const hooks = createQualityHooks({ scriptsDir: root, logsDir: root });
+    rememberBashOutputPolicy("call-retention-failure", { command: "npm test" });
     await hooks.toolExecuteAfter({ tool: "bash", callID: "call-retention-failure" }, output);
     assert.equal(output.output, native);
   } finally {

--- a/.agents/scripts/output-sandbox-helper.sh
+++ b/.agents/scripts/output-sandbox-helper.sh
@@ -18,6 +18,8 @@ RAW_DIR="${AIDEVOPS_OUTPUT_SANDBOX_RAW_DIR:-${SANDBOX_ROOT}/raw}"
 DEFAULT_SUMMARY_LINES="${AIDEVOPS_OUTPUT_SANDBOX_SUMMARY_LINES:-20}"
 DEFAULT_DIAGNOSTIC_LINES="${AIDEVOPS_OUTPUT_SANDBOX_DIAGNOSTIC_LINES:-20}"
 DEFAULT_RETENTION_DAYS="${AIDEVOPS_OUTPUT_SANDBOX_RETENTION_DAYS:-14}"
+DEFAULT_COMPACT_BYTES="${AIDEVOPS_OUTPUT_SANDBOX_COMPACT_BYTES:-8192}"
+DEFAULT_COMPACT_LINES="${AIDEVOPS_OUTPUT_SANDBOX_COMPACT_LINES:-80}"
 
 usage() {
 	cat <<'EOF'
@@ -34,7 +36,7 @@ auditable pointer. Exact/verbatim/security-sensitive commands are bypassed.
 
 Run options:
   --tag TAG                    Evidence category (default: run)
-  --success-mode MODE          receipt|summary|full (default: receipt)
+  --success-mode MODE          auto|receipt|summary|full (default: auto)
   --failure-mode MODE          diagnostic|summary|full (default: diagnostic)
   --summary-lines N            Maximum summary lines (default: 20)
   --diagnostic-lines N         Maximum failure diagnostic lines (default: 20)
@@ -244,7 +246,7 @@ redact_capture_files() {
 validate_mode() {
 	local mode="$1"
 	case "$mode" in
-	receipt | summary | diagnostic | full) return 0 ;;
+	auto | receipt | summary | diagnostic | full) return 0 ;;
 	*) return 1 ;;
 	esac
 }
@@ -383,6 +385,67 @@ print_presentation() {
 	return 0
 }
 
+is_verbose_success() {
+	local byte_count="$1"
+	local line_count="$2"
+	[[ "$byte_count" -ge "$DEFAULT_COMPACT_BYTES" || "$line_count" -ge "$DEFAULT_COMPACT_LINES" ]]
+	return $?
+}
+
+print_verbose_success_summary() {
+	local output_id="$1"
+	local command_text="$2"
+	local exit_code="$3"
+	local duration_seconds="$4"
+	local byte_count="$5"
+	local line_count="$6"
+	local sensitive="$7"
+	local raw_path="$8"
+	if [[ "$sensitive" == "1" ]]; then
+		printf 'command: %s\n' "$command_text"
+		printf 'exit_status: %s\n' "$exit_code"
+		printf 'duration_seconds: %s\n' "$duration_seconds"
+		printf 'output: %s bytes across %s lines; sensitive content redacted\n' "$byte_count" "$line_count"
+		printf 'full_log: output-sandbox-helper.sh show %s\n' "$output_id"
+		return 0
+	fi
+	python3 - "$raw_path" "$command_text" "$exit_code" "$duration_seconds" "$byte_count" "$line_count" "$output_id" <<'PY'
+import re
+import sys
+
+path, command, exit_code, duration, byte_count, line_count, output_id = sys.argv[1:]
+with open(path, "r", encoding="utf-8", errors="replace") as handle:
+    lines = handle.read().splitlines()
+warning_pattern = re.compile(r"(?i)(warning|deprecated|deprecation|lint|compiler)")
+warnings = [line for line in lines if warning_pattern.search(line)]
+test_patterns = (
+    re.compile(r"(?i)\btests?\s*[:=]\s*(.+)$"),
+    re.compile(r"(?i)\b(\d+)\s+(?:tests?\s+)?passed\b(?:.*?\b(\d+)\s+failed\b)?"),
+    re.compile(r"(?i)^#\s*(pass|fail)\s+(\d+)\b"),
+)
+test_lines = []
+for line in lines:
+    if any(pattern.search(line) for pattern in test_patterns):
+        test_lines.append(line.strip())
+
+print(f"command: {command}")
+print(f"exit_status: {exit_code}")
+print(f"duration_seconds: {duration}")
+print(f"output: {byte_count} bytes across {line_count} lines")
+print(f"warnings: {len(warnings)}")
+for line in warnings[:4]:
+    print(f"  warning: {line}")
+if len(warnings) > 4:
+    print(f"  ... {len(warnings) - 4} additional warning line(s) retained")
+if test_lines:
+    print("test_totals:")
+    for line in test_lines[:4]:
+        print(f"  {line}")
+print(f"full_log: output-sandbox-helper.sh show {output_id}")
+PY
+	return 0
+}
+
 cmd_store() {
 	local command_text="stdin"
 	local exit_code="0"
@@ -426,7 +489,7 @@ cmd_store() {
 
 cmd_run() {
 	local tag="run" summary_lines="$DEFAULT_SUMMARY_LINES" diagnostic_lines="$DEFAULT_DIAGNOSTIC_LINES"
-	local success_mode="receipt" failure_mode="diagnostic"
+	local success_mode="auto" failure_mode="diagnostic"
 	local expected_text="" format="text"
 	while [[ $# -gt 0 ]]; do
 		local opt="$1"
@@ -474,7 +537,8 @@ cmd_run() {
 		return $?
 	fi
 	local output_id raw_path stdout_path stderr_path summary_file diagnostic_file
-	local process_exit exit_code byte_count line_count sensitive outcome basis mode
+	local process_exit exit_code byte_count line_count sensitive outcome basis mode start_seconds duration_seconds
+	start_seconds=$SECONDS
 	output_id=$(make_output_id)
 	raw_path="${RAW_DIR}/${output_id}.txt"
 	stdout_path="${raw_path}.stdout"
@@ -506,6 +570,7 @@ cmd_run() {
 	fi
 	byte_count=$(wc -c <"$raw_path" | tr -d ' ')
 	line_count=$(wc -l <"$raw_path" | tr -d ' ')
+	duration_seconds=$((SECONDS - start_seconds))
 	if ! summarize_file "$raw_path" "$summary_lines" "$sensitive" >"$summary_file" || \
 		! diagnose_file "$raw_path" "$diagnostic_lines" "$sensitive" >"$diagnostic_file" || \
 		! record_output "$output_id" "$command_text" "$PWD" "$exit_code" "$tag" "$raw_path" "$byte_count" "$line_count" "$sensitive" "$summary_file"; then
@@ -518,6 +583,18 @@ cmd_run() {
 	if [[ "$exit_code" -ne 0 ]]; then
 		outcome="failed"
 		mode="$failure_mode"
+	fi
+	if [[ "$outcome" == "succeeded" && "$mode" == "auto" && "$format" == "text" ]]; then
+		if is_verbose_success "$byte_count" "$line_count"; then
+			print_verbose_success_summary "$output_id" "$command_text" "$exit_code" "$duration_seconds" \
+				"$byte_count" "$line_count" "$sensitive" "$raw_path"
+		else
+			emit_native_capture "$stdout_path" "$stderr_path"
+		fi
+		return "$exit_code"
+	fi
+	if [[ "$mode" == "auto" ]]; then
+		mode="receipt"
 	fi
 	print_presentation "$format" "$mode" "$output_id" "$outcome" "$exit_code" "$process_exit" \
 		"$byte_count" "$line_count" "$sensitive" "$basis" "$raw_path" "$summary_file" "$diagnostic_file"

--- a/.agents/scripts/output-sandbox-helper.sh
+++ b/.agents/scripts/output-sandbox-helper.sh
@@ -111,7 +111,7 @@ PY
 
 looks_sensitive_file() {
 	local path="$1"
-	if grep -Eiq '(BEGIN ((RSA|DSA|EC|OPENSSH) )?PRIVATE KEY|aws_secret_access_key|api[_-]?key[=:][[:space:]]*[A-Za-z0-9_./+=-]{20,}|token[=:][[:space:]]*[A-Za-z0-9_./+=-]{24,}|password[=:][^[:space:]]{8,}|gh[pousr]_[A-Za-z0-9_]{20,})' "$path" 2>/dev/null; then
+	if grep -Eiq '(BEGIN ((RSA|DSA|EC|OPENSSH) )?PRIVATE KEY|aws_secret_access_key|[A-Za-z0-9_]*(api[_-]?key|token|password|authorization)[A-Za-z0-9_]*[=:][[:space:]]*[^[:space:]]{8,}|gh[pousr]_[A-Za-z0-9_]{20,})' "$path" 2>/dev/null; then
 		return 0
 	fi
 	return 1
@@ -127,7 +127,7 @@ data = open(src, 'r', encoding='utf-8', errors='replace').read()
 patterns = [
     r'-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----',
     r'(?i)(aws_secret_access_key\s*[=:]\s*)\S+',
-    r'(?i)((?:api[_-]?key|token|password)\s*[=:]\s*)\S+',
+    r'(?i)(\b[A-Za-z0-9_]*(?:api[_-]?key|token|password|authorization)[A-Za-z0-9_]*\s*[=:]\s*)\S+',
     r'gh[pousr]_[A-Za-z0-9_]{20,}',
 ]
 for pat in patterns:

--- a/.agents/scripts/output-sandbox-helper.sh
+++ b/.agents/scripts/output-sandbox-helper.sh
@@ -20,6 +20,8 @@ DEFAULT_DIAGNOSTIC_LINES="${AIDEVOPS_OUTPUT_SANDBOX_DIAGNOSTIC_LINES:-20}"
 DEFAULT_RETENTION_DAYS="${AIDEVOPS_OUTPUT_SANDBOX_RETENTION_DAYS:-14}"
 DEFAULT_COMPACT_BYTES="${AIDEVOPS_OUTPUT_SANDBOX_COMPACT_BYTES:-8192}"
 DEFAULT_COMPACT_LINES="${AIDEVOPS_OUTPUT_SANDBOX_COMPACT_LINES:-80}"
+OUTPUT_MODE_AUTO="auto"
+OUTCOME_SUCCEEDED="succeeded"
 
 usage() {
 	cat <<'EOF'
@@ -27,6 +29,7 @@ Usage:
   output-sandbox-helper.sh init
   output-sandbox-helper.sh run [options] -- COMMAND [ARGS...]
   output-sandbox-helper.sh store [--command TEXT] [--exit-code N] [--tag TAG] < output.txt
+  output-sandbox-helper.sh compact [--command NAME] [--duration-ms N] [--tag TAG] < output.txt
   output-sandbox-helper.sh show OUTPUT_ID [--offset N] [--limit N]
   output-sandbox-helper.sh cleanup [--max-age-days N]
   output-sandbox-helper.sh stats
@@ -401,23 +404,21 @@ print_verbose_success_summary() {
 	local line_count="$6"
 	local sensitive="$7"
 	local raw_path="$8"
-	if [[ "$sensitive" == "1" ]]; then
-		printf 'command: %s\n' "$command_text"
-		printf 'exit_status: %s\n' "$exit_code"
-		printf 'duration_seconds: %s\n' "$duration_seconds"
-		printf 'output: %s bytes across %s lines; sensitive content redacted\n' "$byte_count" "$line_count"
-		printf 'full_log: output-sandbox-helper.sh show %s\n' "$output_id"
-		return 0
-	fi
-	python3 - "$raw_path" "$command_text" "$exit_code" "$duration_seconds" "$byte_count" "$line_count" "$output_id" <<'PY'
+	local duration_label="${9:-duration_seconds}"
+	if ! python3 - "$raw_path" "$command_text" "$exit_code" "$duration_seconds" "$byte_count" "$line_count" "$output_id" "$sensitive" "$duration_label" <<'PY'
+import os
 import re
 import sys
 
-path, command, exit_code, duration, byte_count, line_count, output_id = sys.argv[1:]
-with open(path, "r", encoding="utf-8", errors="replace") as handle:
-    lines = handle.read().splitlines()
-warning_pattern = re.compile(r"(?i)(warning|deprecated|deprecation|lint|compiler)")
-warnings = [line for line in lines if warning_pattern.search(line)]
+path, command, exit_code, duration, byte_count, line_count, output_id, sensitive, duration_label = sys.argv[1:]
+lines = []
+if sensitive != "1":
+    with open(path, "r", encoding="utf-8", errors="replace") as handle:
+        lines = handle.read().splitlines()
+diagnostic_pattern = re.compile(
+    r"(?i)(warning|deprecated|deprecation|lint|compiler|error|fail(?:ed|ure)?|fatal|exception|sanitizer|notice)"
+)
+diagnostics = [line for line in lines if diagnostic_pattern.search(line)]
 test_patterns = (
     re.compile(r"(?i)\btests?\s*[:=]\s*(.+)$"),
     re.compile(r"(?i)\b(\d+)\s+(?:tests?\s+)?passed\b(?:.*?\b(\d+)\s+failed\b)?"),
@@ -428,21 +429,90 @@ for line in lines:
     if any(pattern.search(line) for pattern in test_patterns):
         test_lines.append(line.strip())
 
-print(f"command: {command}")
-print(f"exit_status: {exit_code}")
-print(f"duration_seconds: {duration}")
-print(f"output: {byte_count} bytes across {line_count} lines")
-print(f"warnings: {len(warnings)}")
-for line in warnings[:4]:
-    print(f"  warning: {line}")
-if len(warnings) > 4:
-    print(f"  ... {len(warnings) - 4} additional warning line(s) retained")
-if test_lines:
-    print("test_totals:")
-    for line in test_lines[:4]:
-        print(f"  {line}")
-print(f"full_log: output-sandbox-helper.sh show {output_id}")
+credential_pattern = re.compile(
+    r"(?i)(?:sk-|GOCSPX-|gh[pousr]_|github_pat_|glpat-|xox[apb]-)[A-Za-z0-9_-]{10,}"
+)
+private_path_pattern = re.compile(r"(?<![\w.])/(?:Users|home|private/var|tmp|var/folders)/[^\s]+")
+
+def bounded(value, limit=320):
+    value = credential_pattern.sub("[redacted-credential]", str(value))
+    value = private_path_pattern.sub("[private-path]", value)
+    value = re.sub(r"[\x00-\x1f\x7f]+", " ", value).strip()
+    return value if len(value) <= limit else value[:limit - 15] + "... [truncated]"
+
+command = bounded(os.path.basename(command), 120)
+body = [
+    f"command: {command}",
+    f"exit_status: {exit_code}",
+    f"{duration_label}: {duration}",
+    f"output: {byte_count} bytes across {line_count} lines",
+]
+if sensitive == "1":
+    body.append("diagnostics: suppressed after sensitive content was redacted")
+else:
+    body.append(f"diagnostics: {len(diagnostics)}")
+    body.extend(f"  {bounded(line)}" for line in diagnostics[:6])
+    if len(diagnostics) > 6:
+        body.append(f"  ... {len(diagnostics) - 6} additional diagnostic line(s) retained")
+    if test_lines:
+        body.append("test_totals:")
+        body.extend(f"  {bounded(line)}" for line in test_lines[:4])
+
+receipt = f"full_log: output-sandbox-helper.sh show {output_id}"
+rendered = ""
+for item in body:
+    candidate = rendered + bounded(item) + "\n"
+    if len(candidate.encode("utf-8")) > 3500:
+        rendered += "... additional summary evidence retained\n"
+        break
+    rendered = candidate
+sys.stdout.write(rendered + receipt + "\n")
 PY
+	then
+		return 1
+	fi
+	return 0
+}
+
+cmd_compact() {
+	local command_text="bash" duration_ms="0" tag="opencode-tool"
+	while [[ $# -gt 0 ]]; do
+		local opt="$1"
+		case "$opt" in
+		--command) local command_value="$2"; command_text="${command_value##*/}"; shift 2 ;;
+		--duration-ms) local duration_value="$2"; duration_ms="$duration_value"; shift 2 ;;
+		--tag) local tag_value="$2"; tag="$tag_value"; shift 2 ;;
+		*) log_error "Unknown compact option: $opt"; return 1 ;;
+		esac
+	done
+	if [[ ! "$duration_ms" =~ ^[0-9]+$ ]]; then
+		log_error "duration must be a non-negative integer"
+		return 1
+	fi
+	init_db || return 1
+	local output_id raw_path tmp_input summary_file byte_count line_count sensitive
+	output_id=$(make_output_id)
+	raw_path="${RAW_DIR}/${output_id}.txt"
+	tmp_input="${raw_path}.tmp"
+	summary_file="${raw_path}.summary"
+	cat >"$tmp_input"
+	sensitive=0
+	if looks_sensitive_file "$tmp_input"; then
+		sensitive=1
+		redact_file "$tmp_input" "$raw_path" || return 1
+		rm -f "$tmp_input"
+	else
+		mv "$tmp_input" "$raw_path" || return 1
+	fi
+	byte_count=$(wc -c <"$raw_path" | tr -d ' ')
+	line_count=$(wc -l <"$raw_path" | tr -d ' ')
+	summarize_file "$raw_path" "$DEFAULT_SUMMARY_LINES" "$sensitive" >"$summary_file" || return 1
+	record_output "$output_id" "$command_text" "$PWD" "0" "$tag" "$raw_path" "$byte_count" "$line_count" "$sensitive" "$summary_file" || return 1
+	if is_verbose_success "$byte_count" "$line_count"; then
+		print_verbose_success_summary "$output_id" "$command_text" "0" "$duration_ms" "$byte_count" "$line_count" "$sensitive" "$raw_path" "duration_ms" || return 1
+	else
+		cat "$raw_path"
+	fi
 	return 0
 }
 
@@ -462,7 +532,7 @@ present_run_result() {
 	local diagnostic_file="${13}"
 	local duration_seconds="${14}"
 	local command_text="${15}"
-	if [[ "$outcome" == "succeeded" && "$mode" == "auto" && "$format" == "text" ]]; then
+	if [[ "$outcome" == "$OUTCOME_SUCCEEDED" && "$mode" == "$OUTPUT_MODE_AUTO" && "$format" == "text" ]]; then
 		if is_verbose_success "$byte_count" "$line_count"; then
 			print_verbose_success_summary "$output_id" "$command_text" "$exit_code" "$duration_seconds" \
 				"$byte_count" "$line_count" "$sensitive" "$raw_path"
@@ -471,7 +541,7 @@ present_run_result() {
 		fi
 		return "$exit_code"
 	fi
-	[[ "$mode" == "auto" ]] && mode="receipt"
+	[[ "$mode" == "$OUTPUT_MODE_AUTO" ]] && mode="receipt"
 	print_presentation "$format" "$mode" "$output_id" "$outcome" "$exit_code" "$process_exit" \
 		"$byte_count" "$line_count" "$sensitive" "$basis" "$raw_path" "$summary_file" "$diagnostic_file"
 	return "$exit_code"
@@ -512,7 +582,7 @@ cmd_store() {
 	line_count=$(wc -l <"$raw_path" | tr -d ' ')
 	summarize_file "$raw_path" "$DEFAULT_SUMMARY_LINES" "$sensitive" >"$summary_file"
 	record_output "$output_id" "$command_text" "$PWD" "$exit_code" "$tag" "$raw_path" "$byte_count" "$line_count" "$sensitive" "$summary_file"
-	local outcome="succeeded"
+	local outcome="$OUTCOME_SUCCEEDED"
 	[[ "$exit_code" -eq 0 ]] || outcome="failed"
 	print_receipt_text "$output_id" "$outcome" "$exit_code" "$exit_code" "$byte_count" "$line_count" "$sensitive" "exit-code"
 	return 0
@@ -520,7 +590,7 @@ cmd_store() {
 
 cmd_run() {
 	local tag="run" summary_lines="$DEFAULT_SUMMARY_LINES" diagnostic_lines="$DEFAULT_DIAGNOSTIC_LINES"
-	local success_mode="auto" failure_mode="diagnostic"
+	local success_mode="$OUTPUT_MODE_AUTO" failure_mode="diagnostic"
 	local expected_text="" format="text"
 	while [[ $# -gt 0 ]]; do
 		local opt="$1"
@@ -568,7 +638,7 @@ cmd_run() {
 		return $?
 	fi
 	local output_id raw_path stdout_path stderr_path summary_file diagnostic_file
-	local process_exit exit_code byte_count line_count sensitive outcome="succeeded" basis mode="$success_mode" start_seconds duration_seconds
+	local process_exit exit_code byte_count line_count sensitive outcome="$OUTCOME_SUCCEEDED" basis mode="$success_mode" start_seconds duration_seconds
 	start_seconds=$SECONDS
 	output_id=$(make_output_id)
 	raw_path="${RAW_DIR}/${output_id}.txt"
@@ -709,6 +779,7 @@ main() {
 	init) init_db ;;
 	run) cmd_run "$@" ;;
 	store) cmd_store "$@" ;;
+	compact) cmd_compact "$@" ;;
 	show) [[ $# -ge 1 ]] || { log_error "show requires OUTPUT_ID"; return 1; }; cmd_show "$@" ;;
 	cleanup) cmd_cleanup "$@" ;;
 	stats) cmd_stats ;;

--- a/.agents/scripts/output-sandbox-helper.sh
+++ b/.agents/scripts/output-sandbox-helper.sh
@@ -22,6 +22,7 @@ DEFAULT_COMPACT_BYTES="${AIDEVOPS_OUTPUT_SANDBOX_COMPACT_BYTES:-8192}"
 DEFAULT_COMPACT_LINES="${AIDEVOPS_OUTPUT_SANDBOX_COMPACT_LINES:-80}"
 OUTPUT_MODE_AUTO="auto"
 OUTCOME_SUCCEEDED="succeeded"
+OUTPUT_FORMAT_TEXT="text"
 
 usage() {
 	cat <<'EOF'
@@ -297,11 +298,60 @@ PY
 should_bypass_command() {
 	local command_text="$1"
 	case "$command_text" in
-	cat\ * | head\ * | tail\ * | less\ * | more\ * | git\ diff* | *" --json"* | *" security "* | *secret* | *credential*)
+	cat\ * | head\ * | tail\ * | less\ * | more\ * | sed\ * | rg\ * | jq\ * | git\ diff* | git\ show* | *" --json"* | *" security "* | *secret* | *credential* | *password* | *authorization* | *token*)
 		return 0
 		;;
 	esac
 	return 1
+}
+
+is_package_compaction_candidate() {
+	local command_text="$1"
+	local package_pattern='^(npm|pnpm|yarn|bun) (test|build|lint|check|typecheck|ci)( |$)'
+	local script_pattern='^(npm|pnpm|yarn|bun) run (test|build|lint|check|typecheck)([:_.-][[:alnum:]_.-]+)?( |$)'
+	[[ "$command_text" =~ $package_pattern || "$command_text" =~ $script_pattern ]]
+	return $?
+}
+
+is_toolchain_compaction_candidate() {
+	local command_text="$1"
+	local pattern='^((python3? -m )?pytest|go test|cargo (test|build|check|clippy)|make( (test|check|build|lint)([:_.-][[:alnum:]_.-]+)?)?|cmake --build|gradle (test|build|check|lint)|\./gradlew (test|build|check|lint)|mvn (test|verify|package|install|compile)|dotnet (test|build)|shellcheck)( |$)'
+	[[ "$command_text" =~ $pattern ]]
+	return $?
+}
+
+is_script_compaction_candidate() {
+	local command_text="$1"
+	local pattern='(^|/)(linters-local\.sh)( |$)|^bash [^[:space:]]*(test|lint)[^[:space:]]*\.sh( |$)'
+	[[ "$command_text" =~ $pattern ]]
+	return $?
+}
+
+is_compaction_candidate() {
+	local command_text="$1"
+	case "$command_text" in
+	*';'* | *'&&'* | *'||'* | *'|'* | *'`'* | *"\$("* | *'>'* | *'<'*)
+		return 1
+		;;
+	esac
+	if is_package_compaction_candidate "$command_text" || \
+		is_toolchain_compaction_candidate "$command_text" || \
+		is_script_compaction_candidate "$command_text"; then
+		return 0
+	fi
+	return 1
+}
+
+resolve_success_mode() {
+	local success_mode="$1"
+	local format="$2"
+	local command_shape="$3"
+	if [[ "$success_mode" == "$OUTPUT_MODE_AUTO" && "$format" == "$OUTPUT_FORMAT_TEXT" ]] && ! is_compaction_candidate "$command_shape"; then
+		printf 'native\n'
+	else
+		printf '%s\n' "$success_mode"
+	fi
+	return 0
 }
 
 print_receipt_text() {
@@ -528,7 +578,11 @@ present_run_result() {
 	local diagnostic_file="${13}"
 	local duration_seconds="${14}"
 	local command_text="${15}"
-	if [[ "$outcome" == "$OUTCOME_SUCCEEDED" && "$mode" == "$OUTPUT_MODE_AUTO" && "$format" == "text" ]]; then
+	if [[ "$outcome" == "$OUTCOME_SUCCEEDED" && "$mode" == "native" ]]; then
+		emit_native_capture "$raw_path.stdout" "$raw_path.stderr"
+		return "$exit_code"
+	fi
+	if [[ "$outcome" == "$OUTCOME_SUCCEEDED" && "$mode" == "$OUTPUT_MODE_AUTO" && "$format" == "$OUTPUT_FORMAT_TEXT" ]]; then
 		if is_verbose_success "$byte_count" "$line_count"; then
 			print_verbose_success_summary "$output_id" "$command_text" "$exit_code" "$duration_seconds" \
 				"$byte_count" "$line_count" "$sensitive" "$raw_path"
@@ -587,7 +641,7 @@ cmd_store() {
 cmd_run() {
 	local tag="run" summary_lines="$DEFAULT_SUMMARY_LINES" diagnostic_lines="$DEFAULT_DIAGNOSTIC_LINES"
 	local success_mode="$OUTPUT_MODE_AUTO" failure_mode="diagnostic"
-	local expected_text="" format="text"
+	local expected_text="" format="$OUTPUT_FORMAT_TEXT"
 	while [[ $# -gt 0 ]]; do
 		local opt="$1"
 		case "$opt" in
@@ -628,6 +682,7 @@ cmd_run() {
 		"$@"
 		return $?
 	fi
+	success_mode=$(resolve_success_mode "$success_mode" "$format" "$command_shape")
 	if ! init_db; then
 		printf 'output_sandbox: evidence store unavailable; running with native output\n' >&2
 		"$@"

--- a/.agents/scripts/output-sandbox-helper.sh
+++ b/.agents/scripts/output-sandbox-helper.sh
@@ -508,11 +508,7 @@ cmd_compact() {
 	line_count=$(wc -l <"$raw_path" | tr -d ' ')
 	summarize_file "$raw_path" "$DEFAULT_SUMMARY_LINES" "$sensitive" >"$summary_file" || return 1
 	record_output "$output_id" "$command_text" "$PWD" "0" "$tag" "$raw_path" "$byte_count" "$line_count" "$sensitive" "$summary_file" || return 1
-	if is_verbose_success "$byte_count" "$line_count"; then
-		print_verbose_success_summary "$output_id" "$command_text" "0" "$duration_ms" "$byte_count" "$line_count" "$sensitive" "$raw_path" "duration_ms" || return 1
-	else
-		cat "$raw_path"
-	fi
+	print_verbose_success_summary "$output_id" "$command_text" "0" "$duration_ms" "$byte_count" "$line_count" "$sensitive" "$raw_path" "duration_ms" || return 1
 	return 0
 }
 

--- a/.agents/scripts/output-sandbox-helper.sh
+++ b/.agents/scripts/output-sandbox-helper.sh
@@ -446,6 +446,37 @@ PY
 	return 0
 }
 
+present_run_result() {
+	local format="$1"
+	local mode="$2"
+	local output_id="$3"
+	local outcome="$4"
+	local exit_code="$5"
+	local process_exit="$6"
+	local byte_count="$7"
+	local line_count="$8"
+	local sensitive="$9"
+	local basis="${10}"
+	local raw_path="${11}"
+	local summary_file="${12}"
+	local diagnostic_file="${13}"
+	local duration_seconds="${14}"
+	local command_text="${15}"
+	if [[ "$outcome" == "succeeded" && "$mode" == "auto" && "$format" == "text" ]]; then
+		if is_verbose_success "$byte_count" "$line_count"; then
+			print_verbose_success_summary "$output_id" "$command_text" "$exit_code" "$duration_seconds" \
+				"$byte_count" "$line_count" "$sensitive" "$raw_path"
+		else
+			emit_native_capture "$raw_path.stdout" "$raw_path.stderr"
+		fi
+		return "$exit_code"
+	fi
+	[[ "$mode" == "auto" ]] && mode="receipt"
+	print_presentation "$format" "$mode" "$output_id" "$outcome" "$exit_code" "$process_exit" \
+		"$byte_count" "$line_count" "$sensitive" "$basis" "$raw_path" "$summary_file" "$diagnostic_file"
+	return "$exit_code"
+}
+
 cmd_store() {
 	local command_text="stdin"
 	local exit_code="0"
@@ -537,7 +568,7 @@ cmd_run() {
 		return $?
 	fi
 	local output_id raw_path stdout_path stderr_path summary_file diagnostic_file
-	local process_exit exit_code byte_count line_count sensitive outcome basis mode start_seconds duration_seconds
+	local process_exit exit_code byte_count line_count sensitive outcome="succeeded" basis mode="$success_mode" start_seconds duration_seconds
 	start_seconds=$SECONDS
 	output_id=$(make_output_id)
 	raw_path="${RAW_DIR}/${output_id}.txt"
@@ -578,26 +609,13 @@ cmd_run() {
 		emit_native_capture "$stdout_path" "$stderr_path"
 		return "$exit_code"
 	fi
-	outcome="succeeded"
-	mode="$success_mode"
 	if [[ "$exit_code" -ne 0 ]]; then
 		outcome="failed"
 		mode="$failure_mode"
 	fi
-	if [[ "$outcome" == "succeeded" && "$mode" == "auto" && "$format" == "text" ]]; then
-		if is_verbose_success "$byte_count" "$line_count"; then
-			print_verbose_success_summary "$output_id" "$command_text" "$exit_code" "$duration_seconds" \
-				"$byte_count" "$line_count" "$sensitive" "$raw_path"
-		else
-			emit_native_capture "$stdout_path" "$stderr_path"
-		fi
-		return "$exit_code"
-	fi
-	if [[ "$mode" == "auto" ]]; then
-		mode="receipt"
-	fi
-	print_presentation "$format" "$mode" "$output_id" "$outcome" "$exit_code" "$process_exit" \
-		"$byte_count" "$line_count" "$sensitive" "$basis" "$raw_path" "$summary_file" "$diagnostic_file"
+	present_run_result "$format" "$mode" "$output_id" "$outcome" "$exit_code" "$process_exit" \
+		"$byte_count" "$line_count" "$sensitive" "$basis" "$raw_path" "$summary_file" "$diagnostic_file" \
+		"$duration_seconds" "$command_text" || return $?
 	return "$exit_code"
 }
 

--- a/.agents/scripts/tests/test-output-sandbox-helper.sh
+++ b/.agents/scripts/tests/test-output-sandbox-helper.sh
@@ -60,7 +60,7 @@ file_mode() {
 }
 
 # shellcheck disable=SC2016 # Inner bash expands $i, not this test harness.
-run_output=$("$HELPER" run --summary-lines 4 -- bash -c 'for i in 1 2 3 4 5 6; do printf "line%s\n" "$i"; done')
+run_output=$("$HELPER" run --success-mode receipt --summary-lines 4 -- bash -c 'for i in 1 2 3 4 5 6; do printf "line%s\n" "$i"; done')
 assert_contains "run prints output id" "output_id: out_" "$run_output"
 assert_contains "successful run reports outcome" "outcome: succeeded" "$run_output"
 assert_not_contains "success receipt hides raw path" "raw_path:" "$run_output"
@@ -74,6 +74,20 @@ assert_contains "show respects limit" "3: line3" "$show_output"
 # shellcheck disable=SC2016 # Inner bash expands $i, not this test harness.
 summary_output=$("$HELPER" run --success-mode summary --summary-lines 4 -- bash -c 'for i in 1 2 3 4 5 6; do printf "line%s\n" "$i"; done')
 assert_contains "explicit success summary reports omission" "omitted" "$summary_output"
+
+short_output=$("$HELPER" run -- bash -c 'printf "short successful output\n"')
+[[ "$short_output" == "short successful output" ]] && \
+	pass "ordinary short successful output remains unchanged" || \
+	fail "ordinary short successful output remains unchanged" "got ${short_output}"
+
+# shellcheck disable=SC2016 # Inner bash expands $i, not this test harness.
+verbose_output=$("$HELPER" run -- bash -c 'for i in $(seq 1 100); do printf "asset %s\n" "$i"; done; printf "warning: fixture deprecation\n"; printf "Tests: 100 passed, 0 failed\n"')
+assert_contains "verbose success reports command identity" "command: bash" "$verbose_output"
+assert_contains "verbose success reports exit status" "exit_status: 0" "$verbose_output"
+assert_contains "verbose success preserves warning evidence" "warning: fixture deprecation" "$verbose_output"
+assert_contains "verbose success preserves test totals" "Tests: 100 passed, 0 failed" "$verbose_output"
+assert_contains "verbose success retains retrievable full log" "full_log: output-sandbox-helper.sh show out_" "$verbose_output"
+assert_not_contains "verbose success bounds raw asset listing" "asset 50" "$verbose_output"
 
 set +e
 failure_output=$("$HELPER" run --diagnostic-lines 4 -- bash -c 'printf "routine line\n"; printf "fatal: fixture failed\n" >&2; exit 7')

--- a/.agents/scripts/tests/test-output-sandbox-helper.sh
+++ b/.agents/scripts/tests/test-output-sandbox-helper.sh
@@ -89,6 +89,16 @@ assert_contains "verbose success preserves test totals" "Tests: 100 passed, 0 fa
 assert_contains "verbose success retains retrievable full log" "full_log: output-sandbox-helper.sh show out_" "$verbose_output"
 assert_not_contains "verbose success bounds raw asset listing" "asset 50" "$verbose_output"
 
+huge_diagnostic=$(python3 -c 'print("warning: /Users/private/project " + "x" * 20000)')
+compact_output=$(printf '%s\n' "$huge_diagnostic" | "$HELPER" compact --command /private/example/bash --duration-ms 42)
+compact_bytes=$(printf '%s' "$compact_output" | wc -c | tr -d ' ')
+[[ "$compact_bytes" -le 4096 ]] && pass "compact presentation has a hard byte bound" || fail "compact presentation has a hard byte bound" "got ${compact_bytes}"
+assert_contains "compact presentation reports duration" "duration_ms: 42" "$compact_output"
+assert_contains "compact presentation retains opaque log id" "full_log: output-sandbox-helper.sh show out_" "$compact_output"
+assert_not_contains "compact presentation hides private command path" "/private/example" "$compact_output"
+assert_not_contains "compact presentation redacts private diagnostic paths" "/Users/private" "$compact_output"
+assert_contains "compact presentation marks truncated diagnostics" "[truncated]" "$compact_output"
+
 set +e
 failure_output=$("$HELPER" run --diagnostic-lines 4 -- bash -c 'printf "routine line\n"; printf "fatal: fixture failed\n" >&2; exit 7')
 failure_rc=$?

--- a/.agents/scripts/tests/test-output-sandbox-helper.sh
+++ b/.agents/scripts/tests/test-output-sandbox-helper.sh
@@ -111,6 +111,12 @@ redacted_compact=$(python3 -c 'print("api_key=" + "x" * 10000)' | "$HELPER" comp
 assert_contains "redaction cannot downgrade compact output to raw" "full_log: output-sandbox-helper.sh show out_" "$redacted_compact"
 assert_not_contains "redaction does not expose raw secret marker" "api_key=" "$redacted_compact"
 
+named_secret=$(printf 'warning: NPM_TOKEN=supersecretvalue123\n' | "$HELPER" store --command fixture)
+named_secret_id=$(printf '%s\n' "$named_secret" | awk '/^output_id:/ {print $2; exit}')
+named_secret_show=$("$HELPER" show "$named_secret_id" 2>&1)
+assert_contains "named environment secret is redacted before storage" "NPM_TOKEN=[REDACTED]" "$named_secret_show"
+assert_not_contains "named environment secret value is not retained" "supersecretvalue123" "$named_secret_show"
+
 set +e
 failure_output=$("$HELPER" run --diagnostic-lines 4 -- bash -c 'printf "routine line\n"; printf "fatal: fixture failed\n" >&2; exit 7')
 failure_rc=$?

--- a/.agents/scripts/tests/test-output-sandbox-helper.sh
+++ b/.agents/scripts/tests/test-output-sandbox-helper.sh
@@ -99,6 +99,10 @@ assert_not_contains "compact presentation hides private command path" "/private/
 assert_not_contains "compact presentation redacts private diagnostic paths" "/Users/private" "$compact_output"
 assert_contains "compact presentation marks truncated diagnostics" "[truncated]" "$compact_output"
 
+redacted_compact=$(python3 -c 'print("api_key=" + "x" * 10000)' | "$HELPER" compact --command bash --duration-ms 1)
+assert_contains "redaction cannot downgrade compact output to raw" "full_log: output-sandbox-helper.sh show out_" "$redacted_compact"
+assert_not_contains "redaction does not expose raw secret marker" "api_key=" "$redacted_compact"
+
 set +e
 failure_output=$("$HELPER" run --diagnostic-lines 4 -- bash -c 'printf "routine line\n"; printf "fatal: fixture failed\n" >&2; exit 7')
 failure_rc=$?

--- a/.agents/scripts/tests/test-output-sandbox-helper.sh
+++ b/.agents/scripts/tests/test-output-sandbox-helper.sh
@@ -80,14 +80,22 @@ short_output=$("$HELPER" run -- bash -c 'printf "short successful output\n"')
 	pass "ordinary short successful output remains unchanged" || \
 	fail "ordinary short successful output remains unchanged" "got ${short_output}"
 
-# shellcheck disable=SC2016 # Inner bash expands $i, not this test harness.
-verbose_output=$("$HELPER" run -- bash -c 'for i in $(seq 1 100); do printf "asset %s\n" "$i"; done; printf "warning: fixture deprecation\n"; printf "Tests: 100 passed, 0 failed\n"')
+verbose_fixture="${TMPDIR_TEST}/test-verbose-output.sh"
+# shellcheck disable=SC2016 # Fixture script expands its own loop variables.
+printf '%s\n' '#!/usr/bin/env bash' 'for i in $(seq 1 100); do printf "asset %s\n" "$i"; done' 'printf "warning: fixture deprecation\n"' 'printf "Tests: 100 passed, 0 failed\n"' >"$verbose_fixture"
+chmod 700 "$verbose_fixture"
+verbose_output=$("$HELPER" run -- bash "$verbose_fixture")
 assert_contains "verbose success reports command identity" "command: bash" "$verbose_output"
 assert_contains "verbose success reports exit status" "exit_status: 0" "$verbose_output"
 assert_contains "verbose success preserves warning evidence" "warning: fixture deprecation" "$verbose_output"
 assert_contains "verbose success preserves test totals" "Tests: 100 passed, 0 failed" "$verbose_output"
 assert_contains "verbose success retains retrievable full log" "full_log: output-sandbox-helper.sh show out_" "$verbose_output"
 assert_not_contains "verbose success bounds raw asset listing" "asset 50" "$verbose_output"
+
+# shellcheck disable=SC2016 # Inner bash expands its own loop variables.
+arbitrary_output=$("$HELPER" run -- bash -c 'for i in $(seq 1 100); do printf "exact %s\n" "$i"; done')
+assert_contains "unrecognized verbose success remains native" "exact 50" "$arbitrary_output"
+assert_not_contains "unrecognized verbose success has no compact receipt" "full_log:" "$arbitrary_output"
 
 huge_diagnostic=$(python3 -c 'print("warning: /Users/private/project " + "x" * 20000)')
 compact_output=$(printf '%s\n' "$huge_diagnostic" | "$HELPER" compact --command /private/example/bash --duration-ms 42)


### PR DESCRIPTION
## Summary

- integrate successful Bash-output compaction into the live OpenCode before/after hook lifecycle
- compact only recognized verbose successful build, test, and lint commands while preserving short, failed, structured, exact, sensitive, and unpaired flows
- retain redacted full output behind opaque IDs with bounded actionable receipts and fail-open native output
- harden named environment-secret redaction and pre-scrub verbosity handling

## Context

PR #31036 auto-merged at its earlier worker head before independent review of the live integration completed. This follow-up contains the maintainer adoption and review fixes needed to satisfy the original acceptance criteria.

Ref #31026

## Verification

- `shellcheck .agents/scripts/output-sandbox-helper.sh .agents/scripts/tests/test-output-sandbox-helper.sh`
- `.agents/scripts/tests/test-output-sandbox-helper.sh` — 49 passed, 0 failed
- focused OpenCode output-compaction and observability tests — 31 passed, 0 failed
- full OpenCode plugin suite — 711 passed, 0 failed
- `.agents/scripts/linters-local.sh --changed` — passed
- controlled replay: 17,027 raw bytes → 235 receipt bytes (98.6% reduction; bounded below 4,096 bytes)
- independent exact-head review of `a843e7d1591eb2b3a036136f11626d604a66c45a` — approved with no findings

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 2h 44m and 1,393,346 tokens on this with the user in an interactive session.