### PR TITLE
GH#31080: fix: retain origin label failure diagnostics

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -1003,16 +1003,46 @@ _gh_create_pr_enforce_origin_postcondition() {
 	fi
 
 	local origin_name="${expected_origin#origin:}"
+	local origin_error_file=""
+	local origin_write_rc=127
 	if declare -F set_origin_label >/dev/null 2>&1; then
-		set_origin_label "$_GH_CREATE_PR_DURABLE_NUMBER" \
-			"$_GH_CREATE_PR_DURABLE_REPO" "$origin_name" --pr >/dev/null 2>&1 || true
+		local previous_umask=""
+		previous_umask=$(umask)
+		umask 077
+		origin_error_file=$(mktemp -t aidevops-pr-origin-error.XXXXXX 2>/dev/null) || origin_error_file=""
+		umask "$previous_umask"
+		if [[ -n "$origin_error_file" ]]; then
+			local cleanup_cmd=""
+			printf -v cleanup_cmd 'rm -f -- %q' "$origin_error_file"
+			push_cleanup "$cleanup_cmd"
+		fi
+		origin_write_rc=0
+		if [[ -n "$origin_error_file" ]]; then
+			set_origin_label "$_GH_CREATE_PR_DURABLE_NUMBER" \
+				"$_GH_CREATE_PR_DURABLE_REPO" "$origin_name" --pr \
+				>/dev/null 2>"$origin_error_file" || origin_write_rc=$?
+		else
+			set_origin_label "$_GH_CREATE_PR_DURABLE_NUMBER" \
+				"$_GH_CREATE_PR_DURABLE_REPO" "$origin_name" --pr \
+				>/dev/null 2>&1 || origin_write_rc=$?
+		fi
 	fi
 	# A transport can report failure after applying its mutation. Read back even
 	# when set_origin_label returned non-zero before classifying partial success.
 	if _gh_create_pr_origin_is_exact "$_GH_CREATE_PR_DURABLE_REPO" \
 		"$_GH_CREATE_PR_DURABLE_NUMBER" "$expected_origin"; then
+		[[ -z "$origin_error_file" ]] || rm -f "$origin_error_file"
 		return 0
 	fi
+	local origin_failure_kind="origin-label reconciler is unavailable"
+	if [[ "$origin_write_rc" -eq 0 ]]; then
+		origin_failure_kind="label write returned success but exact provenance readback failed"
+	elif [[ "$origin_write_rc" -ne 127 ]]; then
+		origin_failure_kind=$(_gh_origin_label_failure_kind "$origin_error_file" "$origin_write_rc")
+	fi
+	[[ -z "$origin_error_file" ]] || rm -f "$origin_error_file"
+	printf '[aidevops] gh_create_pr: origin label reconciliation failed: %s\n' \
+		"$origin_failure_kind" >&2
 	printf '[aidevops] gh_create_pr: durable PR #%s exists but exact %s provenance is unverified; not retrying creation\n' \
 		"$_GH_CREATE_PR_DURABLE_NUMBER" "$expected_origin" >&2
 	return "$_GH_PR_CREATE_PARTIAL_RC"

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -958,6 +958,28 @@ _set_origin_label_rest() {
 	return 0
 }
 
+#######################################
+# Classify an origin-label write failure without exposing raw API output.
+# Args: $1=stderr file (optional) $2=write exit code
+# Output: bounded operator-safe failure reason
+#######################################
+_gh_origin_label_failure_kind() {
+	local error_file="$1"
+	local write_rc="$2"
+	if [[ -n "$error_file" ]] &&
+		grep -qiE 'permission|forbidden|Resource not accessible|HTTP 403' "$error_file" 2>/dev/null; then
+		printf '%s\n' "credential lacks origin-label permission"
+	elif [[ -n "$error_file" ]] &&
+		grep -qiE 'rate limit|rateLimitExceeded|HTTP 429' "$error_file" 2>/dev/null; then
+		printf '%s\n' "GitHub API rate limited the label write"
+	elif [[ "$write_rc" -eq 124 ]]; then
+		printf '%s\n' "GitHub label write timed out"
+	else
+		printf '%s\n' "GitHub label write failed"
+	fi
+	return 0
+}
+
 set_origin_label() {
 	local issue_num="$1"
 	local repo_slug="$2"
@@ -1041,6 +1063,9 @@ set_origin_label() {
 		rm -f "$_err_file"
 		return 0
 	fi
+	local _failure_kind=""
+	_failure_kind=$(_gh_origin_label_failure_kind "$_err_file" "$_gh_rc")
+	printf 'set_origin_label: %s\n' "$_failure_kind" >&2
 	rm -f "$_err_file"
 	return "$_gh_rc"
 }

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -377,7 +377,10 @@ set_origin_label() {
 	local repo_slug="$2"
 	local origin_name="$3"
 	printf 'set-origin %s %s %s\n' "$pr_number" "$repo_slug" "$origin_name" >>"$GH_CALLS"
-	[[ "${STUB_SET_ORIGIN_FAIL:-0}" != "1" ]] || return 1
+	if [[ "${STUB_SET_ORIGIN_FAIL:-0}" == "1" ]]; then
+		printf 'GraphQL: API rate limit exceeded for test identity\n' >&2
+		return 1
+	fi
 	STUB_CREATE_ORIGIN_FIXTURE=$(jq -cn --arg name "origin:${origin_name}" '{labels: [{name: $name}]}') || return 1
 	export STUB_CREATE_ORIGIN_FIXTURE
 	return 0
@@ -1045,10 +1048,13 @@ origin_partial_output=$(gh_create_pr \
 	--base "main" \
 	--body "origin partial body" 2>"$origin_partial_stderr") || origin_partial_rc=$?
 origin_partial_create_count=$(grep -cE '^pr create' "$GH_CALLS" 2>/dev/null || true)
-if [[ "$origin_partial_rc" -eq 78 \
-	&& "$origin_partial_output" == "https://github.com/owner/repo/pull/9100" \
-	&& "$origin_partial_create_count" -eq 1 ]] \
-	&& grep -q 'durable PR #9100 exists but exact origin:interactive provenance is unverified; not retrying creation' \
+if [[ "$origin_partial_rc" -eq 78 &&
+	"$origin_partial_output" == "https://github.com/owner/repo/pull/9100" &&
+	"$origin_partial_create_count" -eq 1 ]] &&
+	grep -q 'origin label reconciliation failed: GitHub API rate limited the label write' \
+		"$origin_partial_stderr" 2>/dev/null &&
+	! grep -q 'test identity' "$origin_partial_stderr" 2>/dev/null &&
+	grep -q 'durable PR #9100 exists but exact origin:interactive provenance is unverified; not retrying creation' \
 		"$origin_partial_stderr" 2>/dev/null; then
 	pass "gh_create_pr preserves URL and returns typed partial success"
 else

--- a/.agents/scripts/tests/test-origin-label-exclusion.sh
+++ b/.agents/scripts/tests/test-origin-label-exclusion.sh
@@ -237,13 +237,16 @@ _set_origin_label_rest() {
 	return 1
 }
 export GH_FAIL_ISSUE_EDIT=1 GH_FAIL_REST_LABEL_POST=1
-set_origin_label 801 "owner/repo" "worker" >/dev/null 2>&1
+origin_failure_output=""
+origin_failure_output=$(set_origin_label 801 "owner/repo" "worker" 2>&1)
 rc=$?
-if [[ "$rc" -ne 0 ]]; then
-	print_result "set_origin_label GraphQL exhaustion: REST failure returns non-zero" 0
+if [[ "$rc" -ne 0 ]] &&
+	[[ "$origin_failure_output" == *"GitHub API rate limited the label write"* ]] &&
+	[[ "$origin_failure_output" != *"user ID 99999"* ]]; then
+	print_result "set_origin_label GraphQL exhaustion: REST failure returns bounded reason" 0
 else
-	print_result "set_origin_label GraphQL exhaustion: REST failure returns non-zero" 1 \
-		"(expected non-zero, calls: $(tr '\n' ';' <"$GH_RECORD_FILE"))"
+	print_result "set_origin_label GraphQL exhaustion: REST failure returns bounded reason" 1 \
+		"(rc=$rc output=$origin_failure_output calls: $(tr '\n' ';' <"$GH_RECORD_FILE"))"
 fi
 unset GH_FAIL_ISSUE_EDIT GH_FAIL_REST_LABEL_POST
 


### PR DESCRIPTION
## Summary

Preserve bounded permission, rate-limit, timeout, and generic failure reasons when origin-label reconciliation cannot reach its exact postcondition.

## Files Changed

.agents/scripts/shared-gh-wrappers-create.sh, .agents/scripts/shared-gh-wrappers.sh, .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh, .agents/scripts/tests/test-origin-label-exclusion.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified production wrapper execution with controlled GitHub transport failures; linters-local, ShellCheck, wrapper fallback, origin exclusion, partial-success, managed-label, pulse routing, and zsh compatibility checks pass

Resolves #31080


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.303 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 33m and 410,398 tokens on this with the user in an interactive session.