### PR TITLE
GH#31067: reject invalid OpenCode Bash workdirs

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import { execFileSync } from "child_process";
-import { existsSync } from "fs";
+import { existsSync, lstatSync, realpathSync, statSync } from "fs";
 import { homedir } from "os";
 import { join, resolve } from "path";
 import { classifyFullLoopCommitAndPr } from "./quality-hooks-full-loop-trust.mjs";
@@ -117,6 +117,42 @@ function parsePolicyPayload(raw) {
     throw new TypeError("policy returned a non-object payload");
   }
   return result;
+}
+
+export function validateBashWorkingDirectory(cwd) {
+  if (typeof cwd !== "string" || !cwd.trim()) {
+    throw new Error("BLOCKED: Bash workdir must be a non-empty path");
+  }
+
+  let lexicalState;
+  try {
+    lexicalState = lstatSync(cwd);
+  } catch (error) {
+    const reason = ["ENOENT", "ENOTDIR"].includes(error?.code)
+      ? "does not exist"
+      : "could not be verified";
+    throw new Error(`BLOCKED: Bash workdir ${reason}: ${cwd}`);
+  }
+
+  let resolvedCwd;
+  try {
+    resolvedCwd = realpathSync(cwd);
+  } catch (error) {
+    const reason = lexicalState.isSymbolicLink() && error?.code === "ENOENT"
+      ? "is a broken symlink"
+      : "could not be resolved";
+    throw new Error(`BLOCKED: Bash workdir ${reason}: ${cwd}`);
+  }
+
+  let resolvedState;
+  try {
+    resolvedState = statSync(resolvedCwd);
+  } catch {
+    throw new Error(`BLOCKED: Bash workdir could not be verified: ${cwd}`);
+  }
+  if (!resolvedState.isDirectory()) {
+    throw new Error(`BLOCKED: Bash workdir is not a directory: ${cwd}`);
+  }
 }
 
 export function checkCanonicalWriteSafetyGate(

--- a/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import { execFileSync } from "child_process";
-import { existsSync, lstatSync, realpathSync, statSync } from "fs";
+import { existsSync } from "fs";
 import { homedir } from "os";
 import { join, resolve } from "path";
 import { classifyFullLoopCommitAndPr } from "./quality-hooks-full-loop-trust.mjs";
@@ -117,42 +117,6 @@ function parsePolicyPayload(raw) {
     throw new TypeError("policy returned a non-object payload");
   }
   return result;
-}
-
-export function validateBashWorkingDirectory(cwd) {
-  if (typeof cwd !== "string" || !cwd.trim()) {
-    throw new Error("BLOCKED: Bash workdir must be a non-empty path");
-  }
-
-  let lexicalState;
-  try {
-    lexicalState = lstatSync(cwd);
-  } catch (error) {
-    const reason = ["ENOENT", "ENOTDIR"].includes(error?.code)
-      ? "does not exist"
-      : "could not be verified";
-    throw new Error(`BLOCKED: Bash workdir ${reason}: ${cwd}`);
-  }
-
-  let resolvedCwd;
-  try {
-    resolvedCwd = realpathSync(cwd);
-  } catch (error) {
-    const reason = lexicalState.isSymbolicLink() && error?.code === "ENOENT"
-      ? "is a broken symlink"
-      : "could not be resolved";
-    throw new Error(`BLOCKED: Bash workdir ${reason}: ${cwd}`);
-  }
-
-  let resolvedState;
-  try {
-    resolvedState = statSync(resolvedCwd);
-  } catch {
-    throw new Error(`BLOCKED: Bash workdir could not be verified: ${cwd}`);
-  }
-  if (!resolvedState.isDirectory()) {
-    throw new Error(`BLOCKED: Bash workdir is not a directory: ${cwd}`);
-  }
 }
 
 export function checkCanonicalWriteSafetyGate(

--- a/.agents/plugins/opencode-aidevops/quality-hooks-workdir.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-workdir.mjs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { lstatSync, realpathSync, statSync } from "fs";
+
+export function validateBashWorkingDirectory(cwd) {
+  if (typeof cwd !== "string" || !cwd.trim()) {
+    throw new Error("BLOCKED: Bash workdir must be a non-empty path");
+  }
+
+  let lexicalState;
+  try {
+    lexicalState = lstatSync(cwd);
+  } catch (error) {
+    const reason = ["ENOENT", "ENOTDIR"].includes(error?.code)
+      ? "does not exist"
+      : "could not be verified";
+    throw new Error(`BLOCKED: Bash workdir ${reason}: ${cwd}`);
+  }
+
+  let resolvedCwd;
+  try {
+    resolvedCwd = realpathSync(cwd);
+  } catch (error) {
+    const reason = lexicalState.isSymbolicLink() && error?.code === "ENOENT"
+      ? "is a broken symlink"
+      : "could not be resolved";
+    throw new Error(`BLOCKED: Bash workdir ${reason}: ${cwd}`);
+  }
+
+  let resolvedState;
+  try {
+    resolvedState = statSync(resolvedCwd);
+  } catch {
+    throw new Error(`BLOCKED: Bash workdir could not be verified: ${cwd}`);
+  }
+  if (!resolvedState.isDirectory()) {
+    throw new Error(`BLOCKED: Bash workdir is not a directory: ${cwd}`);
+  }
+}

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -42,6 +42,7 @@ import {
   checkCanonicalWriteSafetyGate,
   isApplyPatchMutationTool,
   isDirectFileMutationTool,
+  validateBashWorkingDirectory,
 } from "./quality-hooks-git-safety.mjs";
 
 // Re-export for consumers that import from this module
@@ -296,7 +297,8 @@ function prepareToolIntent(log, input, output) {
 function enforceBashToolSafety(ctx, log, input, output, sessionId) {
   if (!isBashTool(input.tool)) return;
   const bashArgs = output.args ?? {};
-  const bashCwd = bashArgs.workdir || bashArgs.cwd || process.cwd();
+  const bashCwd = bashArgs.workdir ?? bashArgs.cwd ?? process.cwd();
+  validateBashWorkingDirectory(bashCwd);
   bashArgs.command = checkCanonicalGitSafetyGate(
     bashArgs.command || "",
     ctx.scriptsDir,

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -42,8 +42,8 @@ import {
   checkCanonicalWriteSafetyGate,
   isApplyPatchMutationTool,
   isDirectFileMutationTool,
-  validateBashWorkingDirectory,
 } from "./quality-hooks-git-safety.mjs";
+import { validateBashWorkingDirectory } from "./quality-hooks-workdir.mjs";
 
 // Re-export for consumers that import from this module
 export { scanForSecrets } from "./quality-logging.mjs";

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -23,6 +23,7 @@ import {
   checkCanonicalWriteSafetyGate,
   checkCommandSafetyGate,
   isDirectFileMutationTool,
+  validateBashWorkingDirectory,
 } from "../quality-hooks-git-safety.mjs";
 import { createQualityHooks } from "../quality-hooks.mjs";
 
@@ -55,6 +56,79 @@ test("classifies built-in and namespaced direct file mutation tools", () => {
   }
   for (const tool of ["Bash", "read", "functions.read", "glob"]) {
     assert.equal(isDirectFileMutationTool(tool), false, tool);
+  }
+});
+
+test("validates Bash workdirs without rewriting valid external paths", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-bash-workdir-"));
+  const directory = join(root, "directory");
+  const directoryAlias = join(root, "directory-alias");
+  const regularFile = join(root, "regular-file");
+  const brokenAlias = join(root, "broken-alias");
+  const missing = join(root, "missing");
+  mkdirSync(directory);
+  symlinkSync(directory, directoryAlias, "dir");
+  writeFileSync(regularFile, "not a directory\n");
+  symlinkSync(missing, brokenAlias, "dir");
+  try {
+    assert.equal(validateBashWorkingDirectory(directory), undefined);
+    assert.equal(validateBashWorkingDirectory(directoryAlias), undefined);
+    assert.throws(() => validateBashWorkingDirectory(missing), /workdir does not exist/);
+    assert.throws(() => validateBashWorkingDirectory(brokenAlias), /workdir is a broken symlink/);
+    assert.throws(() => validateBashWorkingDirectory(regularFile), /workdir is not a directory/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("blocks an invalid Bash workdir before command policy execution", async () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-bash-workdir-order-"));
+  try {
+    const hooks = createQualityHooks({
+      scriptsDir: join(root, "missing-scripts"),
+      logsDir: root,
+      repositoryDir: root,
+    });
+    for (const args of [
+      { command: "pwd", workdir: join(root, "missing-workdir") },
+      { command: "pwd", cwd: join(root, "missing-cwd") },
+    ]) {
+      await assert.rejects(
+        () => hooks.toolExecuteBefore({ tool: "Bash" }, { args }),
+        /Bash workdir does not exist/,
+      );
+    }
+    for (const args of [
+      { command: "pwd", workdir: "" },
+      { command: "pwd", cwd: " " },
+    ]) {
+      await assert.rejects(
+        () => hooks.toolExecuteBefore({ tool: "Bash" }, { args }),
+        /Bash workdir must be a non-empty path/,
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("preserves valid Bash workdir inputs and the implicit fallback", async () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-bash-workdir-valid-"));
+  const directoryAlias = join(root, "directory-alias");
+  symlinkSync(root, directoryAlias, "dir");
+  try {
+    const hooks = createQualityHooks({ scriptsDir, logsDir: root, repositoryDir: root });
+    for (const args of [
+      { command: "pwd", workdir: root },
+      { command: "pwd", cwd: directoryAlias },
+      { command: "pwd" },
+    ]) {
+      const output = { args: { ...args } };
+      await assert.doesNotReject(() => hooks.toolExecuteBefore({ tool: "Bash" }, output));
+      assert.deepEqual(output.args, args);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -23,8 +23,8 @@ import {
   checkCanonicalWriteSafetyGate,
   checkCommandSafetyGate,
   isDirectFileMutationTool,
-  validateBashWorkingDirectory,
 } from "../quality-hooks-git-safety.mjs";
+import { validateBashWorkingDirectory } from "../quality-hooks-workdir.mjs";
 import { createQualityHooks } from "../quality-hooks.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary

Reject nonexistent, broken-symlink, empty, and non-directory Bash workdirs in the OpenCode pre-execution hook without rewriting valid external paths.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs, .agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --test .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs (25/25 passed); .agents/scripts/linters-local.sh --changed passed; node --check and git diff --check passed

Resolves #31067


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.301 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 34m and 234,327 tokens on this with the user in an interactive session.