### PR TITLE
GH#31045: fix: trust fast-uri Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -36,6 +36,7 @@ elysia
 @fontsource/ubuntu-mono
 @secretlint/secretlint-rule-preset-recommend
 typescript
+npm_and_yarn:fast-uri
 actions:actions/checkout
 actions:actions/github-script
 actions:qltysh/qlty-action/install

--- a/.agents/package-lock.json
+++ b/.agents/package-lock.json
@@ -35,9 +35,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Allowlist the reviewed npm_and_yarn fast-uri update and apply Dependabot's exact 3.1.7 lockfile integrity data.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf, .agents/package-lock.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; npm ci --prefix .agents --ignore-scripts; npm ls --prefix .agents fast-uri; npm audit --prefix .agents --omit=dev --audit-level=high

Resolves #31045


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.298 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 3m and 104,827 tokens on this as a headless worker.