### PR TITLE
t18313: Add OAuth-first multi-account GPT Image 2 generation

### DIFF
--- a/.agents/plugins/opencode-aidevops/gpt-image-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-auth.mjs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { execFileSync } from "node:child_process";
+import { patchAccount } from "./oauth-pool-storage.mjs";
+
+const API_SECRET_PREFIX = "OPENAI_IMAGE_API_KEY_";
+const DEFAULT_COOLDOWN_MS = 300_000;
+
+export function normalizeImageAccountAlias(value) {
+  const alias = String(value || "").trim();
+  if (!/^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(alias)) {
+    throw new Error("API image account must use 1-64 letters, numbers, or underscores and start with a letter.");
+  }
+  return alias.toUpperCase();
+}
+
+export function imageApiSecretName(account, env = process.env) {
+  const selected = account || env.AIDEVOPS_OPENAI_IMAGE_ACCOUNT;
+  if (!selected) {
+    throw new Error(
+      "API image generation requires an explicit account alias or AIDEVOPS_OPENAI_IMAGE_ACCOUNT default.",
+    );
+  }
+  return `${API_SECRET_PREFIX}${normalizeImageAccountAlias(selected)}`;
+}
+
+function validateCredential(value, secretName) {
+  const credential = String(value || "").trim();
+  if (credential.length < 20 || /\s/.test(credential)) {
+    throw new Error(`Configured secret ${secretName} is missing or invalid.`);
+  }
+  return credential;
+}
+
+export function readImageApiKey(secretName, options = {}) {
+  const env = options.env || process.env;
+  if (env[secretName]) return validateCredential(env[secretName], secretName);
+
+  const run = options.execFile || execFileSync;
+  try {
+    const value = run("aidevops", ["secret", "get", secretName], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 10_000,
+    });
+    return validateCredential(value, secretName);
+  } catch {
+    throw new Error(
+      `OpenAI image API secret ${secretName} is not configured. Run: aidevops secret set ${secretName}`,
+    );
+  }
+}
+
+async function resolveOAuthAuth(args, options) {
+  const resolver = options.resolveOAuthAccount;
+  if (typeof resolver !== "function") {
+    throw new Error("OpenAI OAuth account selection is unavailable in this runtime.");
+  }
+  const requestedAccount = String(args.account || "").trim();
+  const account = await resolver(requestedAccount || undefined);
+  if (!account?.access) {
+    const qualifier = requestedAccount ? "requested" : "available";
+    throw new Error(
+      `No ${qualifier} ChatGPT OAuth account can generate images. Add or inspect OpenAI Pool accounts with model-accounts-pool.`,
+    );
+  }
+  return {
+    mode: "oauth",
+    accessToken: account.access,
+    accountId: account.accountId || "",
+    account,
+    pinned: Boolean(requestedAccount),
+  };
+}
+
+function resolveApiAuth(args, options) {
+  const env = options.env || process.env;
+  const secretName = imageApiSecretName(args.account, env);
+  const reader = options.readSecret || ((name) => readImageApiKey(name, options));
+  return {
+    mode: "api",
+    accessToken: reader(secretName),
+    accountId: "",
+    account: null,
+    pinned: true,
+  };
+}
+
+export async function resolveGptImageAuth(args, options = {}) {
+  const mode = args.auth || "oauth";
+  if (mode === "oauth") return resolveOAuthAuth(args, options);
+  if (mode === "api") return resolveApiAuth(args, options);
+  throw new Error("Image auth must be oauth or api.");
+}
+
+function retryAfterMs(response) {
+  const raw = response.headers?.get?.("retry-after");
+  const seconds = Number.parseInt(raw || "", 10);
+  if (Number.isFinite(seconds) && seconds > 0) {
+    return Math.max(seconds * 1000, DEFAULT_COOLDOWN_MS);
+  }
+  return DEFAULT_COOLDOWN_MS;
+}
+
+export function markOAuthImageRateLimit(auth, response) {
+  if (!auth.account?.email) return;
+  patchAccount("openai", auth.account.email, {
+    status: "rate-limited",
+    cooldownUntil: Date.now() + retryAfterMs(response),
+    lastUsed: new Date().toISOString(),
+  });
+}
+
+export function markOAuthImageSuccess(auth) {
+  if (!auth.account?.email) return;
+  patchAccount("openai", auth.account.email, {
+    status: "active",
+    cooldownUntil: null,
+    lastUsed: new Date().toISOString(),
+  });
+}
+
+export async function rotateOAuthImageAccount(auth, options = {}) {
+  if (auth.mode !== "oauth" || auth.pinned || !auth.account?.email) return null;
+  const rotate = options.rotateOAuthAccount;
+  if (typeof rotate !== "function") return null;
+  const account = await rotate(auth.account.email);
+  if (!account?.access) return null;
+  return {
+    mode: "oauth",
+    accessToken: account.access,
+    accountId: account.accountId || "",
+    account,
+    pinned: false,
+  };
+}

--- a/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {
+  link,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  realpath,
+  unlink,
+} from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
+
+const MAX_REFERENCE_IMAGES = 8;
+const MAX_REFERENCE_BYTES = 20 * 1024 * 1024;
+const MAX_REFERENCE_TOTAL_BYTES = 50 * 1024 * 1024;
+const MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
+const MAX_OUTPUT_VERSION = 999;
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function pathIsWithin(parent, candidate) {
+  const relation = relative(parent, candidate);
+  return relation === "" || (relation !== ".." && !relation.startsWith(`..${sep}`) && !isAbsolute(relation));
+}
+
+function requireRelativePath(value, label) {
+  const requested = String(value || "").trim();
+  if (!requested || isAbsolute(requested) || requested.split(/[\\/]+/).includes("..")) {
+    throw new Error(`${label} must be a project-relative path without parent traversal.`);
+  }
+  return requested;
+}
+
+async function requireProjectRoot(projectRoot) {
+  const root = await realpath(projectRoot);
+  const stats = await lstat(root);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error("OpenCode project root must be a regular directory.");
+  }
+  return root;
+}
+
+async function assertNoSymlinkSegments(root, target) {
+  const relation = relative(root, target);
+  let cursor = root;
+  for (const segment of relation.split(sep).filter(Boolean)) {
+    cursor = join(cursor, segment);
+    try {
+      const stats = await lstat(cursor);
+      if (stats.isSymbolicLink()) throw new Error("Image paths cannot traverse symbolic links.");
+    } catch (error) {
+      if (error?.code === "ENOENT") return;
+      throw error;
+    }
+  }
+}
+
+function detectImageMime(buffer) {
+  if (buffer.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) return "image/png";
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return "image/jpeg";
+  if (buffer.subarray(0, 4).toString("ascii") === "RIFF" && buffer.subarray(8, 12).toString("ascii") === "WEBP") {
+    return "image/webp";
+  }
+  return "";
+}
+
+function validateReferenceBuffer(buffer, requested) {
+  if (buffer.length === 0 || buffer.length > MAX_REFERENCE_BYTES) {
+    throw new Error(`Reference image ${requested} must be between 1 byte and 20 MiB.`);
+  }
+  const mime = detectImageMime(buffer);
+  if (!mime) throw new Error(`Reference image ${requested} must be PNG, JPEG, or WebP.`);
+  return mime;
+}
+
+async function readReferenceImage(requested, root) {
+  const relativePath = requireRelativePath(requested, "Reference image");
+  const target = resolve(root, relativePath);
+  if (!pathIsWithin(root, target)) throw new Error("Reference image escapes the project root.");
+  await assertNoSymlinkSegments(root, target);
+  const stats = await lstat(target);
+  if (!stats.isFile() || stats.isSymbolicLink()) throw new Error(`Reference image ${relativePath} is not a regular file.`);
+  const physical = await realpath(target);
+  if (!pathIsWithin(root, physical)) throw new Error("Reference image resolves outside the project root.");
+  const buffer = await readFile(physical);
+  const mime = validateReferenceBuffer(buffer, relativePath);
+  return { buffer, mime, name: basename(relativePath), dataUrl: `data:${mime};base64,${buffer.toString("base64")}` };
+}
+
+export async function readReferenceImages(paths, projectRoot) {
+  const requested = paths || [];
+  if (!Array.isArray(requested) || requested.length > MAX_REFERENCE_IMAGES) {
+    throw new Error(`Reference images must contain at most ${MAX_REFERENCE_IMAGES} paths.`);
+  }
+  const root = await requireProjectRoot(projectRoot);
+  const images = [];
+  let totalBytes = 0;
+  for (const imagePath of requested) {
+    const image = await readReferenceImage(imagePath, root);
+    totalBytes += image.buffer.length;
+    if (totalBytes > MAX_REFERENCE_TOTAL_BYTES) {
+      throw new Error("Reference images exceed the 50 MiB combined limit.");
+    }
+    images.push(image);
+  }
+  return images;
+}
+
+function validatePngBase64(base64) {
+  const encoded = String(base64 || "").trim();
+  if (!encoded || encoded.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(encoded)) {
+    throw new Error("Image provider returned invalid base64 data.");
+  }
+  const buffer = Buffer.from(encoded, "base64");
+  if (buffer.length === 0 || buffer.length > MAX_OUTPUT_BYTES || !buffer.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
+    throw new Error("Image provider returned an invalid or oversized PNG.");
+  }
+  return buffer;
+}
+
+function versionedPath(requestedPath, version) {
+  if (version === 1) return requestedPath;
+  const extension = extname(requestedPath);
+  const stem = basename(requestedPath, extension);
+  return join(dirname(requestedPath), `${stem}-v${version}${extension}`);
+}
+
+export async function validateImageOutputPath(out, projectRoot) {
+  const requested = requireRelativePath(out, "Image output");
+  if (extname(requested).toLowerCase() !== ".png") {
+    throw new Error("Image output must end in .png.");
+  }
+  if (requested.split(/[\\/]+/)[0] === ".git") {
+    throw new Error("Image output cannot be written inside .git.");
+  }
+  const root = await requireProjectRoot(projectRoot);
+  const target = resolve(root, requested);
+  if (!pathIsWithin(root, target)) throw new Error("Image output escapes the project root.");
+  const parent = dirname(target);
+  await assertNoSymlinkSegments(root, parent);
+  await mkdir(parent, { recursive: true, mode: 0o700 });
+  await assertNoSymlinkSegments(root, parent);
+  const physicalParent = await realpath(parent);
+  if (!pathIsWithin(root, physicalParent)) throw new Error("Image output resolves outside the project root.");
+  return join(physicalParent, basename(target));
+}
+
+async function writePrivateTempFile(target, buffer) {
+  const tempPath = join(dirname(target), `.${basename(target)}.aidevops-${randomUUID()}.tmp`);
+  const handle = await open(tempPath, "wx", 0o600);
+  try {
+    await handle.writeFile(buffer);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  return tempPath;
+}
+
+async function commitWithoutOverwrite(tempPath, requestedPath) {
+  for (let version = 1; version <= MAX_OUTPUT_VERSION; version += 1) {
+    const candidate = versionedPath(requestedPath, version);
+    try {
+      await link(tempPath, candidate);
+      return { savedPath: candidate, versioned: version > 1 };
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+    }
+  }
+  throw new Error(`No available image filename after ${MAX_OUTPUT_VERSION} versions.`);
+}
+
+export async function saveGeneratedPng(out, projectRoot, base64) {
+  const buffer = validatePngBase64(base64);
+  const requestedPath = await validateImageOutputPath(out, projectRoot);
+  const tempPath = await writePrivateTempFile(requestedPath, buffer);
+  try {
+    return await commitWithoutOverwrite(tempPath, requestedPath);
+  } finally {
+    await unlink(tempPath).catch(() => {});
+  }
+}

--- a/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
@@ -106,6 +106,7 @@ async function readReferenceImage(requested, root, remainingBytes) {
     throw new Error(`Reference image ${relativePath} is unavailable or unsafe.`);
   }
   let buffer;
+  let operationError;
   try {
     const openedStats = await handle.stat();
     if (!openedStats.isFile()) throw new Error(`Reference image ${relativePath} is not a regular file.`);
@@ -120,15 +121,18 @@ async function readReferenceImage(requested, root, remainingBytes) {
     }
     buffer = await readBoundedReference(handle, Math.min(MAX_REFERENCE_BYTES, remainingBytes));
   } catch (error) {
-    if (error?.code) throw new Error(`Reference image ${relativePath} is unavailable or unsafe.`);
-    throw error;
-  } finally {
-    try {
-      await handle.close();
-    } catch {
-      throw new Error(`Reference image ${relativePath} could not be closed safely.`);
-    }
+    operationError = error?.code
+      ? new Error(`Reference image ${relativePath} is unavailable or unsafe.`)
+      : error;
   }
+  let closeFailed = false;
+  try {
+    await handle.close();
+  } catch {
+    closeFailed = true;
+  }
+  if (operationError) throw operationError;
+  if (closeFailed) throw new Error(`Reference image ${relativePath} could not be closed safely.`);
   const mime = validateReferenceBuffer(buffer, relativePath);
   return { buffer, mime, name: basename(relativePath), dataUrl: `data:${mime};base64,${buffer.toString("base64")}` };
 }

--- a/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
@@ -1,160 +1,21 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
+import { dirname, extname, resolve } from "node:path";
+import { readReferenceImages } from "./gpt-image-reference-io.mjs";
 import {
-  lstat,
-  open,
-  realpath,
-} from "node:fs/promises";
-import { constants as fsConstants } from "node:fs";
-import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
+  assertNoSymlinkSegments,
+  pathIsWithin,
+  requireProjectRoot,
+  requireRelativePath,
+} from "./gpt-image-paths.mjs";
 import { secureWriteGeneratedPng } from "./gpt-image-secure-write.mjs";
 
-const MAX_REFERENCE_IMAGES = 8;
-const MAX_REFERENCE_BYTES = 20 * 1024 * 1024;
-const MAX_REFERENCE_TOTAL_BYTES = 50 * 1024 * 1024;
 const MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const PNG_IEND = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82]);
 
-function pathIsWithin(parent, candidate) {
-  const relation = relative(parent, candidate);
-  return relation === "" || (relation !== ".." && !relation.startsWith(`..${sep}`) && !isAbsolute(relation));
-}
-
-function requireRelativePath(value, label) {
-  const requested = String(value || "").trim();
-  if (!requested || isAbsolute(requested) || requested.split(/[\\/]+/).includes("..")) {
-    throw new Error(`${label} must be a project-relative path without parent traversal.`);
-  }
-  return requested;
-}
-
-async function requireProjectRoot(projectRoot) {
-  try {
-    const requestedRoot = resolve(projectRoot);
-    const requestedStats = await lstat(requestedRoot);
-    if (!requestedStats.isDirectory() || requestedStats.isSymbolicLink()) throw new Error("unsafe root");
-    const root = await realpath(requestedRoot);
-    const stats = await lstat(root);
-    if (!stats.isDirectory() || stats.isSymbolicLink()) throw new Error("unsafe root");
-    return root;
-  } catch {
-    throw new Error("OpenCode project root is unavailable or unsafe.");
-  }
-}
-
-async function readBoundedReference(handle, byteLimit) {
-  const chunks = [];
-  let totalBytes = 0;
-  while (totalBytes <= byteLimit) {
-    const chunk = Buffer.allocUnsafe(Math.min(1024 * 1024, byteLimit - totalBytes + 1));
-    const { bytesRead } = await handle.read(chunk, 0, chunk.length, null);
-    if (bytesRead === 0) break;
-    totalBytes += bytesRead;
-    if (totalBytes > byteLimit) throw new Error("Reference image exceeds the remaining safe size limit.");
-    chunks.push(chunk.subarray(0, bytesRead));
-  }
-  return Buffer.concat(chunks, totalBytes);
-}
-
-async function assertNoSymlinkSegments(root, target) {
-  const relation = relative(root, target);
-  let cursor = root;
-  for (const segment of relation.split(sep).filter(Boolean)) {
-    cursor = join(cursor, segment);
-    try {
-      const stats = await lstat(cursor);
-      if (stats.isSymbolicLink()) throw new Error("Image paths cannot traverse symbolic links.");
-    } catch (error) {
-      if (error?.code === "ENOENT") return;
-      if (error?.message === "Image paths cannot traverse symbolic links.") throw error;
-      throw new Error("Image path is unavailable or unsafe.");
-    }
-  }
-}
-
-function detectImageMime(buffer) {
-  if (buffer.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) return "image/png";
-  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return "image/jpeg";
-  if (buffer.subarray(0, 4).toString("ascii") === "RIFF" && buffer.subarray(8, 12).toString("ascii") === "WEBP") {
-    return "image/webp";
-  }
-  return "";
-}
-
-function validateReferenceBuffer(buffer, requested) {
-  if (buffer.length === 0 || buffer.length > MAX_REFERENCE_BYTES) {
-    throw new Error(`Reference image ${requested} must be between 1 byte and 20 MiB.`);
-  }
-  const mime = detectImageMime(buffer);
-  if (!mime) throw new Error(`Reference image ${requested} must be PNG, JPEG, or WebP.`);
-  return mime;
-}
-
-async function readReferenceImage(requested, root, remainingBytes) {
-  const relativePath = requireRelativePath(requested, "Reference image");
-  const target = resolve(root, relativePath);
-  if (!pathIsWithin(root, target)) throw new Error("Reference image escapes the project root.");
-  await assertNoSymlinkSegments(root, target);
-  if (!fsConstants.O_NOFOLLOW) throw new Error("Secure reference-image reads are unsupported on this platform.");
-  const flags = fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW;
-  let handle;
-  try {
-    handle = await open(target, flags);
-  } catch {
-    throw new Error(`Reference image ${relativePath} is unavailable or unsafe.`);
-  }
-  let buffer;
-  let operationError;
-  try {
-    const openedStats = await handle.stat();
-    if (!openedStats.isFile()) throw new Error(`Reference image ${relativePath} is not a regular file.`);
-    if (openedStats.size > MAX_REFERENCE_BYTES || openedStats.size > remainingBytes) {
-      throw new Error(`Reference image ${relativePath} exceeds the remaining safe size limit.`);
-    }
-    const physical = await realpath(target);
-    if (!pathIsWithin(root, physical)) throw new Error("Reference image resolves outside the project root.");
-    const currentStats = await lstat(physical);
-    if (openedStats.dev !== currentStats.dev || openedStats.ino !== currentStats.ino) {
-      throw new Error("Reference image changed during secure open.");
-    }
-    buffer = await readBoundedReference(handle, Math.min(MAX_REFERENCE_BYTES, remainingBytes));
-  } catch (error) {
-    operationError = error?.code
-      ? new Error(`Reference image ${relativePath} is unavailable or unsafe.`)
-      : error;
-  }
-  let closeFailed = false;
-  try {
-    await handle.close();
-  } catch {
-    closeFailed = true;
-  }
-  if (operationError) throw operationError;
-  if (closeFailed) throw new Error(`Reference image ${relativePath} could not be closed safely.`);
-  const mime = validateReferenceBuffer(buffer, relativePath);
-  return { buffer, mime, name: basename(relativePath), dataUrl: `data:${mime};base64,${buffer.toString("base64")}` };
-}
-
-export async function readReferenceImages(paths, projectRoot) {
-  const requested = paths || [];
-  if (!Array.isArray(requested) || requested.length > MAX_REFERENCE_IMAGES) {
-    throw new Error(`Reference images must contain at most ${MAX_REFERENCE_IMAGES} paths.`);
-  }
-  const root = await requireProjectRoot(projectRoot);
-  const images = [];
-  let totalBytes = 0;
-  for (const imagePath of requested) {
-    const image = await readReferenceImage(imagePath, root, MAX_REFERENCE_TOTAL_BYTES - totalBytes);
-    totalBytes += image.buffer.length;
-    if (totalBytes > MAX_REFERENCE_TOTAL_BYTES) {
-      throw new Error("Reference images exceed the 50 MiB combined limit.");
-    }
-    images.push(image);
-  }
-  return images;
-}
+export { readReferenceImages };
 
 function validatePngBase64(base64) {
   const encoded = String(base64 || "").trim();

--- a/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
@@ -2,23 +2,20 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import {
-  link,
   lstat,
-  mkdir,
   open,
-  readFile,
   realpath,
-  unlink,
 } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { secureWriteGeneratedPng } from "./gpt-image-secure-write.mjs";
 
 const MAX_REFERENCE_IMAGES = 8;
 const MAX_REFERENCE_BYTES = 20 * 1024 * 1024;
 const MAX_REFERENCE_TOTAL_BYTES = 50 * 1024 * 1024;
 const MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
-const MAX_OUTPUT_VERSION = 999;
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PNG_IEND = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82]);
 
 function pathIsWithin(parent, candidate) {
   const relation = relative(parent, candidate);
@@ -34,12 +31,31 @@ function requireRelativePath(value, label) {
 }
 
 async function requireProjectRoot(projectRoot) {
-  const root = await realpath(projectRoot);
-  const stats = await lstat(root);
-  if (!stats.isDirectory() || stats.isSymbolicLink()) {
-    throw new Error("OpenCode project root must be a regular directory.");
+  try {
+    const requestedRoot = resolve(projectRoot);
+    const requestedStats = await lstat(requestedRoot);
+    if (!requestedStats.isDirectory() || requestedStats.isSymbolicLink()) throw new Error("unsafe root");
+    const root = await realpath(requestedRoot);
+    const stats = await lstat(root);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) throw new Error("unsafe root");
+    return root;
+  } catch {
+    throw new Error("OpenCode project root is unavailable or unsafe.");
   }
-  return root;
+}
+
+async function readBoundedReference(handle, byteLimit) {
+  const chunks = [];
+  let totalBytes = 0;
+  while (totalBytes <= byteLimit) {
+    const chunk = Buffer.allocUnsafe(Math.min(1024 * 1024, byteLimit - totalBytes + 1));
+    const { bytesRead } = await handle.read(chunk, 0, chunk.length, null);
+    if (bytesRead === 0) break;
+    totalBytes += bytesRead;
+    if (totalBytes > byteLimit) throw new Error("Reference image exceeds the remaining safe size limit.");
+    chunks.push(chunk.subarray(0, bytesRead));
+  }
+  return Buffer.concat(chunks, totalBytes);
 }
 
 async function assertNoSymlinkSegments(root, target) {
@@ -52,7 +68,8 @@ async function assertNoSymlinkSegments(root, target) {
       if (stats.isSymbolicLink()) throw new Error("Image paths cannot traverse symbolic links.");
     } catch (error) {
       if (error?.code === "ENOENT") return;
-      throw error;
+      if (error?.message === "Image paths cannot traverse symbolic links.") throw error;
+      throw new Error("Image path is unavailable or unsafe.");
     }
   }
 }
@@ -75,16 +92,43 @@ function validateReferenceBuffer(buffer, requested) {
   return mime;
 }
 
-async function readReferenceImage(requested, root) {
+async function readReferenceImage(requested, root, remainingBytes) {
   const relativePath = requireRelativePath(requested, "Reference image");
   const target = resolve(root, relativePath);
   if (!pathIsWithin(root, target)) throw new Error("Reference image escapes the project root.");
   await assertNoSymlinkSegments(root, target);
-  const stats = await lstat(target);
-  if (!stats.isFile() || stats.isSymbolicLink()) throw new Error(`Reference image ${relativePath} is not a regular file.`);
-  const physical = await realpath(target);
-  if (!pathIsWithin(root, physical)) throw new Error("Reference image resolves outside the project root.");
-  const buffer = await readFile(physical);
+  if (!fsConstants.O_NOFOLLOW) throw new Error("Secure reference-image reads are unsupported on this platform.");
+  const flags = fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW;
+  let handle;
+  try {
+    handle = await open(target, flags);
+  } catch {
+    throw new Error(`Reference image ${relativePath} is unavailable or unsafe.`);
+  }
+  let buffer;
+  try {
+    const openedStats = await handle.stat();
+    if (!openedStats.isFile()) throw new Error(`Reference image ${relativePath} is not a regular file.`);
+    if (openedStats.size > MAX_REFERENCE_BYTES || openedStats.size > remainingBytes) {
+      throw new Error(`Reference image ${relativePath} exceeds the remaining safe size limit.`);
+    }
+    const physical = await realpath(target);
+    if (!pathIsWithin(root, physical)) throw new Error("Reference image resolves outside the project root.");
+    const currentStats = await lstat(physical);
+    if (openedStats.dev !== currentStats.dev || openedStats.ino !== currentStats.ino) {
+      throw new Error("Reference image changed during secure open.");
+    }
+    buffer = await readBoundedReference(handle, Math.min(MAX_REFERENCE_BYTES, remainingBytes));
+  } catch (error) {
+    if (error?.code) throw new Error(`Reference image ${relativePath} is unavailable or unsafe.`);
+    throw error;
+  } finally {
+    try {
+      await handle.close();
+    } catch {
+      throw new Error(`Reference image ${relativePath} could not be closed safely.`);
+    }
+  }
   const mime = validateReferenceBuffer(buffer, relativePath);
   return { buffer, mime, name: basename(relativePath), dataUrl: `data:${mime};base64,${buffer.toString("base64")}` };
 }
@@ -98,7 +142,7 @@ export async function readReferenceImages(paths, projectRoot) {
   const images = [];
   let totalBytes = 0;
   for (const imagePath of requested) {
-    const image = await readReferenceImage(imagePath, root);
+    const image = await readReferenceImage(imagePath, root, MAX_REFERENCE_TOTAL_BYTES - totalBytes);
     totalBytes += image.buffer.length;
     if (totalBytes > MAX_REFERENCE_TOTAL_BYTES) {
       throw new Error("Reference images exceed the 50 MiB combined limit.");
@@ -114,17 +158,15 @@ function validatePngBase64(base64) {
     throw new Error("Image provider returned invalid base64 data.");
   }
   const buffer = Buffer.from(encoded, "base64");
-  if (buffer.length === 0 || buffer.length > MAX_OUTPUT_BYTES || !buffer.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
+  const hasHeader = buffer.length >= 45
+    && buffer.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)
+    && buffer.readUInt32BE(8) === 13
+    && buffer.subarray(12, 16).toString("ascii") === "IHDR";
+  const hasEnd = buffer.subarray(-PNG_IEND.length).equals(PNG_IEND);
+  if (buffer.length > MAX_OUTPUT_BYTES || !hasHeader || !hasEnd) {
     throw new Error("Image provider returned an invalid or oversized PNG.");
   }
   return buffer;
-}
-
-function versionedPath(requestedPath, version) {
-  if (version === 1) return requestedPath;
-  const extension = extname(requestedPath);
-  const stem = basename(requestedPath, extension);
-  return join(dirname(requestedPath), `${stem}-v${version}${extension}`);
 }
 
 export async function validateImageOutputPath(out, projectRoot) {
@@ -132,7 +174,7 @@ export async function validateImageOutputPath(out, projectRoot) {
   if (extname(requested).toLowerCase() !== ".png") {
     throw new Error("Image output must end in .png.");
   }
-  if (requested.split(/[\\/]+/)[0] === ".git") {
+  if (requested.split(/[\\/]+/).some((part) => part.toLowerCase() === ".git")) {
     throw new Error("Image output cannot be written inside .git.");
   }
   const root = await requireProjectRoot(projectRoot);
@@ -140,45 +182,12 @@ export async function validateImageOutputPath(out, projectRoot) {
   if (!pathIsWithin(root, target)) throw new Error("Image output escapes the project root.");
   const parent = dirname(target);
   await assertNoSymlinkSegments(root, parent);
-  await mkdir(parent, { recursive: true, mode: 0o700 });
-  await assertNoSymlinkSegments(root, parent);
-  const physicalParent = await realpath(parent);
-  if (!pathIsWithin(root, physicalParent)) throw new Error("Image output resolves outside the project root.");
-  return join(physicalParent, basename(target));
+  return requested;
 }
 
-async function writePrivateTempFile(target, buffer) {
-  const tempPath = join(dirname(target), `.${basename(target)}.aidevops-${randomUUID()}.tmp`);
-  const handle = await open(tempPath, "wx", 0o600);
-  try {
-    await handle.writeFile(buffer);
-    await handle.sync();
-  } finally {
-    await handle.close();
-  }
-  return tempPath;
-}
-
-async function commitWithoutOverwrite(tempPath, requestedPath) {
-  for (let version = 1; version <= MAX_OUTPUT_VERSION; version += 1) {
-    const candidate = versionedPath(requestedPath, version);
-    try {
-      await link(tempPath, candidate);
-      return { savedPath: candidate, versioned: version > 1 };
-    } catch (error) {
-      if (error?.code !== "EEXIST") throw error;
-    }
-  }
-  throw new Error(`No available image filename after ${MAX_OUTPUT_VERSION} versions.`);
-}
-
-export async function saveGeneratedPng(out, projectRoot, base64) {
+export async function saveGeneratedPng(out, projectRoot, base64, options = {}) {
   const buffer = validatePngBase64(base64);
   const requestedPath = await validateImageOutputPath(out, projectRoot);
-  const tempPath = await writePrivateTempFile(requestedPath, buffer);
-  try {
-    return await commitWithoutOverwrite(tempPath, requestedPath);
-  } finally {
-    await unlink(tempPath).catch(() => {});
-  }
+  const root = await requireProjectRoot(projectRoot);
+  return secureWriteGeneratedPng(buffer, requestedPath, root, options);
 }

--- a/.agents/plugins/opencode-aidevops/gpt-image-paths.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-paths.mjs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { lstat, realpath } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+
+export function pathIsWithin(parent, candidate) {
+  const relation = relative(parent, candidate);
+  return relation === "" || (relation !== ".." && !relation.startsWith(`..${sep}`) && !isAbsolute(relation));
+}
+
+export function requireRelativePath(value, label) {
+  const requested = String(value || "").trim();
+  if (!requested || isAbsolute(requested) || requested.split(/[\\/]+/).includes("..")) {
+    throw new Error(`${label} must be a project-relative path without parent traversal.`);
+  }
+  return requested;
+}
+
+export async function requireProjectRoot(projectRoot) {
+  try {
+    const requestedRoot = resolve(projectRoot);
+    const requestedStats = await lstat(requestedRoot);
+    if (!requestedStats.isDirectory() || requestedStats.isSymbolicLink()) throw new Error("unsafe root");
+    const root = await realpath(requestedRoot);
+    const stats = await lstat(root);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) throw new Error("unsafe root");
+    return root;
+  } catch {
+    throw new Error("OpenCode project root is unavailable or unsafe.");
+  }
+}
+
+export async function assertNoSymlinkSegments(root, target) {
+  const relation = relative(root, target);
+  let cursor = root;
+  for (const segment of relation.split(sep).filter(Boolean)) {
+    cursor = join(cursor, segment);
+    try {
+      const stats = await lstat(cursor);
+      if (stats.isSymbolicLink()) throw new Error("Image paths cannot traverse symbolic links.");
+    } catch (error) {
+      if (error?.code === "ENOENT") return;
+      if (error?.message === "Image paths cannot traverse symbolic links.") throw error;
+      throw new Error("Image path is unavailable or unsafe.");
+    }
+  }
+}

--- a/.agents/plugins/opencode-aidevops/gpt-image-reference-io.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-reference-io.mjs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { constants as fsConstants } from "node:fs";
+import { lstat, open, realpath } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import {
+  assertNoSymlinkSegments,
+  pathIsWithin,
+  requireProjectRoot,
+  requireRelativePath,
+} from "./gpt-image-paths.mjs";
+
+const MAX_REFERENCE_IMAGES = 8;
+const MAX_REFERENCE_BYTES = 20 * 1024 * 1024;
+const MAX_REFERENCE_TOTAL_BYTES = 50 * 1024 * 1024;
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+async function readBoundedReference(handle, byteLimit) {
+  const chunks = [];
+  let totalBytes = 0;
+  while (totalBytes <= byteLimit) {
+    const chunk = Buffer.allocUnsafe(Math.min(1024 * 1024, byteLimit - totalBytes + 1));
+    const { bytesRead } = await handle.read(chunk, 0, chunk.length, null);
+    if (bytesRead === 0) break;
+    totalBytes += bytesRead;
+    if (totalBytes > byteLimit) throw new Error("Reference image exceeds the remaining safe size limit.");
+    chunks.push(chunk.subarray(0, bytesRead));
+  }
+  return Buffer.concat(chunks, totalBytes);
+}
+
+function detectImageMime(buffer) {
+  if (buffer.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) return "image/png";
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return "image/jpeg";
+  if (buffer.subarray(0, 4).toString("ascii") === "RIFF" && buffer.subarray(8, 12).toString("ascii") === "WEBP") {
+    return "image/webp";
+  }
+  return "";
+}
+
+function validateReferenceBuffer(buffer, requested) {
+  if (buffer.length === 0 || buffer.length > MAX_REFERENCE_BYTES) {
+    throw new Error(`Reference image ${requested} must be between 1 byte and 20 MiB.`);
+  }
+  const mime = detectImageMime(buffer);
+  if (!mime) throw new Error(`Reference image ${requested} must be PNG, JPEG, or WebP.`);
+  return mime;
+}
+
+async function readReferenceImage(requested, root, remainingBytes) {
+  const relativePath = requireRelativePath(requested, "Reference image");
+  const target = resolve(root, relativePath);
+  if (!pathIsWithin(root, target)) throw new Error("Reference image escapes the project root.");
+  await assertNoSymlinkSegments(root, target);
+  if (!fsConstants.O_NOFOLLOW) throw new Error("Secure reference-image reads are unsupported on this platform.");
+  const flags = fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW;
+  let handle;
+  try {
+    handle = await open(target, flags);
+  } catch {
+    throw new Error(`Reference image ${relativePath} is unavailable or unsafe.`);
+  }
+  let buffer;
+  let operationError;
+  try {
+    const openedStats = await handle.stat();
+    if (!openedStats.isFile()) throw new Error(`Reference image ${relativePath} is not a regular file.`);
+    if (openedStats.size > MAX_REFERENCE_BYTES || openedStats.size > remainingBytes) {
+      throw new Error(`Reference image ${relativePath} exceeds the remaining safe size limit.`);
+    }
+    const physical = await realpath(target);
+    if (!pathIsWithin(root, physical)) throw new Error("Reference image resolves outside the project root.");
+    const currentStats = await lstat(physical);
+    if (openedStats.dev !== currentStats.dev || openedStats.ino !== currentStats.ino) {
+      throw new Error("Reference image changed during secure open.");
+    }
+    buffer = await readBoundedReference(handle, Math.min(MAX_REFERENCE_BYTES, remainingBytes));
+  } catch (error) {
+    operationError = error?.code
+      ? new Error(`Reference image ${relativePath} is unavailable or unsafe.`)
+      : error;
+  }
+  let closeFailed = false;
+  try {
+    await handle.close();
+  } catch {
+    closeFailed = true;
+  }
+  if (operationError) throw operationError;
+  if (closeFailed) throw new Error(`Reference image ${relativePath} could not be closed safely.`);
+  const mime = validateReferenceBuffer(buffer, relativePath);
+  return { buffer, mime, name: basename(relativePath), dataUrl: `data:${mime};base64,${buffer.toString("base64")}` };
+}
+
+export async function readReferenceImages(paths, projectRoot) {
+  const requested = paths || [];
+  if (!Array.isArray(requested) || requested.length > MAX_REFERENCE_IMAGES) {
+    throw new Error(`Reference images must contain at most ${MAX_REFERENCE_IMAGES} paths.`);
+  }
+  const root = await requireProjectRoot(projectRoot);
+  const images = [];
+  let totalBytes = 0;
+  for (const imagePath of requested) {
+    const image = await readReferenceImage(imagePath, root, MAX_REFERENCE_TOTAL_BYTES - totalBytes);
+    totalBytes += image.buffer.length;
+    if (totalBytes > MAX_REFERENCE_TOTAL_BYTES) {
+      throw new Error("Reference images exceed the 50 MiB combined limit.");
+    }
+    images.push(image);
+  }
+  return images;
+}

--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -10,7 +10,21 @@ const OPENAI_IMAGES_GENERATE_ENDPOINT = "https://api.openai.com/v1/images/genera
 const OPENAI_IMAGES_EDIT_ENDPOINT = "https://api.openai.com/v1/images/edits";
 const SUBSCRIPTION_ROUTER_MODEL = "gpt-5.5";
 const MAX_SSE_BUFFER_CHARS = 96 * 1024 * 1024;
+const MAX_SSE_TOTAL_BYTES = 128 * 1024 * 1024;
 const MAX_API_RESPONSE_BYTES = 96 * 1024 * 1024;
+const MAX_ERROR_RESPONSE_BYTES = 64 * 1024;
+const IMAGE_REQUEST_TIMEOUT_MS = 180_000;
+
+async function withImageRequestTimeout(operation) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), IMAGE_REQUEST_TIMEOUT_MS);
+  timer.unref?.();
+  try {
+    return await operation(controller.signal);
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 function imageToolArgs(args) {
   return {
@@ -79,12 +93,22 @@ export async function parseImageSse(stream) {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let pending = "";
+  let totalBytes = 0;
   while (true) {
     const { done, value } = await reader.read();
+    totalBytes += value?.byteLength || 0;
+    if (totalBytes > MAX_SSE_TOTAL_BYTES) {
+      await reader.cancel().catch(() => {});
+      throw new Error("OAuth image response exceeded the safe event-stream limit.");
+    }
     pending += decoder.decode(value || new Uint8Array(), { stream: !done });
     let next;
     while ((next = takeNextSseBlock(pending))) {
       pending = next.rest;
+      if (next.block.length > MAX_SSE_BUFFER_CHARS) {
+        await reader.cancel().catch(() => {});
+        throw new Error("OAuth image event exceeded the safe event-stream limit.");
+      }
       const result = parseSseBlock(next.block);
       if (result) {
         await reader.cancel().catch(() => {});
@@ -103,13 +127,16 @@ export async function parseImageSse(stream) {
 }
 
 export async function requestOAuthImage(auth, args, images, fetchImpl) {
-  const response = await fetchImpl(CODEX_RESPONSES_ENDPOINT, {
-    method: "POST",
-    headers: oauthHeaders(auth),
-    body: JSON.stringify(oauthRequestBody(args, images)),
+  return withImageRequestTimeout(async (signal) => {
+    const response = await fetchImpl(CODEX_RESPONSES_ENDPOINT, {
+      method: "POST",
+      headers: oauthHeaders(auth),
+      body: JSON.stringify(oauthRequestBody(args, images)),
+      signal,
+    });
+    if (!response.ok) return { response, base64: "", error: await imageRequestError(response, "oauth") };
+    return { response, base64: await parseImageSse(response.body) };
   });
-  if (!response.ok) return { response, base64: "" };
-  return { response, base64: await parseImageSse(response.body) };
 }
 
 function apiJsonBody(args) {
@@ -135,36 +162,54 @@ function apiMultipartBody(args, images) {
   return body;
 }
 
-function apiRequest(auth, args, images) {
+function apiRequest(auth, args, images, signal) {
   const headers = { Authorization: `Bearer ${auth.accessToken}` };
   if (images.length === 0) {
     headers["Content-Type"] = "application/json";
     return {
       endpoint: OPENAI_IMAGES_GENERATE_ENDPOINT,
-      init: { method: "POST", headers, body: JSON.stringify(apiJsonBody(args)) },
+      init: { method: "POST", headers, body: JSON.stringify(apiJsonBody(args)), signal },
     };
   }
   return {
     endpoint: OPENAI_IMAGES_EDIT_ENDPOINT,
-    init: { method: "POST", headers, body: apiMultipartBody(args, images) },
+    init: { method: "POST", headers, body: apiMultipartBody(args, images), signal },
   };
 }
 
+async function readBoundedJson(response, byteLimit, label) {
+  if (!response.body?.getReader) throw new Error(`${label} did not include a response body.`);
+  const reader = response.body.getReader();
+  const chunks = [];
+  let totalBytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > byteLimit) {
+      await reader.cancel().catch(() => {});
+      throw new Error(`${label} exceeded the safe response limit.`);
+    }
+    chunks.push(Buffer.from(value));
+  }
+  return JSON.parse(Buffer.concat(chunks, totalBytes).toString("utf8"));
+}
+
 export async function requestApiImage(auth, args, images, fetchImpl) {
-  const request = apiRequest(auth, args, images);
-  const response = await fetchImpl(request.endpoint, request.init);
-  if (!response.ok) return { response, base64: "" };
-  const contentLength = Number(response.headers.get("content-length") || 0);
-  if (contentLength > MAX_API_RESPONSE_BYTES) {
-    await response.body?.cancel?.().catch(() => {});
-    throw new Error("OpenAI Images API response exceeded the safe response limit.");
-  }
-  const payload = await response.json();
-  const base64 = payload?.data?.[0]?.b64_json;
-  if (typeof base64 !== "string" || !base64) {
-    throw new Error("OpenAI Images API response did not contain an image.");
-  }
-  return { response, base64 };
+  return withImageRequestTimeout(async (signal) => {
+    const request = apiRequest(auth, args, images, signal);
+    const response = await fetchImpl(request.endpoint, request.init);
+    if (!response.ok) return { response, base64: "", error: await imageRequestError(response, "api") };
+    const contentLength = Number(response.headers.get("content-length") || 0);
+    if (contentLength > MAX_API_RESPONSE_BYTES) {
+      await response.body?.cancel?.().catch(() => {});
+      throw new Error("OpenAI Images API response exceeded the safe response limit.");
+    }
+    const payload = await readBoundedJson(response, MAX_API_RESPONSE_BYTES, "OpenAI Images API response");
+    const base64 = payload?.data?.[0]?.b64_json;
+    if (typeof base64 !== "string" || !base64) throw new Error("OpenAI Images API response did not contain an image.");
+    return { response, base64 };
+  });
 }
 
 function redactProviderDetail(value) {
@@ -179,7 +224,7 @@ export async function imageRequestError(response, mode) {
   let code = "";
   let message = "";
   try {
-    const payload = await response.json();
+    const payload = await readBoundedJson(response, MAX_ERROR_RESPONSE_BYTES, "OpenAI image error response");
     code = payload?.error?.code || payload?.error?.type || "";
     message = payload?.error?.message || "";
   } catch {

--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+// OAuth request semantics were independently implemented after reviewing the
+// MIT-licensed opencode-gpt-imagegen project by Yuji Hatakeyama:
+// https://github.com/yuji-hatakeyama/opencode-gpt-imagegen
+
+const CODEX_RESPONSES_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
+const OPENAI_IMAGES_GENERATE_ENDPOINT = "https://api.openai.com/v1/images/generations";
+const OPENAI_IMAGES_EDIT_ENDPOINT = "https://api.openai.com/v1/images/edits";
+const SUBSCRIPTION_ROUTER_MODEL = "gpt-5.5";
+const MAX_SSE_BUFFER_CHARS = 96 * 1024 * 1024;
+
+function imageToolArgs(args) {
+  return {
+    type: "image_generation",
+    output_format: "png",
+    quality: args.quality || "auto",
+    ...(args.size && args.size !== "auto" ? { size: args.size } : {}),
+  };
+}
+
+function oauthRequestBody(args, images) {
+  const content = [{ type: "input_text", text: args.prompt }];
+  for (const image of images) content.push({ type: "input_image", image_url: image.dataUrl });
+  return {
+    model: SUBSCRIPTION_ROUTER_MODEL,
+    instructions: "Generate the requested image by invoking the image_generation tool exactly once.",
+    input: [{ role: "user", content }],
+    tools: [imageToolArgs(args)],
+    tool_choice: { type: "image_generation" },
+    stream: true,
+    store: false,
+  };
+}
+
+function oauthHeaders(auth) {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${auth.accessToken}`,
+    ...(auth.accountId ? { "ChatGPT-Account-Id": auth.accountId } : {}),
+    originator: "opencode",
+    Accept: "text/event-stream",
+  };
+}
+
+function parseSseBlock(block) {
+  const data = block
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trimStart())
+    .join("\n");
+  if (!data || data === "[DONE]") return "";
+  try {
+    const event = JSON.parse(data);
+    if (
+      event.type === "response.output_item.done"
+      && event.item?.type === "image_generation_call"
+      && typeof event.item.result === "string"
+    ) {
+      return event.item.result;
+    }
+  } catch {
+    return "";
+  }
+  return "";
+}
+
+function takeNextSseBlock(pending) {
+  const delimiter = pending.match(/\r?\n\r?\n/);
+  if (!delimiter || delimiter.index === undefined) return null;
+  const end = delimiter.index + delimiter[0].length;
+  return { block: pending.slice(0, delimiter.index), rest: pending.slice(end) };
+}
+
+export async function parseImageSse(stream) {
+  if (!stream?.getReader) throw new Error("OAuth image response did not include an event stream.");
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let pending = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    pending += decoder.decode(value || new Uint8Array(), { stream: !done });
+    let next;
+    while ((next = takeNextSseBlock(pending))) {
+      pending = next.rest;
+      const result = parseSseBlock(next.block);
+      if (result) {
+        await reader.cancel().catch(() => {});
+        return result;
+      }
+    }
+    if (pending.length > MAX_SSE_BUFFER_CHARS) {
+      await reader.cancel().catch(() => {});
+      throw new Error("OAuth image response exceeded the safe event-stream limit.");
+    }
+    if (done) break;
+  }
+  const finalResult = parseSseBlock(pending);
+  if (finalResult) return finalResult;
+  throw new Error("OAuth image response did not contain a completed image.");
+}
+
+export async function requestOAuthImage(auth, args, images, fetchImpl) {
+  const response = await fetchImpl(CODEX_RESPONSES_ENDPOINT, {
+    method: "POST",
+    headers: oauthHeaders(auth),
+    body: JSON.stringify(oauthRequestBody(args, images)),
+  });
+  if (!response.ok) return { response, base64: "" };
+  return { response, base64: await parseImageSse(response.body) };
+}
+
+function apiJsonBody(args) {
+  return {
+    model: "gpt-image-2",
+    prompt: args.prompt,
+    quality: args.quality || "auto",
+    size: args.size || "auto",
+    output_format: "png",
+  };
+}
+
+function apiMultipartBody(args, images) {
+  const body = new FormData();
+  body.append("model", "gpt-image-2");
+  body.append("prompt", args.prompt);
+  body.append("quality", args.quality || "auto");
+  body.append("size", args.size || "auto");
+  body.append("output_format", "png");
+  for (const image of images) {
+    body.append("image[]", new Blob([image.buffer], { type: image.mime }), image.name);
+  }
+  return body;
+}
+
+function apiRequest(auth, args, images) {
+  const headers = { Authorization: `Bearer ${auth.accessToken}` };
+  if (images.length === 0) {
+    headers["Content-Type"] = "application/json";
+    return {
+      endpoint: OPENAI_IMAGES_GENERATE_ENDPOINT,
+      init: { method: "POST", headers, body: JSON.stringify(apiJsonBody(args)) },
+    };
+  }
+  return {
+    endpoint: OPENAI_IMAGES_EDIT_ENDPOINT,
+    init: { method: "POST", headers, body: apiMultipartBody(args, images) },
+  };
+}
+
+export async function requestApiImage(auth, args, images, fetchImpl) {
+  const request = apiRequest(auth, args, images);
+  const response = await fetchImpl(request.endpoint, request.init);
+  if (!response.ok) return { response, base64: "" };
+  const payload = await response.json();
+  const base64 = payload?.data?.[0]?.b64_json;
+  if (typeof base64 !== "string" || !base64) {
+    throw new Error("OpenAI Images API response did not contain an image.");
+  }
+  return { response, base64 };
+}
+
+function redactProviderDetail(value) {
+  return String(value || "")
+    .replace(/Bearer\s+\S+/gi, "Bearer [REDACTED]")
+    .replace(/\bsk-[A-Za-z0-9_-]+\b/g, "[REDACTED]")
+    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED]")
+    .slice(0, 300);
+}
+
+export async function imageRequestError(response, mode) {
+  let code = "";
+  let message = "";
+  try {
+    const payload = await response.json();
+    code = payload?.error?.code || payload?.error?.type || "";
+    message = payload?.error?.message || "";
+  } catch {
+    message = "provider returned a non-JSON error";
+  }
+  const detail = [code, message].filter(Boolean).map(redactProviderDetail).join(": ");
+  return new Error(`OpenAI ${mode} image request failed (${response.status})${detail ? `: ${detail}` : "."}`);
+}

--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -88,6 +88,30 @@ function takeNextSseBlock(pending) {
   return { block: pending.slice(0, delimiter.index), rest: pending.slice(end) };
 }
 
+async function cancelSseReader(reader) {
+  await reader.cancel().catch(() => {});
+}
+
+async function consumeSseBlocks(reader, pending) {
+  let next;
+  while ((next = takeNextSseBlock(pending))) {
+    pending = next.rest;
+    if (next.block.length > MAX_SSE_BUFFER_CHARS) {
+      await cancelSseReader(reader);
+      throw new Error("OAuth image event exceeded the safe event-stream limit.");
+    }
+    const result = parseSseBlock(next.block);
+    if (result) return { pending, result };
+  }
+  return { pending, result: "" };
+}
+
+async function enforceSseLimit(reader, exceeded, message) {
+  if (!exceeded) return;
+  await cancelSseReader(reader);
+  throw new Error(message);
+}
+
 export async function parseImageSse(stream) {
   if (!stream?.getReader) throw new Error("OAuth image response did not include an event stream.");
   const reader = stream.getReader();
@@ -97,28 +121,23 @@ export async function parseImageSse(stream) {
   while (true) {
     const { done, value } = await reader.read();
     totalBytes += value?.byteLength || 0;
-    if (totalBytes > MAX_SSE_TOTAL_BYTES) {
-      await reader.cancel().catch(() => {});
-      throw new Error("OAuth image response exceeded the safe event-stream limit.");
-    }
+    await enforceSseLimit(
+      reader,
+      totalBytes > MAX_SSE_TOTAL_BYTES,
+      "OAuth image response exceeded the safe event-stream limit.",
+    );
     pending += decoder.decode(value || new Uint8Array(), { stream: !done });
-    let next;
-    while ((next = takeNextSseBlock(pending))) {
-      pending = next.rest;
-      if (next.block.length > MAX_SSE_BUFFER_CHARS) {
-        await reader.cancel().catch(() => {});
-        throw new Error("OAuth image event exceeded the safe event-stream limit.");
-      }
-      const result = parseSseBlock(next.block);
-      if (result) {
-        await reader.cancel().catch(() => {});
-        return result;
-      }
+    const consumed = await consumeSseBlocks(reader, pending);
+    pending = consumed.pending;
+    if (consumed.result) {
+      await cancelSseReader(reader);
+      return consumed.result;
     }
-    if (pending.length > MAX_SSE_BUFFER_CHARS) {
-      await reader.cancel().catch(() => {});
-      throw new Error("OAuth image response exceeded the safe event-stream limit.");
-    }
+    await enforceSseLimit(
+      reader,
+      pending.length > MAX_SSE_BUFFER_CHARS,
+      "OAuth image response exceeded the safe event-stream limit.",
+    );
     if (done) break;
   }
   const finalResult = parseSseBlock(pending);

--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -10,6 +10,7 @@ const OPENAI_IMAGES_GENERATE_ENDPOINT = "https://api.openai.com/v1/images/genera
 const OPENAI_IMAGES_EDIT_ENDPOINT = "https://api.openai.com/v1/images/edits";
 const SUBSCRIPTION_ROUTER_MODEL = "gpt-5.5";
 const MAX_SSE_BUFFER_CHARS = 96 * 1024 * 1024;
+const MAX_API_RESPONSE_BYTES = 96 * 1024 * 1024;
 
 function imageToolArgs(args) {
   return {
@@ -153,6 +154,11 @@ export async function requestApiImage(auth, args, images, fetchImpl) {
   const request = apiRequest(auth, args, images);
   const response = await fetchImpl(request.endpoint, request.init);
   if (!response.ok) return { response, base64: "" };
+  const contentLength = Number(response.headers.get("content-length") || 0);
+  if (contentLength > MAX_API_RESPONSE_BYTES) {
+    await response.body?.cancel?.().catch(() => {});
+    throw new Error("OpenAI Images API response exceeded the safe response limit.");
+  }
   const payload = await response.json();
   const base64 = payload?.data?.[0]?.b64_json;
   if (typeof base64 !== "string" || !base64) {

--- a/.agents/plugins/opencode-aidevops/gpt-image-secure-write.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-secure-write.mjs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { fileURLToPath } from "node:url";
+import { isAbsolute, join } from "node:path";
+import { runImageWriter } from "./gpt-image-writer-process.mjs";
+
+const DEFAULT_HELPER = fileURLToPath(new URL("../../scripts/gpt-image-secure-write.py", import.meta.url));
+
+function pathIsSafe(path) {
+  if (typeof path !== "string" || !path || isAbsolute(path)) return false;
+  const parts = path.split(/[\\/]+/);
+  if (parts.some((part) => !part || part === "." || part === "..")) return false;
+  return parts[0].toLowerCase() !== ".git";
+}
+
+function parseWriterOutput(stdout) {
+  let result;
+  try {
+    result = JSON.parse(stdout);
+  } catch {
+    throw new Error("Secure image writer returned an invalid receipt.");
+  }
+  const path = result?.path;
+  if (!pathIsSafe(path)) throw new Error("Secure image writer returned an unsafe output path.");
+  return {
+    cleanupWarning: result.cleanup_warning === true,
+    projectPath: path,
+    versioned: result.versioned === true,
+  };
+}
+
+export async function secureWriteGeneratedPng(buffer, out, projectRoot, options = {}) {
+  const helper = options.scriptsDir ? join(options.scriptsDir, "gpt-image-secure-write.py") : DEFAULT_HELPER;
+  const stdout = await runImageWriter(helper, buffer, out, projectRoot, options.spawnImpl);
+  return parseWriterOutput(stdout);
+}

--- a/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {
+  markOAuthImageRateLimit,
+  markOAuthImageSuccess,
+  resolveGptImageAuth,
+  rotateOAuthImageAccount,
+} from "./gpt-image-auth.mjs";
+import { readReferenceImages, saveGeneratedPng, validateImageOutputPath } from "./gpt-image-io.mjs";
+import { imageRequestError, requestApiImage, requestOAuthImage } from "./gpt-image-request.mjs";
+
+function validatePrompt(value) {
+  const prompt = String(value || "").trim();
+  if (!prompt || prompt.length > 32_000) {
+    throw new Error("Image prompt must contain 1-32,000 characters.");
+  }
+  return prompt;
+}
+
+function validateSize(value) {
+  const size = value || "auto";
+  if (size === "auto") return size;
+  const match = /^(\d+)x(\d+)$/.exec(size);
+  if (!match) throw new Error("Image size must be auto or WIDTHxHEIGHT.");
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  const longEdge = Math.max(width, height);
+  const shortEdge = Math.min(width, height);
+  const pixels = width * height;
+  if (
+    width % 16 !== 0 || height % 16 !== 0 || longEdge > 3840
+    || longEdge / shortEdge > 3 || pixels < 655_360 || pixels > 8_294_400
+  ) {
+    throw new Error("Image size violates GPT Image 2 dimension constraints.");
+  }
+  return size;
+}
+
+async function requestWithOAuth(auth, args, images, options) {
+  let result = await requestOAuthImage(auth, args, images, options.fetchImpl);
+  if (result.response.status !== 429) return { auth, result };
+
+  (options.markOAuthRateLimit || markOAuthImageRateLimit)(auth, result.response);
+  if (auth.pinned) return { auth, result };
+  const rotated = await rotateOAuthImageAccount(auth, options);
+  if (!rotated) return { auth, result };
+  result = await requestOAuthImage(rotated, args, images, options.fetchImpl);
+  if (result.response.status === 429) {
+    (options.markOAuthRateLimit || markOAuthImageRateLimit)(rotated, result.response);
+  }
+  return { auth: rotated, result };
+}
+
+function billingLabel(mode) {
+  return mode === "oauth" ? "ChatGPT subscription OAuth" : "OpenAI Platform API";
+}
+
+async function executeImageGeneration(rawArgs, options) {
+  const args = {
+    ...rawArgs,
+    prompt: validatePrompt(rawArgs.prompt),
+    size: validateSize(rawArgs.size),
+    quality: rawArgs.quality || "auto",
+  };
+  const images = await readReferenceImages(args.images, options.projectRoot);
+  await validateImageOutputPath(args.out, options.projectRoot);
+  let auth = await resolveGptImageAuth(args, options);
+  let result;
+
+  if (auth.mode === "oauth") {
+    ({ auth, result } = await requestWithOAuth(auth, args, images, options));
+  } else {
+    result = await requestApiImage(auth, args, images, options.fetchImpl);
+  }
+  if (!result.response.ok) throw await imageRequestError(result.response, auth.mode);
+
+  const saved = await saveGeneratedPng(args.out, options.projectRoot, result.base64);
+  if (auth.mode === "oauth") (options.markOAuthSuccess || markOAuthImageSuccess)(auth);
+  const versionNote = saved.versioned ? " Existing output was preserved with a versioned filename." : "";
+  return `Generated image saved to ${saved.savedPath}. Billing route: ${billingLabel(auth.mode)}.${versionNote}`;
+}
+
+export function createGptImageTool(tool, z, options = {}) {
+  const fetchImpl = options.fetchImpl || globalThis.fetch?.bind(globalThis);
+  if (typeof fetchImpl !== "function") throw new Error("GPT image generation requires fetch support.");
+  const executionOptions = { ...options, fetchImpl, projectRoot: options.projectRoot || process.cwd() };
+  return tool({
+    description:
+      "Generate or reference-edit a PNG with GPT Image 2. Uses ChatGPT OAuth by default; API billing must be selected explicitly with auth=api and a named account alias. Writes only inside the OpenCode project and never overwrites an existing image.",
+    args: {
+      prompt: z.string().describe("Description of the image to generate or edit."),
+      out: z.string().describe("Project-relative .png output path."),
+      quality: z.enum(["low", "medium", "high", "auto"]).optional().describe("GPT Image 2 quality; defaults to auto."),
+      size: z.string().optional().describe("auto or WIDTHxHEIGHT satisfying GPT Image 2 constraints."),
+      images: z.array(z.string()).optional().describe("Optional project-relative PNG, JPEG, or WebP reference image paths."),
+      auth: z.enum(["oauth", "api"]).optional().describe("Billing route; defaults to ChatGPT OAuth. API must be explicit."),
+      account: z.string().optional().describe("OAuth pool email when auth=oauth, or named API-key alias when auth=api."),
+    },
+    async execute(args) {
+      return executeImageGeneration(args && typeof args === "object" ? args : {}, executionOptions);
+    },
+  });
+}

--- a/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
@@ -45,6 +45,7 @@ async function requestWithOAuth(auth, args, images, options) {
   if (auth.pinned) return { auth, result };
   const rotated = await rotateOAuthImageAccount(auth, options);
   if (!rotated) return { auth, result };
+  await result.response.body?.cancel?.().catch(() => {});
   result = await requestOAuthImage(rotated, args, images, options.fetchImpl);
   if (result.response.status === 429) {
     (options.markOAuthRateLimit || markOAuthImageRateLimit)(rotated, result.response);

--- a/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
@@ -44,10 +44,10 @@ function validateSize(value) {
   const longEdge = Math.max(width, height);
   const shortEdge = Math.min(width, height);
   const pixels = width * height;
-  if (
-    width % 16 !== 0 || height % 16 !== 0 || longEdge > 3840
-    || longEdge / shortEdge > 3 || pixels < 655_360 || pixels > 8_294_400
-  ) {
+  const aligned = width % 16 === 0 && height % 16 === 0;
+  const boundedEdges = longEdge <= 3840 && longEdge / shortEdge <= 3;
+  const boundedPixels = pixels >= 655_360 && pixels <= 8_294_400;
+  if (!aligned || !boundedEdges || !boundedPixels) {
     throw new Error("Image size violates GPT Image 2 dimension constraints.");
   }
   return size;

--- a/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
@@ -8,7 +8,23 @@ import {
   rotateOAuthImageAccount,
 } from "./gpt-image-auth.mjs";
 import { readReferenceImages, saveGeneratedPng, validateImageOutputPath } from "./gpt-image-io.mjs";
-import { imageRequestError, requestApiImage, requestOAuthImage } from "./gpt-image-request.mjs";
+import { requestApiImage, requestOAuthImage } from "./gpt-image-request.mjs";
+
+const IMAGE_QUALITIES = new Set(["low", "medium", "high", "auto"]);
+
+function validateRawArgs(args) {
+  if (!args || typeof args !== "object" || Array.isArray(args)) throw new Error("Image tool arguments must be an object.");
+  if (typeof args.prompt !== "string" || typeof args.out !== "string") {
+    throw new Error("Image prompt and output path must be strings.");
+  }
+  if (args.quality !== undefined && !IMAGE_QUALITIES.has(args.quality)) throw new Error("Unsupported image quality.");
+  if (args.size !== undefined && typeof args.size !== "string") throw new Error("Image size must be a string.");
+  if (args.images !== undefined && (!Array.isArray(args.images) || args.images.some((path) => typeof path !== "string"))) {
+    throw new Error("Reference images must be an array of path strings.");
+  }
+  if (args.auth !== undefined && !["oauth", "api"].includes(args.auth)) throw new Error("Image auth must be oauth or api.");
+  if (args.account !== undefined && typeof args.account !== "string") throw new Error("Image account must be a string.");
+}
 
 function validatePrompt(value) {
   const prompt = String(value || "").trim();
@@ -58,6 +74,7 @@ function billingLabel(mode) {
 }
 
 async function executeImageGeneration(rawArgs, options) {
+  validateRawArgs(rawArgs);
   const args = {
     ...rawArgs,
     prompt: validatePrompt(rawArgs.prompt),
@@ -74,12 +91,16 @@ async function executeImageGeneration(rawArgs, options) {
   } else {
     result = await requestApiImage(auth, args, images, options.fetchImpl);
   }
-  if (!result.response.ok) throw await imageRequestError(result.response, auth.mode);
+  if (!result.response.ok) throw result.error;
 
-  const saved = await saveGeneratedPng(args.out, options.projectRoot, result.base64);
+  const saved = await saveGeneratedPng(args.out, options.projectRoot, result.base64, {
+    scriptsDir: options.scriptsDir,
+    spawnImpl: options.imageWriterSpawn,
+  });
   if (auth.mode === "oauth") (options.markOAuthSuccess || markOAuthImageSuccess)(auth);
   const versionNote = saved.versioned ? " Existing output was preserved with a versioned filename." : "";
-  return `Generated image saved to ${saved.savedPath}. Billing route: ${billingLabel(auth.mode)}.${versionNote}`;
+  const cleanupNote = saved.cleanupWarning ? " Temporary-file cleanup reported a filesystem warning." : "";
+  return `Generated image saved to ${saved.projectPath}. Billing route: ${billingLabel(auth.mode)}.${versionNote}${cleanupNote}`;
 }
 
 export function createGptImageTool(tool, z, options = {}) {

--- a/.agents/plugins/opencode-aidevops/gpt-image-writer-process.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-writer-process.mjs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { spawn } from "node:child_process";
+
+const WRITER_TIMEOUT_MS = 60_000;
+const MAX_DIAGNOSTIC_CHARS = 4_096;
+const PYTHON_BINARY = "/usr/bin/python3";
+
+function writerProcess(helper, out, projectRoot, spawnImpl) {
+  return spawnImpl(PYTHON_BINARY, ["-I", "-B", helper, "--root", ".", "--out", out], {
+    cwd: projectRoot,
+    env: {
+      LANG: process.env.LANG || "C.UTF-8",
+      PYTHONIOENCODING: "utf-8",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+function collectWriterOutput(child, buffer) {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => child.kill("SIGKILL"), WRITER_TIMEOUT_MS);
+    timer.unref?.();
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout = (stdout + chunk).slice(0, MAX_DIAGNOSTIC_CHARS); });
+    child.stderr.on("data", (chunk) => { stderr = (stderr + chunk).slice(0, MAX_DIAGNOSTIC_CHARS); });
+    child.on("error", () => {
+      clearTimeout(timer);
+      reject(new Error("Secure image writer could not start."));
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      if (signal === "SIGKILL") reject(new Error("Secure image writer timed out."));
+      else if (code !== 0) reject(new Error(stderr.trim() || "Secure image writer failed."));
+      else resolve(stdout);
+    });
+    child.stdin.on("error", () => {});
+    child.stdin.end(buffer);
+  });
+}
+
+export function runImageWriter(helper, buffer, out, projectRoot, spawnImpl = spawn) {
+  return collectWriterOutput(writerProcess(helper, out, projectRoot, spawnImpl), buffer);
+}

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -84,7 +84,14 @@ import {
   recordSubagentOutcome,
 } from "./observability.mjs";
 import { createSessionStartGreetingGate, createTtsrHooks } from "./ttsr.mjs";
-import { createPoolAuthHook, createPoolTool, initPoolAuth, getAccounts } from "./oauth-pool.mjs";
+import {
+  createPoolAuthHook,
+  createPoolTool,
+  getAccounts,
+  initPoolAuth,
+  rotateOpenAIPoolToken,
+  selectOpenAIRequestAccount,
+} from "./oauth-pool.mjs";
 import { createProviderAuthHook } from "./provider-auth.mjs";
 import { installOpenAIProviderFetchRotation } from "./openai-provider-auth.mjs";
 import { startCursorProxy, ensureCursorProxyServer } from "./cursor-proxy.mjs";
@@ -357,9 +364,16 @@ export async function AidevopsPlugin({ directory, client }) {
   // that brought cursor + google onto the same lazy-start pattern.
 
   // Create tools
+  // Capture fetch before installOpenAIProviderFetchRotation wraps globalThis.fetch.
+  // API-key image requests must never be rewritten with OAuth pool credentials.
+  const imageFetch = globalThis.fetch?.bind(globalThis);
   const baseTools = createTools(SCRIPTS_DIR, run, {
     sessionOrigin: process.env.AIDEVOPS_SESSION_ORIGIN,
     poolToolFactory: () => createPoolTool(client),
+    imageFetch,
+    imageOAuthAccountResolver: selectOpenAIRequestAccount,
+    imageOAuthAccountRotator: (skipEmail) => rotateOpenAIPoolToken(client, skipEmail),
+    projectRoot: directory,
     mcpClient: client.mcp,
     mcpDirectory: directory,
     managedMcpNames: getOnDemandMcpAgents().map((mcp) => mcp.name),

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -100,6 +100,10 @@ import { startClaudeProxy } from "./claude-proxy.mjs";
 import { isHeadless } from "./proxy-lifecycle.mjs";
 import { pluginHealthProbeRequested, recordPluginHealthStage } from "./plugin-health.mjs";
 
+// Preserve the runtime-native fetch before any plugin factory installs the
+// OpenAI OAuth rotation wrapper. API-key image requests need an isolated route.
+const IMAGE_FETCH = globalThis.fetch?.bind(globalThis);
+
 // ---------------------------------------------------------------------------
 // Directory constants
 // ---------------------------------------------------------------------------
@@ -364,13 +368,12 @@ export async function AidevopsPlugin({ directory, client }) {
   // that brought cursor + google onto the same lazy-start pattern.
 
   // Create tools
-  // Capture fetch before installOpenAIProviderFetchRotation wraps globalThis.fetch.
-  // API-key image requests must never be rewritten with OAuth pool credentials.
-  const imageFetch = globalThis.fetch?.bind(globalThis);
+  // Use the module-load capture so later plugin factories cannot inherit the
+  // global OAuth fetch wrapper from an earlier OpenCode workspace.
   const baseTools = createTools(SCRIPTS_DIR, run, {
     sessionOrigin: process.env.AIDEVOPS_SESSION_ORIGIN,
     poolToolFactory: () => createPoolTool(client),
-    imageFetch,
+    imageFetch: IMAGE_FETCH,
     imageOAuthAccountResolver: selectOpenAIRequestAccount,
     imageOAuthAccountRotator: (skipEmail) => rotateOpenAIPoolToken(client, skipEmail),
     projectRoot: directory,

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -157,6 +157,20 @@ export async function selectOpenAIStartupAccount(skipEmail) {
   return selectPoolAccount("openai", skipEmail);
 }
 
+/**
+ * Select a valid OpenAI account for a discrete request. An explicit email is
+ * pinned: unavailable or invalid accounts fail instead of falling back.
+ */
+export async function selectOpenAIRequestAccount(email) {
+  const requestedEmail = String(email || "").trim();
+  if (!requestedEmail) return selectOpenAIStartupAccount();
+  const accounts = getAccounts("openai");
+  normalizeExpiredCooldowns("openai", accounts);
+  const account = accounts.find((candidate) => candidate.email === requestedEmail);
+  if (!account || !isAvailableAccount(account)) return null;
+  return await ensureValidToken("openai", account) ? account : null;
+}
+
 // ---------------------------------------------------------------------------
 // Token injection — inject selected account into provider auth
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-auth.mjs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  imageApiSecretName,
+  normalizeImageAccountAlias,
+  readImageApiKey,
+  resolveGptImageAuth,
+} from "../gpt-image-auth.mjs";
+
+describe("GPT image authentication", () => {
+  test("maps explicit API account aliases to isolated secret names", () => {
+    assert.equal(normalizeImageAccountAlias("personal_2"), "PERSONAL_2");
+    assert.equal(imageApiSecretName("work", {}), "OPENAI_IMAGE_API_KEY_WORK");
+    assert.throws(() => normalizeImageAccountAlias("work-main"), /letters, numbers, or underscores/);
+    assert.throws(() => imageApiSecretName("", {}), /explicit account alias/);
+  });
+
+  test("uses only the requested environment secret without invoking a subprocess", () => {
+    let called = false;
+    const value = readImageApiKey("OPENAI_IMAGE_API_KEY_WORK", {
+      env: { OPENAI_IMAGE_API_KEY_WORK: "unit-test-credential-value" },
+      execFile: () => {
+        called = true;
+        return "";
+      },
+    });
+    assert.equal(value, "unit-test-credential-value");
+    assert.equal(called, false);
+  });
+
+  test("keeps OAuth selection pinned when an account is requested", async () => {
+    let requested;
+    const auth = await resolveGptImageAuth({ auth: "oauth", account: "person@example.test" }, {
+      resolveOAuthAccount: async (email) => {
+        requested = email;
+        return { email, access: "oauth-test-token", accountId: "account-test" };
+      },
+    });
+    assert.equal(requested, "person@example.test");
+    assert.equal(auth.pinned, true);
+    assert.equal(auth.mode, "oauth");
+  });
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { afterEach, describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { readReferenceImages, saveGeneratedPng, validateImageOutputPath } from "../gpt-image-io.mjs";
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const roots = [];
+
+async function projectRoot() {
+  const root = await mkdtemp(join(process.env.AIDEVOPS_TEMP_DIR || tmpdir(), "aidevops-gpt-image-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("GPT image file safety", () => {
+  test("creates private PNG output without overwriting an existing image", async () => {
+    const root = await projectRoot();
+    const first = await saveGeneratedPng("assets/result.png", root, PNG_BYTES.toString("base64"));
+    const second = await saveGeneratedPng("assets/result.png", root, PNG_BYTES.toString("base64"));
+    assert.equal(first.versioned, false);
+    assert.equal(second.versioned, true);
+    assert.match(second.savedPath, /result-v2\.png$/);
+    assert.deepEqual(await readFile(first.savedPath), PNG_BYTES);
+    assert.equal((await lstat(first.savedPath)).mode & 0o777, 0o600);
+  });
+
+  test("rejects traversal and symbolic-link output parents", async () => {
+    const root = await projectRoot();
+    const outside = await projectRoot();
+    await symlink(outside, join(root, "linked"), "dir");
+    await assert.rejects(validateImageOutputPath("../escape.png", root), /parent traversal/);
+    await assert.rejects(validateImageOutputPath("linked/escape.png", root), /symbolic links/);
+  });
+
+  test("accepts only regular project-confined reference images with known magic bytes", async () => {
+    const root = await projectRoot();
+    await mkdir(join(root, "refs"));
+    await writeFile(join(root, "refs", "source.png"), PNG_BYTES);
+    const images = await readReferenceImages(["refs/source.png"], root);
+    assert.equal(images[0].mime, "image/png");
+    assert.match(images[0].dataUrl, /^data:image\/png;base64,/);
+    await assert.rejects(readReferenceImages(["../source.png"], root), /parent traversal/);
+  });
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs
@@ -9,7 +9,10 @@ import { tmpdir } from "node:os";
 
 import { readReferenceImages, saveGeneratedPng, validateImageOutputPath } from "../gpt-image-io.mjs";
 
-const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
 const roots = [];
 
 async function projectRoot() {
@@ -29,9 +32,10 @@ describe("GPT image file safety", () => {
     const second = await saveGeneratedPng("assets/result.png", root, PNG_BYTES.toString("base64"));
     assert.equal(first.versioned, false);
     assert.equal(second.versioned, true);
-    assert.match(second.savedPath, /result-v2\.png$/);
-    assert.deepEqual(await readFile(first.savedPath), PNG_BYTES);
-    assert.equal((await lstat(first.savedPath)).mode & 0o777, 0o600);
+    assert.equal(first.projectPath, "assets/result.png");
+    assert.equal(second.projectPath, "assets/result-v2.png");
+    assert.deepEqual(await readFile(join(root, first.projectPath)), PNG_BYTES);
+    assert.equal((await lstat(join(root, first.projectPath))).mode & 0o777, 0o600);
   });
 
   test("rejects traversal and symbolic-link output parents", async () => {
@@ -40,6 +44,8 @@ describe("GPT image file safety", () => {
     await symlink(outside, join(root, "linked"), "dir");
     await assert.rejects(validateImageOutputPath("../escape.png", root), /parent traversal/);
     await assert.rejects(validateImageOutputPath("linked/escape.png", root), /symbolic links/);
+    await assert.rejects(validateImageOutputPath(".GIT/escape.png", root), /inside \.git/);
+    await assert.rejects(validateImageOutputPath("nested/.GiT/escape.png", root), /inside \.git/);
   });
 
   test("accepts only regular project-confined reference images with known magic bytes", async () => {
@@ -50,5 +56,15 @@ describe("GPT image file safety", () => {
     assert.equal(images[0].mime, "image/png");
     assert.match(images[0].dataUrl, /^data:image\/png;base64,/);
     await assert.rejects(readReferenceImages(["../source.png"], root), /parent traversal/);
+  });
+
+  test("rejects a generated PNG with a corrupted chunk checksum", async () => {
+    const root = await projectRoot();
+    const corrupted = Buffer.from(PNG_BYTES);
+    corrupted[45] ^= 0xff;
+    await assert.rejects(
+      saveGeneratedPng("assets/corrupt.png", root, corrupted.toString("base64")),
+      /invalid checksum/,
+    );
   });
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
@@ -68,4 +68,23 @@ describe("GPT image provider requests", () => {
     assert.equal(JSON.parse(captured.init.body).model, "gpt-image-2");
     assert.equal(result.base64, IMAGE_RESULT);
   });
+
+  test("uses multipart GPT Image 2 edits when API references are present", async () => {
+    let captured;
+    const fetchImpl = async (url, init) => {
+      captured = { url, init };
+      return Response.json({ data: [{ b64_json: IMAGE_RESULT }] });
+    };
+    await requestApiImage(
+      { accessToken: "unit-test-credential-value" },
+      { prompt: "edit a test", quality: "high", size: "1024x1024" },
+      [{ buffer: Buffer.from("image"), mime: "image/png", name: "source.png" }],
+      fetchImpl,
+    );
+    assert.equal(captured.url, "https://api.openai.com/v1/images/edits");
+    assert.ok(captured.init.body instanceof FormData);
+    assert.equal(captured.init.body.get("model"), "gpt-image-2");
+    assert.equal(captured.init.body.getAll("image[]").length, 1);
+    assert.equal(new Headers(captured.init.headers).has("Content-Type"), false);
+  });
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseImageSse, requestApiImage, requestOAuthImage } from "../gpt-image-request.mjs";
+
+const IMAGE_RESULT = "aW1hZ2UtcmVzdWx0";
+
+function splitStream(text, splitAt) {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text.slice(0, splitAt)));
+      controller.enqueue(encoder.encode(text.slice(splitAt)));
+      controller.close();
+    },
+  });
+}
+
+describe("GPT image provider requests", () => {
+  test("parses a completed image from split SSE frames", async () => {
+    const event = `data: ${JSON.stringify({
+      type: "response.output_item.done",
+      item: { type: "image_generation_call", result: IMAGE_RESULT },
+    })}\n\n`;
+    assert.equal(await parseImageSse(splitStream(event, 17)), IMAGE_RESULT);
+  });
+
+  test("builds the OAuth hosted-tool request with references", async () => {
+    let captured;
+    const event = `data: ${JSON.stringify({
+      type: "response.output_item.done",
+      item: { type: "image_generation_call", result: IMAGE_RESULT },
+    })}\n\n`;
+    const fetchImpl = async (url, init) => {
+      captured = { url, init };
+      return new Response(splitStream(event, 9), { status: 200, headers: { "Content-Type": "text/event-stream" } });
+    };
+    const result = await requestOAuthImage(
+      { accessToken: "oauth-test-token", accountId: "account-test" },
+      { prompt: "draw a test", quality: "low", size: "1024x1024" },
+      [{ dataUrl: "data:image/png;base64,dGVzdA==" }],
+      fetchImpl,
+    );
+    const body = JSON.parse(captured.init.body);
+    assert.equal(captured.url, "https://chatgpt.com/backend-api/codex/responses");
+    assert.equal(captured.init.headers.Authorization, "Bearer oauth-test-token");
+    assert.equal(body.tools[0].type, "image_generation");
+    assert.equal(body.input[0].content[1].type, "input_image");
+    assert.equal(result.base64, IMAGE_RESULT);
+  });
+
+  test("uses the explicit GPT Image 2 generations endpoint for API auth", async () => {
+    let captured;
+    const fetchImpl = async (url, init) => {
+      captured = { url, init };
+      return Response.json({ data: [{ b64_json: IMAGE_RESULT }] });
+    };
+    const result = await requestApiImage(
+      { accessToken: "unit-test-credential-value" },
+      { prompt: "draw a test", quality: "auto", size: "auto" },
+      [],
+      fetchImpl,
+    );
+    assert.equal(captured.url, "https://api.openai.com/v1/images/generations");
+    assert.equal(JSON.parse(captured.init.body).model, "gpt-image-2");
+    assert.equal(result.base64, IMAGE_RESULT);
+  });
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { afterEach, describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { createGptImageTool } from "../gpt-image-tool.mjs";
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const PNG_BASE64 = PNG_BYTES.toString("base64");
+const roots = [];
+const schemaNode = { _zod: {}, optional() { return this; }, describe() { return this; } };
+const z = {
+  array: () => schemaNode,
+  enum: () => schemaNode,
+  string: () => schemaNode,
+};
+
+async function projectRoot() {
+  const root = await mkdtemp(join(process.env.AIDEVOPS_TEMP_DIR || tmpdir(), "aidevops-gpt-tool-"));
+  roots.push(root);
+  return root;
+}
+
+function oauthSuccess() {
+  const event = `data: ${JSON.stringify({
+    type: "response.output_item.done",
+    item: { type: "image_generation_call", result: PNG_BASE64 },
+  })}\n\n`;
+  return new Response(event, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
+function createTool(options) {
+  return createGptImageTool((definition) => definition, z, {
+    markOAuthRateLimit: () => {},
+    markOAuthSuccess: () => {},
+    ...options,
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("GPT image OpenCode tool", () => {
+  test("uses OAuth by default and writes a generated PNG", async () => {
+    const root = await projectRoot();
+    let calls = 0;
+    const tool = createTool({
+      projectRoot: root,
+      resolveOAuthAccount: async () => ({ email: "person@example.test", access: "oauth-test-token" }),
+      fetchImpl: async () => {
+        calls += 1;
+        return oauthSuccess();
+      },
+    });
+    const output = await tool.execute({ prompt: "draw a test", out: "generated/test.png", quality: "low" });
+    assert.equal(calls, 1);
+    assert.match(output, /ChatGPT subscription OAuth/);
+  });
+
+  test("rotates once after an unpinned OAuth 429", async () => {
+    const root = await projectRoot();
+    let calls = 0;
+    let rotations = 0;
+    const tool = createTool({
+      projectRoot: root,
+      resolveOAuthAccount: async () => ({ email: "first@example.test", access: "first-oauth-token" }),
+      rotateOAuthAccount: async () => {
+        rotations += 1;
+        return { email: "second@example.test", access: "second-oauth-token" };
+      },
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1
+          ? Response.json({ error: { code: "rate_limit_exceeded" } }, { status: 429 })
+          : oauthSuccess();
+      },
+    });
+    await tool.execute({ prompt: "draw a test", out: "rotated.png" });
+    assert.equal(calls, 2);
+    assert.equal(rotations, 1);
+  });
+
+  test("never rotates an explicitly pinned OAuth account", async () => {
+    const root = await projectRoot();
+    let rotations = 0;
+    const tool = createTool({
+      projectRoot: root,
+      resolveOAuthAccount: async (email) => ({ email, access: "pinned-oauth-token" }),
+      rotateOAuthAccount: async () => {
+        rotations += 1;
+        return null;
+      },
+      fetchImpl: async () => Response.json({ error: { code: "rate_limit_exceeded" } }, { status: 429 }),
+    });
+    await assert.rejects(
+      tool.execute({ prompt: "draw a test", out: "pinned.png", account: "person@example.test" }),
+      /failed \(429\)/,
+    );
+    assert.equal(rotations, 0);
+  });
+
+  test("uses a named API secret and never retries API failures", async () => {
+    const root = await projectRoot();
+    let requestedSecret = "";
+    let calls = 0;
+    const tool = createTool({
+      projectRoot: root,
+      readSecret: (name) => {
+        requestedSecret = name;
+        return "unit-test-credential-value";
+      },
+      fetchImpl: async () => {
+        calls += 1;
+        return Response.json({ error: { code: "rate_limit_exceeded" } }, { status: 429 });
+      },
+    });
+    await assert.rejects(
+      tool.execute({ prompt: "draw a test", out: "api.png", auth: "api", account: "work" }),
+      /api image request failed \(429\)/,
+    );
+    assert.equal(requestedSecret, "OPENAI_IMAGE_API_KEY_WORK");
+    assert.equal(calls, 1);
+  });
+
+  test("fails before network access when API account selection is absent", async () => {
+    const root = await projectRoot();
+    let calls = 0;
+    const tool = createTool({
+      projectRoot: root,
+      env: {},
+      fetchImpl: async () => {
+        calls += 1;
+        return Response.json({});
+      },
+    });
+    await assert.rejects(
+      tool.execute({ prompt: "draw a test", out: "api.png", auth: "api" }),
+      /explicit account alias/,
+    );
+    assert.equal(calls, 0);
+  });
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs
@@ -9,7 +9,10 @@ import { tmpdir } from "node:os";
 
 import { createGptImageTool } from "../gpt-image-tool.mjs";
 
-const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
 const PNG_BASE64 = PNG_BYTES.toString("base64");
 const roots = [];
 const schemaNode = { _zod: {}, optional() { return this; }, describe() { return this; } };
@@ -60,6 +63,8 @@ describe("GPT image OpenCode tool", () => {
     const output = await tool.execute({ prompt: "draw a test", out: "generated/test.png", quality: "low" });
     assert.equal(calls, 1);
     assert.match(output, /ChatGPT subscription OAuth/);
+    assert.match(output, /generated\/test\.png/);
+    assert.doesNotMatch(output, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   });
 
   test("rotates once after an unpinned OAuth 429", async () => {

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -222,6 +222,7 @@ export function createTools(scriptsDir, run, options = {}) {
   const tools = {
     aidevops: createAidevopsTool(run),
     gpt_image_generate: createGptImageTool(tool, z, {
+      scriptsDir,
       env: options.env,
       execFile: options.imageExecFile,
       fetchImpl: options.imageFetch,

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -1,6 +1,7 @@
 import { existsSync } from "fs";
 import { join } from "path";
 import { createHookStatusTool } from "./hook-status-tool.mjs";
+import { createGptImageTool } from "./gpt-image-tool.mjs";
 import { createMcpActivationTool } from "./mcp-activation-tool.mjs";
 import { createPreEditCheckTool } from "./pre-edit-check-tool.mjs";
 
@@ -188,12 +189,13 @@ function createMemoryTool(scriptsDir, run) {
 /**
  * Create all tool definitions for the plugin.
  *
- * Tools (6 total):
+ * Tools (7 total):
  *   - aidevops              — aidevops CLI runner
  *   - aidevops_memory       — unified recall/store (merged from former recall + store pair)
  *   - aidevops_pre_edit_check — git safety check before file edits
  *   - aidevops_hook_status — bounded Git hook marker inspection
  *   - aidevops_mcp        — registry-allowlisted on-demand MCP lifecycle
+ *   - gpt_image_generate  — OAuth-first GPT Image 2 generation and reference editing
  *   - model-accounts-pool   — OAuth account pool management (added in index.mjs)
  *
  * NOTE: aidevops_quality_check was removed. Quality checks run automatically
@@ -219,6 +221,17 @@ export function createTools(scriptsDir, run, options = {}) {
 
   const tools = {
     aidevops: createAidevopsTool(run),
+    gpt_image_generate: createGptImageTool(tool, z, {
+      env: options.env,
+      execFile: options.imageExecFile,
+      fetchImpl: options.imageFetch,
+      projectRoot: options.projectRoot,
+      markOAuthRateLimit: options.imageOAuthRateLimitMarker,
+      markOAuthSuccess: options.imageOAuthSuccessMarker,
+      readSecret: options.imageSecretReader,
+      resolveOAuthAccount: options.imageOAuthAccountResolver,
+      rotateOAuthAccount: options.imageOAuthAccountRotator,
+    }),
     aidevops_memory: createMemoryTool(scriptsDir, run),
     aidevops_pre_edit_check: createPreEditCheckTool(tool, z, scriptsDir, options.preEditTimeoutMs),
     aidevops_hook_status: createHookStatusTool(tool, z, { workerWorktree: options.workerWorktree }),

--- a/.agents/scripts/gpt-image-secure-write.py
+++ b/.agents/scripts/gpt-image-secure-write.py
@@ -9,19 +9,30 @@ import argparse
 import json
 import os
 from pathlib import PurePosixPath
+from runpy import run_path
 import secrets
 import stat
 import sys
-import zlib
 
 MAX_OUTPUT_BYTES = 64 * 1024 * 1024
 MAX_OUTPUT_VERSION = 999
-MAX_PIXELS = 8_294_400
-PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 
 
 class SecureWriteError(Exception):
     """Represent a safe user-facing image publication failure."""
+
+
+def load_png_validator():
+    """Load the adjacent validator without enabling ambient Python imports."""
+    validator_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "gpt_image_png.py")
+    try:
+        module = run_path(validator_path)
+        return module["validate_png"], module["PngValidationError"]
+    except (OSError, KeyError) as error:
+        raise SecureWriteError("secure PNG validation is unavailable") from error
+
+
+validate_png, PngValidationError = load_png_validator()
 
 
 def directory_flags() -> int:
@@ -49,81 +60,11 @@ def read_png() -> bytes:
     payload = sys.stdin.buffer.read(MAX_OUTPUT_BYTES + 1)
     if len(payload) > MAX_OUTPUT_BYTES:
         raise SecureWriteError("generated PNG exceeds the 64 MiB limit")
-    validate_png(payload)
+    try:
+        validate_png(payload)
+    except PngValidationError as error:
+        raise SecureWriteError(str(error)) from error
     return payload
-
-
-def validate_png(payload: bytes) -> None:
-    """Validate PNG chunks, CRCs, dimensions, and terminal structure."""
-    if not payload.startswith(PNG_MAGIC):
-        raise SecureWriteError("image provider returned an invalid PNG")
-    offset = len(PNG_MAGIC)
-    chunk_index = 0
-    color_type = -1
-    data_state = "before"
-    seen_chunks: set[bytes] = set()
-    while offset + 12 <= len(payload):
-        length = int.from_bytes(payload[offset : offset + 4], "big")
-        end = offset + 12 + length
-        if end > len(payload):
-            raise SecureWriteError("image provider returned a truncated PNG")
-        chunk_type = payload[offset + 4 : offset + 8]
-        chunk_data = payload[offset + 8 : offset + 8 + length]
-        expected_crc = int.from_bytes(payload[offset + 8 + length : end], "big")
-        if zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF != expected_crc:
-            raise SecureWriteError("image provider returned a PNG with an invalid checksum")
-        if chunk_index == 0:
-            color_type = validate_ihdr(chunk_type, chunk_data)
-        validate_chunk_order(chunk_type, data_state, seen_chunks, color_type)
-        if chunk_type == b"IDAT":
-            data_state = "data"
-        elif data_state == "data":
-            data_state = "after"
-        if chunk_type == b"IEND":
-            if length != 0 or end != len(payload) or b"IDAT" not in seen_chunks:
-                raise SecureWriteError("image provider returned an invalid terminal PNG chunk")
-            return
-        seen_chunks.add(chunk_type)
-        offset = end
-        chunk_index += 1
-    raise SecureWriteError("image provider returned a PNG without a terminal chunk")
-
-
-def validate_ihdr(chunk_type: bytes, data: bytes) -> int:
-    """Validate the required first PNG header chunk."""
-    if chunk_type != b"IHDR" or len(data) != 13:
-        raise SecureWriteError("image provider returned an invalid PNG header")
-    width = int.from_bytes(data[0:4], "big")
-    height = int.from_bytes(data[4:8], "big")
-    bit_depth, color_type, compression, filtering, interlace = data[8:13]
-    valid_depths = {0: {1, 2, 4, 8, 16}, 2: {8, 16}, 3: {1, 2, 4, 8}, 4: {8, 16}, 6: {8, 16}}
-    if width < 1 or height < 1 or width * height > MAX_PIXELS:
-        raise SecureWriteError("generated PNG dimensions exceed the safe limit")
-    if bit_depth not in valid_depths.get(color_type, set()) or compression != 0 or filtering != 0 or interlace not in {0, 1}:
-        raise SecureWriteError("image provider returned unsupported PNG parameters")
-    return color_type
-
-
-def validate_chunk_order(
-    chunk_type: bytes,
-    data_state: str,
-    seen_chunks: set[bytes],
-    color_type: int,
-) -> None:
-    """Reject duplicate, misplaced, and unknown critical PNG chunks."""
-    critical_chunks = {b"IHDR", b"PLTE", b"IDAT", b"IEND"}
-    if chunk_type[0] & 0x20 == 0 and chunk_type not in critical_chunks:
-        raise SecureWriteError("image provider returned an unknown critical PNG chunk")
-    if chunk_type == b"IHDR" and chunk_type in seen_chunks:
-        raise SecureWriteError("image provider returned a duplicate PNG header")
-    if chunk_type == b"PLTE":
-        if chunk_type in seen_chunks or data_state != "before" or color_type in {0, 4}:
-            raise SecureWriteError("image provider returned an invalid PNG palette")
-    if chunk_type == b"IDAT":
-        if data_state == "after" or (color_type == 3 and b"PLTE" not in seen_chunks):
-            raise SecureWriteError("image provider returned invalid PNG image-data ordering")
-    if chunk_type == b"IEND" and data_state != "data":
-        raise SecureWriteError("image provider returned a PNG without contiguous image data")
 
 
 def open_output_directory(root_fd: int, parts: tuple[str, ...]) -> int:

--- a/.agents/scripts/gpt-image-secure-write.py
+++ b/.agents/scripts/gpt-image-secure-write.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Publish a generated PNG through descriptor-relative filesystem operations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import PurePosixPath
+import secrets
+import stat
+import sys
+import zlib
+
+MAX_OUTPUT_BYTES = 64 * 1024 * 1024
+MAX_OUTPUT_VERSION = 999
+MAX_PIXELS = 8_294_400
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+class SecureWriteError(Exception):
+    """Represent a safe user-facing image publication failure."""
+
+
+def directory_flags() -> int:
+    """Return fail-closed flags for pinned directory traversal."""
+    if not hasattr(os, "O_DIRECTORY") or not hasattr(os, "O_NOFOLLOW"):
+        raise SecureWriteError("secure descriptor-relative image writes are unsupported on this platform")
+    return os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | os.O_DIRECTORY | os.O_NOFOLLOW
+
+
+def parse_output_path(value: str) -> tuple[tuple[str, ...], str]:
+    """Validate and split one portable project-relative PNG path."""
+    portable = value.replace("\\", "/")
+    path = PurePosixPath(portable)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise SecureWriteError("image output must be a safe project-relative path")
+    if not path.parts or path.suffix.lower() != ".png":
+        raise SecureWriteError("image output must end in .png")
+    if any(part.casefold() == ".git" for part in path.parts):
+        raise SecureWriteError("image output cannot be written inside .git")
+    return path.parts[:-1], path.parts[-1]
+
+
+def read_png() -> bytes:
+    """Read and structurally validate one bounded PNG from stdin."""
+    payload = sys.stdin.buffer.read(MAX_OUTPUT_BYTES + 1)
+    if len(payload) > MAX_OUTPUT_BYTES:
+        raise SecureWriteError("generated PNG exceeds the 64 MiB limit")
+    validate_png(payload)
+    return payload
+
+
+def validate_png(payload: bytes) -> None:
+    """Validate PNG chunks, CRCs, dimensions, and terminal structure."""
+    if not payload.startswith(PNG_MAGIC):
+        raise SecureWriteError("image provider returned an invalid PNG")
+    offset = len(PNG_MAGIC)
+    chunk_index = 0
+    color_type = -1
+    data_state = "before"
+    seen_chunks: set[bytes] = set()
+    while offset + 12 <= len(payload):
+        length = int.from_bytes(payload[offset : offset + 4], "big")
+        end = offset + 12 + length
+        if end > len(payload):
+            raise SecureWriteError("image provider returned a truncated PNG")
+        chunk_type = payload[offset + 4 : offset + 8]
+        chunk_data = payload[offset + 8 : offset + 8 + length]
+        expected_crc = int.from_bytes(payload[offset + 8 + length : end], "big")
+        if zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF != expected_crc:
+            raise SecureWriteError("image provider returned a PNG with an invalid checksum")
+        if chunk_index == 0:
+            color_type = validate_ihdr(chunk_type, chunk_data)
+        validate_chunk_order(chunk_type, data_state, seen_chunks, color_type)
+        if chunk_type == b"IDAT":
+            data_state = "data"
+        elif data_state == "data":
+            data_state = "after"
+        if chunk_type == b"IEND":
+            if length != 0 or end != len(payload) or b"IDAT" not in seen_chunks:
+                raise SecureWriteError("image provider returned an invalid terminal PNG chunk")
+            return
+        seen_chunks.add(chunk_type)
+        offset = end
+        chunk_index += 1
+    raise SecureWriteError("image provider returned a PNG without a terminal chunk")
+
+
+def validate_ihdr(chunk_type: bytes, data: bytes) -> int:
+    """Validate the required first PNG header chunk."""
+    if chunk_type != b"IHDR" or len(data) != 13:
+        raise SecureWriteError("image provider returned an invalid PNG header")
+    width = int.from_bytes(data[0:4], "big")
+    height = int.from_bytes(data[4:8], "big")
+    bit_depth, color_type, compression, filtering, interlace = data[8:13]
+    valid_depths = {0: {1, 2, 4, 8, 16}, 2: {8, 16}, 3: {1, 2, 4, 8}, 4: {8, 16}, 6: {8, 16}}
+    if width < 1 or height < 1 or width * height > MAX_PIXELS:
+        raise SecureWriteError("generated PNG dimensions exceed the safe limit")
+    if bit_depth not in valid_depths.get(color_type, set()) or compression != 0 or filtering != 0 or interlace not in {0, 1}:
+        raise SecureWriteError("image provider returned unsupported PNG parameters")
+    return color_type
+
+
+def validate_chunk_order(
+    chunk_type: bytes,
+    data_state: str,
+    seen_chunks: set[bytes],
+    color_type: int,
+) -> None:
+    """Reject duplicate, misplaced, and unknown critical PNG chunks."""
+    critical_chunks = {b"IHDR", b"PLTE", b"IDAT", b"IEND"}
+    if chunk_type[0] & 0x20 == 0 and chunk_type not in critical_chunks:
+        raise SecureWriteError("image provider returned an unknown critical PNG chunk")
+    if chunk_type == b"IHDR" and chunk_type in seen_chunks:
+        raise SecureWriteError("image provider returned a duplicate PNG header")
+    if chunk_type == b"PLTE":
+        if chunk_type in seen_chunks or data_state != "before" or color_type in {0, 4}:
+            raise SecureWriteError("image provider returned an invalid PNG palette")
+    if chunk_type == b"IDAT":
+        if data_state == "after" or (color_type == 3 and b"PLTE" not in seen_chunks):
+            raise SecureWriteError("image provider returned invalid PNG image-data ordering")
+    if chunk_type == b"IEND" and data_state != "data":
+        raise SecureWriteError("image provider returned a PNG without contiguous image data")
+
+
+def open_output_directory(root_fd: int, parts: tuple[str, ...]) -> int:
+    """Create and pin output directories beneath the project descriptor."""
+    descriptor = os.dup(root_fd)
+    try:
+        for part in parts:
+            try:
+                os.mkdir(part, 0o700, dir_fd=descriptor)
+                os.fsync(descriptor)
+            except FileExistsError:
+                pass
+            child = os.open(part, directory_flags(), dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except OSError as error:
+        os.close(descriptor)
+        raise SecureWriteError("image output directory is unsafe") from error
+
+
+def open_existing_directory(root_fd: int, parts: tuple[str, ...]) -> int:
+    """Pin an existing output directory without creating path components."""
+    descriptor = os.dup(root_fd)
+    try:
+        for part in parts:
+            child = os.open(part, directory_flags(), dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except OSError as error:
+        os.close(descriptor)
+        raise SecureWriteError("image output directory binding is unsafe") from error
+
+
+def directory_binding_matches(root_fd: int, parts: tuple[str, ...], expected_fd: int) -> bool:
+    """Confirm the project path still names the pinned output directory."""
+    current = -1
+    try:
+        current = open_existing_directory(root_fd, parts)
+        expected = os.fstat(expected_fd)
+        observed = os.fstat(current)
+        return (expected.st_dev, expected.st_ino) == (observed.st_dev, observed.st_ino)
+    except (OSError, SecureWriteError):
+        return False
+    finally:
+        if current >= 0:
+            os.close(current)
+
+
+def versioned_name(requested: str, version: int) -> str:
+    """Return the requested name or a bounded non-overwriting variant."""
+    if version == 1:
+        return requested
+    stem, extension = os.path.splitext(requested)
+    return f"{stem}-v{version}{extension}"
+
+
+def entry_matches(directory_fd: int, name: str, descriptor: int) -> bool:
+    """Return whether a pinned descriptor still owns one regular entry."""
+    try:
+        linked = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        opened = os.fstat(descriptor)
+        return stat.S_ISREG(linked.st_mode) and (linked.st_dev, linked.st_ino) == (
+            opened.st_dev,
+            opened.st_ino,
+        )
+    except OSError:
+        return False
+
+
+def cleanup_temporary(directory_fd: int, temporary: str, temp_fd: int) -> bool:
+    """Clean temporary state and report whether durability cleanup failed."""
+    failed = False
+    try:
+        os.close(temp_fd)
+    except OSError:
+        failed = True
+    try:
+        os.unlink(temporary, dir_fd=directory_fd)
+        os.fsync(directory_fd)
+    except FileNotFoundError:
+        pass
+    except OSError:
+        failed = True
+    return failed
+
+
+def publish_png(directory_fd: int, requested: str, payload: bytes) -> tuple[str, bool, bool]:
+    """Write and hard-link a private PNG without replacing existing output."""
+    temporary = f".{requested}.aidevops-{secrets.token_hex(12)}.tmp"
+    temp_fd = -1
+    published = ""
+    try:
+        temp_fd = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=directory_fd,
+        )
+        with os.fdopen(os.dup(temp_fd), "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        for version in range(1, MAX_OUTPUT_VERSION + 1):
+            candidate = versioned_name(requested, version)
+            try:
+                os.link(
+                    temporary,
+                    candidate,
+                    src_dir_fd=directory_fd,
+                    dst_dir_fd=directory_fd,
+                    follow_symlinks=False,
+                )
+                published = candidate
+                os.fsync(directory_fd)
+                if not entry_matches(directory_fd, candidate, temp_fd):
+                    raise SecureWriteError("generated image changed during secure publication")
+                cleanup_warning = cleanup_temporary(directory_fd, temporary, temp_fd)
+                temp_fd = -1
+                return candidate, version > 1, cleanup_warning
+            except FileExistsError:
+                continue
+        raise SecureWriteError(f"no available image filename after {MAX_OUTPUT_VERSION} versions")
+    except BaseException:
+        if published and entry_matches(directory_fd, published, temp_fd):
+            try:
+                os.unlink(published, dir_fd=directory_fd)
+                os.fsync(directory_fd)
+            except OSError:
+                pass
+        raise
+    finally:
+        if temp_fd >= 0:
+            cleanup_temporary(directory_fd, temporary, temp_fd)
+
+
+def main() -> int:
+    """Securely publish stdin and emit bounded project-relative JSON."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+    directories, requested = parse_output_path(args.out)
+    payload = read_png()
+    root_fd = os.open(args.root, directory_flags())
+    directory_fd = -1
+    candidate = ""
+    try:
+        if not stat.S_ISDIR(os.fstat(root_fd).st_mode):
+            raise SecureWriteError("OpenCode project root must be a regular directory")
+        directory_fd = open_output_directory(root_fd, directories)
+        candidate, versioned, cleanup_warning = publish_png(directory_fd, requested, payload)
+        if not directory_binding_matches(root_fd, directories, directory_fd):
+            os.unlink(candidate, dir_fd=directory_fd)
+            os.fsync(directory_fd)
+            raise SecureWriteError("image output directory changed during secure publication")
+        project_path = "/".join((*directories, candidate))
+        receipt = {"path": project_path, "versioned": versioned, "cleanup_warning": cleanup_warning}
+        print(json.dumps(receipt, separators=(",", ":")))
+        return 0
+    finally:
+        if directory_fd >= 0:
+            os.close(directory_fd)
+        os.close(root_fd)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SecureWriteError as error:
+        print(f"Secure image write failed: {error}", file=sys.stderr)
+        raise SystemExit(1) from None
+    except OSError:
+        print("Secure image write failed: a filesystem operation failed", file=sys.stderr)
+        raise SystemExit(1) from None

--- a/.agents/scripts/gpt_image_png.py
+++ b/.agents/scripts/gpt_image_png.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate bounded PNG structure for the secure GPT image writer."""
+
+from __future__ import annotations
+
+import zlib
+
+MAX_PIXELS = 8_294_400
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+class PngValidationError(Exception):
+    """Represent a safe user-facing PNG validation failure."""
+
+
+def validate_png(payload: bytes) -> None:
+    """Validate PNG chunks, CRCs, dimensions, and terminal structure."""
+    if not payload.startswith(PNG_MAGIC):
+        raise PngValidationError("image provider returned an invalid PNG")
+    offset = len(PNG_MAGIC)
+    chunk_index = 0
+    color_type = -1
+    data_state = "before"
+    seen_chunks: set[bytes] = set()
+    while offset + 12 <= len(payload):
+        length = int.from_bytes(payload[offset : offset + 4], "big")
+        end = offset + 12 + length
+        if end > len(payload):
+            raise PngValidationError("image provider returned a truncated PNG")
+        chunk_type = payload[offset + 4 : offset + 8]
+        chunk_data = payload[offset + 8 : offset + 8 + length]
+        expected_crc = int.from_bytes(payload[offset + 8 + length : end], "big")
+        if zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF != expected_crc:
+            raise PngValidationError("image provider returned a PNG with an invalid checksum")
+        if chunk_index == 0:
+            color_type = validate_ihdr(chunk_type, chunk_data)
+        validate_chunk_order(chunk_type, data_state, seen_chunks, color_type)
+        if chunk_type == b"IDAT":
+            data_state = "data"
+        elif data_state == "data":
+            data_state = "after"
+        if chunk_type == b"IEND":
+            if length != 0 or end != len(payload) or b"IDAT" not in seen_chunks:
+                raise PngValidationError("image provider returned an invalid terminal PNG chunk")
+            return
+        seen_chunks.add(chunk_type)
+        offset = end
+        chunk_index += 1
+    raise PngValidationError("image provider returned a PNG without a terminal chunk")
+
+
+def validate_ihdr(chunk_type: bytes, data: bytes) -> int:
+    """Validate the required first PNG header chunk."""
+    if chunk_type != b"IHDR" or len(data) != 13:
+        raise PngValidationError("image provider returned an invalid PNG header")
+    width = int.from_bytes(data[0:4], "big")
+    height = int.from_bytes(data[4:8], "big")
+    bit_depth, color_type, compression, filtering, interlace = data[8:13]
+    valid_depths = {0: {1, 2, 4, 8, 16}, 2: {8, 16}, 3: {1, 2, 4, 8}, 4: {8, 16}, 6: {8, 16}}
+    if width < 1 or height < 1 or width * height > MAX_PIXELS:
+        raise PngValidationError("generated PNG dimensions exceed the safe limit")
+    if bit_depth not in valid_depths.get(color_type, set()) or compression != 0 or filtering != 0 or interlace not in {0, 1}:
+        raise PngValidationError("image provider returned unsupported PNG parameters")
+    return color_type
+
+
+def validate_chunk_order(
+    chunk_type: bytes,
+    data_state: str,
+    seen_chunks: set[bytes],
+    color_type: int,
+) -> None:
+    """Reject duplicate, misplaced, and unknown critical PNG chunks."""
+    critical_chunks = {b"IHDR", b"PLTE", b"IDAT", b"IEND"}
+    if chunk_type[0] & 0x20 == 0 and chunk_type not in critical_chunks:
+        raise PngValidationError("image provider returned an unknown critical PNG chunk")
+    if chunk_type == b"IHDR" and chunk_type in seen_chunks:
+        raise PngValidationError("image provider returned a duplicate PNG header")
+    if chunk_type == b"PLTE":
+        if chunk_type in seen_chunks or data_state != "before" or color_type in {0, 4}:
+            raise PngValidationError("image provider returned an invalid PNG palette")
+    if chunk_type == b"IDAT":
+        if data_state == "after" or (color_type == 3 and b"PLTE" not in seen_chunks):
+            raise PngValidationError("image provider returned invalid PNG image-data ordering")
+    if chunk_type == b"IEND" and data_state != "data":
+        raise PngValidationError("image provider returned a PNG without contiguous image data")

--- a/.agents/tools/credentials/api-key-setup.md
+++ b/.agents/tools/credentials/api-key-setup.md
@@ -83,6 +83,21 @@ bash ~/Git/aidevops/.agents/scripts/setup-local-api-keys.sh set <service-name> Y
 
 **Multi-account naming**: When you hold credentials for several accounts on the same provider at once (personal + work GitHub, multiple OpenAI projects, several Hetzner projects), suffix the bare name with `-<account>` / `_<ACCOUNT>` — e.g. `github-token-personal` and `github-token-work`, or `hcloud-token-project-a` and `hcloud-token-project-b`. The bare provider name remains the default for the single-account case. Full convention: `gopass.md` "Naming with multiple accounts".
 
+**GPT Image 2 accounts**: OpenCode image generation deliberately uses a more
+specific key namespace so Platform billing identities cannot be confused with
+ChatGPT OAuth pool identities:
+
+```bash
+aidevops secret set OPENAI_IMAGE_API_KEY_PERSONAL
+aidevops secret set OPENAI_IMAGE_API_KEY_WORK
+```
+
+Select the matching alias (`PERSONAL` or `WORK`) with `auth: "api"` in
+`gpt_image_generate`. Aliases contain only letters, numbers, and underscores.
+The non-secret `AIDEVOPS_OPENAI_IMAGE_ACCOUNT` setting may define a deliberate
+default alias, but API billing still requires explicit `auth: "api"`. The tool
+never falls back to `OPENAI_API_KEY` or silently chooses among named keys.
+
 **Provider token label + value pairs**: Secure backends (via `aidevops secret set <NAME>`, preferring `gopass` over plaintext) and the plaintext fallback both store only one value per name. If a provider has a non-sensitive local token label and a sensitive access token value, keep them separate: `<PROVIDER>_<ORG>_<PURPOSE>_TOKEN_NAME` for the label and `<PROVIDER>_<ORG>_<PURPOSE>_ACCESS_TOKEN` for the value. Add a developer or device discriminator, such as `_DEV_A` or `_LAPTOP_2`, before `TOKEN_NAME` / `ACCESS_TOKEN` when a shared store or workstation holds tokens for multiple developers or devices. Never document token values; token labels may be documented only when they are non-sensitive.
 
 ### 4. Verify

--- a/.agents/tools/vision/image-editing.md
+++ b/.agents/tools/vision/image-editing.md
@@ -22,7 +22,7 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Modify existing images — inpainting, outpainting, upscaling, style transfer, background removal, batch edits
-- **Cloud**: DALL-E 2 edit API, Google Imagen edit, Adobe Firefly
+- **Cloud**: GPT Image 2, Google Imagen edit, Adobe Firefly
 - **Local**: Stable Diffusion inpaint, FLUX fill, Real-ESRGAN (upscaling), ControlNet
 - **Workflow tool**: ComfyUI (node-based pipelines for complex edits)
 
@@ -32,7 +32,7 @@ tools:
 
 | Capability | Description | Best Tool |
 |------------|-------------|-----------|
-| **Inpainting** | Replace selected region with AI content | SD inpaint, DALL-E 2 edit |
+| **Inpainting** | Replace selected region with AI content | SD inpaint, GPT Image 2 |
 | **Outpainting** | Extend image beyond original boundaries | SD outpaint, FLUX fill |
 | **Upscaling** | Increase resolution with AI enhancement | Real-ESRGAN, Topaz |
 | **Background removal** | Remove or replace backgrounds | rembg, Segment Anything |
@@ -42,22 +42,20 @@ tools:
 
 ## Cloud APIs
 
-### DALL-E 2 Edit (OpenAI)
+### GPT Image 2 Reference Editing (OpenAI)
 
-DALL-E 2 only (not 3). Source + mask: square PNGs, same dimensions, <4MB. Transparent mask areas = edit region.
+The OpenCode `gpt_image_generate` tool accepts up to 8 project-relative
+reference images through `images`. Describe each image's role in the prompt.
+ChatGPT OAuth is the default billing route; explicit `auth: "api"` uses the
+named `OPENAI_IMAGE_API_KEY_<ACCOUNT>` secret and OpenAI's Images edit endpoint.
+GPT Image 2 processes references at high fidelity automatically.
 
-```bash
-# Inpainting: replace masked area
-curl https://api.openai.com/v1/images/edits \
-  -H "Authorization: Bearer $OPENAI_API_KEY" \
-  -F image="@photo.png" -F mask="@mask.png" \
-  -F prompt="A red sports car" -F size="1024x1024" -F n=1
-
-# Variation: generate similar images
-curl https://api.openai.com/v1/images/variations \
-  -H "Authorization: Bearer $OPENAI_API_KEY" \
-  -F image="@photo.png" -F size="1024x1024" -F n=3
+```text
+Using refs/product.png as the product reference, place it on a clean marble counter in soft morning light. Save to assets/product-morning.png.
 ```
+
+The current aidevops tool supports reference-guided edits, not mask inpainting.
+Use a dedicated local inpainting workflow when pixel-specific masks are needed.
 
 ### Google Imagen Edit (Vertex AI)
 
@@ -117,7 +115,7 @@ Structural guides for precise control. Used within ComfyUI or Automatic1111.
 
 ### Product Photo Enhancement
 
-`rembg` → Real-ESRGAN 2x (if needed) → SD inpaint / DALL-E (new background) → ImageMagick / Pillow (colour correct)
+`rembg` → Real-ESRGAN 2x (if needed) → SD inpaint / GPT Image 2 (new background) → ImageMagick / Pillow (colour correct)
 
 ### Batch Background Removal
 

--- a/.agents/tools/vision/image-generation.md
+++ b/.agents/tools/vision/image-generation.md
@@ -17,11 +17,24 @@ tools:
 
 # Image Generation
 
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **OpenCode tool**: `gpt_image_generate`
+- **Default billing route**: ChatGPT subscription OAuth from the aidevops OpenAI account pool
+- **Platform billing route**: explicit `auth: "api"` plus a named account alias
+- **Model**: GPT Image 2 (`gpt-image-2`); output is a project-confined PNG
+- **Reference images**: up to 8 project-relative PNG, JPEG, or WebP files
+- **Safety**: existing files are never overwritten; versioned paths use `-v2`, `-v3`, and so on
+
+<!-- AI-CONTEXT-END -->
+
 ## Model Comparison
 
 | Model | Provider | Quality | Speed | Cost | Local | Best For |
 |-------|----------|---------|-------|------|-------|----------|
-| **DALL-E 3** | OpenAI | High | Fast | $0.04-0.12/img | No | General purpose, text rendering |
+| **GPT Image 2** | OpenAI | Very high | Medium | Subscription or API pricing | No | General purpose, text rendering, reference-guided edits |
 | **Midjourney v6** | Midjourney | Very high | Medium | $10-60/mo | No | Artistic, photorealistic |
 | **Imagen 3** | Google | High | Fast | API pricing | No | Photorealism, Google ecosystem |
 | **Ideogram 2.0** | Ideogram | High | Fast | Free tier + paid | No | Text in images, logos |
@@ -31,34 +44,53 @@ tools:
 | **SD 3.5** | Stability AI | High | Medium | Free (local) | Yes | Latest Stability model |
 
 ```text
-Text in images?       → DALL-E 3 or Ideogram
+Text in images?       → GPT Image 2 or Ideogram
 Photorealistic?       → Midjourney or Imagen 3
 Full local control?   → FLUX.1 [dev] or SD XL
 Fast local iteration? → FLUX.1 [schnell]
 ControlNet / img2img? → SD XL (most mature ecosystem)
-Simplest API?         → DALL-E 3
+Simplest OpenCode use? → gpt_image_generate with ChatGPT OAuth
 Budget-conscious?     → FLUX or SD locally (GPU cost only)
 ```
 
 ## Cloud APIs
 
-### DALL-E 3 (OpenAI)
+### GPT Image 2 (OpenAI)
+
+In OpenCode, ask naturally for an image and include the desired project-relative
+PNG path. The aidevops plugin exposes `gpt_image_generate` automatically.
+
+```text
+Generate a low-quality 1024x1024 watercolor lighthouse draft and save it to assets/lighthouse.png.
+```
+
+The tool defaults to the existing ChatGPT OAuth pool. Add an account through
+`opencode auth login` → **OpenAI Pool**. An optional OAuth `account` pins the
+request to that pool email; a pinned account never falls back to another login.
+
+Platform API billing is always explicit and uses an account-specific secret:
 
 ```bash
-aidevops secret set OPENAI_API_KEY
-
-curl https://api.openai.com/v1/images/generations \
-  -H "Authorization: Bearer $OPENAI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"model": "dall-e-3", "prompt": "...", "size": "1024x1024", "quality": "hd", "style": "natural"}'
+aidevops secret set OPENAI_IMAGE_API_KEY_WORK
 ```
+
+Then select `auth: "api"` and `account: "WORK"` in the tool call. To configure
+a deliberate local default alias, set `AIDEVOPS_OPENAI_IMAGE_ACCOUNT=WORK`;
+the tool still requires `auth: "api"`, so it cannot silently switch billing
+from a subscription to API credits. Never paste an API key into chat.
 
 | Parameter | Options | Notes |
 |-----------|---------|-------|
-| `size` | 1024x1024, 1024x1792, 1792x1024 | Square, portrait, landscape |
-| `quality` | standard, hd | Standard $0.04, HD $0.08/image |
-| `style` | natural, vivid | Natural = photorealistic, vivid = artistic |
-| `n` | 1 | DALL-E 3 supports 1/request; use v2 API for edits |
+| `quality` | low, medium, high, auto | `auto` is the default; use low for drafts |
+| `size` | auto or WIDTHxHEIGHT | Edges must be multiples of 16, max 3840px, ratio ≤3:1, total 655,360-8,294,400px |
+| `images` | 0-8 project-relative paths | Reference-guided generation/editing; PNG, JPEG, or WebP, 20 MiB each |
+| `auth` | oauth, api | OAuth is the default; API billing must be explicit |
+| `account` | OAuth email or API alias | Exact selection only; no silent account substitution |
+
+OAuth uses OpenCode's Codex channel and is therefore runtime-specific and
+experimental. The public API route calls `gpt-image-2` directly. OpenCode V2
+remains fail-closed until the aidevops V2 adapter implements equivalent tool,
+permission, credential, and session contracts.
 
 ### Midjourney
 
@@ -114,33 +146,10 @@ blurry, low quality, distorted, deformed, ugly, duplicate, watermark,
 text, signature, oversaturated, underexposed, overexposed
 ```
 
-**Batch generation (DALL-E 3)**:
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-generate_batch() {
-  local prompt="$1"
-  local count="${2:-4}"
-  local output_dir="${3:-.}"
-  mkdir -p "$output_dir"
-
-  for i in $(seq 1 "$count"); do
-    local target="$output_dir/gen_$i.png"
-    curl -sf https://api.openai.com/v1/images/generations \
-      -H "Authorization: Bearer $OPENAI_API_KEY" \
-      -H "Content-Type: application/json" \
-      -d "$(jq -n --arg p "$prompt" '{model: "dall-e-3", prompt: $p, size: "1024x1024", quality: "hd"}')" \
-      | python3 -c "import json,sys,urllib.request; url=json.load(sys.stdin)['data'][0]['url']; urllib.request.urlretrieve(url, sys.argv[1])" "$target" \
-      || { echo "Error generating image $i" >&2; return 1; }
-    echo "Saved: $target"
-  done
-  return 0
-}
-
-generate_batch "$@"
-```
+**Batch generation**: invoke `gpt_image_generate` once per distinct asset. Each
+call returns one PNG and preserves an existing output by choosing a versioned
+filename. Avoid unattended high-quality batches because API and subscription
+usage limits still apply.
 
 ## See Also
 

--- a/.agents/tools/vision/overview.md
+++ b/.agents/tools/vision/overview.md
@@ -22,9 +22,9 @@ tools:
 ## Quick Reference
 
 - **Route by task**: generate → `image-generation.md`; analyze → `image-understanding.md`; edit → `image-editing.md`; tiled image mosaic / photo mosaic / collage wallpaper / image grid background / mozaic → `image-mosaic-skill.md`
-- **Create**: DALL-E 3, Midjourney, FLUX, Stable Diffusion
+- **Create**: GPT Image 2 via `gpt_image_generate`, Midjourney, FLUX, Stable Diffusion
 - **Analyze**: GPT-4o vision, Claude vision, Gemini, LLaVA, Qwen-VL
-- **Edit**: DALL-E 3 edit, Stable Diffusion inpaint, FLUX fill
+- **Edit**: GPT Image 2 reference editing, Stable Diffusion inpaint, FLUX fill
 - **Local stack**: Ollama for VLMs, ComfyUI for generation/editing, `tools/infrastructure/cloud-gpu.md` for GPU deployment
 - **Specialized routes**: OCR → `tools/ocr/glm-ocr.md`; GUI screenshots → `tools/browser/peekaboo.md`
 
@@ -34,20 +34,20 @@ tools:
 
 | Need | Route | Best Options | Deployment Notes |
 |------|-------|--------------|------------------|
-| Text-to-image, concept art, marketing assets | `image-generation.md` | DALL-E 3, Midjourney, FLUX, Stable Diffusion | Cloud APIs are fastest to integrate; ComfyUI gives local control |
+| Text-to-image, concept art, marketing assets | `image-generation.md` | GPT Image 2, Midjourney, FLUX, Stable Diffusion | OpenCode uses OAuth-first `gpt_image_generate`; ComfyUI gives local control |
 | Tiled image mosaic, photo mosaic, collage wallpaper, image grid background, mozaic | `image-mosaic-skill.md` | Approved source photos, square cover-crops, deterministic raster tiles | Use 200px square tiles for recognisable photos; smaller tiles only for texture grids |
 | Image analysis, captioning, visual Q&A | `image-understanding.md` | GPT-4o vision, Claude vision, Gemini, LLaVA, Qwen-VL | Ollama fits privacy-sensitive local analysis; cloud models fit large-context reasoning |
-| Inpainting, outpainting, style transfer | `image-editing.md` | DALL-E 3 edit, Stable Diffusion inpaint, FLUX fill | ComfyUI is the main local editing stack |
-| Product photos / marketing visuals | `image-generation.md` | DALL-E 3 (cloud), FLUX (local) | Choose cloud for speed, local for cost/control |
+| Inpainting, outpainting, style transfer | `image-editing.md` | GPT Image 2 references, Stable Diffusion inpaint, FLUX fill | Use ComfyUI when pixel-specific masks are required |
+| Product photos / marketing visuals | `image-generation.md` | GPT Image 2 (cloud), FLUX (local) | Choose cloud for speed, local for cost/control |
 | Code screenshots, diagrams, alt text | `image-understanding.md` | Claude vision, GPT-4o vision, Gemini, LLaVA | Gemini and GPT-4o fit large diagrams; LLaVA fits local captioning |
 | Documents, receipts, GUI screenshots | `tools/ocr/glm-ocr.md` or `tools/browser/peekaboo.md` | GLM-OCR, Peekaboo | Prefer dedicated OCR or browser capture flows over general VLM analysis |
-| Background removal, upscaling, enhancement | `image-editing.md` | Stable Diffusion inpaint, DALL-E 3 edit, Real-ESRGAN, Topaz | Local tools are strongest for enhancement workflows |
+| Background removal, upscaling, enhancement | `image-editing.md` | Stable Diffusion inpaint, GPT Image 2, Real-ESRGAN, Topaz | Local tools are strongest for enhancement workflows |
 
 ## Deployment Options
 
 | Deployment | Models | Best For |
 |------------|--------|----------|
-| **Cloud API** | DALL-E 3, GPT-4o vision, Claude vision, Gemini, Midjourney | Fast integration, no GPU needed |
+| **Cloud API** | GPT Image 2, GPT-4o vision, Claude vision, Gemini, Midjourney | Fast integration, no GPU needed |
 | **Local (Ollama)** | LLaVA, MiniCPM-o, Qwen-VL | Private understanding tasks, no API cost |
 | **Local (ComfyUI)** | FLUX, Stable Diffusion XL, ControlNet | Generation, editing, workflow control |
 | **Cloud GPU** | Any model via vLLM/ComfyUI | Scale, large local models, batch processing |

--- a/TODO.md
+++ b/TODO.md
@@ -1315,6 +1315,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18311 Add an authenticated Playwriter relay lifecycle #bug ref:GH#30868
 
+- [ ] t18313 Add OAuth-first multi-account GPT Image 2 generation #api #auth #auto-dispatch #feat #multi-tenant #opencode #priority:high #tools ref:GH#31054
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

- add `gpt_image_generate` with ChatGPT subscription OAuth as the default billing route
- support explicit named OpenAI Platform API accounts and reference-image editing
- confine private, non-overwriting PNG output through descriptor-relative filesystem operations
- bound provider streams, response bodies, input files, execution time, and diagnostics
- document account routing, secure secret setup, image generation, and editing

## Security

- never reads OpenCode credential files or falls back to a generic Platform API key
- keeps pinned OAuth identities from rotating and allows one 429-only retry when unpinned
- launches the secure writer with a fixed interpreter and a credential-free environment
- rejects traversal, symlinks, `.git` components, malformed PNGs, and absolute-path receipts

## Verification

- `node --test tests/test-gpt-image-auth.mjs tests/test-gpt-image-io.mjs tests/test-gpt-image-request.mjs tests/test-gpt-image-tool.mjs` — 16 passed
- `npm test` — 739 passed
- `.agents/scripts/linters-local.sh` — passed
- Qlty check of the new secure-writer files — no issues
- `./setup.sh --stage agents` — deployed successfully
- deployed module syntax and `gpt_image_generate` registration probes — passed

Resolves #31054

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.300 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 1h 58m and 1,023,113 tokens on this with the user in an interactive session.