### PR TITLE
GH#31073: fix approval lifecycle label provisioning

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -90,6 +90,7 @@ readonly _APPROVAL_BATCH_FAILURE_AUTH="shared-auth-failure"
 
 _APPROVAL_GH_RATE_LIMIT_RESET=""
 _APPROVAL_GH_AUTH_FAILURE=""
+_APPROVAL_LABEL_SETS_ENSURED=""
 
 # shellcheck source=approval-snapshot-v2.sh
 source "${SCRIPT_DIR}/approval-snapshot-v2.sh"
@@ -855,6 +856,29 @@ _approval_apply_pr_lifecycle_updates() {
 	return 0
 }
 
+_approval_ensure_lifecycle_labels() {
+	local target_type="$1"
+	local slug="$2"
+	local cache_key="${slug}:${target_type}"
+
+	case ",${_APPROVAL_LABEL_SETS_ENSURED}," in
+	*",${cache_key},"*) return 0 ;;
+	esac
+	if ! command -v managed_labels_ensure_approval_set >/dev/null 2>&1 ||
+		! command -v _gh_managed_label_names_snapshot >/dev/null 2>&1 ||
+		! command -v _gh_managed_label_create_runner >/dev/null 2>&1; then
+		_print_error "Managed approval label provisioning is unavailable; approval was not posted"
+		return 1
+	fi
+	if ! managed_labels_ensure_approval_set "$slug" "$target_type" \
+		_gh_managed_label_names_snapshot _gh_managed_label_create_runner; then
+		_print_error "Could not provision approval lifecycle labels in ${slug}; approval was not posted"
+		return 1
+	fi
+	_APPROVAL_LABEL_SETS_ENSURED="${_APPROVAL_LABEL_SETS_ENSURED:+${_APPROVAL_LABEL_SETS_ENSURED},}${cache_key}"
+	return 0
+}
+
 _post_issue_approval_updates() {
 	local target_type="$1"
 	local target_number="$2"
@@ -996,6 +1020,10 @@ _approve_target_after_confirmation() {
 	local actual_key="$4"
 
 	local timestamp payload sig_file comment_body
+	# #aidevops:trust-boundary — provision every repository-level label needed by the post-signature
+	# transition before creating irreversible approval evidence. This keeps a
+	# newly managed repository from ending in a signed but undispatchable state.
+	_approval_ensure_lifecycle_labels "$target_type" "$slug" || return 1
 	# #aidevops:trust-boundary — issue continuity can only begin from an
 	# authoritative locked snapshot. PR approval semantics remain unchanged.
 	if [[ "$target_type" == "$APPROVAL_TARGET_ISSUE" ]]; then

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -1788,8 +1788,17 @@ cmd_reconcile() {
 	printf '%s' "$issue_json" | jq -e --arg label "$_APPROVAL_NMR_LABEL" \
 		'(.labels // []) | any(.name == $label)' >/dev/null 2>&1 || nmr_rc=$?
 	if [[ "$nmr_rc" -eq 1 ]]; then
-		printf 'NO_NMR\n'
-		return 3
+		# A failed pre-fix issue approval can have neither NMR nor auto-dispatch:
+		# status provisioning succeeded, then both lifecycle label writes failed.
+		# Recover that exact signed state instead of treating every absent NMR as
+		# an already completed handoff. PRs and dispatch-enabled issues stay no-op.
+		if [[ "$target_type" != "issue" ]] || printf '%s' "$issue_json" | jq -e \
+			--arg label "$_APPROVAL_AUTO_DISPATCH_LABEL" \
+			'(.labels // []) | any(.name == $label)' >/dev/null 2>&1; then
+			printf 'NO_NMR\n'
+			return 3
+		fi
+		nmr_rc=0
 	fi
 	if [[ "$nmr_rc" -ne 0 ]]; then
 		printf 'API_ERROR\n'
@@ -1807,6 +1816,12 @@ cmd_reconcile() {
 		return 6
 	fi
 
+	# #aidevops:trust-boundary — only provision labels after the existing signed
+	# approval and current maintainer authority have both been re-verified.
+	if ! _approval_ensure_lifecycle_labels "$target_type" "$slug" >/dev/null 2>&1; then
+		printf 'UPDATE_FAILED\n'
+		return 8
+	fi
 	if ! _post_issue_approval_updates "$target_type" "$target_number" "$slug" >/dev/null 2>&1; then
 		# A lifecycle writer may fail after partially clearing NMR (for example,
 		# issue label mutation succeeds but its advisory lock fails). Reassert the

--- a/.agents/scripts/managed-label-provisioning-lib.sh
+++ b/.agents/scripts/managed-label-provisioning-lib.sh
@@ -18,6 +18,15 @@ _MANAGED_ORIGIN_LABEL_SPECS=(
 	"origin:worker-takeover" "Worker took over from interactive session" "D4C5F9"
 )
 
+_MANAGED_APPROVAL_HOLD_LABEL_SPECS=(
+	"needs-maintainer-review" "Requires maintainer approval before automated dispatch" "FBCA04"
+)
+
+_MANAGED_APPROVAL_ISSUE_LABEL_SPECS=(
+	"${_MANAGED_APPROVAL_HOLD_LABEL_SPECS[@]}"
+	"auto-dispatch" "Eligible for autonomous worker dispatch" "0E8A16"
+)
+
 managed_label_snapshot_has() {
 	local snapshot="$1"
 	local expected_name="$2"
@@ -74,5 +83,23 @@ managed_labels_ensure_tracking_set() {
 	)
 	managed_labels_ensure_specs "$repo" "$inventory_runner" "$create_runner" \
 		"${tracking_specs[@]}"
+	return $?
+}
+
+managed_labels_ensure_approval_set() {
+	local repo="$1"
+	local target_type="$2"
+	local inventory_runner="$3"
+	local create_runner="$4"
+	local -a approval_specs=()
+
+	case "$target_type" in
+	issue) approval_specs=("${_MANAGED_APPROVAL_ISSUE_LABEL_SPECS[@]}") ;;
+	pr) approval_specs=("${_MANAGED_APPROVAL_HOLD_LABEL_SPECS[@]}") ;;
+	*) return 1 ;;
+	esac
+
+	managed_labels_ensure_specs "$repo" "$inventory_runner" "$create_runner" \
+		"${approval_specs[@]}"
 	return $?
 }

--- a/.agents/scripts/managed-label-provisioning-lib.sh
+++ b/.agents/scripts/managed-label-provisioning-lib.sh
@@ -25,6 +25,7 @@ _MANAGED_APPROVAL_HOLD_LABEL_SPECS=(
 _MANAGED_APPROVAL_ISSUE_LABEL_SPECS=(
 	"${_MANAGED_APPROVAL_HOLD_LABEL_SPECS[@]}"
 	"auto-dispatch" "Eligible for autonomous worker dispatch" "0E8A16"
+	"no-auto-dispatch" "Opt-out: block all auto-dispatch on this issue" "EDEDED"
 )
 
 managed_label_snapshot_has() {

--- a/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
+++ b/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
@@ -461,6 +461,7 @@ run_case "reconcile re-verifies authority immediately before issue lifecycle res
 		printf "VERIFIED\n"
 		return 0
 	}
+	_approval_ensure_lifecycle_labels() { return 0; }
 	_post_issue_approval_updates() {
 		local target_type="${1:-}"
 		local target_number="${2:-}"
@@ -494,6 +495,7 @@ run_case "partial reconciliation failure reasserts NMR before returning" '
 		return 0
 	}
 	cmd_verify() { printf "VERIFIED\n"; return 0; }
+	_approval_ensure_lifecycle_labels() { return 0; }
 	_post_issue_approval_updates() { return 1; }
 	_approval_restore_nmr_hold() {
 		local target_type="${1:-}"
@@ -532,6 +534,33 @@ run_case "reconcile leaves an unchanged approved target as a no-op" '
 assert_contains "no-op reconciliation reports absent restored hold" "$LAST_OUTPUT" "NO_NMR"
 assert_not_contains "no-op reconciliation skips signature work" "$LAST_OUTPUT" "SHOULD_NOT_VERIFY"
 assert_not_contains "no-op reconciliation skips lifecycle mutation" "$LAST_OUTPUT" "SHOULD_NOT_APPLY"
+
+# A signed issue stranded by missing repository labels has no NMR and no
+# auto-dispatch. Reconciliation must provision labels and complete that handoff.
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "reconcile repairs signed issue missing both lifecycle labels" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	trace=$(mktemp)
+	_require_number_arg() { return 0; }
+	_resolve_slug_or_fail() { local slug="${1:-}"; printf "%s" "$slug"; return 0; }
+	_approval_fetch_issue_json() {
+		printf "%s" "{\"state\":\"open\",\"locked\":true,\"labels\":[{\"name\":\"status:available\"}]}"
+		return 0
+	}
+	cmd_verify() { printf "VERIFIED\n"; return 0; }
+	_approval_ensure_lifecycle_labels() { printf "ENSURE_LABELS\n" >>"$trace"; return 0; }
+	_post_issue_approval_updates() { printf "APPLY_LIFECYCLE\n" >>"$trace"; return 0; }
+	rc=0
+	cmd_reconcile issue 123 marcusquinn/aidevops || rc=$?
+	cat "$trace"
+	rm -f "$trace"
+	exit "$rc"
+' 0
+assert_contains "stranded approval provisions lifecycle labels" "$LAST_OUTPUT" "ENSURE_LABELS"
+assert_contains "stranded approval completes lifecycle handoff" "$LAST_OUTPUT" "APPLY_LIFECYCLE"
+assert_contains "stranded approval reconciliation succeeds" "$LAST_OUTPUT" "RECONCILED"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "reconcile preserves NMR when authority verification fails" '

--- a/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
+++ b/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
@@ -335,6 +335,7 @@ run_case "post-approval protection failure blocks final success" '
 	set -uo pipefail
 	# shellcheck disable=SC1090
 	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_ensure_lifecycle_labels() { return 0; }
 	approval_snapshot_v2_payload() { printf "%s" "{\"schema\":\"aidevops-approval/v2\"}"; return 0; }
 	_sign_approval_payload() { local payload="$1"; local actual_key="$2"; local sig_file="$3"; : "$payload" "$actual_key"; printf "mock-signature" >"$sig_file"; return 0; }
 	gh_issue_comment() { return 0; }
@@ -346,6 +347,23 @@ run_case "post-approval protection failure blocks final success" '
 assert_contains "post-approval failure suppresses final success" "$LAST_OUTPUT" "post-approval protection updates did not reach the required state"
 assert_not_contains "post-approval failure does not print success" "$LAST_OUTPUT" "Issue #123 approved and signed"
 assert_contains "post-approval failure queues bounded reconciliation" "$LAST_OUTPUT" "KICKED_RECONCILIATION"
+
+# Missing repository labels must fail before locking, signing, or commenting.
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "approval label provisioning failure is pre-signature" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_ensure_lifecycle_labels() { printf "PROVISION_ATTEMPT"; return 1; }
+	_approval_lock_issue() { printf "UNEXPECTED_LOCK"; return 0; }
+	_sign_approval_payload() { printf "UNEXPECTED_SIGN"; return 0; }
+	gh_issue_comment() { printf "UNEXPECTED_COMMENT"; return 0; }
+	_approve_target_after_confirmation issue 123 marcusquinn/aidevops mock-key
+' 1
+assert_contains "approval attempts lifecycle label provisioning" "$LAST_OUTPUT" "PROVISION_ATTEMPT"
+assert_not_contains "provisioning failure does not lock issue" "$LAST_OUTPUT" "UNEXPECTED_LOCK"
+assert_not_contains "provisioning failure does not sign" "$LAST_OUTPUT" "UNEXPECTED_SIGN"
+assert_not_contains "provisioning failure does not comment" "$LAST_OUTPUT" "UNEXPECTED_COMMENT"
 
 # GH#28717: target reconciliation accepts only the current authenticated actor's
 # signed comment when that actor has maintainer-equivalent authority.

--- a/.agents/scripts/tests/test-managed-label-provisioning.sh
+++ b/.agents/scripts/tests/test-managed-label-provisioning.sh
@@ -99,10 +99,11 @@ TEST_LABEL_SNAPSHOT='needs-maintainer-review'
 managed_labels_ensure_approval_set owner/repo issue \
 	_gh_managed_label_names_snapshot _gh_managed_label_create_runner
 assert_count "issue approval creates missing dispatch label" 1 'gh label create auto-dispatch '
+assert_count "issue approval creates missing dispatch mutex label" 1 'gh label create no-auto-dispatch '
 assert_count "issue approval reuses present review label" 0 'gh label create needs-maintainer-review '
 
 : >"$CALL_LOG"
-TEST_LABEL_SNAPSHOT=$'needs-maintainer-review\nauto-dispatch'
+TEST_LABEL_SNAPSHOT=$'needs-maintainer-review\nauto-dispatch\nno-auto-dispatch'
 managed_labels_ensure_approval_set owner/repo issue \
 	_gh_managed_label_names_snapshot _gh_managed_label_create_runner
 assert_count "converged issue approval performs zero creates" 0 'write route=managed-label-create-rest gh label create'
@@ -113,6 +114,7 @@ managed_labels_ensure_approval_set owner/repo pr \
 	_gh_managed_label_names_snapshot _gh_managed_label_create_runner
 assert_count "PR approval creates only the review label" 1 'gh label create needs-maintainer-review '
 assert_count "PR approval does not create dispatch label" 0 'gh label create auto-dispatch '
+assert_count "PR approval does not create dispatch mutex label" 0 'gh label create no-auto-dispatch '
 
 # Failed inventory is fail-closed: do not fan out speculative writes or cache.
 : >"$CALL_LOG"

--- a/.agents/scripts/tests/test-managed-label-provisioning.sh
+++ b/.agents/scripts/tests/test-managed-label-provisioning.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression coverage for existence-aware origin:* and solved:* provisioning.
+# Regression coverage for existence-aware managed-label provisioning.
 
 set -uo pipefail
 
@@ -92,6 +92,27 @@ managed_labels_ensure_tracking_set owner/repo \
 assert_count "tracking set provisions status label" 1 'gh label create status:in-review '
 assert_count "tracking set provisions bug label" 1 'gh label create bug '
 assert_count "tracking set reuses present origins" 0 'gh label create origin:'
+
+# Approval transitions provision every label before posting signed evidence.
+: >"$CALL_LOG"
+TEST_LABEL_SNAPSHOT='needs-maintainer-review'
+managed_labels_ensure_approval_set owner/repo issue \
+	_gh_managed_label_names_snapshot _gh_managed_label_create_runner
+assert_count "issue approval creates missing dispatch label" 1 'gh label create auto-dispatch '
+assert_count "issue approval reuses present review label" 0 'gh label create needs-maintainer-review '
+
+: >"$CALL_LOG"
+TEST_LABEL_SNAPSHOT=$'needs-maintainer-review\nauto-dispatch'
+managed_labels_ensure_approval_set owner/repo issue \
+	_gh_managed_label_names_snapshot _gh_managed_label_create_runner
+assert_count "converged issue approval performs zero creates" 0 'write route=managed-label-create-rest gh label create'
+
+: >"$CALL_LOG"
+TEST_LABEL_SNAPSHOT=""
+managed_labels_ensure_approval_set owner/repo pr \
+	_gh_managed_label_names_snapshot _gh_managed_label_create_runner
+assert_count "PR approval creates only the review label" 1 'gh label create needs-maintainer-review '
+assert_count "PR approval does not create dispatch label" 0 'gh label create auto-dispatch '
 
 # Failed inventory is fail-closed: do not fan out speculative writes or cache.
 : >"$CALL_LOG"


### PR DESCRIPTION
## Summary

Provision auto-dispatch and needs-maintainer-review repository labels before approval creates signed evidence, using the shared managed-label catalogue and per-process convergence cache.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/managed-label-provisioning-lib.sh, .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh, .agents/scripts/tests/test-managed-label-provisioning.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Focused managed-label tests (17 assertions), approval lifecycle tests (64 assertions), REST fallback tests (10 assertions), content-binding tests (74 assertions), batch/wrapper tests, ShellCheck, and linters-local.sh passed.

Resolves #31073


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.301 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 10m and 233,101 tokens on this with the user in an interactive session.