### PR TITLE
GH#31081: fix guarded remote branch cleanup

### DIFF
--- a/.agents/scripts/remote-branch-cleanup-helper.sh
+++ b/.agents/scripts/remote-branch-cleanup-helper.sh
@@ -9,12 +9,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 # shellcheck source=./shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=./worktree-paths.sh
+source "${SCRIPT_DIR}/worktree-paths.sh"
 
 REPO_PATH="${PWD}"
 REMOTE_NAME="origin"
 APPLY=0
 INCLUDE_CLOSED_PR=0
 SKIP_FETCH=0
+DELETE_TRANSPORT_WORKTREE=""
+DELETE_FAILURES=0
 
 usage() {
 	cat <<'EOF'
@@ -164,7 +168,7 @@ gh_pr_branches() {
 	while [[ "$page" -le 2 ]]; do
 		page_json=$(AIDEVOPS_GH_ROUTE_DECISION="remote-branch-cleanup-pr-branches-rest" \
 			gh api "repos/${slug}/pulls?state=${api_state}&per_page=100&page=${page}" \
-				2>/dev/null) || return 0
+			2>/dev/null) || return 0
 		page_count=$(printf '%s' "$page_json" | jq -r 'if type == "array" then length else -1 end' 2>/dev/null) || return 0
 		[[ "$page_count" =~ ^[0-9]+$ ]] || return 0
 		printf '%s' "$page_json" | jq -r "$jq_filter" 2>/dev/null || return 0
@@ -211,13 +215,107 @@ print_candidate() {
 	return 0
 }
 
+cleanup_delete_transport() {
+	local worktree="$DELETE_TRANSPORT_WORKTREE"
+	[[ -n "$worktree" ]] || return 0
+	if repo_git worktree remove --force "$worktree" >/dev/null 2>&1; then
+		DELETE_TRANSPORT_WORKTREE=""
+		return 0
+	fi
+	print_warning "Unable to remove remote-branch cleanup transport worktree: $worktree"
+	return 1
+}
+
+prepare_delete_transport() {
+	local worktree=""
+	[[ -z "$DELETE_TRANSPORT_WORKTREE" ]] || return 0
+	worktree=$(aidevops_generate_worktree_path "$REPO_PATH" "remote-branch-cleanup-$$") || {
+		print_error "Unable to resolve the remote-branch cleanup transport path"
+		return 1
+	}
+	if [[ -e "$worktree" || -L "$worktree" ]]; then
+		print_error "Remote-branch cleanup transport path already exists: $worktree"
+		return 1
+	fi
+	DELETE_TRANSPORT_WORKTREE="$worktree"
+	if ! repo_git worktree add --detach "$worktree" HEAD >/dev/null 2>&1; then
+		DELETE_TRANSPORT_WORKTREE=""
+		print_error "Unable to create an isolated linked worktree for remote-ref deletion"
+		return 1
+	fi
+	return 0
+}
+
+delete_transport_git() {
+	local worktree="$DELETE_TRANSPORT_WORKTREE"
+	[[ -n "$worktree" ]] || return 1
+	git -C "$worktree" "$@"
+	return $?
+}
+
+record_delete_failure() {
+	local branch="$1"
+	local reason="$2"
+	DELETE_FAILURES=$((DELETE_FAILURES + 1))
+	print_candidate "failed" "$branch" "$reason"
+	return 0
+}
+
 delete_branch() {
 	local branch="$1"
-	if repo_git push "$REMOTE_NAME" --delete "$branch" >/dev/null 2>&1; then
-		print_candidate "deleted" "$branch" "remote branch removed"
-	else
-		print_candidate "failed" "$branch" "git push --delete failed"
+	local expected_sha=""
+	local remote_output=""
+	local remote_sha=""
+	local verify_rc=0
+
+	if ! repo_git check-ref-format --branch "$branch" >/dev/null 2>&1; then
+		record_delete_failure "$branch" "invalid branch ref"
+		return 0
 	fi
+	expected_sha=$(repo_git rev-parse --verify "refs/remotes/${REMOTE_NAME}/${branch}" 2>/dev/null) || expected_sha=""
+	if [[ -z "$expected_sha" ]]; then
+		record_delete_failure "$branch" "unable to resolve audited remote-tracking ref"
+		return 0
+	fi
+	if ! prepare_delete_transport; then
+		record_delete_failure "$branch" "isolated deletion transport unavailable"
+		return 0
+	fi
+	if ! remote_output=$(delete_transport_git ls-remote --heads "$REMOTE_NAME" "refs/heads/${branch}" 2>/dev/null); then
+		record_delete_failure "$branch" "unable to verify remote ref before deletion"
+		return 0
+	fi
+	if [[ -z "$remote_output" ]]; then
+		print_candidate "deleted" "$branch" "remote absence verified"
+		return 0
+	fi
+	remote_sha="${remote_output%%[[:space:]]*}"
+	if [[ "$remote_sha" != "$expected_sha" ]]; then
+		record_delete_failure "$branch" "remote ref changed after safety scan"
+		return 0
+	fi
+	if ! delete_transport_git push \
+		"--force-with-lease=refs/heads/${branch}:${expected_sha}" \
+		"$REMOTE_NAME" ":refs/heads/${branch}" >/dev/null 2>&1; then
+		record_delete_failure "$branch" "lease-bound remote deletion failed"
+		return 0
+	fi
+	if remote_output=$(delete_transport_git ls-remote --exit-code --heads "$REMOTE_NAME" "refs/heads/${branch}" 2>/dev/null); then
+		verify_rc=0
+	else
+		verify_rc=$?
+	fi
+	case "$verify_rc" in
+	2)
+		print_candidate "deleted" "$branch" "remote absence verified"
+		;;
+	0)
+		record_delete_failure "$branch" "remote ref still present after deletion"
+		;;
+	*)
+		record_delete_failure "$branch" "remote absence verification failed"
+		;;
+	esac
 	return 0
 }
 
@@ -372,13 +470,21 @@ scan_branches() {
 		printf 'Dry-run only. Re-run with --apply to delete safe candidates.\n'
 	fi
 	sync_default_branch_after_cleanup "$default"
+	[[ "$DELETE_FAILURES" -eq 0 ]] || return 1
 	return 0
 }
 
 main() {
+	local scan_rc=0
+	local cleanup_rc=0
 	parse_args "$@"
-	scan_branches
-	return $?
+	trap 'cleanup_delete_transport >/dev/null 2>&1 || true' EXIT
+	scan_branches || scan_rc=$?
+	cleanup_delete_transport || cleanup_rc=$?
+	trap - EXIT
+	[[ "$scan_rc" -eq 0 ]] || return "$scan_rc"
+	[[ "$cleanup_rc" -eq 0 ]] || return "$cleanup_rc"
+	return 0
 }
 
 main "$@"

--- a/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
+++ b/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
 HELPER="${SCRIPTS_DIR}/remote-branch-cleanup-helper.sh"
+GIT_SHIM="${SCRIPTS_DIR}/git"
 TEST_ROOT="${PWD}/.agents/tmp/test-remote-branch-cleanup.$$"
 
 fail() {
@@ -132,6 +133,21 @@ STUB
 	return 0
 }
 
+install_readback_failure_git_stub() {
+	local bin_dir="$1"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/git" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\$*" == *"ls-remote --exit-code --heads origin refs/heads/merged-readback"* ]]; then
+	exit 1
+fi
+exec "${GIT_SHIM}" "\$@"
+STUB
+	chmod +x "${bin_dir}/git"
+	return 0
+}
+
 setup_repo() {
 	mkdir -p "$TEST_ROOT"
 	git init -q --bare "$TEST_ROOT/origin.git"
@@ -195,13 +211,61 @@ run_dry_run_assertions() {
 run_apply_assertions() {
 	local repo="$1"
 	local gh_bin="$TEST_ROOT/bin"
-	PATH="$gh_bin:$PATH" bash "$HELPER" --repo "$repo" --skip-fetch --apply >/dev/null
+	local repos_file="$TEST_ROOT/repos.json"
+	local worktree_base="$TEST_ROOT/worktrees"
+	local direct_output=""
+	local direct_rc=0
+	printf '{"initialized_repos":[{"path":"%s"}]}\n' "$repo" >"$repos_file"
+	if direct_output=$(cd "$repo" && AIDEVOPS_REPOS_FILE="$repos_file" PATH="$SCRIPTS_DIR:$PATH" git push origin --delete merged-safe 2>&1); then
+		fail "direct canonical git push must remain blocked"
+	else
+		direct_rc=$?
+	fi
+	[[ "$direct_rc" -eq 42 ]] || fail "direct canonical git push returns guard exit 42 (rc=$direct_rc)"
+	assert_contains "$direct_output" "BLOCKED by canonical Git guard" "direct canonical git push remains blocked"
+	assert_ref_exists "$repo" merged-safe "blocked direct push preserves merged branch"
+
+	AIDEVOPS_REPOS_FILE="$repos_file" \
+		AIDEVOPS_WORKTREE_BASE_DIR="$worktree_base" \
+		PATH="$SCRIPTS_DIR:$gh_bin:$PATH" \
+		bash "$HELPER" --repo "$repo" --skip-fetch --apply >/dev/null
 
 	assert_ref_missing "$repo" merged-safe "apply deletes merged safe branch"
 	assert_ref_exists "$repo" unmerged "apply preserves unmerged branch"
 	assert_ref_exists "$repo" open-pr "apply preserves open PR branch"
 	assert_ref_exists "$repo" active-worktree "apply preserves active worktree branch"
 	assert_ref_exists "$repo" main "apply preserves default branch"
+	if git -C "$repo" worktree list --porcelain | grep -F "$worktree_base" >/dev/null 2>&1; then
+		fail "apply must remove its isolated deletion transport"
+	fi
+	pass "apply removes its isolated deletion transport"
+	return 0
+}
+
+run_readback_failure_assertions() {
+	local repo="$1"
+	local gh_bin="$TEST_ROOT/bin"
+	local git_bin="$TEST_ROOT/readback-bin"
+	local repos_file="$TEST_ROOT/repos.json"
+	local worktree_base="$TEST_ROOT/worktrees"
+	local output=""
+	local rc=0
+
+	make_branch "$repo" merged-readback merged-readback.txt merged-readback
+	merge_branch_to_main "$repo" merged-readback
+	git -C "$repo" fetch -q origin
+	install_readback_failure_git_stub "$git_bin"
+	if output=$(AIDEVOPS_REPOS_FILE="$repos_file" \
+		AIDEVOPS_WORKTREE_BASE_DIR="$worktree_base" \
+		PATH="$git_bin:$gh_bin:$PATH" \
+		bash "$HELPER" --repo "$repo" --skip-fetch --apply 2>&1); then
+		fail "apply must fail when remote absence read-back is indeterminate"
+	else
+		rc=$?
+	fi
+	[[ "$rc" -eq 1 ]] || fail "indeterminate read-back returns terminal failure (rc=$rc)"
+	assert_contains "$output" "remote absence verification failed" "apply reports indeterminate remote read-back"
+	assert_ref_missing "$repo" merged-readback "fixture confirms deletion occurred before read-back failure"
 	return 0
 }
 
@@ -258,6 +322,7 @@ main() {
 	setup_repo
 	run_dry_run_assertions "$TEST_ROOT/repo"
 	run_apply_assertions "$TEST_ROOT/repo"
+	run_readback_failure_assertions "$TEST_ROOT/repo"
 	run_sync_assertions
 	return 0
 }


### PR DESCRIPTION
## Summary

Run audited remote-ref deletion from a temporary detached linked worktree, bind deletion to the classified SHA with force-with-lease, and fail unless remote read-back proves absence.

## Files Changed

.agents/scripts/remote-branch-cleanup-helper.sh, .agents/scripts/tests/test-remote-branch-cleanup-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Runtime fixture proves canonical direct push remains blocked while apply deletes only the merged branch; open-PR, active-worktree, default, and unmerged branches remain; read-back uncertainty fails terminally. ShellCheck, shfmt, canonical Git guard tests, and linters-local pass.

Resolves #31081


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.303 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 11m and 157,767 tokens on this with the user in an interactive session.