### PR TITLE
GH#31064: add native GPT image output formats

### DIFF
--- a/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
@@ -9,35 +9,82 @@ import {
   requireProjectRoot,
   requireRelativePath,
 } from "./gpt-image-paths.mjs";
-import { secureWriteGeneratedPng } from "./gpt-image-secure-write.mjs";
+import { secureWriteGeneratedImage } from "./gpt-image-secure-write.mjs";
 
 const MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const PNG_IEND = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82]);
+const IMAGE_EXTENSIONS = {
+  png: new Set([".png"]),
+  jpeg: new Set([".jpg", ".jpeg"]),
+  webp: new Set([".webp"]),
+};
 
 export { readReferenceImages };
 
-function validatePngBase64(base64) {
+function requireImageFormat(format) {
+  if (!Object.hasOwn(IMAGE_EXTENSIONS, format)) throw new Error("Unsupported generated image format.");
+  return format;
+}
+
+function decodeBase64(base64) {
   const encoded = String(base64 || "").trim();
   if (!encoded || encoded.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(encoded)) {
     throw new Error("Image provider returned invalid base64 data.");
   }
   const buffer = Buffer.from(encoded, "base64");
+  if (buffer.length > MAX_OUTPUT_BYTES) throw new Error("Image provider returned an oversized image.");
+  return buffer;
+}
+
+function validatePng(buffer) {
   const hasHeader = buffer.length >= 45
     && buffer.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)
     && buffer.readUInt32BE(8) === 13
     && buffer.subarray(12, 16).toString("ascii") === "IHDR";
   const hasEnd = buffer.subarray(-PNG_IEND.length).equals(PNG_IEND);
-  if (buffer.length > MAX_OUTPUT_BYTES || !hasHeader || !hasEnd) {
-    throw new Error("Image provider returned an invalid or oversized PNG.");
+  if (!hasHeader || !hasEnd) throw new Error("Image provider returned an invalid PNG.");
+}
+
+function validateJpeg(buffer) {
+  const hasStart = buffer.length >= 4 && buffer[0] === 0xff && buffer[1] === 0xd8;
+  const hasEnd = buffer[buffer.length - 2] === 0xff && buffer[buffer.length - 1] === 0xd9;
+  if (!hasStart || !hasEnd) throw new Error("Image provider returned an invalid JPEG.");
+}
+
+function validateWebp(buffer) {
+  const hasHeader = buffer.length >= 20
+    && buffer.subarray(0, 4).toString("ascii") === "RIFF"
+    && buffer.subarray(8, 12).toString("ascii") === "WEBP"
+    && buffer.readUInt32LE(4) + 8 === buffer.length;
+  if (!hasHeader) throw new Error("Image provider returned an invalid WebP.");
+  let offset = 12;
+  let imageChunk = false;
+  while (offset + 8 <= buffer.length) {
+    const chunkType = buffer.subarray(offset, offset + 4).toString("ascii");
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    const end = offset + 8 + chunkSize;
+    if (end > buffer.length) throw new Error("Image provider returned a truncated WebP.");
+    if (["VP8 ", "VP8L", "VP8X"].includes(chunkType)) imageChunk = true;
+    offset = end + (chunkSize % 2);
   }
+  if (offset !== buffer.length || !imageChunk) throw new Error("Image provider returned an invalid WebP.");
+}
+
+function validateGeneratedImageBase64(base64, format) {
+  const selected = requireImageFormat(format);
+  const buffer = decodeBase64(base64);
+  if (selected === "png") validatePng(buffer);
+  else if (selected === "jpeg") validateJpeg(buffer);
+  else validateWebp(buffer);
   return buffer;
 }
 
-export async function validateImageOutputPath(out, projectRoot) {
+export async function validateImageOutputPath(out, projectRoot, format = "png") {
   const requested = requireRelativePath(out, "Image output");
-  if (extname(requested).toLowerCase() !== ".png") {
-    throw new Error("Image output must end in .png.");
+  const selected = requireImageFormat(format);
+  if (!IMAGE_EXTENSIONS[selected].has(extname(requested).toLowerCase())) {
+    throw new Error(`Image output extension must match ${selected}.`);
   }
   if (requested.split(/[\\/]+/).some((part) => part.toLowerCase() === ".git")) {
     throw new Error("Image output cannot be written inside .git.");
@@ -50,9 +97,9 @@ export async function validateImageOutputPath(out, projectRoot) {
   return requested;
 }
 
-export async function saveGeneratedPng(out, projectRoot, base64, options = {}) {
-  const buffer = validatePngBase64(base64);
-  const requestedPath = await validateImageOutputPath(out, projectRoot);
+export async function saveGeneratedImage(out, projectRoot, base64, format = "png", options = {}) {
+  const buffer = validateGeneratedImageBase64(base64, format);
+  const requestedPath = await validateImageOutputPath(out, projectRoot, format);
   const root = await requireProjectRoot(projectRoot);
-  return secureWriteGeneratedPng(buffer, requestedPath, root, options);
+  return secureWriteGeneratedImage(buffer, requestedPath, root, options);
 }

--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -29,7 +29,7 @@ async function withImageRequestTimeout(operation) {
 function imageToolArgs(args) {
   return {
     type: "image_generation",
-    output_format: "png",
+    output_format: args.format || "png",
     quality: args.quality || "auto",
     ...(args.size && args.size !== "auto" ? { size: args.size } : {}),
   };
@@ -164,7 +164,7 @@ function apiJsonBody(args) {
     prompt: args.prompt,
     quality: args.quality || "auto",
     size: args.size || "auto",
-    output_format: "png",
+    output_format: args.format || "png",
   };
 }
 
@@ -174,7 +174,7 @@ function apiMultipartBody(args, images) {
   body.append("prompt", args.prompt);
   body.append("quality", args.quality || "auto");
   body.append("size", args.size || "auto");
-  body.append("output_format", "png");
+  body.append("output_format", args.format || "png");
   for (const image of images) {
     body.append("image[]", new Blob([image.buffer], { type: image.mime }), image.name);
   }

--- a/.agents/plugins/opencode-aidevops/gpt-image-secure-write.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-secure-write.mjs
@@ -30,7 +30,7 @@ function parseWriterOutput(stdout) {
   };
 }
 
-export async function secureWriteGeneratedPng(buffer, out, projectRoot, options = {}) {
+export async function secureWriteGeneratedImage(buffer, out, projectRoot, options = {}) {
   const helper = options.scriptsDir ? join(options.scriptsDir, "gpt-image-secure-write.py") : DEFAULT_HELPER;
   const stdout = await runImageWriter(helper, buffer, out, projectRoot, options.spawnImpl);
   return parseWriterOutput(stdout);

--- a/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
@@ -7,23 +7,37 @@ import {
   resolveGptImageAuth,
   rotateOAuthImageAccount,
 } from "./gpt-image-auth.mjs";
-import { readReferenceImages, saveGeneratedPng, validateImageOutputPath } from "./gpt-image-io.mjs";
+import { readReferenceImages, saveGeneratedImage, validateImageOutputPath } from "./gpt-image-io.mjs";
 import { requestApiImage, requestOAuthImage } from "./gpt-image-request.mjs";
 
 const IMAGE_QUALITIES = new Set(["low", "medium", "high", "auto"]);
+const IMAGE_FORMATS = new Set(["png", "jpeg", "webp"]);
 
-function validateRawArgs(args) {
-  if (!args || typeof args !== "object" || Array.isArray(args)) throw new Error("Image tool arguments must be an object.");
+function validateOutputArgs(args) {
   if (typeof args.prompt !== "string" || typeof args.out !== "string") {
     throw new Error("Image prompt and output path must be strings.");
   }
   if (args.quality !== undefined && !IMAGE_QUALITIES.has(args.quality)) throw new Error("Unsupported image quality.");
+  if (args.format !== undefined && !IMAGE_FORMATS.has(args.format)) throw new Error("Unsupported image format.");
   if (args.size !== undefined && typeof args.size !== "string") throw new Error("Image size must be a string.");
+}
+
+function validateReferenceArgs(args) {
   if (args.images !== undefined && (!Array.isArray(args.images) || args.images.some((path) => typeof path !== "string"))) {
     throw new Error("Reference images must be an array of path strings.");
   }
+}
+
+function validateAuthArgs(args) {
   if (args.auth !== undefined && !["oauth", "api"].includes(args.auth)) throw new Error("Image auth must be oauth or api.");
   if (args.account !== undefined && typeof args.account !== "string") throw new Error("Image account must be a string.");
+}
+
+function validateRawArgs(args) {
+  if (!args || typeof args !== "object" || Array.isArray(args)) throw new Error("Image tool arguments must be an object.");
+  validateOutputArgs(args);
+  validateReferenceArgs(args);
+  validateAuthArgs(args);
 }
 
 function validatePrompt(value) {
@@ -80,9 +94,10 @@ async function executeImageGeneration(rawArgs, options) {
     prompt: validatePrompt(rawArgs.prompt),
     size: validateSize(rawArgs.size),
     quality: rawArgs.quality || "auto",
+    format: rawArgs.format || "png",
   };
+  await validateImageOutputPath(args.out, options.projectRoot, args.format);
   const images = await readReferenceImages(args.images, options.projectRoot);
-  await validateImageOutputPath(args.out, options.projectRoot);
   let auth = await resolveGptImageAuth(args, options);
   let result;
 
@@ -93,7 +108,7 @@ async function executeImageGeneration(rawArgs, options) {
   }
   if (!result.response.ok) throw result.error;
 
-  const saved = await saveGeneratedPng(args.out, options.projectRoot, result.base64, {
+  const saved = await saveGeneratedImage(args.out, options.projectRoot, result.base64, args.format, {
     scriptsDir: options.scriptsDir,
     spawnImpl: options.imageWriterSpawn,
   });
@@ -109,10 +124,11 @@ export function createGptImageTool(tool, z, options = {}) {
   const executionOptions = { ...options, fetchImpl, projectRoot: options.projectRoot || process.cwd() };
   return tool({
     description:
-      "Generate or reference-edit a PNG with GPT Image 2. Uses ChatGPT OAuth by default; API billing must be selected explicitly with auth=api and a named account alias. Writes only inside the OpenCode project and never overwrites an existing image.",
+      "Generate or reference-edit a PNG, JPEG, or WebP with GPT Image 2. Uses ChatGPT OAuth by default; API billing must be selected explicitly with auth=api and a named account alias. Writes only inside the OpenCode project and never overwrites an existing image.",
     args: {
       prompt: z.string().describe("Description of the image to generate or edit."),
-      out: z.string().describe("Project-relative .png output path."),
+      out: z.string().describe("Project-relative output path with an extension matching format."),
+      format: z.enum(["png", "jpeg", "webp"]).optional().describe("Native output format; defaults to png."),
       quality: z.enum(["low", "medium", "high", "auto"]).optional().describe("GPT Image 2 quality; defaults to auto."),
       size: z.string().optional().describe("auto or WIDTHxHEIGHT satisfying GPT Image 2 constraints."),
       images: z.array(z.string()).optional().describe("Optional project-relative PNG, JPEG, or WebP reference image paths."),

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs
@@ -7,12 +7,27 @@ import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { readReferenceImages, saveGeneratedPng, validateImageOutputPath } from "../gpt-image-io.mjs";
+import { readReferenceImages, saveGeneratedImage, validateImageOutputPath } from "../gpt-image-io.mjs";
 
 const PNG_BYTES = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
   "base64",
 );
+const JPEG_BYTES = Buffer.from([
+  0xff, 0xd8,
+  0xff, 0xc0, 0x00, 0x0b, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00,
+  0xff, 0xda, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0x00,
+  0xff, 0xd9,
+]);
+const WEBP_BYTES = Buffer.from([
+  0x52, 0x49, 0x46, 0x46, 0x12, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+  0x56, 0x50, 0x38, 0x4c, 0x05, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00,
+]);
+const OUTPUT_CASES = [
+  { bytes: PNG_BYTES, extension: "png", format: "png" },
+  { bytes: JPEG_BYTES, extension: "jpg", format: "jpeg" },
+  { bytes: WEBP_BYTES, extension: "webp", format: "webp" },
+];
 const roots = [];
 
 async function projectRoot() {
@@ -26,16 +41,19 @@ afterEach(async () => {
 });
 
 describe("GPT image file safety", () => {
-  test("creates private PNG output without overwriting an existing image", async () => {
+  test("creates private raster outputs without overwriting existing images", async () => {
     const root = await projectRoot();
-    const first = await saveGeneratedPng("assets/result.png", root, PNG_BYTES.toString("base64"));
-    const second = await saveGeneratedPng("assets/result.png", root, PNG_BYTES.toString("base64"));
-    assert.equal(first.versioned, false);
-    assert.equal(second.versioned, true);
-    assert.equal(first.projectPath, "assets/result.png");
-    assert.equal(second.projectPath, "assets/result-v2.png");
-    assert.deepEqual(await readFile(join(root, first.projectPath)), PNG_BYTES);
-    assert.equal((await lstat(join(root, first.projectPath))).mode & 0o777, 0o600);
+    for (const { bytes, extension, format } of OUTPUT_CASES) {
+      const requested = `assets/result.${extension}`;
+      const first = await saveGeneratedImage(requested, root, bytes.toString("base64"), format);
+      const second = await saveGeneratedImage(requested, root, bytes.toString("base64"), format);
+      assert.equal(first.versioned, false);
+      assert.equal(second.versioned, true);
+      assert.equal(first.projectPath, requested);
+      assert.equal(second.projectPath, `assets/result-v2.${extension}`);
+      assert.deepEqual(await readFile(join(root, first.projectPath)), bytes);
+      assert.equal((await lstat(join(root, first.projectPath))).mode & 0o777, 0o600);
+    }
   });
 
   test("rejects traversal and symbolic-link output parents", async () => {
@@ -46,6 +64,14 @@ describe("GPT image file safety", () => {
     await assert.rejects(validateImageOutputPath("linked/escape.png", root), /symbolic links/);
     await assert.rejects(validateImageOutputPath(".GIT/escape.png", root), /inside \.git/);
     await assert.rejects(validateImageOutputPath("nested/.GiT/escape.png", root), /inside \.git/);
+  });
+
+  test("requires the output extension to match the selected native format", async () => {
+    const root = await projectRoot();
+    await validateImageOutputPath("assets/result.jpg", root, "jpeg");
+    await validateImageOutputPath("assets/result.jpeg", root, "jpeg");
+    await assert.rejects(validateImageOutputPath("assets/result.png", root, "webp"), /must match webp/);
+    await assert.rejects(validateImageOutputPath("assets/result.svg", root, "png"), /must match png/);
   });
 
   test("accepts only regular project-confined reference images with known magic bytes", async () => {
@@ -63,8 +89,20 @@ describe("GPT image file safety", () => {
     const corrupted = Buffer.from(PNG_BYTES);
     corrupted[45] ^= 0xff;
     await assert.rejects(
-      saveGeneratedPng("assets/corrupt.png", root, corrupted.toString("base64")),
+      saveGeneratedImage("assets/corrupt.png", root, corrupted.toString("base64")),
       /invalid checksum/,
+    );
+  });
+
+  test("rejects bytes that do not match the selected output format", async () => {
+    const root = await projectRoot();
+    await assert.rejects(
+      saveGeneratedImage("assets/mismatch.webp", root, PNG_BYTES.toString("base64"), "webp"),
+      /invalid WebP/,
+    );
+    await assert.rejects(
+      saveGeneratedImage("assets/truncated.jpg", root, Buffer.from([0xff, 0xd8, 0xff, 0xd9]).toString("base64"), "jpeg"),
+      /without a terminal marker|invalid terminal JPEG marker/,
     );
   });
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
@@ -40,7 +40,7 @@ describe("GPT image provider requests", () => {
     };
     const result = await requestOAuthImage(
       { accessToken: "oauth-test-token", accountId: "account-test" },
-      { prompt: "draw a test", quality: "low", size: "1024x1024" },
+      { prompt: "draw a test", quality: "low", size: "1024x1024", format: "webp" },
       [{ dataUrl: "data:image/png;base64,dGVzdA==" }],
       fetchImpl,
     );
@@ -48,6 +48,7 @@ describe("GPT image provider requests", () => {
     assert.equal(captured.url, "https://chatgpt.com/backend-api/codex/responses");
     assert.equal(captured.init.headers.Authorization, "Bearer oauth-test-token");
     assert.equal(body.tools[0].type, "image_generation");
+    assert.equal(body.tools[0].output_format, "webp");
     assert.equal(body.input[0].content[1].type, "input_image");
     assert.equal(result.base64, IMAGE_RESULT);
   });
@@ -65,8 +66,25 @@ describe("GPT image provider requests", () => {
       fetchImpl,
     );
     assert.equal(captured.url, "https://api.openai.com/v1/images/generations");
-    assert.equal(JSON.parse(captured.init.body).model, "gpt-image-2");
+    const body = JSON.parse(captured.init.body);
+    assert.equal(body.model, "gpt-image-2");
+    assert.equal(body.output_format, "png");
     assert.equal(result.base64, IMAGE_RESULT);
+  });
+
+  test("selects JPEG output for API generation", async () => {
+    let captured;
+    const fetchImpl = async (url, init) => {
+      captured = { url, init };
+      return Response.json({ data: [{ b64_json: IMAGE_RESULT }] });
+    };
+    await requestApiImage(
+      { accessToken: "unit-test-credential-value" },
+      { prompt: "draw a test", quality: "auto", size: "auto", format: "jpeg" },
+      [],
+      fetchImpl,
+    );
+    assert.equal(JSON.parse(captured.init.body).output_format, "jpeg");
   });
 
   test("uses multipart GPT Image 2 edits when API references are present", async () => {
@@ -77,13 +95,14 @@ describe("GPT image provider requests", () => {
     };
     await requestApiImage(
       { accessToken: "unit-test-credential-value" },
-      { prompt: "edit a test", quality: "high", size: "1024x1024" },
+      { prompt: "edit a test", quality: "high", size: "1024x1024", format: "webp" },
       [{ buffer: Buffer.from("image"), mime: "image/png", name: "source.png" }],
       fetchImpl,
     );
     assert.equal(captured.url, "https://api.openai.com/v1/images/edits");
     assert.ok(captured.init.body instanceof FormData);
     assert.equal(captured.init.body.get("model"), "gpt-image-2");
+    assert.equal(captured.init.body.get("output_format"), "webp");
     assert.equal(captured.init.body.getAll("image[]").length, 1);
     assert.equal(new Headers(captured.init.headers).has("Content-Type"), false);
   });

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs
@@ -14,6 +14,10 @@ const PNG_BYTES = Buffer.from(
   "base64",
 );
 const PNG_BASE64 = PNG_BYTES.toString("base64");
+const WEBP_BASE64 = Buffer.from([
+  0x52, 0x49, 0x46, 0x46, 0x12, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+  0x56, 0x50, 0x38, 0x4c, 0x05, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00,
+]).toString("base64");
 const roots = [];
 const schemaNode = { _zod: {}, optional() { return this; }, describe() { return this; } };
 const z = {
@@ -28,10 +32,10 @@ async function projectRoot() {
   return root;
 }
 
-function oauthSuccess() {
+function oauthSuccess(base64 = PNG_BASE64) {
   const event = `data: ${JSON.stringify({
     type: "response.output_item.done",
-    item: { type: "image_generation_call", result: PNG_BASE64 },
+    item: { type: "image_generation_call", result: base64 },
   })}\n\n`;
   return new Response(event, { status: 200, headers: { "Content-Type": "text/event-stream" } });
 }
@@ -65,6 +69,39 @@ describe("GPT image OpenCode tool", () => {
     assert.match(output, /ChatGPT subscription OAuth/);
     assert.match(output, /generated\/test\.png/);
     assert.doesNotMatch(output, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  });
+
+  test("requests and writes a selected native WebP", async () => {
+    const root = await projectRoot();
+    let requestBody;
+    const tool = createTool({
+      projectRoot: root,
+      resolveOAuthAccount: async () => ({ email: "person@example.test", access: "oauth-test-token" }),
+      fetchImpl: async (_url, init) => {
+        requestBody = JSON.parse(init.body);
+        return oauthSuccess(WEBP_BASE64);
+      },
+    });
+    const output = await tool.execute({ prompt: "draw a test", out: "generated/test.webp", format: "webp" });
+    assert.equal(requestBody.tools[0].output_format, "webp");
+    assert.match(output, /generated\/test\.webp/);
+  });
+
+  test("rejects format and extension mismatches before network access", async () => {
+    const root = await projectRoot();
+    let calls = 0;
+    const tool = createTool({
+      projectRoot: root,
+      fetchImpl: async () => {
+        calls += 1;
+        return oauthSuccess();
+      },
+    });
+    await assert.rejects(
+      tool.execute({ prompt: "draw a test", out: "generated/test.png", format: "jpeg" }),
+      /extension must match jpeg/,
+    );
+    assert.equal(calls, 0);
   });
 
   test("rotates once after an unpinned OAuth 429", async () => {

--- a/.agents/scripts/gpt-image-secure-write.py
+++ b/.agents/scripts/gpt-image-secure-write.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Publish a generated PNG through descriptor-relative filesystem operations."""
+"""Publish a generated raster image through descriptor-relative operations."""
 
 from __future__ import annotations
 
@@ -16,23 +16,26 @@ import sys
 
 MAX_OUTPUT_BYTES = 64 * 1024 * 1024
 MAX_OUTPUT_VERSION = 999
+VALIDATOR_MODULES = {
+    "png": ("gpt_image_png.py", "validate_png", "PngValidationError"),
+    "jpeg": ("gpt_image_jpeg.py", "validate_jpeg", "JpegValidationError"),
+    "webp": ("gpt_image_webp.py", "validate_webp", "WebpValidationError"),
+}
 
 
 class SecureWriteError(Exception):
     """Represent a safe user-facing image publication failure."""
 
 
-def load_png_validator():
-    """Load the adjacent validator without enabling ambient Python imports."""
-    validator_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "gpt_image_png.py")
+def load_image_validator(image_format: str):
+    """Load one adjacent format validator without ambient Python imports."""
     try:
+        filename, function_name, error_name = VALIDATOR_MODULES[image_format]
+        validator_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), filename)
         module = run_path(validator_path)
-        return module["validate_png"], module["PngValidationError"]
+        return module[function_name], module[error_name]
     except (OSError, KeyError) as error:
-        raise SecureWriteError("secure PNG validation is unavailable") from error
-
-
-validate_png, PngValidationError = load_png_validator()
+        raise SecureWriteError("secure image validation is unavailable") from error
 
 
 def directory_flags() -> int:
@@ -42,27 +45,31 @@ def directory_flags() -> int:
     return os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | os.O_DIRECTORY | os.O_NOFOLLOW
 
 
-def parse_output_path(value: str) -> tuple[tuple[str, ...], str]:
-    """Validate and split one portable project-relative PNG path."""
+def parse_output_path(value: str) -> tuple[tuple[str, ...], str, str]:
+    """Validate and split one portable project-relative raster image path."""
     portable = value.replace("\\", "/")
     path = PurePosixPath(portable)
     if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
         raise SecureWriteError("image output must be a safe project-relative path")
-    if not path.parts or path.suffix.lower() != ".png":
-        raise SecureWriteError("image output must end in .png")
+    formats = {".png": "png", ".jpg": "jpeg", ".jpeg": "jpeg", ".webp": "webp"}
+    try:
+        image_format = formats[path.suffix.lower()]
+    except KeyError as error:
+        raise SecureWriteError("image output must end in .png, .jpg, .jpeg, or .webp") from error
     if any(part.casefold() == ".git" for part in path.parts):
         raise SecureWriteError("image output cannot be written inside .git")
-    return path.parts[:-1], path.parts[-1]
+    return path.parts[:-1], path.parts[-1], image_format
 
 
-def read_png() -> bytes:
-    """Read and structurally validate one bounded PNG from stdin."""
+def read_image(image_format: str) -> bytes:
+    """Read and structurally validate one bounded raster image from stdin."""
     payload = sys.stdin.buffer.read(MAX_OUTPUT_BYTES + 1)
     if len(payload) > MAX_OUTPUT_BYTES:
-        raise SecureWriteError("generated PNG exceeds the 64 MiB limit")
+        raise SecureWriteError("generated image exceeds the 64 MiB limit")
+    validate_image, image_validation_error = load_image_validator(image_format)
     try:
-        validate_png(payload)
-    except PngValidationError as error:
+        validate_image(payload)
+    except image_validation_error as error:
         raise SecureWriteError(str(error)) from error
     return payload
 
@@ -153,8 +160,8 @@ def cleanup_temporary(directory_fd: int, temporary: str, temp_fd: int) -> bool:
     return failed
 
 
-def publish_png(directory_fd: int, requested: str, payload: bytes) -> tuple[str, bool, bool]:
-    """Write and hard-link a private PNG without replacing existing output."""
+def publish_image(directory_fd: int, requested: str, payload: bytes) -> tuple[str, bool, bool]:
+    """Write and hard-link a private image without replacing existing output."""
     temporary = f".{requested}.aidevops-{secrets.token_hex(12)}.tmp"
     temp_fd = -1
     published = ""
@@ -208,8 +215,8 @@ def main() -> int:
     parser.add_argument("--root", required=True)
     parser.add_argument("--out", required=True)
     args = parser.parse_args()
-    directories, requested = parse_output_path(args.out)
-    payload = read_png()
+    directories, requested, image_format = parse_output_path(args.out)
+    payload = read_image(image_format)
     root_fd = os.open(args.root, directory_flags())
     directory_fd = -1
     candidate = ""
@@ -217,7 +224,7 @@ def main() -> int:
         if not stat.S_ISDIR(os.fstat(root_fd).st_mode):
             raise SecureWriteError("OpenCode project root must be a regular directory")
         directory_fd = open_output_directory(root_fd, directories)
-        candidate, versioned, cleanup_warning = publish_png(directory_fd, requested, payload)
+        candidate, versioned, cleanup_warning = publish_image(directory_fd, requested, payload)
         if not directory_binding_matches(root_fd, directories, directory_fd):
             os.unlink(candidate, dir_fd=directory_fd)
             os.fsync(directory_fd)

--- a/.agents/scripts/gpt_image_jpeg.py
+++ b/.agents/scripts/gpt_image_jpeg.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate bounded JPEG structure for the secure GPT image writer."""
+
+from __future__ import annotations
+
+MAX_PIXELS = 8_294_400
+STANDALONE_MARKERS = {0x01, *range(0xD0, 0xD8)}
+FRAME_MARKERS = {
+    0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7,
+    0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF,
+}
+
+
+class JpegValidationError(Exception):
+    """Represent a safe user-facing JPEG validation failure."""
+
+
+def validate_dimensions(width: int, height: int) -> None:
+    """Reject empty or excessively large decoded JPEG dimensions."""
+    if width < 1 or height < 1 or width * height > MAX_PIXELS:
+        raise JpegValidationError("generated JPEG dimensions exceed the safe limit")
+
+
+def jpeg_scan_end(payload: bytes, offset: int) -> int:
+    """Return the offset of the next non-stuffed JPEG marker after scan data."""
+    while offset < len(payload):
+        if payload[offset] != 0xFF:
+            offset += 1
+            continue
+        marker_start = offset
+        while offset < len(payload) and payload[offset] == 0xFF:
+            offset += 1
+        if offset >= len(payload):
+            break
+        marker = payload[offset]
+        if marker == 0x00 or 0xD0 <= marker <= 0xD7:
+            offset += 1
+            continue
+        return marker_start
+    raise JpegValidationError("image provider returned a JPEG without a terminal marker")
+
+
+def read_marker(payload: bytes, offset: int) -> tuple[int, int]:
+    """Read one JPEG marker and return it with the following offset."""
+    if payload[offset] != 0xFF:
+        raise JpegValidationError("image provider returned invalid JPEG marker ordering")
+    while offset < len(payload) and payload[offset] == 0xFF:
+        offset += 1
+    if offset >= len(payload):
+        raise JpegValidationError("image provider returned a JPEG without a terminal marker")
+    return payload[offset], offset + 1
+
+
+def read_segment(payload: bytes, offset: int) -> tuple[bytes, int]:
+    """Read one bounded length-prefixed JPEG segment."""
+    if offset + 2 > len(payload):
+        raise JpegValidationError("image provider returned an invalid JPEG marker")
+    segment_length = int.from_bytes(payload[offset : offset + 2], "big")
+    segment_end = offset + segment_length
+    if segment_length < 2 or segment_end > len(payload):
+        raise JpegValidationError("image provider returned a truncated JPEG segment")
+    return payload[offset + 2 : segment_end], segment_end
+
+
+def validate_frame(segment: bytes) -> None:
+    """Validate dimensions from one JPEG start-of-frame segment."""
+    if len(segment) < 6:
+        raise JpegValidationError("image provider returned an invalid JPEG frame")
+    validate_dimensions(
+        int.from_bytes(segment[3:5], "big"),
+        int.from_bytes(segment[1:3], "big"),
+    )
+
+
+def process_segment(payload: bytes, marker: int, offset: int) -> tuple[int, bool, bool]:
+    """Validate one non-terminal marker and return parser-state updates."""
+    if marker in STANDALONE_MARKERS:
+        return offset, False, False
+    if marker in {0x00, 0xD8}:
+        raise JpegValidationError("image provider returned an invalid JPEG marker")
+    segment, offset = read_segment(payload, offset)
+    found_dimensions = marker in FRAME_MARKERS
+    if found_dimensions:
+        validate_frame(segment)
+    found_scan = marker == 0xDA
+    if found_scan:
+        if len(segment) < 6:
+            raise JpegValidationError("image provider returned an invalid JPEG scan")
+        offset = jpeg_scan_end(payload, offset)
+    return offset, found_dimensions, found_scan
+
+
+def validate_terminal(offset: int, length: int, saw_dimensions: bool, saw_scan: bool) -> None:
+    """Validate the final JPEG marker position and required prior segments."""
+    if offset != length or not saw_dimensions or not saw_scan:
+        raise JpegValidationError("image provider returned an invalid terminal JPEG marker")
+
+
+def validate_jpeg(payload: bytes) -> None:
+    """Validate JPEG segments, dimensions, scan presence, and terminal marker."""
+    if len(payload) < 4 or payload[:2] != b"\xff\xd8":
+        raise JpegValidationError("image provider returned an invalid JPEG")
+    offset = 2
+    saw_dimensions = False
+    saw_scan = False
+    while offset < len(payload):
+        marker, offset = read_marker(payload, offset)
+        if marker == 0xD9:
+            validate_terminal(offset, len(payload), saw_dimensions, saw_scan)
+            return
+        offset, found_dimensions, found_scan = process_segment(payload, marker, offset)
+        saw_dimensions = saw_dimensions or found_dimensions
+        saw_scan = saw_scan or found_scan
+    raise JpegValidationError("image provider returned a JPEG without a terminal marker")

--- a/.agents/scripts/gpt_image_webp.py
+++ b/.agents/scripts/gpt_image_webp.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate bounded WebP structure for the secure GPT image writer."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+MAX_PIXELS = 8_294_400
+IMAGE_CHUNKS = {b"VP8 ", b"VP8L"}
+
+
+class WebpValidationError(Exception):
+    """Represent a safe user-facing WebP validation failure."""
+
+
+def validate_dimensions(width: int, height: int) -> None:
+    """Reject empty or excessively large decoded WebP dimensions."""
+    if width < 1 or height < 1 or width * height > MAX_PIXELS:
+        raise WebpValidationError("generated WebP dimensions exceed the safe limit")
+
+
+def webp_dimensions(chunk_type: bytes, chunk: bytes) -> Optional[tuple[int, int]]:
+    """Read dimensions from a WebP canvas or image-data chunk."""
+    if chunk_type == b"VP8X" and len(chunk) == 10:
+        return 1 + int.from_bytes(chunk[4:7], "little"), 1 + int.from_bytes(chunk[7:10], "little")
+    if chunk_type == b"VP8 " and len(chunk) >= 10 and chunk[3:6] == b"\x9d\x01\x2a":
+        return (
+            int.from_bytes(chunk[6:8], "little") & 0x3FFF,
+            int.from_bytes(chunk[8:10], "little") & 0x3FFF,
+        )
+    if chunk_type == b"VP8L" and len(chunk) >= 5 and chunk[0] == 0x2F:
+        bits = int.from_bytes(chunk[1:5], "little")
+        return 1 + (bits & 0x3FFF), 1 + ((bits >> 14) & 0x3FFF)
+    return None
+
+
+def validate_header(payload: bytes) -> None:
+    """Validate the outer RIFF and WebP container headers."""
+    if (
+        len(payload) < 20
+        or payload[:4] != b"RIFF"
+        or payload[8:12] != b"WEBP"
+        or int.from_bytes(payload[4:8], "little") + 8 != len(payload)
+    ):
+        raise WebpValidationError("image provider returned an invalid WebP")
+
+
+def read_chunk(payload: bytes, offset: int) -> tuple[bytes, bytes, int]:
+    """Read one bounded RIFF chunk and its padded following offset."""
+    chunk_type = payload[offset : offset + 4]
+    chunk_length = int.from_bytes(payload[offset + 4 : offset + 8], "little")
+    chunk_end = offset + 8 + chunk_length
+    if chunk_end > len(payload):
+        raise WebpValidationError("image provider returned a truncated WebP chunk")
+    return chunk_type, payload[offset + 8 : chunk_end], chunk_end + (chunk_length % 2)
+
+
+def inspect_chunk(
+    chunk_type: bytes,
+    chunk: bytes,
+    dimensions: Optional[tuple[int, int]],
+) -> tuple[Optional[tuple[int, int]], bool]:
+    """Validate one WebP chunk and return dimensions plus image-data state."""
+    candidate = webp_dimensions(chunk_type, chunk)
+    if candidate is None:
+        if chunk_type in IMAGE_CHUNKS:
+            raise WebpValidationError("image provider returned invalid WebP image data")
+        return dimensions, False
+    validate_dimensions(*candidate)
+    if dimensions is not None and dimensions != candidate:
+        raise WebpValidationError("image provider returned inconsistent WebP dimensions")
+    return candidate, chunk_type in IMAGE_CHUNKS
+
+
+def validate_structure(
+    offset: int,
+    length: int,
+    dimensions: Optional[tuple[int, int]],
+    saw_image_data: bool,
+) -> None:
+    """Validate final RIFF alignment and required WebP image data."""
+    if offset != length or dimensions is None or not saw_image_data:
+        raise WebpValidationError("image provider returned an invalid WebP structure")
+
+
+def validate_webp(payload: bytes) -> None:
+    """Validate a static WebP RIFF container, dimensions, and image-data chunk."""
+    validate_header(payload)
+    offset = 12
+    saw_image_data = False
+    dimensions: Optional[tuple[int, int]] = None
+    while offset + 8 <= len(payload):
+        chunk_type, chunk, offset = read_chunk(payload, offset)
+        dimensions, found_image_data = inspect_chunk(chunk_type, chunk, dimensions)
+        saw_image_data = saw_image_data or found_image_data
+    validate_structure(offset, len(payload), dimensions, saw_image_data)

--- a/.agents/tools/vision/image-editing.md
+++ b/.agents/tools/vision/image-editing.md
@@ -48,7 +48,9 @@ The OpenCode `gpt_image_generate` tool accepts up to 8 project-relative
 reference images through `images`. Describe each image's role in the prompt.
 ChatGPT OAuth is the default billing route; explicit `auth: "api"` uses the
 named `OPENAI_IMAGE_API_KEY_<ACCOUNT>` secret and OpenAI's Images edit endpoint.
-GPT Image 2 processes references at high fidelity automatically.
+GPT Image 2 processes references at high fidelity automatically. Edited output
+can be native PNG (default), JPEG, or WebP when `format` matches the output path
+extension; SVG and PDF remain artifact/document workflows.
 
 ```text
 Using refs/product.png as the product reference, place it on a clean marble counter in soft morning light. Save to assets/product-morning.png.

--- a/.agents/tools/vision/image-generation.md
+++ b/.agents/tools/vision/image-generation.md
@@ -24,7 +24,7 @@ tools:
 - **OpenCode tool**: `gpt_image_generate`
 - **Default billing route**: ChatGPT subscription OAuth from the aidevops OpenAI account pool
 - **Platform billing route**: explicit `auth: "api"` plus a named account alias
-- **Model**: GPT Image 2 (`gpt-image-2`); output is a project-confined PNG
+- **Model**: GPT Image 2 (`gpt-image-2`); project-confined PNG, JPEG, or WebP output
 - **Reference images**: up to 8 project-relative PNG, JPEG, or WebP files
 - **Safety**: existing files are never overwritten; versioned paths use `-v2`, `-v3`, and so on
 
@@ -58,11 +58,16 @@ Budget-conscious?     → FLUX or SD locally (GPU cost only)
 ### GPT Image 2 (OpenAI)
 
 In OpenCode, ask naturally for an image and include the desired project-relative
-PNG path. The aidevops plugin exposes `gpt_image_generate` automatically.
+output path. The aidevops plugin exposes `gpt_image_generate` automatically.
 
 ```text
 Generate a low-quality 1024x1024 watercolor lighthouse draft and save it to assets/lighthouse.png.
 ```
+
+PNG is the default. Select `format: "jpeg"` or `format: "webp"` for another
+native raster format; the output path must use the matching `.jpg`/`.jpeg` or
+`.webp` extension. SVG and PDF belong to artifact/document workflows and are not
+GPT Image output formats.
 
 The tool defaults to the existing ChatGPT OAuth pool. Add an account through
 `opencode auth login` → **OpenAI Pool**. An optional OAuth `account` pins the
@@ -81,6 +86,7 @@ from a subscription to API credits. Never paste an API key into chat.
 
 | Parameter | Options | Notes |
 |-----------|---------|-------|
+| `format` | png, jpeg, webp | `png` is the default; output extension must match |
 | `quality` | low, medium, high, auto | `auto` is the default; use low for drafts |
 | `size` | auto or WIDTHxHEIGHT | Edges must be multiples of 16, max 3840px, ratio ≤3:1, total 655,360-8,294,400px |
 | `images` | 0-8 project-relative paths | Reference-guided generation/editing; PNG, JPEG, or WebP, 20 MiB each |
@@ -147,9 +153,9 @@ text, signature, oversaturated, underexposed, overexposed
 ```
 
 **Batch generation**: invoke `gpt_image_generate` once per distinct asset. Each
-call returns one PNG and preserves an existing output by choosing a versioned
-filename. Avoid unattended high-quality batches because API and subscription
-usage limits still apply.
+call returns one native raster image and preserves an existing output by choosing
+a versioned filename. Avoid unattended high-quality batches because API and
+subscription usage limits still apply.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Add native PNG, JPEG, and WebP selection to the OpenCode GPT image tool, propagate the format through OAuth and API request paths, and validate matching extensions plus raster structure before atomic publication.

## Files Changed

.agents/plugins/opencode-aidevops/gpt-image-io.mjs, .agents/plugins/opencode-aidevops/gpt-image-request.mjs, .agents/plugins/opencode-aidevops/gpt-image-secure-write.mjs, .agents/plugins/opencode-aidevops/gpt-image-tool.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs, .agents/scripts/gpt-image-secure-write.py, .agents/scripts/gpt_image_jpeg.py, .agents/scripts/gpt_image_webp.py, .agents/tools/vision/image-editing.md, .agents/tools/vision/image-generation.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 18 focused GPT image tests; full OpenCode plugin suite; `.agents/scripts/linters-local.sh`; targeted Qlty smell scan; Python 3.9 syntax checks; live OAuth JPEG and WebP generation with file-type and 0600-mode verification.

Resolves #31064
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.301 plugin for [OpenCode](https://opencode.ai) v1.18.25 with gpt-5.6-sol spent 47m and 490,393 tokens on this with the user in an interactive session.