### PR TITLE
GH#31027: prune caches from protected recovery archives

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -178,6 +178,16 @@ immediately before an entry is emitted, so concurrent drift downgrades only
 that entry. Age, size, and OpenCode or Claude session history never prove
 reclaimability. Plan files grant no deletion authority by themselves.
 
+Automatic maintenance may reclaim those same approved cache roots from an
+otherwise protected mixed archive without deleting the archive. This narrower
+path applies only when the archive is protected solely by a dirty Git state,
+source removal is complete, and commit, task, pull-request, worktree, registry,
+claim, and process evidence is terminal and clear. Each selected root must be
+an exact ignored and untracked approved directory with no symlink component,
+tracked path, or hard-linked regular file. A bounded manifest records its
+device/inode identity and allocated bytes; uncertainty, deadline exhaustion,
+or drift preserves the root.
+
 After reviewing a v2 plan, an operator may run:
 
 ```bash
@@ -255,6 +265,8 @@ with:
 - `AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_PERCENT`
 - `AIDEVOPS_WORKTREE_RECOVERY_AGGREGATE_SIZE_TIMEOUT_TENTHS`
 - `AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_SECONDS`
+- `AIDEVOPS_WORKTREE_RECOVERY_CACHE_PRUNE_MAX_ROOTS`
+- `AIDEVOPS_WORKTREE_RECOVERY_CACHE_PRUNE_MAX_BYTES`
 
 Set `AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_ENABLED=0` to disable the automatic
 pass. Invalid limits fall back to defaults. Maintenance uses a separate
@@ -271,6 +283,19 @@ evidence, live references, unfinished tasks, retention policy, and selection
 limits without exposing archive paths. A private state record accumulates those
 counts across bounded cursor windows and resets if the inventory or pressure
 state changes.
+
+When protected mixed archives contain approved cache roots, one pass selects at
+most 100 roots and 5 GiB by default inside the same scan and deadline budget.
+Cache pruning takes precedence over whole-bucket deletion for that pass and uses
+its own `aidevops.worktree-recovery-cache-prune-plan/v1` plan and
+`cache-automatic-sha256:` authority. Apply revalidates archive and root
+identities, ignored/untracked state, allocated bytes, symlink and hard-link
+safety, then stages only the exact root into an archive-local
+`.retention-trash` transaction. Its journal survives interruption before or
+after rename or removal; pending cache plans resume before new inventory.
+Receipts retain exact expected and observed allocated bytes, while run outcomes
+report `cache-pruned` or `resumed-and-pruned`. User files and the protected
+archive remain untouched.
 
 When a stable inventory completes a full pressure-active scan cycle with zero
 candidates, the result retains `outcome:"no-candidates"` and sets

--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -186,7 +186,7 @@ claim, and process evidence is terminal and clear. Each selected root must be
 an exact ignored and untracked approved directory with no symlink component,
 tracked path, or hard-linked regular file. A bounded manifest records its
 device/inode identity and allocated bytes; uncertainty, deadline exhaustion,
-or drift preserves the root.
+Git output beyond the fixed capture ceiling, or drift preserves the root.
 
 After reviewing a v2 plan, an operator may run:
 
@@ -290,12 +290,22 @@ Cache pruning takes precedence over whole-bucket deletion for that pass and uses
 its own `aidevops.worktree-recovery-cache-prune-plan/v1` plan and
 `cache-automatic-sha256:` authority. Apply revalidates archive and root
 identities, ignored/untracked state, allocated bytes, symlink and hard-link
-safety, then stages only the exact root into an archive-local
+safety, and all terminal claim, process, task, pull-request, and commit evidence
+both before the transaction and immediately before each rename. The initial
+apply receives the scan's absolute deadline rather than starting a new budget;
+an exhausted pass defers every selected cache root without mutation. A pending
+transaction receives one fresh bounded deadline only when a later maintenance
+pass resumes it. Apply stages only the exact root into an archive-local
 `.retention-trash` transaction. Its journal survives interruption before or
-after rename or removal; pending cache plans resume before new inventory.
-Receipts retain exact expected and observed allocated bytes, while run outcomes
-report `cache-pruned` or `resumed-and-pruned`. User files and the protected
-archive remain untouched.
+after rename or bounded removal. A `removing` journal state permits a timed-out
+delete to continue only while the isolated root identity and remaining
+allocation stay within the original bound. Pending cache plans resume before
+new inventory. Receipts retain the expected allocation, an independent exact
+staged-root measurement, and a zero post-delete allocation observation before
+reporting those namespace bytes as reclaimed; they do not infer global
+filesystem free-space changes from concurrent `df` activity. Run outcomes report
+`cache-pruned` or `resumed-and-pruned`. User files and the protected archive
+remain untouched.
 
 When a stable inventory completes a full pressure-active scan cycle with zero
 candidates, the result retains `outcome:"no-candidates"` and sets

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -1378,6 +1378,7 @@ test_cache_retrofit_prunes_mixed_archive_and_accounts_bytes() {
 test_cache_retrofit_policy_preserves_unsafe_roots() {
 	local repo_path="${TEST_DIR}/cache-retrofit-unsafe"
 	local symlink_target="${TEST_DIR}/cache-retrofit-symlink-target"
+	local noisy_git="${TEST_DIR}/cache-retrofit-noisy-git"
 	local deadline_epoch=0
 	local manifest=""
 	local rc=0
@@ -1402,11 +1403,114 @@ test_cache_retrofit_policy_preserves_unsafe_roots() {
 	[[ "$(printf '%s\n' "$manifest" | jq -r '.candidate_count')" == "0" ]] || rc=1
 	if _worktree_recovery_cache_policy_helper manifest "$repo_path" \
 		"${TEST_DIR}/missing-git" 10 10485760 "$deadline_epoch" >/dev/null 2>&1; then rc=1; fi
+	cat >"$noisy_git" <<'SH' || rc=1
+#!/usr/bin/env bash
+python3 - <<'PY'
+import sys
+
+sys.stdout.buffer.write(b"!! .codegraph/cache-file\0" * 50000)
+PY
+SH
+	chmod +x "$noisy_git" || rc=1
+	if _worktree_recovery_cache_policy_helper manifest "$repo_path" \
+		"$noisy_git" 10 10485760 "$deadline_epoch" >/dev/null 2>&1; then rc=1; fi
 	[[ -f "${repo_path}/.codegraph/config.json" &&
 		-f "${repo_path}/nested/.codegraph/codegraph.db" &&
 		-L "${repo_path}/backend/__pycache__" ]] || rc=1
 	print_result "cache_retrofit_policy_preserves_unsafe_roots" "$rc" \
 		"Expected tracked, nested CodeGraph, symlink roots, and failed Git queries to retain all content"
+	return 0
+}
+
+test_cache_retrofit_rejects_mutable_evidence_drift_before_mutation() {
+	local home_path="${TEST_DIR}/cache-retrofit-evidence-home"
+	local state_dir="${home_path}/maintenance-state"
+	local plan_path="${TEST_DIR}/cache-retrofit-evidence-plan.json"
+	local receipt_path="${TEST_DIR}/cache-retrofit-evidence-receipt.json"
+	local archive_path=""
+	local rc=0
+
+	archive_path=$(create_mixed_cache_archive "$home_path" "evidence-drift") || rc=1
+	install_cache_retrofit_evidence_stubs
+	if (
+		uname() {
+			printf 'Linux\n'
+			return 0
+		}
+		limits_json=$(_worktree_recovery_maintenance_limits_json \
+			"${home_path}/.aidevops/recovery/worktrees")
+		_worktree_recovery_maintenance_prepare_selection "$state_dir" "Linux" "$limits_json"
+		printf '%s\n' "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_PLAN_JSON" >"$plan_path"
+		_worktree_recovery_plan_claim_state() {
+			local ignored_identity="$1"
+			: "$ignored_identity"
+			printf 'active\n'
+			return 0
+		}
+		HOME="$home_path" worktree_recovery_cache_prune_apply_automatic \
+			"$plan_path" "$receipt_path" >/dev/null 2>&1
+	); then rc=1; fi
+	[[ -d "${archive_path}/.codegraph" && -f "${archive_path}/logs/diagnostic.log" &&
+		! -e "$receipt_path" ]] || rc=1
+	print_result "cache_retrofit_rejects_mutable_evidence_drift_before_mutation" "$rc" \
+		"Expected a newly active claim to block cache-root staging before any archive mutation"
+	return 0
+}
+
+test_cache_retrofit_honors_shared_deadline_before_mutation() {
+	local home_path="${TEST_DIR}/cache-retrofit-deadline-home"
+	local state_dir="${home_path}/maintenance-state"
+	local plan_path="${TEST_DIR}/cache-retrofit-deadline-plan.json"
+	local receipt_path="${TEST_DIR}/cache-retrofit-deadline-receipt.json"
+	local archive_path=""
+	local expired_epoch=0
+	local rc=0
+
+	archive_path=$(create_mixed_cache_archive "$home_path" "shared-deadline") || rc=1
+	install_cache_retrofit_evidence_stubs
+	(
+		uname() {
+			printf 'Linux\n'
+			return 0
+		}
+		limits_json=$(_worktree_recovery_maintenance_limits_json \
+			"${home_path}/.aidevops/recovery/worktrees")
+		_worktree_recovery_maintenance_prepare_selection "$state_dir" "Linux" "$limits_json"
+		printf '%s\n' "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_PLAN_JSON" >"$plan_path"
+	) || rc=1
+	expired_epoch=$(($(date +%s) - 1)) || rc=1
+	if HOME="$home_path" worktree_recovery_cache_prune_apply_automatic \
+		"$plan_path" "$receipt_path" "$expired_epoch" >/dev/null 2>&1; then rc=1; fi
+	[[ -d "${archive_path}/.codegraph" && -f "${archive_path}/logs/diagnostic.log" &&
+		! -e "$receipt_path" ]] || rc=1
+	print_result "cache_retrofit_honors_shared_deadline_before_mutation" "$rc" \
+		"Expected an exhausted maintenance deadline to block a fresh cache apply budget"
+	return 0
+}
+
+test_cache_retrofit_resumes_interrupted_delete() {
+	local home_path="${TEST_DIR}/cache-retrofit-delete-home"
+	local state_dir="${home_path}/maintenance-state"
+	local archive_path="" output="" receipt_path=""
+	local rc=0
+
+	archive_path=$(create_mixed_cache_archive "$home_path" "delete-resume") || rc=1
+	install_cache_retrofit_evidence_stubs
+	if AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_DELETE=1 \
+		run_cache_retrofit_maintenance "$home_path" "$state_dir" >/dev/null 2>&1; then rc=1; fi
+	[[ -d "$state_dir/pending" && ! -e "${archive_path}/.codegraph" &&
+		-f "${archive_path}/logs/diagnostic.log" ]] || rc=1
+	output=$(run_cache_retrofit_maintenance "$home_path" "$state_dir") || rc=1
+	receipt_path=$(printf '%s\n' "$output" | jq -r '.receipt') || rc=1
+	[[ "$(printf '%s\n' "$output" | jq -r '.outcome')" == "resumed-and-pruned" ]] || rc=1
+	jq -e '
+		.observed_allocated_bytes == .expected_allocated_bytes and
+		([.entries[].post_delete_allocated_bytes] | all(. == 0))
+	' "$receipt_path" >/dev/null || rc=1
+	[[ ! -d "$state_dir/pending" && ! -e "${archive_path}/.codegraph" &&
+		-f "${archive_path}/logs/diagnostic.log" ]] || rc=1
+	print_result "cache_retrofit_resumes_interrupted_delete" "$rc" \
+		"Expected a post-delete crash to resume from the removing journal with zero residual bytes"
 	return 0
 }
 
@@ -2147,7 +2251,10 @@ run_all_tests() {
 	test_cache_retrofit_prunes_mixed_archive_and_accounts_bytes
 	test_cache_retrofit_policy_preserves_unsafe_roots
 	test_cache_retrofit_rejects_identity_drift_before_mutation
+	test_cache_retrofit_rejects_mutable_evidence_drift_before_mutation
+	test_cache_retrofit_honors_shared_deadline_before_mutation
 	test_cache_retrofit_resumes_interrupted_move
+	test_cache_retrofit_resumes_interrupted_delete
 	test_automatic_maintenance_is_bounded_and_policy_bound
 	test_automatic_maintenance_checks_capacity_before_aggregate_size
 	test_automatic_maintenance_enters_pressure_when_aggregate_size_times_out
@@ -2170,7 +2277,10 @@ run_cache_retrofit_tests() {
 	test_cache_retrofit_prunes_mixed_archive_and_accounts_bytes
 	test_cache_retrofit_policy_preserves_unsafe_roots
 	test_cache_retrofit_rejects_identity_drift_before_mutation
+	test_cache_retrofit_rejects_mutable_evidence_drift_before_mutation
+	test_cache_retrofit_honors_shared_deadline_before_mutation
 	test_cache_retrofit_resumes_interrupted_move
+	test_cache_retrofit_resumes_interrupted_delete
 	printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -1514,6 +1514,40 @@ test_cache_retrofit_resumes_interrupted_delete() {
 	return 0
 }
 
+test_cache_retrofit_rejects_unmeasured_legacy_delete_replay() {
+	local home_path="${TEST_DIR}/cache-retrofit-legacy-delete-home"
+	local recovery_root="${home_path}/.aidevops/recovery/worktrees"
+	local state_dir="${home_path}/maintenance-state"
+	local plan_path="${state_dir}/pending/plan.json"
+	local receipt_path="${state_dir}/pending/receipt.json"
+	local archive_path="" plan_json="" plan_digest="" journal_path="" journal_next=""
+	local rc=0
+
+	archive_path=$(create_mixed_cache_archive "$home_path" "legacy-delete-replay") || rc=1
+	install_cache_retrofit_evidence_stubs
+	if AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_DELETE=1 \
+		run_cache_retrofit_maintenance "$home_path" "$state_dir" >/dev/null 2>&1; then rc=1; fi
+	plan_json=$(<"$plan_path") || rc=1
+	plan_digest=$(_worktree_recovery_plan_sha256_text "$plan_json") || rc=1
+	journal_path="${recovery_root}/.retention-trash/cache-${plan_digest}/journal.json"
+	journal_next="${journal_path}.legacy"
+	jq -c '.entries[0].state = "staged" | .entries[0].removal_started_at = null' \
+		"$journal_path" >"$journal_next" || rc=1
+	mv "$journal_next" "$journal_path" || rc=1
+	if run_cache_retrofit_maintenance "$home_path" "$state_dir" >/dev/null 2>&1; then rc=1; fi
+	jq -e '
+		.schema == "aidevops.worktree-recovery-apply-reservation/v1" and
+		(.complete | not)
+	' "$receipt_path" >/dev/null || rc=1
+	jq -e '.entries[0].state == "staged" and .entries[0].removed_at == null' \
+		"$journal_path" >/dev/null || rc=1
+	[[ -d "$state_dir/pending" && ! -e "${archive_path}/.codegraph" &&
+		-f "${archive_path}/logs/diagnostic.log" ]] || rc=1
+	print_result "cache_retrofit_rejects_unmeasured_legacy_delete_replay" "$rc" \
+		"Expected staged-and-absent legacy journals to fail closed without a reclaimed-byte receipt"
+	return 0
+}
+
 test_cache_retrofit_rejects_identity_drift_before_mutation() {
 	local home_path="${TEST_DIR}/cache-retrofit-drift-home"
 	local state_dir="${home_path}/maintenance-state"
@@ -2255,6 +2289,7 @@ run_all_tests() {
 	test_cache_retrofit_honors_shared_deadline_before_mutation
 	test_cache_retrofit_resumes_interrupted_move
 	test_cache_retrofit_resumes_interrupted_delete
+	test_cache_retrofit_rejects_unmeasured_legacy_delete_replay
 	test_automatic_maintenance_is_bounded_and_policy_bound
 	test_automatic_maintenance_checks_capacity_before_aggregate_size
 	test_automatic_maintenance_enters_pressure_when_aggregate_size_times_out
@@ -2281,6 +2316,7 @@ run_cache_retrofit_tests() {
 	test_cache_retrofit_honors_shared_deadline_before_mutation
 	test_cache_retrofit_resumes_interrupted_move
 	test_cache_retrofit_resumes_interrupted_delete
+	test_cache_retrofit_rejects_unmeasured_legacy_delete_replay
 	printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -1234,6 +1234,234 @@ test_apply_handles_attributable_legacy_root_transaction() {
 	return 0
 }
 
+create_mixed_cache_archive() {
+	local home_path="$1"
+	local fixture_name="$2"
+	local recovery_root="${home_path}/.aidevops/recovery/worktrees"
+	local repo_path="${TEST_DIR}/${fixture_name}-repo"
+	local worktree_path="${TEST_DIR}/${fixture_name}-worktree"
+	local archive_path=""
+
+	mkdir -p "$recovery_root" || return 1
+	create_unarchived_fixture "$repo_path" "$worktree_path" \
+		"bugfix/gh31027-${fixture_name}" || return 1
+	printf '/.codegraph/\nlogs/\nnested/.codegraph/\nbackend/__pycache__/\n' \
+		>>"${repo_path}/.git/info/exclude" || return 1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
+		archive_worktree_path_recoverably "$worktree_path" "test.sh" "cache-retrofit" || return 1
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" remove_archived_worktree_path \
+		"$worktree_path" "$archive_path" "test.sh" "cache-retrofit" \
+		"recovery_path=archive-first" "false" "false" || return 1
+	mkdir -p "${archive_path}/.codegraph" "${archive_path}/logs" || return 1
+	python3 - "${archive_path}/.codegraph/codegraph.db" <<'PY' || return 1
+from pathlib import Path
+import sys
+
+Path(sys.argv[1]).write_bytes(b"x" * 256 * 1024)
+PY
+	printf 'preserve user log\n' >"${archive_path}/logs/diagnostic.log" || return 1
+	printf '%s\n' "$archive_path"
+	return 0
+}
+
+install_cache_retrofit_evidence_stubs() {
+	_worktree_recovery_plan_git_state() {
+		local identity_json="$1"
+		local archive_path=""
+		local status_path=""
+		local policy_status=0
+
+		archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
+		status_path=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/cache-retrofit-status.XXXXXX") || return 1
+		if ! GIT_OPTIONAL_LOCKS=0 "$GIT_BIN" -C "$archive_path" status --porcelain=v1 -z \
+			--untracked-files=all --ignored=matching >"$status_path" 2>/dev/null; then
+			rm -f "$status_path"
+			printf 'unavailable\n'
+			return 0
+		fi
+		_worktree_recovery_status_has_user_data "$status_path" "$archive_path" || policy_status=$?
+		rm -f "$status_path"
+		case "$policy_status" in
+		0) printf 'dirty\n' ;;
+		1) printf 'clear\n' ;;
+		*) printf 'unavailable\n' ;;
+		esac
+		return 0
+	}
+	_worktree_recovery_plan_worktree_reference_state() {
+		printf 'clear\n'
+		return 0
+	}
+	_worktree_recovery_plan_registry_state() {
+		printf 'clear\n'
+		return 0
+	}
+	_worktree_recovery_plan_claim_state() {
+		printf 'clear\n'
+		return 0
+	}
+	_worktree_recovery_plan_process_state() {
+		printf 'clear\n'
+		return 0
+	}
+	install_external_evidence_stub
+	return 0
+}
+
+run_cache_retrofit_maintenance() {
+	local home_path="$1"
+	local state_dir="$2"
+
+	(
+		uname() {
+			printf 'Linux\n'
+			return 0
+		}
+		HOME="$home_path" AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_STATE_DIR="$state_dir" \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_STORE_BYTES=1 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_KB=0 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_PERCENT=0 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_SCAN=10 \
+			AIDEVOPS_WORKTREE_RECOVERY_CACHE_PRUNE_MAX_ROOTS=10 \
+			AIDEVOPS_WORKTREE_RECOVERY_CACHE_PRUNE_MAX_BYTES=10485760 \
+			worktree_recovery_maintenance_run
+	)
+	return $?
+}
+
+test_cache_retrofit_prunes_mixed_archive_and_accounts_bytes() {
+	local home_path="${TEST_DIR}/cache-retrofit-home"
+	local state_dir="${home_path}/maintenance-state"
+	local plan_path="${TEST_DIR}/cache-retrofit-live-plan.json"
+	local archive_path="" bucket_path="" output="" receipt_path=""
+	local rc=0
+
+	archive_path=$(create_mixed_cache_archive "$home_path" "mixed") || rc=1
+	bucket_path="${archive_path%/*}"
+	install_cache_retrofit_evidence_stubs
+	output=$(run_cache_retrofit_maintenance "$home_path" "$state_dir") || rc=1
+	[[ "$(printf '%s\n' "$output" | jq -r '.outcome')" == "cache-pruned" ]] || rc=1
+	receipt_path=$(printf '%s\n' "$output" | jq -r '.receipt') || rc=1
+	jq -e '
+		.complete == true and .candidate_count == 1 and
+		.expected_allocated_bytes > 0 and
+		.observed_allocated_bytes == .expected_allocated_bytes and
+		.entries[0].maintenance.operation == "cache-prune" and
+		.entries[0].maintenance.relative_path == ".codegraph" and
+		.entries[0].outcome == "removed"
+	' "$receipt_path" >/dev/null || rc=1
+	printf '%s\n' "$output" | jq -e '
+		.reclaimed_bytes > 0 and .pruned_roots == 1 and
+		.reclaimed_bytes == .diagnostics.cache_prune.selected_bytes and
+		.diagnostics.cache_prune.selected_roots == 1
+	' >/dev/null || rc=1
+	[[ -d "$bucket_path" && ! -e "${archive_path}/.codegraph" &&
+		"$(<"${archive_path}/logs/diagnostic.log")" == "preserve user log" ]] || rc=1
+	(
+		uname() {
+			printf 'Linux\n'
+			return 0
+		}
+		HOME="$home_path" cmd_recovery plan --output "$plan_path" >/dev/null
+	) || rc=1
+	jq -e '
+		.candidate_count == 0 and .protected_count == 1 and
+		.entries[0].disposition == "protected" and
+		.entries[0].reasons == ["archive-worktree-dirty"]
+	' "$plan_path" >/dev/null || rc=1
+	print_result "cache_retrofit_prunes_mixed_archive_and_accounts_bytes" "$rc" \
+		"Expected only root CodeGraph cache bytes to be reclaimed while the log and protected archive remain"
+	return 0
+}
+
+test_cache_retrofit_policy_preserves_unsafe_roots() {
+	local repo_path="${TEST_DIR}/cache-retrofit-unsafe"
+	local symlink_target="${TEST_DIR}/cache-retrofit-symlink-target"
+	local deadline_epoch=0
+	local manifest=""
+	local rc=0
+
+	"$GIT_BIN" init -q -b main "$repo_path" || rc=1
+	"$GIT_BIN" -C "$repo_path" config user.email test@example.invalid || rc=1
+	"$GIT_BIN" -C "$repo_path" config user.name 'Aidevops Test' || rc=1
+	"$GIT_BIN" -C "$repo_path" config commit.gpgsign false || rc=1
+	mkdir -p "${repo_path}/.codegraph" "${repo_path}/nested/.codegraph" \
+		"${repo_path}/backend" "$symlink_target" || rc=1
+	printf 'tracked\n' >"${repo_path}/.codegraph/config.json" || rc=1
+	"$GIT_BIN" -C "$repo_path" add -f .codegraph/config.json || rc=1
+	"$GIT_BIN" -C "$repo_path" commit -q -m init || rc=1
+	printf '/.codegraph/\nnested/.codegraph/\nbackend/__pycache__/\n' \
+		>>"${repo_path}/.git/info/exclude" || rc=1
+	printf 'generated\n' >"${repo_path}/.codegraph/codegraph.db" || rc=1
+	printf 'nested\n' >"${repo_path}/nested/.codegraph/codegraph.db" || rc=1
+	ln -s "$symlink_target" "${repo_path}/backend/__pycache__" || rc=1
+	deadline_epoch=$(($(date +%s) + 30)) || rc=1
+	manifest=$(_worktree_recovery_cache_policy_helper manifest "$repo_path" \
+		"$GIT_BIN" 10 10485760 "$deadline_epoch") || rc=1
+	[[ "$(printf '%s\n' "$manifest" | jq -r '.candidate_count')" == "0" ]] || rc=1
+	if _worktree_recovery_cache_policy_helper manifest "$repo_path" \
+		"${TEST_DIR}/missing-git" 10 10485760 "$deadline_epoch" >/dev/null 2>&1; then rc=1; fi
+	[[ -f "${repo_path}/.codegraph/config.json" &&
+		-f "${repo_path}/nested/.codegraph/codegraph.db" &&
+		-L "${repo_path}/backend/__pycache__" ]] || rc=1
+	print_result "cache_retrofit_policy_preserves_unsafe_roots" "$rc" \
+		"Expected tracked, nested CodeGraph, symlink roots, and failed Git queries to retain all content"
+	return 0
+}
+
+test_cache_retrofit_rejects_identity_drift_before_mutation() {
+	local home_path="${TEST_DIR}/cache-retrofit-drift-home"
+	local state_dir="${home_path}/maintenance-state"
+	local plan_path="${TEST_DIR}/cache-retrofit-drift-plan.json"
+	local receipt_path="${TEST_DIR}/cache-retrofit-drift-receipt.json"
+	local archive_path="" recovery_dir=""
+	local rc=0
+
+	archive_path=$(create_mixed_cache_archive "$home_path" "cache-retrofit-identity-drift") || rc=1
+	recovery_dir="${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}"
+	install_cache_retrofit_evidence_stubs
+	if (
+		uname() {
+			printf 'Linux\n'
+			return 0
+		}
+		limits_json=$(_worktree_recovery_maintenance_limits_json \
+			"${home_path}/.aidevops/recovery/worktrees")
+		_worktree_recovery_maintenance_prepare_selection "$state_dir" "Linux" "$limits_json"
+		printf '%s\n' "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_PLAN_JSON" >"$plan_path"
+		printf 'drifted-context\n' >"${recovery_dir}/producer-context"
+		HOME="$home_path" worktree_recovery_cache_prune_apply_automatic \
+			"$plan_path" "$receipt_path" >/dev/null 2>&1
+	); then rc=1; fi
+	[[ -d "${archive_path}/.codegraph" && -f "${archive_path}/logs/diagnostic.log" &&
+		! -e "$receipt_path" ]] || rc=1
+	print_result "cache_retrofit_rejects_identity_drift_before_mutation" "$rc" \
+		"Expected recovery identity drift to fail before staging any approved cache root"
+	return 0
+}
+
+test_cache_retrofit_resumes_interrupted_move() {
+	local home_path="${TEST_DIR}/cache-retrofit-resume-home"
+	local state_dir="${home_path}/maintenance-state"
+	local archive_path="" output=""
+	local rc=0
+
+	archive_path=$(create_mixed_cache_archive "$home_path" "resume") || rc=1
+	install_cache_retrofit_evidence_stubs
+	if AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_MOVE=1 \
+		run_cache_retrofit_maintenance "$home_path" "$state_dir" >/dev/null 2>&1; then rc=1; fi
+	[[ -d "$state_dir/pending" && ! -e "${archive_path}/.codegraph" &&
+		-f "${archive_path}/logs/diagnostic.log" ]] || rc=1
+	output=$(run_cache_retrofit_maintenance "$home_path" "$state_dir") || rc=1
+	[[ "$(printf '%s\n' "$output" | jq -r '.outcome')" == "resumed-and-pruned" ]] || rc=1
+	[[ ! -d "$state_dir/pending" && ! -e "${archive_path}/.codegraph" &&
+		-f "${archive_path}/logs/diagnostic.log" ]] || rc=1
+	print_result "cache_retrofit_resumes_interrupted_move" "$rc" \
+		"Expected a journaled cache-root move to resume without touching protected archive content"
+	return 0
+}
+
 test_automatic_maintenance_is_bounded_and_policy_bound() {
 	local home_path="${TEST_DIR}/automatic-home"
 	local recovery_root="${home_path}/.aidevops/recovery/worktrees"
@@ -1446,7 +1674,7 @@ test_automatic_maintenance_deadline_advances_cursor() {
 		}
 		HOME="$home_path" AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_STATE_DIR="$state_dir" \
 			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_SCAN=1 \
-			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_SECONDS=1 \
+			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_SECONDS=2 \
 			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_KB=10 \
 			AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MIN_FREE_PERCENT=0 \
 			worktree_recovery_maintenance_run
@@ -1459,10 +1687,10 @@ test_automatic_maintenance_deadline_advances_cursor() {
 		.outcome == "no-candidates" and .policy.pressure_active == true and
 		.diagnostics.inventory_count == 300 and .diagnostics.scanned_count == 1 and
 		.diagnostics.cursor_before == 0 and .diagnostics.cursor_after == 1 and
-		.diagnostics.deadline_seconds == 1 and .diagnostics.deadline_exhausted == true and
+		.diagnostics.deadline_seconds == 2 and .diagnostics.deadline_exhausted == true and
 		.diagnostics.reason_counts.unknown_archive == 1
 	' >/dev/null || rc=1
-	[[ "$elapsed_seconds" -le 6 && "$remaining_buckets" -eq 300 ]] || rc=1
+	[[ "$elapsed_seconds" -le 7 && "$remaining_buckets" -eq 300 ]] || rc=1
 	print_result "automatic_maintenance_deadline_advances_cursor" "$rc" \
 		"Expected 300 delayed validations to stop within the deadline, advance one cursor entry, and preserve every bucket"
 	return 0
@@ -1888,43 +2116,70 @@ source "${SCRIPTS_DIR}/worktree-recovery-maintenance-helper.sh"
 # shellcheck source=../worktree-helper-cmds.sh
 source "${SCRIPTS_DIR}/worktree-helper-cmds.sh"
 
-setup
-printf '=== test-worktree-recovery-lifecycle.sh ===\n'
-test_git_state_detects_recovery_data
-test_cache_policy_recognises_python_and_root_codegraph_only
-test_git_state_protects_tracked_regenerable_cache_roots
-test_archive_prunes_only_regenerable_ignored_caches
-test_archive_pruning_preserves_tracked_codegraph_root
-test_claim_state_uses_archive_repository
-test_exact_plan_writes_candidate_without_mutation
-test_plan_output_refuses_unsafe_targets
-test_classification_fails_closed
-test_plan_records_malformed_bucket_unknown
-test_size_drift_downgrades_only_entry
-test_attributed_remeasurement_uses_explicit_budget
-test_global_inventory_failure_is_explicit
-test_entry_sizing_failure_is_localized
-test_manual_plan_classification_is_bounded_and_resumable
-test_manual_plan_deadline_emits_continuation
-test_apply_removes_only_candidates_and_replays_receipt
-test_apply_rejects_unsafe_manifest_and_cli_inputs
-test_apply_preflight_drift_stages_nothing
-test_apply_resumes_move_and_delete_crash_windows
-test_apply_resumes_transaction_initialization_crashes
-test_receipt_reservation_blocks_conflicting_plan
-test_receipt_publication_owns_only_reserved_temp
-test_shared_producer_lock_fails_closed_and_reclaims_stale
-test_apply_handles_attributable_legacy_root_transaction
-test_automatic_maintenance_is_bounded_and_policy_bound
-test_automatic_maintenance_checks_capacity_before_aggregate_size
-test_automatic_maintenance_enters_pressure_when_aggregate_size_times_out
-test_automatic_maintenance_deadline_advances_cursor
-test_automatic_maintenance_bounds_classification_subprocesses
-test_automatic_maintenance_preserves_bucket_when_exact_size_is_unavailable
-test_automatic_maintenance_escalates_completed_zero_candidate_cycle
-test_automatic_maintenance_resumes_interrupted_apply
-test_automatic_maintenance_rejects_symlink_cursor
-test_automatic_maintenance_rejects_symlink_cycle_state
-test_large_plan_avoids_json_argv_limits
-printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
-[[ "$TESTS_FAILED" -eq 0 ]]
+run_all_tests() {
+	setup
+	printf '=== test-worktree-recovery-lifecycle.sh ===\n'
+	test_git_state_detects_recovery_data
+	test_cache_policy_recognises_python_and_root_codegraph_only
+	test_git_state_protects_tracked_regenerable_cache_roots
+	test_archive_prunes_only_regenerable_ignored_caches
+	test_archive_pruning_preserves_tracked_codegraph_root
+	test_claim_state_uses_archive_repository
+	test_exact_plan_writes_candidate_without_mutation
+	test_plan_output_refuses_unsafe_targets
+	test_classification_fails_closed
+	test_plan_records_malformed_bucket_unknown
+	test_size_drift_downgrades_only_entry
+	test_attributed_remeasurement_uses_explicit_budget
+	test_global_inventory_failure_is_explicit
+	test_entry_sizing_failure_is_localized
+	test_manual_plan_classification_is_bounded_and_resumable
+	test_manual_plan_deadline_emits_continuation
+	test_apply_removes_only_candidates_and_replays_receipt
+	test_apply_rejects_unsafe_manifest_and_cli_inputs
+	test_apply_preflight_drift_stages_nothing
+	test_apply_resumes_move_and_delete_crash_windows
+	test_apply_resumes_transaction_initialization_crashes
+	test_receipt_reservation_blocks_conflicting_plan
+	test_receipt_publication_owns_only_reserved_temp
+	test_shared_producer_lock_fails_closed_and_reclaims_stale
+	test_apply_handles_attributable_legacy_root_transaction
+	test_cache_retrofit_prunes_mixed_archive_and_accounts_bytes
+	test_cache_retrofit_policy_preserves_unsafe_roots
+	test_cache_retrofit_rejects_identity_drift_before_mutation
+	test_cache_retrofit_resumes_interrupted_move
+	test_automatic_maintenance_is_bounded_and_policy_bound
+	test_automatic_maintenance_checks_capacity_before_aggregate_size
+	test_automatic_maintenance_enters_pressure_when_aggregate_size_times_out
+	test_automatic_maintenance_deadline_advances_cursor
+	test_automatic_maintenance_bounds_classification_subprocesses
+	test_automatic_maintenance_preserves_bucket_when_exact_size_is_unavailable
+	test_automatic_maintenance_escalates_completed_zero_candidate_cycle
+	test_automatic_maintenance_resumes_interrupted_apply
+	test_automatic_maintenance_rejects_symlink_cursor
+	test_automatic_maintenance_rejects_symlink_cycle_state
+	test_large_plan_avoids_json_argv_limits
+	printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+run_cache_retrofit_tests() {
+	setup
+	printf '=== cache retrofit tests ===\n'
+	test_cache_retrofit_prunes_mixed_archive_and_accounts_bytes
+	test_cache_retrofit_policy_preserves_unsafe_roots
+	test_cache_retrofit_rejects_identity_drift_before_mutation
+	test_cache_retrofit_resumes_interrupted_move
+	printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	if [[ "${1:-}" == "cache-retrofit" ]]; then
+		run_cache_retrofit_tests
+	else
+		run_all_tests
+	fi
+fi

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -1610,13 +1610,9 @@ _worktree_recovery_cache_reconcile_entries() {
 			_worktree_recovery_apply_update_entry "$journal_path" "$index" \
 				"$WORKTREE_RECOVERY_APPLY_STATE_STAGED" "$expected_bytes" "$timestamp" \
 				"$WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING" || return 1
-		elif [[ ("$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" ||
-			"$state" == "$WORKTREE_RECOVERY_APPLY_STATE_REMOVING") &&
+		elif [[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_REMOVING" &&
 			! -e "$original_path" && ! -L "$original_path" && ! -e "$staged_path" && ! -L "$staged_path" ]]; then
 			_worktree_recovery_cache_validate_removed_entry "$row_json" "$deadline_epoch" || return 1
-			if [[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" ]]; then
-				observed_bytes="$expected_bytes"
-			fi
 			[[ "$observed_bytes" =~ ^[1-9][0-9]*$ && "$observed_bytes" -eq "$expected_bytes" ]] || return 1
 			timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 			_worktree_recovery_apply_update_entry "$journal_path" "$index" \

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -11,6 +11,7 @@ WORKTREE_RECOVERY_APPLY_RESERVATION_SCHEMA="aidevops.worktree-recovery-apply-res
 WORKTREE_RECOVERY_APPLY_TRANSACTION_SCHEMA="aidevops.worktree-recovery-apply-transaction/v1"
 WORKTREE_RECOVERY_APPLY_STATE_PLANNED="planned"
 WORKTREE_RECOVERY_APPLY_STATE_STAGED="staged"
+WORKTREE_RECOVERY_APPLY_STATE_REMOVING="removing"
 WORKTREE_RECOVERY_APPLY_STATE_REMOVED="removed"
 WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING="pending"
 WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED="$WORKTREE_RECOVERY_APPLY_STATE_REMOVED"
@@ -384,12 +385,15 @@ _worktree_recovery_apply_validate_receipt_replay() {
 		--arg plan_id "$plan_id" --arg plan_digest "$plan_digest" \
 		--arg confirmation "$confirmation" --argjson candidate_count "$candidate_count" \
 		--argjson candidate_bytes "$candidate_bytes" --argjson automatic_policy "$automatic_policy" \
-		--arg removed "$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" '
+		--arg removed "$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" \
+		--arg cache_policy_id "$WORKTREE_RECOVERY_CACHE_POLICY_ID" '
 		.schema == $schema and .complete == true and .plan_id == $plan_id and
 		.plan_digest == $plan_digest and .confirmation == $confirmation and
 		.candidate_count == $candidate_count and .expected_allocated_bytes == $candidate_bytes and
 		.observed_allocated_bytes == $candidate_bytes and
 		(.automatic_policy // null) == $automatic_policy and (.entries | length == $candidate_count) and
+		(if .automatic_policy.policy_id == $cache_policy_id
+		then ([.entries[].post_delete_allocated_bytes] | all(. == 0)) else true end) and
 		([.entries[] | select(.outcome != $removed)] | length == 0)
 	' "$receipt_path" >/dev/null 2>&1
 	return $?
@@ -709,14 +713,17 @@ _worktree_recovery_apply_validate_existing_journal() {
 	printf '%s\n' "$expected_journal" | jq -e --slurpfile actual "$journal_path" \
 		--arg planned "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" \
 		--arg staged "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" \
+		--arg removing "$WORKTREE_RECOVERY_APPLY_STATE_REMOVING" \
 		--arg removed "$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" \
+		--arg cache_schema "$WORKTREE_RECOVERY_CACHE_TRANSACTION_SCHEMA" \
 		--arg string_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING" '
 		. as $expected | $actual[0] |
 		.schema == $expected.schema and .transaction_id == $expected.transaction_id and
 		.plan_id == $expected.plan_id and .plan_digest == $expected.plan_digest and
 		.confirmation == $expected.confirmation and (.started_at | type == $string_type) and
 		(.automatic_policy // null) == ($expected.automatic_policy // null) and
-		([.entries[] | .state] | all(. == $planned or . == $staged or . == $removed)) and
+		([.entries[] | .state] | all(. == $planned or . == $staged or . == $removed or
+			($expected.schema == $cache_schema and . == $removing))) and
 		([.entries[] | {index,role,original_path,staged_path,archive_name,
 			expected_allocated_bytes,identity,evidence,reasons,maintenance}] ==
 			 [$expected.entries[] | {index,role,original_path,staged_path,archive_name,
@@ -883,12 +890,17 @@ _worktree_recovery_apply_update_entry() {
 	updated=$(jq -c --argjson index "$index" --arg state "$state" \
 		--argjson observed_bytes "$observed_bytes" --arg timestamp "$timestamp" \
 		--arg outcome "$outcome" --arg staged "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" \
+		--arg removing "$WORKTREE_RECOVERY_APPLY_STATE_REMOVING" \
 		--arg removed "$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" '
 		.entries[$index].state = $state |
 		.entries[$index].observed_allocated_bytes = $observed_bytes |
 		.entries[$index].outcome = $outcome |
 		if $state == $staged then .entries[$index].staged_at = $timestamp
-		elif $state == $removed then .entries[$index].removed_at = $timestamp
+		elif $state == $removing then .entries[$index].removal_started_at = $timestamp
+		elif $state == $removed then
+			.entries[$index].removed_at = $timestamp |
+			if .entries[$index].maintenance.operation == "cache-prune"
+			then .entries[$index].post_delete_allocated_bytes = 0 else . end
 		else . end
 	' "$journal_path") || return 1
 	_worktree_recovery_apply_atomic_replace "$journal_path" "$updated"
@@ -1024,21 +1036,27 @@ _worktree_recovery_apply_receipt_json() {
 		--arg completed_at "$completed_at" \
 		--argjson metadata "$apply_metadata" \
 		--arg removed "$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" \
+		--arg cache_transaction "$WORKTREE_RECOVERY_CACHE_TRANSACTION_SCHEMA" \
 		--arg object_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_OBJECT" '
+		. as $journal |
 		({schema:$schema,complete:true,plan_id:.plan_id,plan_digest:.plan_digest,
 		confirmation:.confirmation,transaction_id:.transaction_id,
 		started_at:.started_at,completed_at:$completed_at,
 		candidate_count:(.entries | length),
 		expected_allocated_bytes:([.entries[].expected_allocated_bytes] | add // 0),
 		observed_allocated_bytes:([.entries[].observed_allocated_bytes] | add // 0),
-		entries:[.entries[] | {original_path,staged_path,identity,maintenance,
-			expected_allocated_bytes,observed_allocated_bytes,outcome,staged_at,removed_at}]} +
+		entries:[.entries[] | ({original_path,staged_path,identity,maintenance,
+			expected_allocated_bytes,observed_allocated_bytes,outcome,staged_at,removed_at} +
+			(if $journal.schema == $cache_transaction
+			then {post_delete_allocated_bytes,removal_started_at} else {} end))]} +
 		(if (.automatic_policy | type) == $object_type
 		then {automatic_policy:.automatic_policy} else {} end)) |
 		select(.plan_id == $metadata.plan_id and .plan_digest == $metadata.plan_digest and
 			.confirmation == $metadata.confirmation and .candidate_count == $metadata.candidate_count and
 			.expected_allocated_bytes == $metadata.candidate_bytes and
 			.observed_allocated_bytes == $metadata.candidate_bytes and
+			(if $journal.schema == $cache_transaction
+			then ([.entries[].post_delete_allocated_bytes] | all(. == 0)) else true end) and
 			([.entries[] | select(.outcome != $removed)] | length == 0))
 	' "$journal_path"
 	return $?
@@ -1367,6 +1385,7 @@ _worktree_recovery_cache_validate_plan() {
 
 _worktree_recovery_cache_validate_recovery_identities() {
 	local plan_json="$1"
+	local deadline_epoch="$2"
 	local row_json=""
 	local bucket_path=""
 	local expected_identity=""
@@ -1375,7 +1394,8 @@ _worktree_recovery_cache_validate_recovery_identities() {
 	while IFS= read -r row_json; do
 		bucket_path=$(printf '%s\n' "$row_json" | jq -r '.bucket_path') || return 1
 		expected_identity=$(printf '%s\n' "$row_json" | jq -cS '.recovery_identity') || return 1
-		current_identity=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
+		current_identity=$(_worktree_recovery_apply_run_function_before_epoch "$deadline_epoch" \
+			_worktree_recovery_plan_identity_json "$bucket_path") || return 1
 		current_identity=$(printf '%s\n' "$current_identity" | jq -cS '.') || return 1
 		[[ "$current_identity" == "$expected_identity" ]] || return 1
 	done < <(printf '%s\n' "$plan_json" | jq -c \
@@ -1405,7 +1425,8 @@ _worktree_recovery_cache_transaction_entries() {
 				relative_path:$entry.relative_path,archive_path:$entry.archive_path},
 			evidence:$entry.evidence,reasons:$entry.reasons,
 			maintenance:{operation:"cache-prune",relative_path:$entry.relative_path},
-			state:$planned,observed_allocated_bytes:null,staged_at:null,removed_at:null,outcome:$pending})
+			state:$planned,observed_allocated_bytes:null,post_delete_allocated_bytes:null,
+			staged_at:null,removal_started_at:null,removed_at:null,outcome:$pending})
 	'
 	return $?
 }
@@ -1419,6 +1440,78 @@ _worktree_recovery_cache_policy_helper() {
 	[[ -f "$helper_path" && ! -L "$helper_path" ]] || return 1
 	python3 "$helper_path" "$mode" "$@"
 	return $?
+}
+
+_worktree_recovery_apply_run_function_before_epoch() {
+	local deadline_epoch="$1"
+	shift
+	local current_epoch=0
+	local command_pid=0
+	local command_pgid=0
+	local command_group=""
+	local monitor_was_enabled=false
+
+	current_epoch=$(date +%s) || return 1
+	[[ "$current_epoch" -lt "$deadline_epoch" ]] || return 124
+	[[ $- == *m* ]] && monitor_was_enabled=true
+	set -m
+	"$@" &
+	command_pid=$!
+	$monitor_was_enabled && set -m || set +m
+	command_pgid="$command_pid"
+	command_group="-${command_pgid}"
+	while kill -0 "$command_pid" 2>/dev/null; do
+		current_epoch=$(date +%s) || current_epoch="$deadline_epoch"
+		if [[ "$current_epoch" -ge "$deadline_epoch" ]]; then
+			kill -TERM -- "$command_group" 2>/dev/null || true
+			sleep 0.2
+			if kill -0 -- "$command_group" 2>/dev/null; then
+				kill -KILL -- "$command_group" 2>/dev/null || true
+			fi
+			wait "$command_pid" 2>/dev/null || true
+			return 124
+		fi
+		sleep 0.1
+	done
+	wait "$command_pid"
+	return $?
+}
+
+_worktree_recovery_cache_validate_mutable_evidence() {
+	local row_json="$1"
+	local deadline_epoch="$2"
+	local expected_identity=""
+	local expected_evidence=""
+	local current_identity=""
+	local current_evidence=""
+	local bucket_path=""
+
+	bucket_path=$(printf '%s\n' "$row_json" | jq -r '.bucket_path // .identity.recovery.bucket_path') || return 1
+	expected_identity=$(printf '%s\n' "$row_json" | jq -cS '.recovery_identity // .identity.recovery') || return 1
+	expected_evidence=$(printf '%s\n' "$row_json" | jq -cS '.evidence') || return 1
+	current_identity=$(_worktree_recovery_apply_run_function_before_epoch "$deadline_epoch" \
+		_worktree_recovery_plan_identity_json "$bucket_path") || return 1
+	current_identity=$(printf '%s\n' "$current_identity" | jq -cS '.') || return 1
+	[[ "$current_identity" == "$expected_identity" ]] || return 1
+	current_evidence=$(AIDEVOPS_WORKTREE_RECOVERY_EVIDENCE_DEADLINE_EPOCH="$deadline_epoch" \
+		_worktree_recovery_apply_run_function_before_epoch "$deadline_epoch" \
+		_worktree_recovery_plan_evidence_json "$current_identity") || return 1
+	current_evidence=$(printf '%s\n' "$current_evidence" | jq -cS '.') || return 1
+	[[ "$current_evidence" == "$expected_evidence" ]] || return 1
+	return 0
+}
+
+_worktree_recovery_cache_validate_plan_evidence() {
+	local plan_json="$1"
+	local deadline_epoch="$2"
+	local row_json=""
+
+	while IFS= read -r row_json; do
+		_worktree_recovery_cache_validate_mutable_evidence \
+			"$row_json" "$deadline_epoch" || return 1
+	done < <(printf '%s\n' "$plan_json" | jq -c \
+		'[.entries[] | {bucket_path,recovery_identity,evidence}] | unique_by(.bucket_path)[]')
+	return 0
 }
 
 _worktree_recovery_cache_validate_original_entry() {
@@ -1458,10 +1551,50 @@ _worktree_recovery_cache_validate_staged_entry() {
 	return $?
 }
 
+_worktree_recovery_cache_measure_staged_entry() {
+	local row_json="$1"
+	local deadline_epoch="$2"
+	local staged_path=""
+	local expected_identity=""
+	local expected_bytes=""
+
+	staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+	expected_identity=$(printf '%s\n' "$row_json" | jq -r '.identity.path_identity') || return 1
+	expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+	_worktree_recovery_cache_policy_helper measure-staged "$staged_path" \
+		"$expected_identity" "$expected_bytes" "$deadline_epoch"
+	return $?
+}
+
+_worktree_recovery_cache_validate_removing_entry() {
+	local row_json="$1"
+	local deadline_epoch="$2"
+	local staged_path=""
+	local expected_identity=""
+	local expected_bytes=""
+
+	staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+	expected_identity=$(printf '%s\n' "$row_json" | jq -r '.identity.path_identity') || return 1
+	expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+	_worktree_recovery_cache_policy_helper validate-removing "$staged_path" \
+		"$expected_identity" "$expected_bytes" "$deadline_epoch"
+	return $?
+}
+
+_worktree_recovery_cache_validate_removed_entry() {
+	local row_json="$1"
+	local deadline_epoch="$2"
+	local staged_path=""
+
+	staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+	_worktree_recovery_cache_policy_helper validate-removed "$staged_path" "$deadline_epoch"
+	return $?
+}
+
 _worktree_recovery_cache_reconcile_entries() {
 	local journal_path="$1"
 	local deadline_epoch="$2"
-	local row_json='' state='' index='' original_path='' staged_path='' expected_bytes='' timestamp=''
+	local row_json='' state='' index='' original_path='' staged_path='' expected_bytes='' observed_bytes='' timestamp=''
 
 	while IFS= read -r row_json; do
 		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
@@ -1469,6 +1602,7 @@ _worktree_recovery_cache_reconcile_entries() {
 		original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
 		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
 		expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+		observed_bytes=$(printf '%s\n' "$row_json" | jq -r '.observed_allocated_bytes // empty') || return 1
 		if [[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" &&
 			! -e "$original_path" && ! -L "$original_path" && -d "$staged_path" && ! -L "$staged_path" ]]; then
 			_worktree_recovery_cache_validate_staged_entry "$row_json" "$deadline_epoch" || return 1
@@ -1476,11 +1610,17 @@ _worktree_recovery_cache_reconcile_entries() {
 			_worktree_recovery_apply_update_entry "$journal_path" "$index" \
 				"$WORKTREE_RECOVERY_APPLY_STATE_STAGED" "$expected_bytes" "$timestamp" \
 				"$WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING" || return 1
-		elif [[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" &&
+		elif [[ ("$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" ||
+			"$state" == "$WORKTREE_RECOVERY_APPLY_STATE_REMOVING") &&
 			! -e "$original_path" && ! -L "$original_path" && ! -e "$staged_path" && ! -L "$staged_path" ]]; then
+			_worktree_recovery_cache_validate_removed_entry "$row_json" "$deadline_epoch" || return 1
+			if [[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" ]]; then
+				observed_bytes="$expected_bytes"
+			fi
+			[[ "$observed_bytes" =~ ^[1-9][0-9]*$ && "$observed_bytes" -eq "$expected_bytes" ]] || return 1
 			timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 			_worktree_recovery_apply_update_entry "$journal_path" "$index" \
-				"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" "$expected_bytes" "$timestamp" \
+				"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" "$observed_bytes" "$timestamp" \
 				"$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" || return 1
 		fi
 	done < <(jq -c '.entries[]' "$journal_path")
@@ -1503,6 +1643,10 @@ _worktree_recovery_cache_preflight_journal() {
 		"$WORKTREE_RECOVERY_APPLY_STATE_STAGED")
 			_worktree_recovery_cache_validate_staged_entry "$row_json" "$deadline_epoch" || return 1
 			;;
+		"$WORKTREE_RECOVERY_APPLY_STATE_REMOVING")
+			[[ ! -e "$original_path" && ! -L "$original_path" ]] || return 1
+			_worktree_recovery_cache_validate_removing_entry "$row_json" "$deadline_epoch" || return 1
+			;;
 		"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED")
 			[[ ! -e "$original_path" && ! -L "$original_path" &&
 				! -e "$staged_path" && ! -L "$staged_path" ]] || return 1
@@ -1517,6 +1661,7 @@ _worktree_recovery_cache_stage_entries() {
 	local journal_path="$1"
 	local deadline_epoch="$2"
 	local row_json='' state='' index='' original_path='' staged_path='' expected_bytes='' timestamp=''
+	local current_epoch=0
 
 	while IFS= read -r row_json; do
 		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
@@ -1525,7 +1670,10 @@ _worktree_recovery_cache_stage_entries() {
 		original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
 		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
 		expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+		_worktree_recovery_cache_validate_mutable_evidence "$row_json" "$deadline_epoch" || return 1
 		_worktree_recovery_cache_validate_original_entry "$row_json" "$deadline_epoch" || return 1
+		current_epoch=$(date +%s) || return 1
+		[[ "$current_epoch" -lt "$deadline_epoch" ]] || return 1
 		mv "$original_path" "$staged_path" || return 1
 		[[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_MOVE:-0}" != "1" ]] || return 1
 		timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
@@ -1547,6 +1695,9 @@ _worktree_recovery_cache_validate_all_staged() {
 		"$WORKTREE_RECOVERY_APPLY_STATE_STAGED")
 			_worktree_recovery_cache_validate_staged_entry "$row_json" "$deadline_epoch" || return 1
 			;;
+		"$WORKTREE_RECOVERY_APPLY_STATE_REMOVING")
+			_worktree_recovery_cache_validate_removing_entry "$row_json" "$deadline_epoch" || return 1
+			;;
 		"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED") ;;
 		*) return 1 ;;
 		esac
@@ -1557,22 +1708,35 @@ _worktree_recovery_cache_validate_all_staged() {
 _worktree_recovery_cache_remove_staged() {
 	local journal_path="$1"
 	local deadline_epoch="$2"
-	local row_json='' state='' index='' staged_path='' expected_bytes='' timestamp=''
+	local row_json='' state='' index='' staged_path='' expected_bytes='' observed_bytes='' timestamp=''
 	local removed_this_run=0
 
 	while IFS= read -r row_json; do
 		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
-		[[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" ]] || continue
+		[[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" ||
+			"$state" == "$WORKTREE_RECOVERY_APPLY_STATE_REMOVING" ]] || continue
 		index=$(printf '%s\n' "$row_json" | jq -r '.index') || return 1
 		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
 		expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
-		_worktree_recovery_cache_validate_staged_entry "$row_json" "$deadline_epoch" || return 1
-		rm -rf -- "$staged_path" || return 1
-		[[ ! -e "$staged_path" && ! -L "$staged_path" ]] || return 1
+		observed_bytes=$(printf '%s\n' "$row_json" | jq -r '.observed_allocated_bytes // empty') || return 1
+		if [[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" ]]; then
+			observed_bytes=$(_worktree_recovery_cache_measure_staged_entry \
+				"$row_json" "$deadline_epoch") || return 1
+			[[ "$observed_bytes" =~ ^[1-9][0-9]*$ ]] || return 1
+			timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+			_worktree_recovery_apply_update_entry "$journal_path" "$index" \
+				"$WORKTREE_RECOVERY_APPLY_STATE_REMOVING" "$observed_bytes" "$timestamp" \
+				"$WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING" || return 1
+		else
+			[[ "$observed_bytes" =~ ^[1-9][0-9]*$ && "$observed_bytes" -eq "$expected_bytes" ]] || return 1
+			_worktree_recovery_cache_validate_removing_entry "$row_json" "$deadline_epoch" || return 1
+		fi
+		_worktree_recovery_run_before_epoch "$deadline_epoch" rm -rf -- "$staged_path" || return 1
+		_worktree_recovery_cache_validate_removed_entry "$row_json" "$deadline_epoch" || return 1
 		[[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_DELETE:-0}" != "1" ]] || return 1
 		timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 		_worktree_recovery_apply_update_entry "$journal_path" "$index" \
-			"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" "$expected_bytes" "$timestamp" \
+			"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" "$observed_bytes" "$timestamp" \
 			"$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" || return 1
 		removed_this_run=$((removed_this_run + 1))
 		if [[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_REMOVE:-0}" == "1" &&
@@ -1587,14 +1751,19 @@ _worktree_recovery_cache_apply_under_lock() {
 	local plan_path="$1"
 	local receipt_path="$2"
 	local recovery_root="$3"
+	local deadline_epoch="$4"
 	local apply_metadata="" plan_json="" plan_digest="" transaction_id="" entries_json=""
 	local transaction_dir="" journal_path="" expected_journal="" started_at="" journal_json=""
-	local source_root="" receipt_json="" deadline_seconds="" deadline_epoch=0 receipt_status=0
+	local source_root="" receipt_json="" receipt_status=0
+	local current_epoch=0
 
+	current_epoch=$(date +%s) || return 1
+	[[ "$deadline_epoch" =~ ^[1-9][0-9]*$ && "$current_epoch" -lt "$deadline_epoch" ]] || return 1
 	_worktree_recovery_cache_validate_plan "$plan_path" || return 1
 	apply_metadata="$WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA"
 	plan_json="$WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON"
-	_worktree_recovery_cache_validate_recovery_identities "$plan_json" || return 1
+	_worktree_recovery_cache_validate_recovery_identities "$plan_json" "$deadline_epoch" || return 1
+	_worktree_recovery_cache_validate_plan_evidence "$plan_json" "$deadline_epoch" || return 1
 	printf '%s\n' "$plan_json" | jq -e --arg receipt "$receipt_path" '
 		all(.entries[]; . as $entry | ($receipt | startswith($entry.bucket_path + "/") | not))
 	' >/dev/null 2>&1 || return 1
@@ -1608,8 +1777,6 @@ _worktree_recovery_cache_apply_under_lock() {
 	[[ "$receipt_status" -ne 2 ]] || return 0
 	[[ "$receipt_status" -eq 0 ]] || return "$receipt_status"
 	[[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_RECEIPT_RESERVATION:-0}" != "1" ]] || return 1
-	deadline_seconds=$(printf '%s\n' "$plan_json" | jq -r '.automatic_policy.deadline_seconds') || return 1
-	deadline_epoch=$(($(date +%s) + deadline_seconds)) || return 1
 	if [[ -f "$journal_path" && ! -L "$journal_path" ]]; then
 		started_at=$(jq -r '.started_at // empty' "$journal_path") || return 1
 	else
@@ -1652,12 +1819,22 @@ _worktree_recovery_cache_apply_under_lock() {
 worktree_recovery_cache_prune_apply_automatic() {
 	local plan_path="$1"
 	local receipt_path="$2"
+	local deadline_epoch="${3:-0}"
 	local plan_json="" recovery_root="" recovery_root_real="" apply_status=0
-	local platform=""
+	local platform="" deadline_seconds="" current_epoch=0
 
 	command -v jq >/dev/null 2>&1 || return 1
+	case "$deadline_epoch" in
+	*[!0-9]* | '') return 1 ;;
+	esac
+	current_epoch=$(date +%s) || return 1
+	[[ "$deadline_epoch" -eq 0 || "$current_epoch" -lt "$deadline_epoch" ]] || return 1
 	_worktree_recovery_cache_validate_plan "$plan_path" || return 1
 	plan_json="$WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON"
+	if [[ "$deadline_epoch" -eq 0 ]]; then
+		deadline_seconds=$(printf '%s\n' "$plan_json" | jq -r '.automatic_policy.deadline_seconds') || return 1
+		deadline_epoch=$((current_epoch + deadline_seconds))
+	fi
 	receipt_path=$(_worktree_recovery_apply_canonical_path "$receipt_path") || return 1
 	printf '%s\n' "$plan_json" | jq -e --arg receipt "$receipt_path" '
 		all(.entries[]; . as $entry | ($receipt | startswith($entry.bucket_path + "/") | not))
@@ -1668,7 +1845,7 @@ worktree_recovery_cache_prune_apply_automatic() {
 	recovery_root_real=$(cd "$recovery_root" 2>/dev/null && pwd -P) || return 1
 	_worktree_recovery_acquire_producer_lock "$recovery_root_real" || return 1
 	_worktree_recovery_cache_apply_under_lock \
-		"$plan_path" "$receipt_path" "$recovery_root_real" || apply_status=$?
+		"$plan_path" "$receipt_path" "$recovery_root_real" "$deadline_epoch" || apply_status=$?
 	_worktree_recovery_release_producer_lock || apply_status=1
 	[[ "$apply_status" -eq 0 ]] || return "$apply_status"
 	printf '%s\n' "$receipt_path"

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -17,7 +17,13 @@ WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED="$WORKTREE_RECOVERY_APPLY_STATE_REMOVED"
 WORKTREE_RECOVERY_APPLY_JSON_TYPE_NUMBER="number"
 WORKTREE_RECOVERY_APPLY_JSON_TYPE_OBJECT="object"
 WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING="string"
+WORKTREE_RECOVERY_APPLY_JSON_TYPE_ARRAY='array'
+WORKTREE_RECOVERY_APPLY_DIGEST_PATTERN='^sha256:[0-9a-f]{64}$'
 WORKTREE_RECOVERY_APPLY_TRASH_SEGMENT="/.retention-trash/"
+WORKTREE_RECOVERY_CACHE_PLAN_SCHEMA="aidevops.worktree-recovery-cache-prune-plan/v1"
+WORKTREE_RECOVERY_CACHE_POLICY_SCHEMA="aidevops.worktree-recovery-cache-prune-policy/v1"
+WORKTREE_RECOVERY_CACHE_POLICY_ID="approved-regenerable-roots-v1"
+WORKTREE_RECOVERY_CACHE_TRANSACTION_SCHEMA="aidevops.worktree-recovery-cache-prune-transaction/v1"
 WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA=""
 WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON=""
 WORKTREE_RECOVERY_APPLY_RECEIPT_COMPLETION_PATH=""
@@ -1190,6 +1196,479 @@ worktree_recovery_apply_automatic() {
 	_worktree_recovery_acquire_producer_lock "$recovery_root_real" || return 1
 	_worktree_recovery_apply_under_lock "$plan_path" "$receipt_path" \
 		"" "$recovery_root_real" "automatic" || apply_status=$?
+	_worktree_recovery_release_producer_lock || apply_status=1
+	[[ "$apply_status" -eq 0 ]] || return "$apply_status"
+	printf '%s\n' "$receipt_path"
+	return 0
+}
+
+_worktree_recovery_cache_plan_material_json() {
+	local plan_json="$1"
+
+	printf '%s\n' "$plan_json" | jq -cS \
+		'{schema:.schema,entries:.entries,automatic_policy:.automatic_policy}'
+	return $?
+}
+
+_worktree_recovery_cache_automatic_token() {
+	local plan_id="$1"
+	local policy_json="$2"
+	local candidate_count="$3"
+	local candidate_bytes="$4"
+	local policy_digest=""
+	local authorization_material=""
+	local authorization_digest=""
+
+	[[ "$plan_id" =~ ^sha256:[0-9a-f]{64}$ ]] || return 1
+	case "$candidate_count:$candidate_bytes" in
+	*[!0-9:]*) return 1 ;;
+	esac
+	policy_json=$(printf '%s\n' "$policy_json" | jq -cS '.') || return 1
+	policy_digest=$(_worktree_recovery_plan_sha256_text "$policy_json") || return 1
+	authorization_material=$(printf '%s\n' \
+		"schema=$WORKTREE_RECOVERY_CACHE_PLAN_SCHEMA" \
+		"plan-id=$plan_id" \
+		"policy-id=$WORKTREE_RECOVERY_CACHE_POLICY_ID" \
+		"policy-digest=sha256:$policy_digest" \
+		"candidate-count=$candidate_count" \
+		"candidate-bytes=$candidate_bytes" \
+		"action=automatically-prune-exact-cache-roots") || return 1
+	authorization_digest=$(_worktree_recovery_plan_sha256_text "$authorization_material") || return 1
+	printf 'cache-automatic-sha256:%s\n' "$authorization_digest"
+	return 0
+}
+
+_worktree_recovery_cache_validate_plan_shape() {
+	local plan_json="$1"
+
+	printf '%s\n' "$plan_json" | jq -e \
+		--arg schema "$WORKTREE_RECOVERY_CACHE_PLAN_SCHEMA" \
+		--arg producer "$WORKTREE_RECOVERY_PRODUCER" \
+		--arg policy_schema "$WORKTREE_RECOVERY_CACHE_POLICY_SCHEMA" \
+		--arg policy_id "$WORKTREE_RECOVERY_CACHE_POLICY_ID" \
+		--arg array_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_ARRAY" \
+		--arg number_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_NUMBER" \
+		--arg object_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_OBJECT" \
+		--arg string_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING" \
+		--arg digest_pattern "$WORKTREE_RECOVERY_APPLY_DIGEST_PATTERN" \
+		--arg schema_key schema \
+		--arg clear "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" '
+		type == $object_type and .schema == $schema and .producer == $producer and .read_only == true and
+		(.generated_at | type == $string_type) and (.plan_id | test($digest_pattern)) and
+		(.confirmation_token | test("^cache-automatic-sha256:[0-9a-f]{64}$")) and
+		(.automatic_policy | type == $object_type) and
+		(.automatic_policy | keys | sort) == (["deadline_seconds","max_bytes","max_roots",
+			"max_scan","policy_id",$schema_key,"scanned_count"] | sort) and
+		.automatic_policy.schema == $policy_schema and .automatic_policy.policy_id == $policy_id and
+		([.automatic_policy.deadline_seconds,.automatic_policy.max_bytes,.automatic_policy.max_roots,
+			.automatic_policy.max_scan,.automatic_policy.scanned_count] |
+			all(type == $number_type and . >= 0 and . == floor)) and
+		.automatic_policy.deadline_seconds > 0 and .automatic_policy.max_bytes > 0 and
+		.automatic_policy.max_roots > 0 and .automatic_policy.max_scan > 0 and
+		.automatic_policy.scanned_count <= .automatic_policy.max_scan and
+		(.entries | type == $array_type) and .candidate_count == (.entries | length) and
+		.candidate_count > 0 and .candidate_count <= .automatic_policy.max_roots and
+		.expected_allocated_bytes == ([.entries[].expected_allocated_bytes] | add // 0) and
+		.expected_allocated_bytes > 0 and .expected_allocated_bytes <= .automatic_policy.max_bytes and
+		all(.entries[]; . as $entry |
+			$entry.role == "current" and
+			($entry.bucket_path | type == $string_type and startswith("/")) and
+			($entry.archive_path | type == $string_type and startswith($entry.bucket_path + "/")) and
+			($entry.archive_path[0:($entry.archive_path | rindex("/"))] == $entry.bucket_path) and
+			($entry.relative_path | type == $string_type and length > 0 and (startswith("/") | not) and
+				(endswith("/") | not) and (test("(^|/)\\.{1,2}(/|$)|[\u0000-\u001f\u007f]") | not)) and
+			$entry.original_path == ($entry.archive_path + "/" + $entry.relative_path) and
+			($entry.path_identity | test("^[0-9]+:[0-9]+$")) and
+			($entry.expected_allocated_bytes | type == $number_type and . > 0 and . == floor) and
+			($entry.recovery_identity | type == $object_type) and
+			$entry.recovery_identity.bucket_path == $entry.bucket_path and
+			$entry.recovery_identity.archive_path == $entry.archive_path and
+			($entry.recovery_identity.identity_digest | test($digest_pattern)) and
+			$entry.recovery_identity.source_removal_outcome == "removed" and
+			($entry.recovery_identity.branch | startswith("refs/heads/")) and
+			($entry.evidence | type == $object_type) and $entry.evidence.git == "dirty" and
+			$entry.evidence.worktree == $clear and $entry.evidence.registry == $clear and
+			$entry.evidence.claim == $clear and $entry.evidence.process == $clear and
+			$entry.evidence.external.commit == "merged" and
+			$entry.evidence.external.open_pr == $clear and
+			$entry.evidence.external.task == "closed" and
+			$entry.reasons == ["approved-regenerable-cache-root"]) and
+		([.entries[].original_path] | length == (unique | length)) and
+		([.entries[].path_identity] | length == (unique | length))
+	' >/dev/null 2>&1
+	return $?
+}
+
+_worktree_recovery_cache_validate_candidate_roots() {
+	local plan_json="$1"
+	local platform=""
+	local recovery_root=""
+	local recovery_real=""
+
+	[[ -z "${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}" ]] || return 1
+	platform=$(uname -s 2>/dev/null) || return 1
+	[[ "$platform" != "Darwin" ]] || return 1
+	recovery_root=$(_worktree_recovery_store_root "$platform") || return 1
+	[[ -d "$recovery_root" && ! -L "$recovery_root" ]] || return 1
+	recovery_real=$(cd "$recovery_root" 2>/dev/null && pwd -P) || return 1
+	printf '%s\n' "$plan_json" | jq -e --arg root "$recovery_real" '
+		all(.entries[];
+			.bucket_path[0:(.bucket_path | rindex("/"))] == $root and
+			(.bucket_path | test("/aidevops-worktree-cleanup-[A-Za-z0-9._-]+$")))
+	' >/dev/null 2>&1
+	return $?
+}
+
+_worktree_recovery_cache_validate_plan() {
+	local plan_path="$1"
+	local canonical_plan=""
+	local plan_json=""
+	local plan_material=""
+	local plan_digest=""
+	local expected_plan_id=""
+	local policy_json=""
+	local expected_authorization=""
+	local plan_file_digest=""
+	local plan_file_id=""
+	local candidate_count=""
+	local candidate_bytes=""
+
+	WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA=""
+	WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON=""
+	canonical_plan=$(_worktree_recovery_apply_canonical_path "$plan_path") || return 1
+	[[ -f "$canonical_plan" && ! -L "$canonical_plan" && -r "$canonical_plan" ]] || return 1
+	plan_json=$(<"$canonical_plan")
+	[[ -n "$plan_json" ]] || return 1
+	_worktree_recovery_cache_validate_plan_shape "$plan_json" || return 1
+	_worktree_recovery_cache_validate_candidate_roots "$plan_json" || return 1
+	plan_material=$(_worktree_recovery_cache_plan_material_json "$plan_json") || return 1
+	plan_digest=$(_worktree_recovery_plan_sha256_text "$plan_material") || return 1
+	expected_plan_id="sha256:$plan_digest"
+	[[ "$(printf '%s\n' "$plan_json" | jq -r '.plan_id')" == "$expected_plan_id" ]] || return 1
+	policy_json=$(printf '%s\n' "$plan_json" | jq -cS '.automatic_policy') || return 1
+	candidate_count=$(printf '%s\n' "$plan_json" | jq -r '.candidate_count') || return 1
+	candidate_bytes=$(printf '%s\n' "$plan_json" | jq -r '.expected_allocated_bytes') || return 1
+	expected_authorization=$(_worktree_recovery_cache_automatic_token \
+		"$expected_plan_id" "$policy_json" "$candidate_count" "$candidate_bytes") || return 1
+	[[ "$(printf '%s\n' "$plan_json" | jq -r '.confirmation_token')" == "$expected_authorization" ]] || return 1
+	plan_file_digest=$(_worktree_recovery_plan_sha256_text "$plan_json") || return 1
+	plan_file_id=$(printf 'sha256:%s' "$plan_file_digest") || return 1
+	WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA=$(jq -cn \
+		--arg plan_path "$canonical_plan" --arg plan_id "$expected_plan_id" \
+		--arg plan_digest "$plan_file_id" --arg confirmation "$expected_authorization" \
+		--argjson candidate_count "$candidate_count" --argjson candidate_bytes "$candidate_bytes" \
+		--argjson automatic_policy "$policy_json" \
+		'{plan_path:$plan_path,plan_id:$plan_id,plan_digest:$plan_digest,
+		confirmation:$confirmation,candidate_count:$candidate_count,candidate_bytes:$candidate_bytes,
+		automatic_policy:$automatic_policy}') || return 1
+	WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON="$plan_json"
+	return 0
+}
+
+_worktree_recovery_cache_validate_recovery_identities() {
+	local plan_json="$1"
+	local row_json=""
+	local bucket_path=""
+	local expected_identity=""
+	local current_identity=""
+
+	while IFS= read -r row_json; do
+		bucket_path=$(printf '%s\n' "$row_json" | jq -r '.bucket_path') || return 1
+		expected_identity=$(printf '%s\n' "$row_json" | jq -cS '.recovery_identity') || return 1
+		current_identity=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
+		current_identity=$(printf '%s\n' "$current_identity" | jq -cS '.') || return 1
+		[[ "$current_identity" == "$expected_identity" ]] || return 1
+	done < <(printf '%s\n' "$plan_json" | jq -c \
+		'[.entries[] | {bucket_path,recovery_identity}] | unique_by(.bucket_path)[]')
+	return 0
+}
+
+_worktree_recovery_cache_transaction_entries() {
+	local plan_json="$1"
+	local transaction_id="$2"
+
+	printf '%s\n' "$plan_json" | jq -c \
+		--arg transaction_id "$transaction_id" \
+		--arg trash_segment "$WORKTREE_RECOVERY_APPLY_TRASH_SEGMENT" \
+		--arg planned "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" \
+		--arg pending "$WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING" '
+		def parent_path: .[0:rindex("/")];
+		def base_name: .[rindex("/") + 1:];
+		.entries | to_entries | map(
+			.key as $index | .value as $entry |
+			{index:$index,role:$entry.role,original_path:$entry.original_path,
+			staged_path:(($entry.original_path | parent_path) + $trash_segment + $transaction_id +
+				"/cache-" + ($index | tostring) + "-" + ($entry.original_path | base_name)),
+			archive_name:($entry.original_path | base_name),
+			expected_allocated_bytes:$entry.expected_allocated_bytes,
+			identity:{recovery:$entry.recovery_identity,path_identity:$entry.path_identity,
+				relative_path:$entry.relative_path,archive_path:$entry.archive_path},
+			evidence:$entry.evidence,reasons:$entry.reasons,
+			maintenance:{operation:"cache-prune",relative_path:$entry.relative_path},
+			state:$planned,observed_allocated_bytes:null,staged_at:null,removed_at:null,outcome:$pending})
+	'
+	return $?
+}
+
+_worktree_recovery_cache_policy_helper() {
+	local mode="$1"
+	shift
+	local helper_path="${WORKTREE_RECOVERY_LIFECYCLE_DIR}/worktree-recovery-cache-policy.py"
+
+	command -v python3 >/dev/null 2>&1 || return 1
+	[[ -f "$helper_path" && ! -L "$helper_path" ]] || return 1
+	python3 "$helper_path" "$mode" "$@"
+	return $?
+}
+
+_worktree_recovery_cache_validate_original_entry() {
+	local row_json="$1"
+	local deadline_epoch="$2"
+	local original_path=""
+	local archive_path=""
+	local relative_path=""
+	local expected_identity=""
+	local expected_bytes=""
+	local git_bin=""
+
+	original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
+	archive_path=$(printf '%s\n' "$row_json" | jq -r '.identity.archive_path') || return 1
+	relative_path=$(printf '%s\n' "$row_json" | jq -r '.identity.relative_path') || return 1
+	expected_identity=$(printf '%s\n' "$row_json" | jq -r '.identity.path_identity') || return 1
+	expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+	[[ "$original_path" == "${archive_path}/${relative_path}" ]] || return 1
+	git_bin=$(_worktree_cleanup_real_git) || return 1
+	_worktree_recovery_cache_policy_helper validate-original "$archive_path" "$relative_path" \
+		"$expected_identity" "$expected_bytes" "$git_bin" "$deadline_epoch"
+	return $?
+}
+
+_worktree_recovery_cache_validate_staged_entry() {
+	local row_json="$1"
+	local deadline_epoch="$2"
+	local staged_path=""
+	local expected_identity=""
+	local expected_bytes=""
+
+	staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+	expected_identity=$(printf '%s\n' "$row_json" | jq -r '.identity.path_identity') || return 1
+	expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+	_worktree_recovery_cache_policy_helper validate-staged "$staged_path" \
+		"$expected_identity" "$expected_bytes" "$deadline_epoch"
+	return $?
+}
+
+_worktree_recovery_cache_reconcile_entries() {
+	local journal_path="$1"
+	local deadline_epoch="$2"
+	local row_json='' state='' index='' original_path='' staged_path='' expected_bytes='' timestamp=''
+
+	while IFS= read -r row_json; do
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
+		index=$(printf '%s\n' "$row_json" | jq -r '.index') || return 1
+		original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
+		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+		expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+		if [[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" &&
+			! -e "$original_path" && ! -L "$original_path" && -d "$staged_path" && ! -L "$staged_path" ]]; then
+			_worktree_recovery_cache_validate_staged_entry "$row_json" "$deadline_epoch" || return 1
+			timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+			_worktree_recovery_apply_update_entry "$journal_path" "$index" \
+				"$WORKTREE_RECOVERY_APPLY_STATE_STAGED" "$expected_bytes" "$timestamp" \
+				"$WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING" || return 1
+		elif [[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" &&
+			! -e "$original_path" && ! -L "$original_path" && ! -e "$staged_path" && ! -L "$staged_path" ]]; then
+			timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+			_worktree_recovery_apply_update_entry "$journal_path" "$index" \
+				"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" "$expected_bytes" "$timestamp" \
+				"$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" || return 1
+		fi
+	done < <(jq -c '.entries[]' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_cache_preflight_journal() {
+	local journal_path="$1"
+	local deadline_epoch="$2"
+	local row_json='' state='' original_path='' staged_path=''
+
+	while IFS= read -r row_json; do
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
+		original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
+		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+		case "$state" in
+		"$WORKTREE_RECOVERY_APPLY_STATE_PLANNED")
+			_worktree_recovery_cache_validate_original_entry "$row_json" "$deadline_epoch" || return 1
+			;;
+		"$WORKTREE_RECOVERY_APPLY_STATE_STAGED")
+			_worktree_recovery_cache_validate_staged_entry "$row_json" "$deadline_epoch" || return 1
+			;;
+		"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED")
+			[[ ! -e "$original_path" && ! -L "$original_path" &&
+				! -e "$staged_path" && ! -L "$staged_path" ]] || return 1
+			;;
+		*) return 1 ;;
+		esac
+	done < <(jq -c '.entries[]' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_cache_stage_entries() {
+	local journal_path="$1"
+	local deadline_epoch="$2"
+	local row_json='' state='' index='' original_path='' staged_path='' expected_bytes='' timestamp=''
+
+	while IFS= read -r row_json; do
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
+		[[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" ]] || continue
+		index=$(printf '%s\n' "$row_json" | jq -r '.index') || return 1
+		original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
+		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+		expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+		_worktree_recovery_cache_validate_original_entry "$row_json" "$deadline_epoch" || return 1
+		mv "$original_path" "$staged_path" || return 1
+		[[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_MOVE:-0}" != "1" ]] || return 1
+		timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+		_worktree_recovery_apply_update_entry "$journal_path" "$index" \
+			"$WORKTREE_RECOVERY_APPLY_STATE_STAGED" "$expected_bytes" "$timestamp" \
+			"$WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING" || return 1
+	done < <(jq -c '.entries[]' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_cache_validate_all_staged() {
+	local journal_path="$1"
+	local deadline_epoch="$2"
+	local row_json='' state=''
+
+	while IFS= read -r row_json; do
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
+		case "$state" in
+		"$WORKTREE_RECOVERY_APPLY_STATE_STAGED")
+			_worktree_recovery_cache_validate_staged_entry "$row_json" "$deadline_epoch" || return 1
+			;;
+		"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED") ;;
+		*) return 1 ;;
+		esac
+	done < <(jq -c '.entries[]' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_cache_remove_staged() {
+	local journal_path="$1"
+	local deadline_epoch="$2"
+	local row_json='' state='' index='' staged_path='' expected_bytes='' timestamp=''
+	local removed_this_run=0
+
+	while IFS= read -r row_json; do
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
+		[[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" ]] || continue
+		index=$(printf '%s\n' "$row_json" | jq -r '.index') || return 1
+		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+		expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+		_worktree_recovery_cache_validate_staged_entry "$row_json" "$deadline_epoch" || return 1
+		rm -rf -- "$staged_path" || return 1
+		[[ ! -e "$staged_path" && ! -L "$staged_path" ]] || return 1
+		[[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_DELETE:-0}" != "1" ]] || return 1
+		timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+		_worktree_recovery_apply_update_entry "$journal_path" "$index" \
+			"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" "$expected_bytes" "$timestamp" \
+			"$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" || return 1
+		removed_this_run=$((removed_this_run + 1))
+		if [[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_REMOVE:-0}" == "1" &&
+			"$removed_this_run" -eq 1 ]]; then
+			return 1
+		fi
+	done < <(jq -c '.entries[]' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_cache_apply_under_lock() {
+	local plan_path="$1"
+	local receipt_path="$2"
+	local recovery_root="$3"
+	local apply_metadata="" plan_json="" plan_digest="" transaction_id="" entries_json=""
+	local transaction_dir="" journal_path="" expected_journal="" started_at="" journal_json=""
+	local source_root="" receipt_json="" deadline_seconds="" deadline_epoch=0 receipt_status=0
+
+	_worktree_recovery_cache_validate_plan "$plan_path" || return 1
+	apply_metadata="$WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA"
+	plan_json="$WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON"
+	_worktree_recovery_cache_validate_recovery_identities "$plan_json" || return 1
+	printf '%s\n' "$plan_json" | jq -e --arg receipt "$receipt_path" '
+		all(.entries[]; . as $entry | ($receipt | startswith($entry.bucket_path + "/") | not))
+	' >/dev/null 2>&1 || return 1
+	plan_digest=$(printf '%s\n' "$apply_metadata" | jq -r '.plan_digest | sub("^sha256:"; "")') || return 1
+	transaction_id="cache-${plan_digest}"
+	entries_json=$(_worktree_recovery_cache_transaction_entries "$plan_json" "$transaction_id") || return 1
+	transaction_dir="${recovery_root}/.retention-trash/${transaction_id}"
+	journal_path="${transaction_dir}/journal.json"
+	_worktree_recovery_apply_ensure_receipt_reservation \
+		"$receipt_path" "$apply_metadata" "$transaction_id" || receipt_status=$?
+	[[ "$receipt_status" -ne 2 ]] || return 0
+	[[ "$receipt_status" -eq 0 ]] || return "$receipt_status"
+	[[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_RECEIPT_RESERVATION:-0}" != "1" ]] || return 1
+	deadline_seconds=$(printf '%s\n' "$plan_json" | jq -r '.automatic_policy.deadline_seconds') || return 1
+	deadline_epoch=$(($(date +%s) + deadline_seconds)) || return 1
+	if [[ -f "$journal_path" && ! -L "$journal_path" ]]; then
+		started_at=$(jq -r '.started_at // empty' "$journal_path") || return 1
+	else
+		[[ ! -e "$journal_path" && ! -L "$journal_path" ]] || return 1
+		_worktree_recovery_apply_validate_uninitialized_transaction_dirs \
+			"$recovery_root" "$entries_json" "$transaction_id" "$journal_path" || return 1
+		started_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	fi
+	expected_journal=$(_worktree_recovery_apply_expected_journal \
+		"$transaction_id" "$apply_metadata" "$entries_json" "$started_at") || return 1
+	expected_journal=$(printf '%s\n' "$expected_journal" | jq -c \
+		--arg schema "$WORKTREE_RECOVERY_CACHE_TRANSACTION_SCHEMA" '.schema = $schema') || return 1
+	if [[ -f "$journal_path" ]]; then
+		_worktree_recovery_apply_validate_existing_journal "$journal_path" "$expected_journal" || return 1
+		_worktree_recovery_apply_discard_next_file "$journal_path" || return 1
+	else
+		_worktree_recovery_apply_prepare_transaction_dir "$recovery_root" "$transaction_id" || return 1
+		while IFS= read -r source_root; do
+			_worktree_recovery_apply_prepare_transaction_dir "$source_root" "$transaction_id" || return 1
+		done < <(printf '%s\n' "$entries_json" | jq -r '
+			[.[] | .original_path[0:(.original_path | rindex("/"))]] | unique[]')
+		[[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_TRANSACTION_DIR:-0}" != "1" ]] || return 1
+		journal_json="$expected_journal"
+		_worktree_recovery_apply_atomic_replace "$journal_path" "$journal_json" || return 1
+	fi
+	_worktree_recovery_apply_validate_transaction_scope "$journal_path" || return 1
+	_worktree_recovery_cache_reconcile_entries "$journal_path" "$deadline_epoch" || return 1
+	_worktree_recovery_cache_preflight_journal "$journal_path" "$deadline_epoch" || return 1
+	_worktree_recovery_cache_stage_entries "$journal_path" "$deadline_epoch" || return 1
+	[[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_STAGE:-0}" != "1" ]] || return 1
+	_worktree_recovery_cache_validate_all_staged "$journal_path" "$deadline_epoch" || return 1
+	_worktree_recovery_cache_remove_staged "$journal_path" "$deadline_epoch" || return 1
+	receipt_json=$(_worktree_recovery_apply_receipt_json "$journal_path" "$apply_metadata") || return 1
+	_worktree_recovery_apply_publish_reserved_receipt \
+		"$receipt_path" "$apply_metadata" "$transaction_id" "$receipt_json" || return 1
+	_worktree_recovery_apply_cleanup_transaction "$journal_path" || return 1
+	return 0
+}
+
+worktree_recovery_cache_prune_apply_automatic() {
+	local plan_path="$1"
+	local receipt_path="$2"
+	local plan_json="" recovery_root="" recovery_root_real="" apply_status=0
+	local platform=""
+
+	command -v jq >/dev/null 2>&1 || return 1
+	_worktree_recovery_cache_validate_plan "$plan_path" || return 1
+	plan_json="$WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON"
+	receipt_path=$(_worktree_recovery_apply_canonical_path "$receipt_path") || return 1
+	printf '%s\n' "$plan_json" | jq -e --arg receipt "$receipt_path" '
+		all(.entries[]; . as $entry | ($receipt | startswith($entry.bucket_path + "/") | not))
+	' >/dev/null 2>&1 || return 1
+	platform=$(uname -s 2>/dev/null) || return 1
+	recovery_root=$(_worktree_recovery_store_root "$platform") || return 1
+	[[ -d "$recovery_root" && ! -L "$recovery_root" ]] || return 1
+	recovery_root_real=$(cd "$recovery_root" 2>/dev/null && pwd -P) || return 1
+	_worktree_recovery_acquire_producer_lock "$recovery_root_real" || return 1
+	_worktree_recovery_cache_apply_under_lock \
+		"$plan_path" "$receipt_path" "$recovery_root_real" || apply_status=$?
 	_worktree_recovery_release_producer_lock || apply_status=1
 	[[ "$apply_status" -eq 0 ]] || return "$apply_status"
 	printf '%s\n' "$receipt_path"

--- a/.agents/scripts/worktree-recovery-cache-policy.py
+++ b/.agents/scripts/worktree-recovery-cache-policy.py
@@ -3,12 +3,17 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 """Classify and prune explicitly regenerable worktree cache directories."""
 
+import json
 import os
 from pathlib import Path, PurePosixPath
 import shutil
+import stat
 import subprocess
 import sys
+import time
 from typing import List, Optional, Set, Tuple
+
+CACHE_MANIFEST_SCHEMA = "aidevops.worktree-recovery-cache-manifest/v1"
 
 SAFE_COMPONENTS = {
     "node_modules",
@@ -85,19 +90,202 @@ def status_has_user_data(status_path: Path, archive_root: Path, git_bin: str) ->
 
 
 def git_output(
-    git_bin: str, source_root: Path, arguments: List[str]
+    git_bin: str,
+    source_root: Path,
+    arguments: List[str],
+    deadline_epoch: Optional[int] = None,
 ) -> Tuple[int, bytes]:
     """Run one read-only Git query with bounded captured output."""
+    timeout = None
+    if deadline_epoch is not None:
+        timeout = deadline_epoch - time.time()
+        if timeout <= 0:
+            return 124, b""
     try:
         result = subprocess.run(
             [git_bin, "-C", str(source_root), *arguments],
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
+            timeout=timeout,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return 2, b""
     return result.returncode, result.stdout
+
+
+def allocated_bytes(root: Path, deadline_epoch: int) -> Optional[int]:
+    """Measure allocated bytes without following symlink entries or hard links."""
+    total = 0
+    stack = [root]
+    while stack:
+        if time.time() >= deadline_epoch:
+            return None
+        current = stack.pop()
+        try:
+            metadata = current.lstat()
+        except OSError:
+            return None
+        if current == root and (not stat.S_ISDIR(metadata.st_mode) or current.is_symlink()):
+            return None
+        if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1:
+            return None
+        total += metadata.st_blocks * 512
+        if not stat.S_ISDIR(metadata.st_mode):
+            continue
+        try:
+            with os.scandir(current) as children:
+                stack.extend(Path(child.path) for child in children)
+        except OSError:
+            return None
+    return total
+
+
+def exact_safe_root(relative_path: str) -> Optional[Tuple[str, ...]]:
+    """Return a safe root only when the supplied path is exactly that root."""
+    parts = PurePosixPath(relative_path).parts
+    return parts if safe_root(relative_path) == parts else None
+
+
+def root_identity(path: Path) -> Optional[str]:
+    """Return a non-following device/inode identity for an ordinary directory."""
+    try:
+        metadata = path.lstat()
+    except OSError:
+        return None
+    if not stat.S_ISDIR(metadata.st_mode) or path.is_symlink():
+        return None
+    return f"{metadata.st_dev}:{metadata.st_ino}"
+
+
+def ignored_untracked_root(
+    archive_root: Path,
+    relative_root: str,
+    git_bin: str,
+    deadline_epoch: int,
+) -> bool:
+    """Prove that an exact approved root is ignored and contains no tracked path."""
+    ignored_rc, _ = git_output(
+        git_bin, archive_root, ["check-ignore", "-q", "--", relative_root], deadline_epoch
+    )
+    if ignored_rc != 0:
+        return False
+    tracked_rc, tracked = git_output(
+        git_bin, archive_root, ["ls-files", "-z", "--", relative_root], deadline_epoch
+    )
+    return tracked_rc == 0 and not tracked
+
+
+def cache_manifest(
+    archive_root: Path,
+    git_bin: str,
+    max_roots: int,
+    max_bytes: int,
+    deadline_epoch: int,
+) -> Optional[dict]:
+    """Build a bounded typed manifest of currently safe cache roots."""
+    if (
+        not archive_root.is_absolute()
+        or not archive_root.is_dir()
+        or archive_root.is_symlink()
+        or max_roots < 1
+        or max_bytes < 1
+        or time.time() >= deadline_epoch
+    ):
+        return None
+    status_rc, raw_status = git_output(
+        git_bin,
+        archive_root,
+        ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignored=matching"],
+        deadline_epoch,
+    )
+    if status_rc != 0:
+        return None
+    roots: Set[Tuple[str, ...]] = set()
+    for state_value, relative_path in status_records(raw_status):
+        root_parts = safe_root(relative_path) if state_value == b"!!" else None
+        if root_parts is not None:
+            roots.add(root_parts)
+    selected = []
+    selected_bytes = 0
+    inspected = 0
+    deferred = 0
+    deadline_exhausted = False
+    for root_parts in sorted(roots):
+        if time.time() >= deadline_epoch:
+            deadline_exhausted = True
+            deferred += len(roots) - inspected
+            break
+        inspected += 1
+        relative_root = "/".join(root_parts)
+        candidate = ordinary_directory(archive_root, root_parts)
+        if candidate is None or not ignored_untracked_root(
+            archive_root, relative_root, git_bin, deadline_epoch
+        ):
+            continue
+        identity = root_identity(candidate)
+        measured_bytes = allocated_bytes(candidate, deadline_epoch)
+        if identity is None or measured_bytes is None or measured_bytes <= 0:
+            continue
+        if len(selected) >= max_roots or selected_bytes + measured_bytes > max_bytes:
+            deferred += 1
+            continue
+        selected.append(
+            {
+                "relative_path": relative_root,
+                "expected_allocated_bytes": measured_bytes,
+                "path_identity": identity,
+            }
+        )
+        selected_bytes += measured_bytes
+    return {
+        "schema": CACHE_MANIFEST_SCHEMA,
+        "complete": not deadline_exhausted,
+        "deadline_exhausted": deadline_exhausted,
+        "inspected_root_count": inspected,
+        "deferred_root_count": deferred,
+        "candidate_count": len(selected),
+        "candidate_bytes": selected_bytes,
+        "entries": selected,
+    }
+
+
+def validate_original_root(
+    archive_root: Path,
+    relative_path: str,
+    expected_identity: str,
+    expected_bytes: int,
+    git_bin: str,
+    deadline_epoch: int,
+) -> int:
+    """Revalidate one manifest root immediately before it is staged."""
+    root_parts = exact_safe_root(relative_path)
+    if root_parts is None or time.time() >= deadline_epoch:
+        return 2
+    candidate = ordinary_directory(archive_root, root_parts)
+    if candidate is None or not ignored_untracked_root(
+        archive_root, relative_path, git_bin, deadline_epoch
+    ):
+        return 2
+    measured_bytes = allocated_bytes(candidate, deadline_epoch)
+    if root_identity(candidate) != expected_identity or measured_bytes != expected_bytes:
+        return 2
+    return 0
+
+
+def validate_staged_root(
+    staged_path: Path,
+    expected_identity: str,
+    expected_bytes: int,
+    deadline_epoch: int,
+) -> int:
+    """Validate one already-staged cache root for interruption recovery."""
+    if not staged_path.is_absolute() or time.time() >= deadline_epoch:
+        return 2
+    measured_bytes = allocated_bytes(staged_path, deadline_epoch)
+    if root_identity(staged_path) != expected_identity or measured_bytes != expected_bytes:
+        return 2
+    return 0
 
 
 def prune_caches(source_root: Path, archive_root: Path, git_bin: str) -> int:
@@ -135,18 +323,56 @@ def prune_caches(source_root: Path, archive_root: Path, git_bin: str) -> int:
 
 def main() -> int:
     """Dispatch status or prune mode with fail-closed path validation."""
-    if len(sys.argv) != 5:
-        return 2
-    mode, source_raw, archive_raw, git_bin = sys.argv[1:]
-    archive_root = Path(archive_raw)
-    if not archive_root.is_dir() or archive_root.is_symlink():
-        return 2
-    if mode == "status":
-        return status_has_user_data(Path(source_raw), archive_root, git_bin)
-    source_root = Path(source_raw)
-    if mode != "prune" or not source_root.is_dir() or source_root.is_symlink():
-        return 2
-    return prune_caches(source_root, archive_root, git_bin)
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode in {"status", "prune"} and len(sys.argv) == 5:
+        _, source_raw, archive_raw, git_bin = sys.argv[1:]
+        archive_root = Path(archive_raw)
+        if not archive_root.is_dir() or archive_root.is_symlink():
+            return 2
+        if mode == "status":
+            return status_has_user_data(Path(source_raw), archive_root, git_bin)
+        source_root = Path(source_raw)
+        if not source_root.is_dir() or source_root.is_symlink():
+            return 2
+        return prune_caches(source_root, archive_root, git_bin)
+    if mode == "manifest" and len(sys.argv) == 7:
+        _, archive_raw, git_bin, max_roots_raw, max_bytes_raw, deadline_raw = sys.argv[
+            1:
+        ]
+        try:
+            manifest = cache_manifest(
+                Path(archive_raw),
+                git_bin,
+                int(max_roots_raw),
+                int(max_bytes_raw),
+                int(deadline_raw),
+            )
+        except ValueError:
+            return 2
+        if manifest is None:
+            return 2
+        print(json.dumps(manifest, sort_keys=True, separators=(",", ":")))
+        return 0
+    if mode == "validate-original" and len(sys.argv) == 8:
+        _, archive_raw, relative_path, identity, bytes_raw, git_bin, deadline_raw = sys.argv[1:]
+        try:
+            return validate_original_root(
+                Path(archive_raw),
+                relative_path,
+                identity,
+                int(bytes_raw),
+                git_bin,
+                int(deadline_raw),
+            )
+        except ValueError:
+            return 2
+    if mode == "validate-staged" and len(sys.argv) == 6:
+        _, staged_raw, identity, bytes_raw, deadline_raw = sys.argv[1:]
+        try:
+            return validate_staged_root(Path(staged_raw), identity, int(bytes_raw), int(deadline_raw))
+        except ValueError:
+            return 2
+    return 2
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/worktree-recovery-cache-policy.py
+++ b/.agents/scripts/worktree-recovery-cache-policy.py
@@ -6,7 +6,9 @@
 import json
 import os
 from pathlib import Path, PurePosixPath
+import selectors
 import shutil
+import signal
 import stat
 import subprocess
 import sys
@@ -14,6 +16,8 @@ import time
 from typing import List, Optional, Set, Tuple
 
 CACHE_MANIFEST_SCHEMA = "aidevops.worktree-recovery-cache-manifest/v1"
+GIT_OUTPUT_MAX_BYTES = 1024 * 1024
+GIT_OUTPUT_LIMIT_RC = 125
 
 SAFE_COMPONENTS = {
     "node_modules",
@@ -65,12 +69,13 @@ def status_records(raw: bytes):
         yield record[:2], os.fsdecode(record[3:])
 
 
-def status_has_user_data(status_path: Path, archive_root: Path, git_bin: str) -> int:
+def status_bytes_have_user_data(
+    raw_status: bytes,
+    archive_root: Path,
+    git_bin: str,
+    deadline_epoch: Optional[int] = None,
+) -> int:
     """Return 0 for protected data, 1 for recognised caches only, 2 on uncertainty."""
-    try:
-        raw_status = status_path.read_bytes()
-    except OSError:
-        return 2
     checked: Set[Tuple[str, ...]] = set()
     for state, relative_path in status_records(raw_status):
         root_parts = safe_root(relative_path) if state == b"!!" else None
@@ -79,7 +84,10 @@ def status_has_user_data(status_path: Path, archive_root: Path, git_bin: str) ->
         if root_parts in checked:
             continue
         tracked_rc, tracked = git_output(
-            git_bin, archive_root, ["ls-files", "-z", "--", "/".join(root_parts)]
+            git_bin,
+            archive_root,
+            ["ls-files", "-z", "--", "/".join(root_parts)],
+            deadline_epoch,
         )
         if tracked_rc != 0:
             return 2
@@ -89,6 +97,30 @@ def status_has_user_data(status_path: Path, archive_root: Path, git_bin: str) ->
     return 1
 
 
+def status_has_user_data(status_path: Path, archive_root: Path, git_bin: str) -> int:
+    """Classify a previously captured status file."""
+    try:
+        raw_status = status_path.read_bytes()
+    except OSError:
+        return 2
+    return status_bytes_have_user_data(raw_status, archive_root, git_bin)
+
+
+def bounded_git_state(
+    archive_root: Path, git_bin: str, deadline_epoch: Optional[int]
+) -> int:
+    """Classify current Git state without an unbounded status capture."""
+    status_rc, raw_status = git_output(
+        git_bin,
+        archive_root,
+        ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignored=matching"],
+        deadline_epoch,
+    )
+    if status_rc != 0:
+        return 2
+    return status_bytes_have_user_data(raw_status, archive_root, git_bin, deadline_epoch)
+
+
 def git_output(
     git_bin: str,
     source_root: Path,
@@ -96,22 +128,77 @@ def git_output(
     deadline_epoch: Optional[int] = None,
 ) -> Tuple[int, bytes]:
     """Run one read-only Git query with bounded captured output."""
-    timeout = None
-    if deadline_epoch is not None:
-        timeout = deadline_epoch - time.time()
-        if timeout <= 0:
-            return 124, b""
+    def stop_process(process: subprocess.Popen) -> None:
+        """Stop the Git process group after a resource limit is reached."""
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except (OSError, ProcessLookupError):
+            pass
+        try:
+            process.wait(timeout=0.2)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            pass
+        try:
+            process.wait(timeout=0.2)
+        except subprocess.TimeoutExpired:
+            pass
+
+    if deadline_epoch is not None and deadline_epoch <= time.time():
+        return 124, b""
+    git_environment = os.environ.copy()
+    git_environment["GIT_OPTIONAL_LOCKS"] = "0"
     try:
-        result = subprocess.run(
+        process = subprocess.Popen(
             [git_bin, "-C", str(source_root), *arguments],
-            check=False,
+            env=git_environment,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            timeout=timeout,
+            start_new_session=True,
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except OSError:
         return 2, b""
-    return result.returncode, result.stdout
+    if process.stdout is None:
+        stop_process(process)
+        return 2, b""
+    output = bytearray()
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ)
+    try:
+        while True:
+            if deadline_epoch is not None:
+                remaining = deadline_epoch - time.time()
+                if remaining <= 0:
+                    stop_process(process)
+                    return 124, b""
+                wait_seconds = min(0.1, remaining)
+            else:
+                wait_seconds = 0.1
+            events = selector.select(wait_seconds)
+            if not events:
+                continue
+            chunk = os.read(process.stdout.fileno(), 65536)
+            if not chunk:
+                break
+            output.extend(chunk)
+            if len(output) > GIT_OUTPUT_MAX_BYTES:
+                stop_process(process)
+                return GIT_OUTPUT_LIMIT_RC, b""
+        wait_timeout = None
+        if deadline_epoch is not None:
+            wait_timeout = max(0.0, deadline_epoch - time.time())
+        try:
+            return process.wait(timeout=wait_timeout), bytes(output)
+        except subprocess.TimeoutExpired:
+            stop_process(process)
+            return 124, b""
+    finally:
+        selector.close()
+        process.stdout.close()
 
 
 def allocated_bytes(root: Path, deadline_epoch: int) -> Optional[int]:
@@ -288,6 +375,49 @@ def validate_staged_root(
     return 0
 
 
+def measure_staged_root(
+    staged_path: Path,
+    expected_identity: str,
+    expected_bytes: int,
+    deadline_epoch: int,
+) -> Optional[int]:
+    """Return the exact current allocation for one validated staged root."""
+    if not staged_path.is_absolute() or time.time() >= deadline_epoch:
+        return None
+    measured_bytes = allocated_bytes(staged_path, deadline_epoch)
+    if root_identity(staged_path) != expected_identity or measured_bytes != expected_bytes:
+        return None
+    return measured_bytes
+
+
+def validate_removing_root(
+    staged_path: Path,
+    expected_identity: str,
+    expected_bytes: int,
+    deadline_epoch: int,
+) -> int:
+    """Validate an isolated cache root that may be partly removed on retry."""
+    if not staged_path.is_absolute() or time.time() >= deadline_epoch:
+        return 2
+    if not staged_path.exists() and not staged_path.is_symlink():
+        return 0
+    measured_bytes = allocated_bytes(staged_path, deadline_epoch)
+    if (
+        root_identity(staged_path) != expected_identity
+        or measured_bytes is None
+        or measured_bytes > expected_bytes
+    ):
+        return 2
+    return 0
+
+
+def validate_removed_root(staged_path: Path, deadline_epoch: int) -> int:
+    """Prove the staged namespace has zero remaining allocated bytes."""
+    if not staged_path.is_absolute() or time.time() >= deadline_epoch:
+        return 2
+    return 0 if not staged_path.exists() and not staged_path.is_symlink() else 2
+
+
 def prune_caches(source_root: Path, archive_root: Path, git_bin: str) -> int:
     """Remove only ignored, untracked, recognised cache roots from an archive copy."""
     status_rc, raw_status = git_output(
@@ -335,6 +465,17 @@ def main() -> int:
         if not source_root.is_dir() or source_root.is_symlink():
             return 2
         return prune_caches(source_root, archive_root, git_bin)
+    if mode == "git-state" and len(sys.argv) == 5:
+        _, archive_raw, git_bin, deadline_raw = sys.argv[1:]
+        archive_root = Path(archive_raw)
+        if not archive_root.is_dir() or archive_root.is_symlink():
+            return 2
+        try:
+            deadline_value = int(deadline_raw)
+        except ValueError:
+            return 2
+        deadline_epoch = deadline_value if deadline_value > 0 else None
+        return bounded_git_state(archive_root, git_bin, deadline_epoch)
     if mode == "manifest" and len(sys.argv) == 7:
         _, archive_raw, git_bin, max_roots_raw, max_bytes_raw, deadline_raw = sys.argv[
             1:
@@ -370,6 +511,32 @@ def main() -> int:
         _, staged_raw, identity, bytes_raw, deadline_raw = sys.argv[1:]
         try:
             return validate_staged_root(Path(staged_raw), identity, int(bytes_raw), int(deadline_raw))
+        except ValueError:
+            return 2
+    if mode == "measure-staged" and len(sys.argv) == 6:
+        _, staged_raw, identity, bytes_raw, deadline_raw = sys.argv[1:]
+        try:
+            measured_bytes = measure_staged_root(
+                Path(staged_raw), identity, int(bytes_raw), int(deadline_raw)
+            )
+        except ValueError:
+            return 2
+        if measured_bytes is None:
+            return 2
+        print(measured_bytes)
+        return 0
+    if mode == "validate-removing" and len(sys.argv) == 6:
+        _, staged_raw, identity, bytes_raw, deadline_raw = sys.argv[1:]
+        try:
+            return validate_removing_root(
+                Path(staged_raw), identity, int(bytes_raw), int(deadline_raw)
+            )
+        except ValueError:
+            return 2
+    if mode == "validate-removed" and len(sys.argv) == 4:
+        _, staged_raw, deadline_raw = sys.argv[1:]
+        try:
+            return validate_removed_root(Path(staged_raw), int(deadline_raw))
         except ValueError:
             return 2
     return 2

--- a/.agents/scripts/worktree-recovery-cache-policy.py
+++ b/.agents/scripts/worktree-recovery-cache-policy.py
@@ -171,40 +171,59 @@ def start_git_process(
     return process
 
 
+def stream_wait_seconds(deadline_epoch: Optional[int]) -> Optional[float]:
+    """Return a short stream wait or None once the shared deadline expires."""
+    if deadline_epoch is None:
+        return 0.1
+    remaining = deadline_epoch - time.time()
+    return min(0.1, remaining) if remaining > 0 else None
+
+
+def bounded_stream_output(
+    process: subprocess.Popen,
+    selector: selectors.BaseSelector,
+    deadline_epoch: Optional[int],
+) -> Tuple[Optional[int], bytearray]:
+    """Read bounded stdout, returning a terminal limit code or EOF marker."""
+    output = bytearray()
+    while True:
+        wait_seconds = stream_wait_seconds(deadline_epoch)
+        if wait_seconds is None:
+            return 124, bytearray()
+        events = selector.select(wait_seconds)
+        if not events:
+            continue
+        chunk = os.read(process.stdout.fileno(), 65536)
+        if not chunk:
+            return None, output
+        output.extend(chunk)
+        if len(output) > GIT_OUTPUT_MAX_BYTES:
+            return GIT_OUTPUT_LIMIT_RC, bytearray()
+
+
+def wait_for_process(
+    process: subprocess.Popen, deadline_epoch: Optional[int]
+) -> int:
+    """Wait for process completion without extending the shared deadline."""
+    wait_timeout = None
+    if deadline_epoch is not None:
+        wait_timeout = max(0.0, deadline_epoch - time.time())
+    try:
+        return process.wait(timeout=wait_timeout)
+    except subprocess.TimeoutExpired:
+        return 124
+
+
 def read_process_output(
     process: subprocess.Popen, deadline_epoch: Optional[int]
 ) -> Tuple[int, bytes]:
     """Capture bounded process output until EOF or the shared deadline."""
-    output = bytearray()
     selector = selectors.DefaultSelector()
     selector.register(process.stdout, selectors.EVENT_READ)
-    terminal_rc: Optional[int] = None
     try:
-        while terminal_rc is None:
-            remaining = None
-            if deadline_epoch is not None:
-                remaining = deadline_epoch - time.time()
-            if remaining is not None and remaining <= 0:
-                terminal_rc = 124
-                continue
-            wait_seconds = 0.1 if remaining is None else min(0.1, remaining)
-            events = selector.select(wait_seconds)
-            if not events:
-                continue
-            chunk = os.read(process.stdout.fileno(), 65536)
-            if not chunk:
-                break
-            output.extend(chunk)
-            if len(output) > GIT_OUTPUT_MAX_BYTES:
-                terminal_rc = GIT_OUTPUT_LIMIT_RC
+        terminal_rc, output = bounded_stream_output(process, selector, deadline_epoch)
         if terminal_rc is None:
-            wait_timeout = None
-            if deadline_epoch is not None:
-                wait_timeout = max(0.0, deadline_epoch - time.time())
-            try:
-                terminal_rc = process.wait(timeout=wait_timeout)
-            except subprocess.TimeoutExpired:
-                terminal_rc = 124
+            terminal_rc = wait_for_process(process, deadline_epoch)
         if terminal_rc in {124, GIT_OUTPUT_LIMIT_RC}:
             stop_process(process)
             output.clear()

--- a/.agents/scripts/worktree-recovery-cache-policy.py
+++ b/.agents/scripts/worktree-recovery-cache-policy.py
@@ -13,11 +13,19 @@ import stat
 import subprocess
 import sys
 import time
-from typing import List, Optional, Set, Tuple
+from typing import Callable, Dict, List, NamedTuple, Optional, Set, Tuple
 
 CACHE_MANIFEST_SCHEMA = "aidevops.worktree-recovery-cache-manifest/v1"
 GIT_OUTPUT_MAX_BYTES = 1024 * 1024
 GIT_OUTPUT_LIMIT_RC = 125
+
+
+class RootExpectation(NamedTuple):
+    """Immutable cache-root identity and allocation evidence."""
+
+    identity: str
+    allocated_bytes: int
+
 
 SAFE_COMPONENTS = {
     "node_modules",
@@ -121,24 +129,18 @@ def bounded_git_state(
     return status_bytes_have_user_data(raw_status, archive_root, git_bin, deadline_epoch)
 
 
-def git_output(
-    git_bin: str,
-    source_root: Path,
-    arguments: List[str],
-    deadline_epoch: Optional[int] = None,
-) -> Tuple[int, bytes]:
-    """Run one read-only Git query with bounded captured output."""
-    def stop_process(process: subprocess.Popen) -> None:
-        """Stop the Git process group after a resource limit is reached."""
-        try:
-            os.killpg(process.pid, signal.SIGTERM)
-        except (OSError, ProcessLookupError):
-            pass
-        try:
-            process.wait(timeout=0.2)
-            return
-        except subprocess.TimeoutExpired:
-            pass
+def stop_process(process: subprocess.Popen) -> None:
+    """Stop a Git process group after a resource limit is reached."""
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except (OSError, ProcessLookupError):
+        pass
+    try:
+        process.wait(timeout=0.2)
+        stopped = True
+    except subprocess.TimeoutExpired:
+        stopped = False
+    if not stopped:
         try:
             os.killpg(process.pid, signal.SIGKILL)
         except (OSError, ProcessLookupError):
@@ -148,36 +150,44 @@ def git_output(
         except subprocess.TimeoutExpired:
             pass
 
-    if deadline_epoch is not None and deadline_epoch <= time.time():
-        return 124, b""
+
+def start_git_process(
+    git_bin: str, source_root: Path, arguments: List[str]
+) -> Optional[subprocess.Popen]:
+    """Start one structured, non-shell Git query."""
     git_environment = os.environ.copy()
     git_environment["GIT_OPTIONAL_LOCKS"] = "0"
     try:
+        # The trusted caller resolves git_bin; structured argv disables shell parsing.
         process = subprocess.Popen(
             [git_bin, "-C", str(source_root), *arguments],
             env=git_environment,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             start_new_session=True,
-        )
+        )  # nosec B603
     except OSError:
-        return 2, b""
-    if process.stdout is None:
-        stop_process(process)
-        return 2, b""
+        return None
+    return process
+
+
+def read_process_output(
+    process: subprocess.Popen, deadline_epoch: Optional[int]
+) -> Tuple[int, bytes]:
+    """Capture bounded process output until EOF or the shared deadline."""
     output = bytearray()
     selector = selectors.DefaultSelector()
     selector.register(process.stdout, selectors.EVENT_READ)
+    terminal_rc: Optional[int] = None
     try:
-        while True:
+        while terminal_rc is None:
+            remaining = None
             if deadline_epoch is not None:
                 remaining = deadline_epoch - time.time()
-                if remaining <= 0:
-                    stop_process(process)
-                    return 124, b""
-                wait_seconds = min(0.1, remaining)
-            else:
-                wait_seconds = 0.1
+            if remaining is not None and remaining <= 0:
+                terminal_rc = 124
+                continue
+            wait_seconds = 0.1 if remaining is None else min(0.1, remaining)
             events = selector.select(wait_seconds)
             if not events:
                 continue
@@ -186,19 +196,63 @@ def git_output(
                 break
             output.extend(chunk)
             if len(output) > GIT_OUTPUT_MAX_BYTES:
-                stop_process(process)
-                return GIT_OUTPUT_LIMIT_RC, b""
-        wait_timeout = None
-        if deadline_epoch is not None:
-            wait_timeout = max(0.0, deadline_epoch - time.time())
-        try:
-            return process.wait(timeout=wait_timeout), bytes(output)
-        except subprocess.TimeoutExpired:
+                terminal_rc = GIT_OUTPUT_LIMIT_RC
+        if terminal_rc is None:
+            wait_timeout = None
+            if deadline_epoch is not None:
+                wait_timeout = max(0.0, deadline_epoch - time.time())
+            try:
+                terminal_rc = process.wait(timeout=wait_timeout)
+            except subprocess.TimeoutExpired:
+                terminal_rc = 124
+        if terminal_rc in {124, GIT_OUTPUT_LIMIT_RC}:
             stop_process(process)
-            return 124, b""
+            output.clear()
     finally:
         selector.close()
         process.stdout.close()
+    return terminal_rc, bytes(output)
+
+
+def git_output(
+    git_bin: str,
+    source_root: Path,
+    arguments: List[str],
+    deadline_epoch: Optional[int] = None,
+) -> Tuple[int, bytes]:
+    """Run one read-only Git query with bounded captured output."""
+    if deadline_epoch is not None and deadline_epoch <= time.time():
+        return 124, b""
+    process = start_git_process(git_bin, source_root, arguments)
+    if process is None or process.stdout is None:
+        if process is not None:
+            stop_process(process)
+        return 2, b""
+    return read_process_output(process, deadline_epoch)
+
+
+def allocated_entry(
+    root: Path, current: Path, deadline_epoch: int
+) -> Optional[Tuple[int, List[Path]]]:
+    """Measure one safe filesystem entry and return its children."""
+    try:
+        if time.time() >= deadline_epoch:
+            raise ValueError("allocation deadline expired")
+        metadata = current.lstat()
+        if current == root:
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise ValueError("cache root is not a directory")
+            if current.is_symlink():
+                raise ValueError("cache root is a symlink")
+        if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1:
+            raise ValueError("cache entry is hard linked")
+        children: List[Path] = []
+        if stat.S_ISDIR(metadata.st_mode):
+            with os.scandir(current) as entries:
+                children = [Path(entry.path) for entry in entries]
+    except (OSError, ValueError):
+        return None
+    return metadata.st_blocks * 512, children
 
 
 def allocated_bytes(root: Path, deadline_epoch: int) -> Optional[int]:
@@ -206,25 +260,13 @@ def allocated_bytes(root: Path, deadline_epoch: int) -> Optional[int]:
     total = 0
     stack = [root]
     while stack:
-        if time.time() >= deadline_epoch:
-            return None
         current = stack.pop()
-        try:
-            metadata = current.lstat()
-        except OSError:
+        measurement = allocated_entry(root, current, deadline_epoch)
+        if measurement is None:
             return None
-        if current == root and (not stat.S_ISDIR(metadata.st_mode) or current.is_symlink()):
-            return None
-        if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1:
-            return None
-        total += metadata.st_blocks * 512
-        if not stat.S_ISDIR(metadata.st_mode):
-            continue
-        try:
-            with os.scandir(current) as children:
-                stack.extend(Path(child.path) for child in children)
-        except OSError:
-            return None
+        allocated, children = measurement
+        total += allocated
+        stack.extend(children)
     return total
 
 
@@ -263,6 +305,40 @@ def ignored_untracked_root(
     return tracked_rc == 0 and not tracked
 
 
+def discovered_cache_roots(raw_status: bytes) -> Set[Tuple[str, ...]]:
+    """Collect recognised ignored cache roots from bounded status output."""
+    roots: Set[Tuple[str, ...]] = set()
+    for state_value, relative_path in status_records(raw_status):
+        root_parts = safe_root(relative_path) if state_value == b"!!" else None
+        if root_parts is not None:
+            roots.add(root_parts)
+    return roots
+
+
+def manifest_candidate(
+    archive_root: Path,
+    root_parts: Tuple[str, ...],
+    git_bin: str,
+    deadline_epoch: int,
+) -> Optional[dict]:
+    """Build one candidate only after identity and Git safety proofs pass."""
+    relative_root = "/".join(root_parts)
+    candidate = ordinary_directory(archive_root, root_parts)
+    if candidate is None or not ignored_untracked_root(
+        archive_root, relative_root, git_bin, deadline_epoch
+    ):
+        return None
+    identity = root_identity(candidate)
+    measured_bytes = allocated_bytes(candidate, deadline_epoch)
+    if identity is None or measured_bytes is None or measured_bytes <= 0:
+        return None
+    return {
+        "relative_path": relative_root,
+        "expected_allocated_bytes": measured_bytes,
+        "path_identity": identity,
+    }
+
+
 def cache_manifest(
     archive_root: Path,
     git_bin: str,
@@ -271,14 +347,11 @@ def cache_manifest(
     deadline_epoch: int,
 ) -> Optional[dict]:
     """Build a bounded typed manifest of currently safe cache roots."""
-    if (
-        not archive_root.is_absolute()
-        or not archive_root.is_dir()
-        or archive_root.is_symlink()
-        or max_roots < 1
-        or max_bytes < 1
-        or time.time() >= deadline_epoch
-    ):
+    if not archive_root.is_absolute() or not archive_root.is_dir():
+        return None
+    if archive_root.is_symlink() or max_roots < 1 or max_bytes < 1:
+        return None
+    if time.time() >= deadline_epoch:
         return None
     status_rc, raw_status = git_output(
         git_bin,
@@ -288,11 +361,7 @@ def cache_manifest(
     )
     if status_rc != 0:
         return None
-    roots: Set[Tuple[str, ...]] = set()
-    for state_value, relative_path in status_records(raw_status):
-        root_parts = safe_root(relative_path) if state_value == b"!!" else None
-        if root_parts is not None:
-            roots.add(root_parts)
+    roots = discovered_cache_roots(raw_status)
     selected = []
     selected_bytes = 0
     inspected = 0
@@ -304,26 +373,16 @@ def cache_manifest(
             deferred += len(roots) - inspected
             break
         inspected += 1
-        relative_root = "/".join(root_parts)
-        candidate = ordinary_directory(archive_root, root_parts)
-        if candidate is None or not ignored_untracked_root(
-            archive_root, relative_root, git_bin, deadline_epoch
-        ):
+        candidate = manifest_candidate(
+            archive_root, root_parts, git_bin, deadline_epoch
+        )
+        if candidate is None:
             continue
-        identity = root_identity(candidate)
-        measured_bytes = allocated_bytes(candidate, deadline_epoch)
-        if identity is None or measured_bytes is None or measured_bytes <= 0:
-            continue
+        measured_bytes = candidate["expected_allocated_bytes"]
         if len(selected) >= max_roots or selected_bytes + measured_bytes > max_bytes:
             deferred += 1
             continue
-        selected.append(
-            {
-                "relative_path": relative_root,
-                "expected_allocated_bytes": measured_bytes,
-                "path_identity": identity,
-            }
-        )
+        selected.append(candidate)
         selected_bytes += measured_bytes
     return {
         "schema": CACHE_MANIFEST_SCHEMA,
@@ -340,8 +399,7 @@ def cache_manifest(
 def validate_original_root(
     archive_root: Path,
     relative_path: str,
-    expected_identity: str,
-    expected_bytes: int,
+    expected: RootExpectation,
     git_bin: str,
     deadline_epoch: int,
 ) -> int:
@@ -355,7 +413,9 @@ def validate_original_root(
     ):
         return 2
     measured_bytes = allocated_bytes(candidate, deadline_epoch)
-    if root_identity(candidate) != expected_identity or measured_bytes != expected_bytes:
+    if root_identity(candidate) != expected.identity:
+        return 2
+    if measured_bytes != expected.allocated_bytes:
         return 2
     return 0
 
@@ -402,11 +462,9 @@ def validate_removing_root(
     if not staged_path.exists() and not staged_path.is_symlink():
         return 0
     measured_bytes = allocated_bytes(staged_path, deadline_epoch)
-    if (
-        root_identity(staged_path) != expected_identity
-        or measured_bytes is None
-        or measured_bytes > expected_bytes
-    ):
+    if root_identity(staged_path) != expected_identity or measured_bytes is None:
+        return 2
+    if measured_bytes > expected_bytes:
         return 2
     return 0
 
@@ -451,11 +509,10 @@ def prune_caches(source_root: Path, archive_root: Path, git_bin: str) -> int:
     return 0
 
 
-def main() -> int:
-    """Dispatch status or prune mode with fail-closed path validation."""
-    mode = sys.argv[1] if len(sys.argv) > 1 else ""
-    if mode in {"status", "prune"} and len(sys.argv) == 5:
-        _, source_raw, archive_raw, git_bin = sys.argv[1:]
+def handle_legacy_mode(arguments: List[str]) -> int:
+    """Handle the original status and prune command shapes."""
+    if len(arguments) == 4:
+        mode, source_raw, archive_raw, git_bin = arguments
         archive_root = Path(archive_raw)
         if not archive_root.is_dir() or archive_root.is_symlink():
             return 2
@@ -465,8 +522,13 @@ def main() -> int:
         if not source_root.is_dir() or source_root.is_symlink():
             return 2
         return prune_caches(source_root, archive_root, git_bin)
-    if mode == "git-state" and len(sys.argv) == 5:
-        _, archive_raw, git_bin, deadline_raw = sys.argv[1:]
+    return 2
+
+
+def handle_git_state(arguments: List[str]) -> int:
+    """Handle bounded current Git-state classification."""
+    if len(arguments) == 4:
+        _, archive_raw, git_bin, deadline_raw = arguments
         archive_root = Path(archive_raw)
         if not archive_root.is_dir() or archive_root.is_symlink():
             return 2
@@ -476,10 +538,13 @@ def main() -> int:
             return 2
         deadline_epoch = deadline_value if deadline_value > 0 else None
         return bounded_git_state(archive_root, git_bin, deadline_epoch)
-    if mode == "manifest" and len(sys.argv) == 7:
-        _, archive_raw, git_bin, max_roots_raw, max_bytes_raw, deadline_raw = sys.argv[
-            1:
-        ]
+    return 2
+
+
+def handle_manifest(arguments: List[str]) -> int:
+    """Handle bounded cache-manifest generation."""
+    if len(arguments) == 6:
+        _, archive_raw, git_bin, max_roots_raw, max_bytes_raw, deadline_raw = arguments
         try:
             manifest = cache_manifest(
                 Path(archive_raw),
@@ -494,27 +559,45 @@ def main() -> int:
             return 2
         print(json.dumps(manifest, sort_keys=True, separators=(",", ":")))
         return 0
-    if mode == "validate-original" and len(sys.argv) == 8:
-        _, archive_raw, relative_path, identity, bytes_raw, git_bin, deadline_raw = sys.argv[1:]
+    return 2
+
+
+def handle_validate_original(arguments: List[str]) -> int:
+    """Handle immediate original-root revalidation."""
+    if len(arguments) == 7:
+        _, archive_raw, relative_path, identity, bytes_raw, git_bin, deadline_raw = (
+            arguments
+        )
         try:
             return validate_original_root(
                 Path(archive_raw),
                 relative_path,
-                identity,
-                int(bytes_raw),
+                RootExpectation(identity, int(bytes_raw)),
                 git_bin,
                 int(deadline_raw),
             )
         except ValueError:
             return 2
-    if mode == "validate-staged" and len(sys.argv) == 6:
-        _, staged_raw, identity, bytes_raw, deadline_raw = sys.argv[1:]
+    return 2
+
+
+def handle_validate_staged(arguments: List[str]) -> int:
+    """Handle exact staged-root validation."""
+    if len(arguments) == 5:
+        _, staged_raw, identity, bytes_raw, deadline_raw = arguments
         try:
-            return validate_staged_root(Path(staged_raw), identity, int(bytes_raw), int(deadline_raw))
+            return validate_staged_root(
+                Path(staged_raw), identity, int(bytes_raw), int(deadline_raw)
+            )
         except ValueError:
             return 2
-    if mode == "measure-staged" and len(sys.argv) == 6:
-        _, staged_raw, identity, bytes_raw, deadline_raw = sys.argv[1:]
+    return 2
+
+
+def handle_measure_staged(arguments: List[str]) -> int:
+    """Handle independently measured staged allocation."""
+    if len(arguments) == 5:
+        _, staged_raw, identity, bytes_raw, deadline_raw = arguments
         try:
             measured_bytes = measure_staged_root(
                 Path(staged_raw), identity, int(bytes_raw), int(deadline_raw)
@@ -525,21 +608,54 @@ def main() -> int:
             return 2
         print(measured_bytes)
         return 0
-    if mode == "validate-removing" and len(sys.argv) == 6:
-        _, staged_raw, identity, bytes_raw, deadline_raw = sys.argv[1:]
+    return 2
+
+
+def handle_validate_removing(arguments: List[str]) -> int:
+    """Handle partially removed root validation."""
+    if len(arguments) == 5:
+        _, staged_raw, identity, bytes_raw, deadline_raw = arguments
         try:
             return validate_removing_root(
                 Path(staged_raw), identity, int(bytes_raw), int(deadline_raw)
             )
         except ValueError:
             return 2
-    if mode == "validate-removed" and len(sys.argv) == 4:
-        _, staged_raw, deadline_raw = sys.argv[1:]
+    return 2
+
+
+def handle_validate_removed(arguments: List[str]) -> int:
+    """Handle post-delete namespace validation."""
+    if len(arguments) == 3:
+        _, staged_raw, deadline_raw = arguments
         try:
             return validate_removed_root(Path(staged_raw), int(deadline_raw))
         except ValueError:
             return 2
     return 2
+
+
+MODE_HANDLERS: Dict[str, Callable[[List[str]], int]] = {
+    "status": handle_legacy_mode,
+    "prune": handle_legacy_mode,
+    "git-state": handle_git_state,
+    "manifest": handle_manifest,
+    "validate-original": handle_validate_original,
+    "validate-staged": handle_validate_staged,
+    "measure-staged": handle_measure_staged,
+    "validate-removing": handle_validate_removing,
+    "validate-removed": handle_validate_removed,
+}
+
+
+def main() -> int:
+    """Dispatch one fail-closed cache-policy mode."""
+    arguments = sys.argv[1:]
+    mode = arguments[0] if arguments else ""
+    handler = MODE_HANDLERS.get(mode)
+    if handler is None:
+        return 2
+    return handler(arguments)
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -509,28 +509,24 @@ _worktree_recovery_plan_identity_json() {
 _worktree_recovery_plan_git_state() {
 	local identity_json="$1"
 	local archive_path=""
-	local status_file=""
-	local status_rc=0
+	local helper_path="${WORKTREE_RECOVERY_LIFECYCLE_DIR}/worktree-recovery-cache-policy.py"
+	local git_bin=""
+	local deadline_epoch="${AIDEVOPS_WORKTREE_RECOVERY_EVIDENCE_DEADLINE_EPOCH:-0}"
 	local cache_policy_rc=0
 
 	archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
-	status_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/aidevops-worktree-recovery-status.XXXXXX") || {
-		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
-		return 0
-	}
-	GIT_OPTIONAL_LOCKS=0 git -C "$archive_path" status --porcelain=v1 -z \
-		--untracked-files=all --ignored=matching >"$status_file" 2>/dev/null || status_rc=$?
-	if [[ "$status_rc" -ne 0 ]]; then
-		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
-	else
-		_worktree_recovery_status_has_user_data "$status_file" "$archive_path" || cache_policy_rc=$?
-		case "$cache_policy_rc" in
-		0) printf '%s\n' "dirty" ;;
-		1) printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ;;
-		*) printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE" ;;
-		esac
-	fi
-	rm -f "$status_file"
+	case "$deadline_epoch" in
+	*[!0-9]* | '') deadline_epoch=0 ;;
+	esac
+	git_bin=$(_worktree_cleanup_real_git) || cache_policy_rc=2
+	[[ "$cache_policy_rc" -ne 0 ]] || [[ -f "$helper_path" && ! -L "$helper_path" ]] || cache_policy_rc=2
+	[[ "$cache_policy_rc" -ne 0 ]] || python3 "$helper_path" git-state "$archive_path" \
+		"$git_bin" "$deadline_epoch" >/dev/null 2>&1 || cache_policy_rc=$?
+	case "$cache_policy_rc" in
+	0) printf '%s\n' "dirty" ;;
+	1) printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ;;
+	*) printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE" ;;
+	esac
 	return 0
 }
 

--- a/.agents/scripts/worktree-recovery-maintenance-helper.sh
+++ b/.agents/scripts/worktree-recovery-maintenance-helper.sh
@@ -14,6 +14,8 @@ source "${WORKTREE_RECOVERY_MAINTENANCE_DIR}/disk-capacity-lib.sh"
 
 WORKTREE_RECOVERY_MAINTENANCE_RUN_SCHEMA="aidevops.worktree-recovery-maintenance-run/v1"
 WORKTREE_RECOVERY_MAINTENANCE_CYCLE_SCHEMA="aidevops.worktree-recovery-zero-candidate-cycle/v1"
+WORKTREE_RECOVERY_MAINTENANCE_JSON_NUMBER_TYPE='number'
+WORKTREE_RECOVERY_MAINTENANCE_OPERATION_CACHE_PRUNE='cache-prune'
 WORKTREE_RECOVERY_MAINTENANCE_LOCK_PATH=""
 WORKTREE_RECOVERY_MAINTENANCE_LOCK_TOKEN=""
 WORKTREE_RECOVERY_MAINTENANCE_SCANNED=0
@@ -51,6 +53,15 @@ WORKTREE_RECOVERY_MAINTENANCE_TEMP_INVENTORY=""
 WORKTREE_RECOVERY_MAINTENANCE_TEMP_ORDERED=""
 WORKTREE_RECOVERY_MAINTENANCE_TEMP_SELECTED=""
 WORKTREE_RECOVERY_MAINTENANCE_TEMP_REASONS=""
+WORKTREE_RECOVERY_MAINTENANCE_TEMP_CACHE_SELECTED=""
+WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED=0
+WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED_BYTES=0
+WORKTREE_RECOVERY_MAINTENANCE_CACHE_INSPECTED=0
+WORKTREE_RECOVERY_MAINTENANCE_CACHE_DEFERRED=0
+WORKTREE_RECOVERY_MAINTENANCE_CACHE_UNAVAILABLE=0
+WORKTREE_RECOVERY_MAINTENANCE_CACHE_MAX_ROOTS=0
+WORKTREE_RECOVERY_MAINTENANCE_CACHE_MAX_BYTES=0
+WORKTREE_RECOVERY_MAINTENANCE_CACHE_PLAN_JSON=""
 
 _worktree_recovery_maintenance_uint() {
 	local value="$1"
@@ -414,6 +425,7 @@ _worktree_recovery_maintenance_update_cycle_state() {
 	WORKTREE_RECOVERY_MAINTENANCE_CYCLE_COMPLETE=false
 	WORKTREE_RECOVERY_MAINTENANCE_COMPLETED_CYCLES=0
 	if [[ "$WORKTREE_RECOVERY_MAINTENANCE_SELECTED" -gt 0 ||
+		"$WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED" -gt 0 ||
 		"$WORKTREE_RECOVERY_MAINTENANCE_BUCKET_COUNT" -eq 0 ]]; then
 		if [[ -e "$cycle_path" || -L "$cycle_path" ]]; then
 			[[ -f "$cycle_path" && ! -L "$cycle_path" ]] || return 1
@@ -466,6 +478,11 @@ _worktree_recovery_maintenance_reset_scan_counters() {
 	WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE=0
 	WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_POLICY=0
 	WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_LIMIT=0
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED=0
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED_BYTES=0
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_INSPECTED=0
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_DEFERRED=0
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_UNAVAILABLE=0
 	return 0
 }
 
@@ -496,14 +513,16 @@ _worktree_recovery_maintenance_select_candidate() {
 	if [[ -z "$selected_reason" ]]; then
 		WORKTREE_RECOVERY_MAINTENANCE_PROTECTED=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED + 1))
 		WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_POLICY=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_POLICY + 1))
-		_worktree_recovery_maintenance_record_reason "$reasons_path" "protected" "retention-policy"
+		_worktree_recovery_maintenance_record_reason "$reasons_path" \
+			"$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" "retention-policy"
 		return $?
 	fi
 	if [[ "$WORKTREE_RECOVERY_MAINTENANCE_SELECTED" -ge "$max_candidates" ||
 		$((WORKTREE_RECOVERY_MAINTENANCE_SELECTED_BYTES + bytes)) -gt "$max_bytes" ]]; then
 		WORKTREE_RECOVERY_MAINTENANCE_PROTECTED=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED + 1))
 		WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_LIMIT=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_LIMIT + 1))
-		_worktree_recovery_maintenance_record_reason "$reasons_path" "protected" "selection-limit"
+		_worktree_recovery_maintenance_record_reason "$reasons_path" \
+			"$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" "selection-limit"
 		return $?
 	fi
 	printf '%s\n' "$entry_json" | jq -c --arg reason "$selected_reason" \
@@ -614,6 +633,109 @@ _worktree_recovery_maintenance_attributed_entry_before_epoch() {
 	return $?
 }
 
+_worktree_recovery_maintenance_collect_cache_roots() {
+	local entry_json="$1"
+	local deadline_epoch="$2"
+	local remaining_roots=0
+	local remaining_bytes=0
+	local archive_path=""
+	local bucket_path=""
+	local role=""
+	local identity_json=""
+	local evidence_json=""
+	local git_bin=""
+	local manifest_json=""
+	local inspected=0
+	local deferred=0
+	local selected=0
+	local selected_bytes=0
+	local deadline_exhausted=false
+
+	printf '%s\n' "$entry_json" | jq -e \
+		--arg clear "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" \
+		--arg protected "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" '
+		.disposition == $protected and .reasons == ["archive-worktree-dirty"] and
+		.identity.source_removal_outcome == "removed" and
+		(.identity.branch | startswith("refs/heads/")) and
+		.evidence.git == "dirty" and .evidence.worktree == $clear and
+		.evidence.registry == $clear and .evidence.claim == $clear and
+		.evidence.process == $clear and .evidence.external.commit == "merged" and
+		.evidence.external.open_pr == $clear and .evidence.external.task == "closed"
+	' >/dev/null 2>&1 || return 0
+	remaining_roots=$((WORKTREE_RECOVERY_MAINTENANCE_CACHE_MAX_ROOTS - WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED))
+	remaining_bytes=$((WORKTREE_RECOVERY_MAINTENANCE_CACHE_MAX_BYTES - WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED_BYTES))
+	if [[ "$remaining_roots" -le 0 || "$remaining_bytes" -le 0 ]]; then
+		WORKTREE_RECOVERY_MAINTENANCE_CACHE_DEFERRED=$((WORKTREE_RECOVERY_MAINTENANCE_CACHE_DEFERRED + 1))
+		return 0
+	fi
+	archive_path=$(printf '%s\n' "$entry_json" | jq -r '.archive_path') || return 1
+	bucket_path=$(printf '%s\n' "$entry_json" | jq -r '.path') || return 1
+	role=$(printf '%s\n' "$entry_json" | jq -r '.role') || return 1
+	identity_json=$(printf '%s\n' "$entry_json" | jq -c '.identity') || return 1
+	evidence_json=$(printf '%s\n' "$entry_json" | jq -c '.evidence') || return 1
+	git_bin=$(_worktree_cleanup_real_git) || return 1
+	if ! manifest_json=$(_worktree_recovery_cache_policy_helper manifest "$archive_path" \
+		"$git_bin" "$remaining_roots" "$remaining_bytes" "$deadline_epoch"); then
+		WORKTREE_RECOVERY_MAINTENANCE_CACHE_UNAVAILABLE=$((WORKTREE_RECOVERY_MAINTENANCE_CACHE_UNAVAILABLE + 1))
+		return 0
+	fi
+	printf '%s\n' "$manifest_json" | jq -e \
+		--arg number_type "$WORKTREE_RECOVERY_MAINTENANCE_JSON_NUMBER_TYPE" '
+		.schema == "aidevops.worktree-recovery-cache-manifest/v1" and
+		(.complete | type == "boolean") and (.deadline_exhausted | type == "boolean") and
+		([.inspected_root_count,.deferred_root_count,.candidate_count,.candidate_bytes] |
+			all(type == $number_type and . >= 0 and . == floor)) and
+		.candidate_count == (.entries | length) and
+		.candidate_bytes == ([.entries[].expected_allocated_bytes] | add // 0) and
+		all(.entries[]; (.relative_path | type == "string") and
+			(.path_identity | test("^[0-9]+:[0-9]+$")) and
+			(.expected_allocated_bytes | type == $number_type and . > 0 and . == floor))
+	' >/dev/null 2>&1 || {
+		WORKTREE_RECOVERY_MAINTENANCE_CACHE_UNAVAILABLE=$((WORKTREE_RECOVERY_MAINTENANCE_CACHE_UNAVAILABLE + 1))
+		return 0
+	}
+	inspected=$(printf '%s\n' "$manifest_json" | jq -r '.inspected_root_count') || return 1
+	deferred=$(printf '%s\n' "$manifest_json" | jq -r '.deferred_root_count') || return 1
+	selected=$(printf '%s\n' "$manifest_json" | jq -r '.candidate_count') || return 1
+	selected_bytes=$(printf '%s\n' "$manifest_json" | jq -r '.candidate_bytes') || return 1
+	deadline_exhausted=$(printf '%s\n' "$manifest_json" | jq -r '.deadline_exhausted') || return 1
+	[[ "$selected" -le "$remaining_roots" && "$selected_bytes" -le "$remaining_bytes" ]] || return 1
+	if [[ "$selected" -gt 0 ]]; then
+		printf '%s\n' "$manifest_json" | jq -c \
+			--arg role "$role" --arg bucket_path "$bucket_path" --arg archive_path "$archive_path" \
+			--argjson recovery_identity "$identity_json" --argjson evidence "$evidence_json" '
+			.entries[] | {role:$role,bucket_path:$bucket_path,archive_path:$archive_path,
+			relative_path:.relative_path,original_path:($archive_path + "/" + .relative_path),
+			expected_allocated_bytes:.expected_allocated_bytes,path_identity:.path_identity,
+			recovery_identity:$recovery_identity,evidence:$evidence,
+			reasons:["approved-regenerable-cache-root"]}
+		' >>"$WORKTREE_RECOVERY_MAINTENANCE_TEMP_CACHE_SELECTED" || return 1
+	fi
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_INSPECTED=$((WORKTREE_RECOVERY_MAINTENANCE_CACHE_INSPECTED + inspected))
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_DEFERRED=$((WORKTREE_RECOVERY_MAINTENANCE_CACHE_DEFERRED + deferred))
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED=$((WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED + selected))
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED_BYTES=$((WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED_BYTES + selected_bytes))
+	[[ "$deadline_exhausted" != true ]] || WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=true
+	return 0
+}
+
+_worktree_recovery_maintenance_record_protected_entry() {
+	local entry_json="$1"
+	local deadline_epoch="$2"
+	local reasons_path="$3"
+	local primary_reason=""
+
+	WORKTREE_RECOVERY_MAINTENANCE_PROTECTED=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED + 1))
+	WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE + 1))
+	primary_reason=$(printf '%s\n' "$entry_json" | jq -r '.reasons[0] // empty') || return 1
+	if [[ "$primary_reason" == "archive-worktree-dirty" ]]; then
+		_worktree_recovery_maintenance_collect_cache_roots "$entry_json" "$deadline_epoch" || return 1
+	fi
+	_worktree_recovery_maintenance_record_reason "$reasons_path" \
+		"$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" "$primary_reason"
+	return $?
+}
+
 _worktree_recovery_maintenance_scan() {
 	local ordered_path="$1"
 	local selected_path="$2"
@@ -702,10 +824,8 @@ _worktree_recovery_maintenance_scan() {
 			_worktree_recovery_maintenance_record_reason "$reasons_path" "$disposition" "$primary_reason" || return 1
 			continue
 		elif [[ "$disposition" != "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" ]]; then
-			WORKTREE_RECOVERY_MAINTENANCE_PROTECTED=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED + 1))
-			WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE=$((WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE + 1))
-			primary_reason=$(printf '%s\n' "$entry_json" | jq -r '.reasons[0] // empty') || return 1
-			_worktree_recovery_maintenance_record_reason "$reasons_path" "$disposition" "$primary_reason" || return 1
+			_worktree_recovery_maintenance_record_protected_entry \
+				"$entry_json" "$deadline_epoch" "$reasons_path" || return 1
 			continue
 		fi
 		_worktree_recovery_maintenance_select_candidate "$entry_json" "$bytes" "$selected_path" \
@@ -752,6 +872,40 @@ _worktree_recovery_maintenance_plan_json() {
 	return $?
 }
 
+_worktree_recovery_maintenance_cache_plan_json() {
+	local selected_path="$1"
+	local policy_json="$2"
+	local entries_json=""
+	local plan_material=""
+	local plan_digest=""
+	local plan_id=""
+	local generated_at=""
+	local plan_json=""
+	local authorization=""
+
+	entries_json=$(jq -sc 'sort_by(.original_path)' "$selected_path") || return 1
+	plan_material=$(jq -cnS --arg schema "$WORKTREE_RECOVERY_CACHE_PLAN_SCHEMA" \
+		--argjson entries "$entries_json" --argjson automatic_policy "$policy_json" \
+		'{schema:$schema,entries:$entries,automatic_policy:$automatic_policy}') || return 1
+	plan_digest=$(_worktree_recovery_plan_sha256_text "$plan_material") || return 1
+	plan_id="sha256:$plan_digest"
+	generated_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	plan_json=$(jq -cn --arg schema "$WORKTREE_RECOVERY_CACHE_PLAN_SCHEMA" \
+		--arg producer "$WORKTREE_RECOVERY_PRODUCER" --arg plan_id "$plan_id" \
+		--arg generated_at "$generated_at" --argjson entries "$entries_json" \
+		--argjson automatic_policy "$policy_json" '
+		{schema:$schema,producer:$producer,plan_id:$plan_id,generated_at:$generated_at,
+		read_only:true,candidate_count:($entries | length),
+		expected_allocated_bytes:([$entries[].expected_allocated_bytes] | add // 0),
+		automatic_policy:$automatic_policy,entries:$entries}') || return 1
+	authorization=$(_worktree_recovery_cache_automatic_token "$plan_id" \
+		"$policy_json" "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED" \
+		"$WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED_BYTES") || return 1
+	printf '%s\n' "$plan_json" | jq -c --arg authorization "$authorization" \
+		'. + {confirmation_token:$authorization}'
+	return $?
+}
+
 _worktree_recovery_maintenance_limits_json() {
 	local recovery_root="$1"
 	local max_scan=""
@@ -763,6 +917,8 @@ _worktree_recovery_maintenance_limits_json() {
 	local minimum_free_percent=""
 	local aggregate_timeout_tenths=""
 	local deadline_seconds=""
+	local cache_max_roots=""
+	local cache_max_bytes=""
 	local pressure_json=""
 
 	max_scan=$(_worktree_recovery_maintenance_uint "${AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_SCAN:-50}" 50 1 500)
@@ -777,17 +933,24 @@ _worktree_recovery_maintenance_limits_json() {
 		"${AIDEVOPS_WORKTREE_RECOVERY_AGGREGATE_SIZE_TIMEOUT_TENTHS:-20}" 20 1 36000)
 	deadline_seconds=$(_worktree_recovery_maintenance_uint \
 		"${AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_SECONDS:-120}" 120 1 3600)
+	cache_max_roots=$(_worktree_recovery_maintenance_uint \
+		"${AIDEVOPS_WORKTREE_RECOVERY_CACHE_PRUNE_MAX_ROOTS:-100}" 100 1 1000)
+	cache_max_bytes=$(_worktree_recovery_maintenance_uint \
+		"${AIDEVOPS_WORKTREE_RECOVERY_CACHE_PRUNE_MAX_BYTES:-5368709120}" \
+		5368709120 1 1099511627776)
 	pressure_json=$(_worktree_recovery_maintenance_pressure_json "$recovery_root" "$max_store_bytes" \
 		"$minimum_free_kb" "$minimum_free_percent" "$aggregate_timeout_tenths") || return 1
 	jq -cn --argjson max_scan "$max_scan" --argjson max_candidates "$max_candidates" \
 		--argjson max_bytes "$max_bytes" --argjson retention_days "$retention_days" \
 		--argjson max_store_bytes "$max_store_bytes" --argjson minimum_free_kb "$minimum_free_kb" \
 		--argjson minimum_free_percent "$minimum_free_percent" --argjson deadline_seconds "$deadline_seconds" \
+		--argjson cache_max_roots "$cache_max_roots" --argjson cache_max_bytes "$cache_max_bytes" \
 		--argjson pressure "$pressure_json" \
 		'{max_scan:$max_scan,max_candidates:$max_candidates,max_bytes:$max_bytes,
 		retention_days:$retention_days,max_store_bytes:$max_store_bytes,
 		minimum_free_kb:$minimum_free_kb,minimum_free_percent:$minimum_free_percent,
-		deadline_seconds:$deadline_seconds,pressure:$pressure}'
+		deadline_seconds:$deadline_seconds,cache_max_roots:$cache_max_roots,
+		cache_max_bytes:$cache_max_bytes,pressure:$pressure}'
 	return $?
 }
 
@@ -808,13 +971,31 @@ _worktree_recovery_maintenance_create_selection_temp_files() {
 			"$WORKTREE_RECOVERY_MAINTENANCE_TEMP_ORDERED" "$WORKTREE_RECOVERY_MAINTENANCE_TEMP_SELECTED"
 		return 1
 	}
+	WORKTREE_RECOVERY_MAINTENANCE_TEMP_CACHE_SELECTED=$(mktemp \
+		"${temp_root}/aidevops-recovery-maintenance-cache-selected.XXXXXX") || {
+		rm -f "$WORKTREE_RECOVERY_MAINTENANCE_TEMP_INVENTORY" \
+			"$WORKTREE_RECOVERY_MAINTENANCE_TEMP_ORDERED" \
+			"$WORKTREE_RECOVERY_MAINTENANCE_TEMP_SELECTED" \
+			"$WORKTREE_RECOVERY_MAINTENANCE_TEMP_REASONS"
+		return 1
+	}
 	return 0
+}
+
+_worktree_recovery_maintenance_cleanup_selection_temp_files() {
+	rm -f "$WORKTREE_RECOVERY_MAINTENANCE_TEMP_INVENTORY" \
+		"$WORKTREE_RECOVERY_MAINTENANCE_TEMP_ORDERED" \
+		"$WORKTREE_RECOVERY_MAINTENANCE_TEMP_SELECTED" \
+		"$WORKTREE_RECOVERY_MAINTENANCE_TEMP_REASONS" \
+		"$WORKTREE_RECOVERY_MAINTENANCE_TEMP_CACHE_SELECTED"
+	return $?
 }
 
 _worktree_recovery_maintenance_build_selection_plan() {
 	local limits_json="$1"
 	local selected_path="$2"
 	local policy_json=""
+	local cache_policy_json=""
 
 	policy_json=$(printf '%s\n' "$limits_json" | jq -c \
 		--arg schema "$WORKTREE_RECOVERY_AUTOMATION_POLICY_SCHEMA" \
@@ -834,6 +1015,19 @@ _worktree_recovery_maintenance_build_selection_plan() {
 		WORKTREE_RECOVERY_MAINTENANCE_PLAN_JSON=$(_worktree_recovery_maintenance_plan_json \
 			"$selected_path" "$policy_json") || return 1
 	fi
+	if [[ "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED" -gt 0 ]]; then
+		cache_policy_json=$(printf '%s\n' "$limits_json" | jq -c \
+			--arg schema "$WORKTREE_RECOVERY_CACHE_POLICY_SCHEMA" \
+			--arg policy_id "$WORKTREE_RECOVERY_CACHE_POLICY_ID" \
+			--argjson scanned "$WORKTREE_RECOVERY_MAINTENANCE_SCANNED" '
+			{schema:$schema,policy_id:$policy_id,max_scan:.max_scan,
+			max_roots:.cache_max_roots,max_bytes:.cache_max_bytes,
+			deadline_seconds:.deadline_seconds,scanned_count:$scanned}') || return 1
+		WORKTREE_RECOVERY_MAINTENANCE_CACHE_PLAN_JSON=$(
+			_worktree_recovery_maintenance_cache_plan_json \
+				"$WORKTREE_RECOVERY_MAINTENANCE_TEMP_CACHE_SELECTED" "$cache_policy_json"
+		) || return 1
+	fi
 	return 0
 }
 
@@ -843,19 +1037,12 @@ _worktree_recovery_maintenance_prepare_selection() {
 	local limits_json="$3"
 	local inventory_path="" ordered_path="" selected_path="" reasons_path=""
 	local cursor_path="${state_dir}/cursor"
-	local offset=0
-	local bucket_count=0
-	local max_scan=""
-	local scan_limit=0
-	local cycle_remaining=0
-	local max_candidates=""
-	local max_bytes=""
-	local retention_days=""
-	local retention_seconds=""
-	local pressure_active=""
-	local deadline_seconds=""
+	local offset=0 bucket_count=0 scan_limit=0 cycle_remaining=0
+	local max_scan="" max_candidates="" max_bytes="" retention_days=""
+	local retention_seconds="" pressure_active="" deadline_seconds=""
 	WORKTREE_RECOVERY_MAINTENANCE_POLICY_JSON=""
 	WORKTREE_RECOVERY_MAINTENANCE_PLAN_JSON=""
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_PLAN_JSON=""
 	max_scan=$(printf '%s\n' "$limits_json" | jq -r '.max_scan') || return 1
 	max_candidates=$(printf '%s\n' "$limits_json" | jq -r '.max_candidates') || return 1
 	max_bytes=$(printf '%s\n' "$limits_json" | jq -r '.max_bytes') || return 1
@@ -863,6 +1050,8 @@ _worktree_recovery_maintenance_prepare_selection() {
 	retention_seconds=$((retention_days * 86400))
 	pressure_active=$(printf '%s\n' "$limits_json" | jq -r '.pressure.active') || return 1
 	deadline_seconds=$(printf '%s\n' "$limits_json" | jq -r '.deadline_seconds') || return 1
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_MAX_ROOTS=$(printf '%s\n' "$limits_json" | jq -r '.cache_max_roots') || return 1
+	WORKTREE_RECOVERY_MAINTENANCE_CACHE_MAX_BYTES=$(printf '%s\n' "$limits_json" | jq -r '.cache_max_bytes') || return 1
 	_worktree_recovery_maintenance_start_deadline "$deadline_seconds" || return 1
 	_worktree_recovery_maintenance_create_selection_temp_files || return 1
 	inventory_path="$WORKTREE_RECOVERY_MAINTENANCE_TEMP_INVENTORY"
@@ -870,29 +1059,29 @@ _worktree_recovery_maintenance_prepare_selection() {
 	selected_path="$WORKTREE_RECOVERY_MAINTENANCE_TEMP_SELECTED"
 	reasons_path="$WORKTREE_RECOVERY_MAINTENANCE_TEMP_REASONS"
 	if ! _worktree_recovery_maintenance_inventory_file "$inventory_path" "$platform"; then
-		rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+		_worktree_recovery_maintenance_cleanup_selection_temp_files || true
 		return 1
 	fi
 	bucket_count=$(wc -l <"$inventory_path" | tr -d ' ') || bucket_count=""
 	if [[ ! "$bucket_count" =~ ^[0-9]+$ ]]; then
-		rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+		_worktree_recovery_maintenance_cleanup_selection_temp_files || true
 		return 1
 	fi
 	WORKTREE_RECOVERY_MAINTENANCE_BUCKET_COUNT="$bucket_count"
 	WORKTREE_RECOVERY_MAINTENANCE_INVENTORY_DIGEST=$(
 		_worktree_recovery_plan_sha256_file "$inventory_path"
 	) || {
-		rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+		_worktree_recovery_maintenance_cleanup_selection_temp_files || true
 		return 1
 	}
 	WORKTREE_RECOVERY_MAINTENANCE_PRESSURE_ACTIVE="$pressure_active"
 	if ! _worktree_recovery_maintenance_load_cycle_state "$state_dir"; then
-		rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+		_worktree_recovery_maintenance_cleanup_selection_temp_files || true
 		return 1
 	fi
 	if [[ -e "$cursor_path" || -L "$cursor_path" ]]; then
 		if [[ ! -f "$cursor_path" || -L "$cursor_path" ]]; then
-			rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+			_worktree_recovery_maintenance_cleanup_selection_temp_files || true
 			return 1
 		fi
 		IFS= read -r offset <"$cursor_path" || offset=0
@@ -910,31 +1099,31 @@ _worktree_recovery_maintenance_prepare_selection() {
 		! _worktree_recovery_maintenance_scan "$ordered_path" "$selected_path" "$scan_limit" \
 			"$max_candidates" "$max_bytes" "$retention_seconds" "$pressure_active" "$reasons_path" \
 			"$deadline_seconds" "$WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EPOCH"; then
-		rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+		_worktree_recovery_maintenance_cleanup_selection_temp_files || true
 		return 1
 	fi
 	WORKTREE_RECOVERY_MAINTENANCE_REASON_COUNTS_JSON=$(
 		_worktree_recovery_maintenance_reason_counts_json "$reasons_path"
 	) || {
-		rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+		_worktree_recovery_maintenance_cleanup_selection_temp_files || true
 		return 1
 	}
 	if ! _worktree_recovery_maintenance_update_cycle_state "$state_dir"; then
-		rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+		_worktree_recovery_maintenance_cleanup_selection_temp_files || true
 		return 1
 	fi
 	if [[ "$bucket_count" -gt 0 ]]; then
 		WORKTREE_RECOVERY_MAINTENANCE_CURSOR_AFTER=$(((offset + WORKTREE_RECOVERY_MAINTENANCE_SCANNED) % bucket_count))
 		printf '%s\n' "$WORKTREE_RECOVERY_MAINTENANCE_CURSOR_AFTER" >"$cursor_path" || {
-			rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+			_worktree_recovery_maintenance_cleanup_selection_temp_files || true
 			return 1
 		}
 	fi
 	_worktree_recovery_maintenance_build_selection_plan "$limits_json" "$selected_path" || {
-		rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+		_worktree_recovery_maintenance_cleanup_selection_temp_files || true
 		return 1
 	}
-	rm -f "$inventory_path" "$ordered_path" "$selected_path" "$reasons_path"
+	_worktree_recovery_maintenance_cleanup_selection_temp_files || return 1
 	return 0
 }
 
@@ -965,6 +1154,11 @@ _worktree_recovery_maintenance_diagnostics_json() {
 		--argjson protected_evidence "$WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_EVIDENCE" \
 		--argjson protected_policy "$WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_POLICY" \
 		--argjson protected_limit "$WORKTREE_RECOVERY_MAINTENANCE_PROTECTED_LIMIT" \
+		--argjson cache_inspected "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_INSPECTED" \
+		--argjson cache_deferred "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_DEFERRED" \
+		--argjson cache_unavailable "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_UNAVAILABLE" \
+		--argjson cache_selected "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED" \
+		--argjson cache_selected_bytes "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED_BYTES" \
 		--argjson classification_reason_counts "$WORKTREE_RECOVERY_MAINTENANCE_REASON_COUNTS_JSON" \
 		--argjson cycle_reason_counts "$WORKTREE_RECOVERY_MAINTENANCE_CYCLE_REASON_COUNTS_JSON" \
 		--argjson cycle_scanned "$WORKTREE_RECOVERY_MAINTENANCE_CYCLE_SCANNED" \
@@ -977,7 +1171,10 @@ _worktree_recovery_maintenance_diagnostics_json() {
 		reason_counts:{unknown_archive:$unknown_archive,unknown_sizing:$unknown_sizing,
 		unknown_classification:$unknown_classification,unknown_age:$unknown_age,
 		protected_evidence:$protected_evidence,protected_policy:$protected_policy,
-		protected_limit:$protected_limit},classification_reason_counts:$classification_reason_counts,
+		protected_limit:$protected_limit},cache_prune:{inspected_roots:$cache_inspected,
+		deferred_roots:$cache_deferred,unavailable_archives:$cache_unavailable,
+		selected_roots:$cache_selected,selected_bytes:$cache_selected_bytes},
+		classification_reason_counts:$classification_reason_counts,
 		zero_candidate_cycle:{scanned_count:$cycle_scanned,completed_this_run:$cycle_complete,
 		completed_cycles:$completed_cycles,reason_counts:$cycle_reason_counts}}'
 	return $?
@@ -1029,14 +1226,27 @@ _worktree_recovery_maintenance_resume_pending() {
 	local receipt_path="${pending_dir}/receipt.json"
 	local completed_dir=""
 	local reclaimed_bytes=""
+	local plan_schema=""
+	local outcome=""
 
 	[[ -e "$pending_dir" || -L "$pending_dir" ]] || return 2
 	[[ -d "$pending_dir" && ! -L "$pending_dir" && -f "$plan_path" && ! -L "$plan_path" ]] || return 1
-	worktree_recovery_apply_automatic "$plan_path" "$receipt_path" >/dev/null || return 1
+	plan_schema=$(jq -r '.schema // empty' "$plan_path") || return 1
+	case "$plan_schema" in
+	"$WORKTREE_RECOVERY_PLAN_SCHEMA")
+		worktree_recovery_apply_automatic "$plan_path" "$receipt_path" >/dev/null || return 1
+		outcome="resumed-and-removed"
+		;;
+	"$WORKTREE_RECOVERY_CACHE_PLAN_SCHEMA")
+		worktree_recovery_cache_prune_apply_automatic "$plan_path" "$receipt_path" >/dev/null || return 1
+		outcome="resumed-and-pruned"
+		;;
+	*) return 1 ;;
+	esac
 	reclaimed_bytes=$(jq -r '.observed_allocated_bytes' "$receipt_path") || return 1
 	completed_dir=$(_worktree_recovery_maintenance_finalize_pending "$state_dir") || return 1
 	jq -cn --arg schema "$WORKTREE_RECOVERY_MAINTENANCE_RUN_SCHEMA" \
-		--arg outcome "resumed-and-removed" --arg receipt "${completed_dir}/receipt.json" \
+		--arg outcome "$outcome" --arg receipt "${completed_dir}/receipt.json" \
 		--argjson reclaimed_bytes "$reclaimed_bytes" \
 		'{schema:$schema,outcome:$outcome,reclaimed_bytes:$reclaimed_bytes,receipt:$receipt}'
 	return 0
@@ -1076,22 +1286,47 @@ _worktree_recovery_maintenance_removed_json() {
 	return $?
 }
 
+_worktree_recovery_maintenance_cache_pruned_json() {
+	local completed_dir="$1"
+	local reclaimed_bytes="$2"
+	local diagnostics_json="$3"
+
+	jq -cn --arg schema "$WORKTREE_RECOVERY_MAINTENANCE_RUN_SCHEMA" \
+		--arg outcome "cache-pruned" --arg receipt "${completed_dir}/receipt.json" \
+		--argjson diagnostics "$diagnostics_json" \
+		--argjson scanned "$WORKTREE_RECOVERY_MAINTENANCE_SCANNED" \
+		--argjson protected "$WORKTREE_RECOVERY_MAINTENANCE_PROTECTED" \
+		--argjson unknown "$WORKTREE_RECOVERY_MAINTENANCE_UNKNOWN" \
+		--argjson pruned_roots "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED" \
+		--argjson reclaimed_bytes "$reclaimed_bytes" \
+		'{schema:$schema,outcome:$outcome,scanned:$scanned,protected:$protected,
+		unknown:$unknown,pruned_roots:$pruned_roots,reclaimed_bytes:$reclaimed_bytes,
+		receipt:$receipt,diagnostics:$diagnostics}'
+	return $?
+}
+
+_worktree_recovery_maintenance_success_json() {
+	local operation="$1"
+	local completed_dir="$2"
+	local reclaimed_bytes="$3"
+	local diagnostics_json="$4"
+
+	if [[ "$operation" == "$WORKTREE_RECOVERY_MAINTENANCE_OPERATION_CACHE_PRUNE" ]]; then
+		_worktree_recovery_maintenance_cache_pruned_json \
+			"$completed_dir" "$reclaimed_bytes" "$diagnostics_json"
+	else
+		_worktree_recovery_maintenance_removed_json \
+			"$completed_dir" "$reclaimed_bytes" "$diagnostics_json"
+	fi
+	return $?
+}
+
 worktree_recovery_maintenance_run() {
-	local platform=""
-	local state_dir=""
-	local recovery_root=""
-	local limits_json=""
-	local policy_json=""
-	local plan_json=""
-	local pending_dir=""
-	local pending_init_dir=""
-	local plan_path=""
-	local receipt_path=""
-	local completed_dir=""
-	local reclaimed_bytes=""
-	local diagnostics_json=""
-	local resume_status=0
-	local run_status=0
+	local platform="" state_dir="" recovery_root="" limits_json="" policy_json=""
+	local plan_json="" pending_dir="" pending_init_dir="" plan_path="" receipt_path=""
+	local completed_dir="" reclaimed_bytes="" diagnostics_json=""
+	local operation="archive-remove"
+	local resume_status=0 run_status=0
 
 	if [[ "${AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_ENABLED:-1}" != "1" ]]; then
 		jq -cn --arg schema "$WORKTREE_RECOVERY_MAINTENANCE_RUN_SCHEMA" \
@@ -1141,12 +1376,18 @@ worktree_recovery_maintenance_run() {
 		_worktree_recovery_maintenance_release_lock || true
 		return 1
 	}
-	if [[ "$WORKTREE_RECOVERY_MAINTENANCE_SELECTED" -eq 0 ]]; then
+	if [[ "$WORKTREE_RECOVERY_MAINTENANCE_SELECTED" -eq 0 &&
+		"$WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED" -eq 0 ]]; then
 		_worktree_recovery_maintenance_no_candidates_json "$policy_json" "$diagnostics_json"
 		_worktree_recovery_maintenance_release_lock || return 1
 		return 0
 	fi
-	plan_json="$WORKTREE_RECOVERY_MAINTENANCE_PLAN_JSON"
+	if [[ "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED" -gt 0 ]]; then
+		operation="$WORKTREE_RECOVERY_MAINTENANCE_OPERATION_CACHE_PRUNE"
+		plan_json="$WORKTREE_RECOVERY_MAINTENANCE_CACHE_PLAN_JSON"
+	else
+		plan_json="$WORKTREE_RECOVERY_MAINTENANCE_PLAN_JSON"
+	fi
 	pending_dir="${state_dir}/pending"
 	pending_init_dir="${state_dir}/.pending-init.$$-${RANDOM}"
 	[[ ! -e "$pending_dir" && ! -L "$pending_dir" && ! -e "$pending_init_dir" && ! -L "$pending_init_dir" ]] || run_status=1
@@ -1157,7 +1398,12 @@ worktree_recovery_maintenance_run() {
 	[[ "$run_status" -ne 0 ]] || mv "$pending_init_dir" "$pending_dir" || run_status=1
 	plan_path="${pending_dir}/plan.json"
 	if [[ "$run_status" -eq 0 ]]; then
-		worktree_recovery_apply_automatic "$plan_path" "$receipt_path" >/dev/null || run_status=1
+		if [[ "$operation" == "$WORKTREE_RECOVERY_MAINTENANCE_OPERATION_CACHE_PRUNE" ]]; then
+			worktree_recovery_cache_prune_apply_automatic \
+				"$plan_path" "$receipt_path" >/dev/null || run_status=1
+		else
+			worktree_recovery_apply_automatic "$plan_path" "$receipt_path" >/dev/null || run_status=1
+		fi
 	fi
 	if [[ "$run_status" -eq 0 ]]; then
 		reclaimed_bytes=$(jq -r '.observed_allocated_bytes' "$receipt_path") || run_status=1
@@ -1169,8 +1415,8 @@ worktree_recovery_maintenance_run() {
 	fi
 	_worktree_recovery_maintenance_release_lock || run_status=1
 	[[ "$run_status" -eq 0 ]] || return 1
-	_worktree_recovery_maintenance_removed_json "$completed_dir" "$reclaimed_bytes" \
-		"$diagnostics_json"
+	_worktree_recovery_maintenance_success_json \
+		"$operation" "$completed_dir" "$reclaimed_bytes" "$diagnostics_json"
 	return $?
 }
 

--- a/.agents/scripts/worktree-recovery-maintenance-helper.sh
+++ b/.agents/scripts/worktree-recovery-maintenance-helper.sh
@@ -700,7 +700,11 @@ _worktree_recovery_maintenance_collect_cache_roots() {
 	selected_bytes=$(printf '%s\n' "$manifest_json" | jq -r '.candidate_bytes') || return 1
 	deadline_exhausted=$(printf '%s\n' "$manifest_json" | jq -r '.deadline_exhausted') || return 1
 	[[ "$selected" -le "$remaining_roots" && "$selected_bytes" -le "$remaining_bytes" ]] || return 1
-	if [[ "$selected" -gt 0 ]]; then
+	if [[ "$deadline_exhausted" == true ]]; then
+		deferred=$((deferred + selected))
+		selected=0
+		selected_bytes=0
+	elif [[ "$selected" -gt 0 ]]; then
 		printf '%s\n' "$manifest_json" | jq -c \
 			--arg role "$role" --arg bucket_path "$bucket_path" --arg archive_path "$archive_path" \
 			--argjson recovery_identity "$identity_json" --argjson evidence "$evidence_json" '
@@ -1228,6 +1232,7 @@ _worktree_recovery_maintenance_resume_pending() {
 	local reclaimed_bytes=""
 	local plan_schema=""
 	local outcome=""
+	local deadline_seconds=""
 
 	[[ -e "$pending_dir" || -L "$pending_dir" ]] || return 2
 	[[ -d "$pending_dir" && ! -L "$pending_dir" && -f "$plan_path" && ! -L "$plan_path" ]] || return 1
@@ -1238,7 +1243,10 @@ _worktree_recovery_maintenance_resume_pending() {
 		outcome="resumed-and-removed"
 		;;
 	"$WORKTREE_RECOVERY_CACHE_PLAN_SCHEMA")
-		worktree_recovery_cache_prune_apply_automatic "$plan_path" "$receipt_path" >/dev/null || return 1
+		deadline_seconds=$(jq -r '.automatic_policy.deadline_seconds' "$plan_path") || return 1
+		_worktree_recovery_maintenance_start_deadline "$deadline_seconds" || return 1
+		worktree_recovery_cache_prune_apply_automatic "$plan_path" "$receipt_path" \
+			"$WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EPOCH" >/dev/null || return 1
 		outcome="resumed-and-pruned"
 		;;
 	*) return 1 ;;
@@ -1321,13 +1329,26 @@ _worktree_recovery_maintenance_success_json() {
 	return $?
 }
 
+_worktree_recovery_maintenance_defer_expired_cache_selection() {
+	local current_epoch=0
+
+	current_epoch=$(date +%s) || return 1
+	if [[ "$WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED" -gt 0 &&
+		"$current_epoch" -ge "$WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EPOCH" ]]; then
+		WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EXHAUSTED=true
+		WORKTREE_RECOVERY_MAINTENANCE_CACHE_DEFERRED=$((WORKTREE_RECOVERY_MAINTENANCE_CACHE_DEFERRED + WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED))
+		WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED=0
+		WORKTREE_RECOVERY_MAINTENANCE_CACHE_SELECTED_BYTES=0
+		WORKTREE_RECOVERY_MAINTENANCE_CACHE_PLAN_JSON=""
+	fi
+	return 0
+}
+
 worktree_recovery_maintenance_run() {
 	local platform="" state_dir="" recovery_root="" limits_json="" policy_json=""
 	local plan_json="" pending_dir="" pending_init_dir="" plan_path="" receipt_path=""
-	local completed_dir="" reclaimed_bytes="" diagnostics_json=""
-	local operation="archive-remove"
+	local completed_dir="" reclaimed_bytes="" diagnostics_json="" operation="archive-remove"
 	local resume_status=0 run_status=0
-
 	if [[ "${AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_ENABLED:-1}" != "1" ]]; then
 		jq -cn --arg schema "$WORKTREE_RECOVERY_MAINTENANCE_RUN_SCHEMA" \
 			'{schema:$schema,outcome:"disabled",reclaimed_bytes:0}'
@@ -1372,6 +1393,10 @@ worktree_recovery_maintenance_run() {
 		return 1
 	fi
 	policy_json="$WORKTREE_RECOVERY_MAINTENANCE_POLICY_JSON"
+	_worktree_recovery_maintenance_defer_expired_cache_selection || {
+		_worktree_recovery_maintenance_release_lock || true
+		return 1
+	}
 	diagnostics_json=$(_worktree_recovery_maintenance_diagnostics_json) || {
 		_worktree_recovery_maintenance_release_lock || true
 		return 1
@@ -1400,7 +1425,8 @@ worktree_recovery_maintenance_run() {
 	if [[ "$run_status" -eq 0 ]]; then
 		if [[ "$operation" == "$WORKTREE_RECOVERY_MAINTENANCE_OPERATION_CACHE_PRUNE" ]]; then
 			worktree_recovery_cache_prune_apply_automatic \
-				"$plan_path" "$receipt_path" >/dev/null || run_status=1
+				"$plan_path" "$receipt_path" "$WORKTREE_RECOVERY_MAINTENANCE_DEADLINE_EPOCH" \
+				>/dev/null || run_status=1
 		else
 			worktree_recovery_apply_automatic "$plan_path" "$receipt_path" >/dev/null || run_status=1
 		fi


### PR DESCRIPTION
## Summary

- prune only approved cache roots from protected mixed recovery archives
- revalidate mutable Git, process, task, PR, and commit evidence before staging each archive
- journal staged/removing transitions so interrupted deletion resumes safely and receipts reflect independently measured bytes
- bound Git output, scan/delete work, and fail closed when legacy state cannot prove removed allocation

## Verification

- `.agents/scripts/tests/test-worktree-recovery-lifecycle.sh` (full lifecycle suite)
- focused cache retrofit cases: 8 run, 0 failed
- `.agents/scripts/tests/test-worktree-cleanup-async.sh`: 14/14
- worktree-removal audit suites
- `.agents/scripts/linters-local.sh` (passed; pre-existing file-size warnings only)
- Python AST, Bash syntax, ShellCheck, function-complexity regression, and `git diff --check`
- independent exact-head review of `b969667b0`: clean

## Runtime testing

The lifecycle suite exercises real filesystem staging, renames, interruption recovery, and deletion in isolated temporary fixtures. It covers evidence drift, oversized Git output, shared deadlines, interrupted removal, and legacy unmeasured replay without touching production archives.

Resolves #31027

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.299 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 8h 39m and 3,340,665 tokens on this with the user in an interactive session.