### PR TITLE
GH#31078: align OpenAI pool setup guidance

### DIFF
--- a/.agents/plugins/opencode-aidevops/gpt-image-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-auth.mjs
@@ -62,7 +62,7 @@ async function resolveOAuthAuth(args, options) {
   if (!account?.access) {
     const qualifier = requestedAccount ? "requested" : "available";
     throw new Error(
-      `No ${qualifier} ChatGPT OAuth account can generate images. Add or inspect OpenAI Pool accounts with model-accounts-pool.`,
+      `No ${qualifier} ChatGPT OAuth account can generate images. Run \`aidevops model-accounts-pool add openai\`, or inspect OpenAI Pool accounts with model-accounts-pool.`,
     );
   }
   return {

--- a/.agents/plugins/opencode-aidevops/oauth-pool-display.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-display.mjs
@@ -24,6 +24,13 @@ export {
 // Pool tool action handlers
 // ---------------------------------------------------------------------------
 
+const POOL_PROVIDERS = new Set(["anthropic", "openai", "cursor", "google"]);
+
+export function poolAccountAddCommand(provider) {
+  const selected = POOL_PROVIDERS.has(provider) ? provider : "anthropic";
+  return `aidevops model-accounts-pool add ${selected}`;
+}
+
 export function poolActionList(provider, accounts, hint, now) {
   if (accounts.length === 0) return `No accounts in the ${provider} pool.\n\n${hint}`;
   const lines = accounts.map((a, i) => {
@@ -65,8 +72,7 @@ export function poolActionStatus(provider, accounts, hint, now) {
 
 export async function poolActionRotate(client, provider, accounts, resolveInjectFn) {
   if (accounts.length < 2) {
-    const pn = { anthropic: "Anthropic Pool", openai: "OpenAI Pool", cursor: "Cursor Pool", google: "Google Pool" };
-    return `Cannot rotate: only ${accounts.length} account(s). Add more via Ctrl+A -> ${pn[provider] || "Pool"}.`;
+    return `Cannot rotate: only ${accounts.length} account(s). Add more with \`${poolAccountAddCommand(provider)}\`.`;
   }
   const current = [...accounts].sort((a, b) => new Date(b.lastUsed || 0) - new Date(a.lastUsed || 0))[0];
   if (!(await resolveInjectFn(provider)(client, current?.email))) {

--- a/.agents/plugins/opencode-aidevops/oauth-pool-health-check.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-health-check.mjs
@@ -104,6 +104,6 @@ export async function poolActionCheck(providerArg, now) {
     if (pending) results.push(`  PENDING: Unassigned token (added: ${pending.added})`);
   }
   return results.length === 0
-    ? `No accounts in any pool.\n\nTo add: run \`opencode auth login\` (Ctrl+A), select a pool provider, enter email, complete OAuth, then switch to the main provider.`
+    ? `No accounts in any pool.\n\nTo add an account, run \`aidevops model-accounts-pool add <provider>\` with anthropic, openai, cursor, or google.`
     : `OAuth Pool Health Check${results.join("\n")}`;
 }

--- a/.agents/plugins/opencode-aidevops/oauth-pool-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-tool.mjs
@@ -13,7 +13,7 @@ import { tool } from "./tools.mjs";
 import {
   poolActionList, poolActionRemove, poolActionStatus,
   poolActionResetCooldowns, poolActionRotate, poolActionAssignPending,
-  poolActionCheck, poolActionSetPriority,
+  poolActionCheck, poolActionSetPriority, poolAccountAddCommand,
 } from "./oauth-pool-display.mjs";
 
 const z = tool.schema;
@@ -36,13 +36,7 @@ export function createPoolTool(client) {
       const provider = args.provider || "anthropic";
       const accounts = getAccounts(provider);
       const now = Date.now();
-      const hints = {
-        anthropic: 'run `opencode auth login` -> "Anthropic Pool"',
-        openai: 'run `opencode auth login` -> "OpenAI Pool"',
-        cursor: 'run `opencode auth login` -> "Cursor Pool"',
-        google: 'run `opencode auth login` -> "Google Pool"',
-      };
-      const hint = `To add an account: ${hints[provider] || hints.anthropic}.`;
+      const hint = `To add an account, run \`${poolAccountAddCommand(provider)}\`.`;
       const actions = {
         "list": () => poolActionList(provider, accounts, hint, now),
         "remove": () => poolActionRemove(provider, args.email),

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-auth.mjs
@@ -44,4 +44,11 @@ describe("GPT image authentication", () => {
     assert.equal(auth.pinned, true);
     assert.equal(auth.mode, "oauth");
   });
+
+  test("points an empty OAuth pool to the supported account-add flow", async () => {
+    await assert.rejects(
+      resolveGptImageAuth({ auth: "oauth" }, { resolveOAuthAccount: async () => null }),
+      /aidevops model-accounts-pool add openai/,
+    );
+  });
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-oauth-pool-display.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-oauth-pool-display.mjs
@@ -8,6 +8,7 @@ import {
   formatDuration, formatAgo, poolActionCheck,
   poolActionRemove, poolActionResetCooldowns,
   poolActionAssignPending, poolActionSetPriority,
+  poolAccountAddCommand, poolActionRotate,
 } from "../oauth-pool-display.mjs";
 import { poolActionCheck as healthCheckAction } from "../oauth-pool-health-check.mjs";
 import {
@@ -32,4 +33,13 @@ test("display module preserves account action exports", () => {
   assert.equal(poolActionResetCooldowns, accountResetCooldownsAction);
   assert.equal(poolActionAssignPending, accountAssignPendingAction);
   assert.equal(poolActionSetPriority, accountSetPriorityAction);
+});
+
+test("pool remediation uses the supported account-add command", async () => {
+  assert.equal(poolAccountAddCommand("openai"), "aidevops model-accounts-pool add openai");
+  assert.equal(poolAccountAddCommand("unknown"), "aidevops model-accounts-pool add anthropic");
+  assert.match(
+    await poolActionRotate({}, "openai", [], () => async () => true),
+    /aidevops model-accounts-pool add openai/,
+  );
 });

--- a/.agents/tools/vision/image-generation.md
+++ b/.agents/tools/vision/image-generation.md
@@ -69,9 +69,10 @@ native raster format; the output path must use the matching `.jpg`/`.jpeg` or
 `.webp` extension. SVG and PDF belong to artifact/document workflows and are not
 GPT Image output formats.
 
-The tool defaults to the existing ChatGPT OAuth pool. Add an account through
-`opencode auth login` → **OpenAI Pool**. An optional OAuth `account` pins the
-request to that pool email; a pinned account never falls back to another login.
+The tool defaults to the existing ChatGPT OAuth pool. Add an account through the
+recommended device OAuth flow with `aidevops model-accounts-pool add openai`.
+An optional OAuth `account` pins the request to that pool email; a pinned account
+never falls back to another login.
 
 Platform API billing is always explicit and uses an account-specific secret:
 


### PR DESCRIPTION
## Summary

Replace unavailable OpenCode OpenAI Pool login guidance with the supported aidevops device-auth command across GPT Image docs and pool remediation messages, with focused regression coverage.

## Files Changed

.agents/plugins/opencode-aidevops/gpt-image-auth.mjs, .agents/plugins/opencode-aidevops/oauth-pool-display.mjs, .agents/plugins/opencode-aidevops/oauth-pool-health-check.mjs, .agents/plugins/opencode-aidevops/oauth-pool-tool.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt-image-auth.mjs, .agents/plugins/opencode-aidevops/tests/test-oauth-pool-display.mjs, .agents/tools/vision/image-generation.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: exercised the production pool status and GPT image OAuth remediation paths with an isolated empty account home; focused OAuth/GPT image tests passed 13/13; node syntax checks and linters-local.sh passed. The broader plugin suite passed 749 tests; its sole failure was the linked worktree lacking the @opencode-ai/plugin v2 dependency required by test-opencode-v2-adapter.mjs.

Resolves #31078


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.303 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 21m and 358,874 tokens on this with the user in an interactive session.