### PR TITLE
GH#31061: fix async cleanup stale worktree metadata prune

### DIFF
--- a/.agents/scripts/cleanup-worktrees-async-helper.sh
+++ b/.agents/scripts/cleanup-worktrees-async-helper.sh
@@ -87,6 +87,10 @@ else
 	echo "[cleanup-worktrees-async] ERROR: pulse-cleanup.sh not found at ${SCRIPT_DIR}" >>"$LOGFILE"
 	exit 1
 fi
+if [[ -f "${SCRIPT_DIR}/audit-worktree-removal-helper.sh" ]]; then
+	# shellcheck source=audit-worktree-removal-helper.sh
+	source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"
+fi
 
 # ============================================================
 # LOCK MANAGEMENT (mkdir-based — POSIX atomic, macOS-safe)
@@ -232,6 +236,43 @@ _maintain_worktree_recovery() {
 	return 0
 }
 
+_prune_current_repo_missing_worktree_metadata() {
+	local repo_context=""
+	local field=""
+	local wt_path=""
+	local prunable_path=""
+
+	declare -F prune_missing_worktree_metadata >/dev/null 2>&1 || return 0
+	command -v git >/dev/null 2>&1 || return 0
+	repo_context=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+	[[ -n "$repo_context" && -d "$repo_context" ]] || return 0
+
+	while IFS= read -r -d '' field; do
+		case "$field" in
+		worktree\ *)
+			wt_path="${field#worktree }"
+			;;
+		prunable\ *)
+			if [[ -n "$wt_path" && ! -e "$wt_path" ]]; then
+				prunable_path="$wt_path"
+				break
+			fi
+			;;
+		"")
+			wt_path=""
+			;;
+		esac
+	done < <(git -C "$repo_context" worktree list --porcelain -z 2>/dev/null || true)
+
+	[[ -n "$prunable_path" ]] || return 0
+	if prune_missing_worktree_metadata "$repo_context" "$prunable_path"; then
+		echo "[cleanup-worktrees-async] pruned missing worktree metadata from current repo" >>"$LOGFILE"
+	else
+		echo "[cleanup-worktrees-async] missing worktree metadata prune failed closed; continuing" >>"$LOGFILE"
+	fi
+	return 0
+}
+
 # ============================================================
 # MAIN
 # ============================================================
@@ -262,6 +303,7 @@ main() {
 		outcome="safety-skip"
 		echo "[cleanup-worktrees-async] cleanup_worktrees skipped by safety gate — last-run NOT updated" >>"$LOGFILE"
 	elif [[ "$rc" -eq 0 ]]; then
+		_prune_current_repo_missing_worktree_metadata
 		_maintain_worktree_recovery
 		_update_last_run
 		echo "[cleanup-worktrees-async] Completed successfully at $(date -u '+%Y-%m-%dT%H:%M:%SZ'). last-run updated." >>"$LOGFILE"

--- a/.agents/scripts/tests/test-cleanup-worktrees-async.sh
+++ b/.agents/scripts/tests/test-cleanup-worktrees-async.sh
@@ -89,6 +89,7 @@ STUB
 	# return-statement ratchet doesn't flag the heredoc-embedded function.
 	local mock_ran_file="${TEST_DIR}/mock-ran"
 	local maintenance_ran_file="${TEST_DIR}/maintenance-ran"
+	local metadata_prune_ran_file="${TEST_DIR}/metadata-prune-ran"
 	local maintenance_result="${MOCK_MAINTENANCE_RESULT:-{\"schema\":\"test\",\"outcome\":\"no-candidates\"}}"
 	if [[ "${MOCK_CLEANUP_SKIPPED:-0}" -eq 1 ]]; then
 		cat >"${stub_dir}/pulse-cleanup.sh" <<STUB
@@ -137,14 +138,44 @@ printf 'MAINTENANCE_RAN\\n' >>"${maintenance_ran_file}"
 printf '%s\\n' '${maintenance_result}'
 STUB
 	chmod +x "${stub_dir}/worktree-recovery-maintenance-helper.sh"
+	cat >"${stub_dir}/audit-worktree-removal-helper.sh" <<STUB
+prune_missing_worktree_metadata() {
+	local repo_arg="\$1"
+	local target_arg="\$2"
+	printf 'METADATA_PRUNE_RAN %s %s\\n' "\$repo_arg" "\$target_arg" >>"${metadata_prune_ran_file}"
+	return 0
+}
+STUB
+	if [[ -n "${MOCK_PRUNABLE_TARGET:-}" ]]; then
+		cat >"${stub_dir}/git" <<STUB
+#!/usr/bin/env bash
+if [[ "\$*" == *"rev-parse --show-toplevel"* ]]; then
+	printf '%s\\n' "${TEST_DIR}/repo"
+	exit 0
+fi
+if [[ "\$*" == *"worktree list --porcelain -z"* ]]; then
+	printf 'worktree %s\\0prunable gitdir file points to non-existent location\\0\\0' "${MOCK_PRUNABLE_TARGET}"
+	exit 0
+fi
+exec /usr/bin/git "\$@"
+STUB
+		chmod +x "${stub_dir}/git"
+		mkdir -p "${TEST_DIR}/repo"
+	fi
+	local helper_path_prefix="${PATH}"
+	if [[ -n "${MOCK_PRUNABLE_TARGET:-}" ]]; then
+		helper_path_prefix="${stub_dir}:${PATH}"
+	fi
 
 	if [[ "${RUN_HELPER_UNSET_HOME:-0}" -eq 1 ]]; then
 		env -u HOME \
+			PATH="$helper_path_prefix" \
 			AIDEVOPS_LOG_DIR="${AIDEVOPS_LOG_DIR:-${TEST_DIR}/custom-logs}" \
 			CLEANUP_WORKTREES_ASYNC_CADENCE_MIN="${CLEANUP_WORKTREES_ASYNC_CADENCE_MIN:-10}" \
 			bash "${stub_dir}/cleanup-worktrees-async-helper.sh" 2>/dev/null || true
 	else
 		env HOME="$TEST_DIR" \
+			PATH="$helper_path_prefix" \
 			CLEANUP_WORKTREES_ASYNC_CADENCE_MIN="${CLEANUP_WORKTREES_ASYNC_CADENCE_MIN:-10}" \
 			bash "${stub_dir}/cleanup-worktrees-async-helper.sh" 2>/dev/null || true
 	fi
@@ -499,6 +530,23 @@ test_archive_outcome_summary_is_logged() {
 	return 0
 }
 
+test_missing_metadata_prune_runs_after_success() {
+	local cleanup_log="${TEST_DIR}/.aidevops/logs/cleanup_worktrees.log"
+	local metadata_prune_ran="${TEST_DIR}/metadata-prune-ran"
+	local prunable_target="${TEST_DIR}/missing-worktree"
+	rm -f "$cleanup_log" "$metadata_prune_ran"
+
+	MOCK_CLEANUP_EXIT=0 MOCK_PRUNABLE_TARGET="$prunable_target" run_helper_in_isolation || true
+	if [[ -f "$metadata_prune_ran" ]] && grep -q "METADATA_PRUNE_RAN" "$metadata_prune_ran" 2>/dev/null &&
+		grep -q 'pruned missing worktree metadata from current repo' "$cleanup_log" 2>/dev/null; then
+		print_result "metadata-prune: async cleanup prunes stale gitdir entries after success" 0
+	else
+		print_result "metadata-prune: async cleanup prunes stale gitdir entries after success" 1 \
+			"metadata prune marker or log entry missing"
+	fi
+	return 0
+}
+
 # ============================================================
 # MAIN
 # ============================================================
@@ -565,6 +613,10 @@ main() {
 	teardown
 	setup
 	test_archive_outcome_summary_is_logged
+
+	teardown
+	setup
+	test_missing_metadata_prune_runs_after_success
 
 	echo ""
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"


### PR DESCRIPTION
## Summary
- Resolves #31061.
- Source existing guarded `prune_missing_worktree_metadata` in async worktree cleanup.
- After a successful cleanup pass, detect the first current-repo `prunable` missing worktree entry and prune it through the audited native-Git helper.
- Keep failures fail-closed and non-fatal so cleanup cadence/archival behavior remains stable.

## Evidence
- Observed transient cleanup service finish successfully while `git worktree list --porcelain | rg -c '^prunable'` still reported `23` missing gitdir metadata entries.
- Direct `git worktree prune` from canonical checkout is blocked by the canonical Git guard, so cleanup needs the existing audited helper path.

## Files
- `.agents/scripts/cleanup-worktrees-async-helper.sh`
- `.agents/scripts/tests/test-cleanup-worktrees-async.sh`

## Verification
- `bash .agents/scripts/tests/test-cleanup-worktrees-async.sh`
- `bash .agents/scripts/tests/test-worktree-metadata-prune.sh`
- `shellcheck .agents/scripts/cleanup-worktrees-async-helper.sh .agents/scripts/tests/test-cleanup-worktrees-async.sh`
- `bun run typecheck`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.301 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.5 spent 2d 19h and 2,477,206 tokens on this with the user in an interactive session.