### PR TITLE
GH#31084: Add guarded repository layout migration command

### DIFF
--- a/.agents/reference/repo-organization.md
+++ b/.agents/reference/repo-organization.md
@@ -63,12 +63,28 @@ Examples:
 
 ## Migration safety
 
-Setup and update do not move canonical repositories. Treat layout migration as a
-separate, reviewed operation: inventory dirty state, branches, remotes, stashes,
-submodules, linked worktrees, and destination collisions; back up unique data;
-move one repository at a time; update explicit registrations; and verify Git
-state before deleting or archiving a source path. Owner names differing only by
-case can collide on case-insensitive filesystems and require a manual decision.
+Setup and update never move canonical repositories. Use a separate, reviewed
+transaction:
+
+```bash
+aidevops repos migrate-layout plan --workspace ~/Git --output plan.json
+aidevops repos migrate-layout apply --plan plan.json --confirm <plan-sha256>
+aidevops repos migrate-layout status --receipt <receipt-id>
+aidevops repos migrate-layout rollback --receipt <receipt-id> --confirm <receipt-sha256>
+```
+
+`plan` is non-mutating. It inventories dirty state, branches, stashes,
+submodules, linked worktrees, registrations, local consumers, and collisions.
+Explicit `initialized_repos[].path` entries remain excluded unless planning uses
+`--include-registered-paths`; that approval is recorded in the content-hashed
+plan. Apply rechecks the complete before-state, rejects cross-device moves and
+active-path ambiguity, moves one repository at a time, and writes owner-private
+append-only receipts. Replaying apply resumes verified steps. Rollback requires
+the latest receipt hash and stops rather than overwriting post-plan changes.
+
+Non-GitHub, local-only, unsupported, and already-conforming repositories are not
+moved. Case-only and destination-inside-source moves use private same-filesystem
+staging; destination collisions always fail closed.
 
 ## Direct-write workspace boundary
 

--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -84,6 +84,13 @@ aidevops repos maintenance off owner/repo
 aidevops repos maintenance on owner/repo
 ```
 
+Repository layout migration treats every explicit `initialized_repos[].path` as
+authoritative. `aidevops repos migrate-layout plan` reports such entries as
+excluded unless `--include-registered-paths` is supplied. That flag approves
+only exact old-to-new paths embedded in the hashed plan. Apply atomically updates
+those exact entries while preserving every unrelated field; rollback restores
+the receipt-owned before-state only when no later config drift is present.
+
 | Field | Type | Example | Description |
 |-------|------|---------|-------------|
 | `pulse_hours` | object or array | `{"start": 17, "end": 5}` or `[17, 5]` | Limits dispatch to window (24h local time). Overnight supported. Omit for 24/7. Array form is accepted for compatibility; object form is preferred for readability. |

--- a/.agents/scripts/repo-layout-migrate-helper.sh
+++ b/.agents/scripts/repo-layout-migrate-helper.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+usage() {
+	cat <<'EOF'
+Usage:
+  aidevops repos migrate-layout plan --workspace PATH --output PLAN.json [options]
+  aidevops repos migrate-layout apply --plan PLAN.json --confirm PLAN_SHA256
+  aidevops repos migrate-layout rollback --receipt ID --confirm RECEIPT_SHA256
+  aidevops repos migrate-layout status --receipt ID
+
+Plan options:
+  --include-registered-paths   Approve exact initialized_repos[].path retargets
+  --repos-json PATH           Override ~/.config/aidevops/repos.json
+  --tabby-config PATH         Include an existing Tabby config
+  --opencode-db PATH          Include an existing OpenCode database
+  --isolated-root PATH        Include isolated OpenCode databases below PATH
+  --recovery-root PATH        Include schema-v1 recovery markers below PATH
+  --state-dir PATH            Override the private receipt directory
+
+The plan command never mutates repositories or consumers. Apply and rollback
+require the exact SHA-256 printed by plan/status and fail closed on drift.
+EOF
+	return 0
+}
+
+main() {
+	local command_name="${1:-}"
+	local engine="${SCRIPT_DIR}/repo_layout_migrate.py"
+	local discovery_lib="${SCRIPT_DIR}/aidevops-cli/repo-discovery-lib.sh"
+	local status=0
+
+	case "$command_name" in
+	plan | apply | rollback | status)
+		shift
+		python3 "$engine" "$command_name" --discovery-lib "$discovery_lib" "$@" || status=$?
+		return "$status"
+		;;
+	-h | --help | help | "")
+		usage
+		return 0
+		;;
+	*)
+		printf 'Unknown migrate-layout command: %s\n' "$command_name" >&2
+		usage >&2
+		return 2
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/repo_layout_migrate.py
+++ b/.agents/scripts/repo_layout_migrate.py
@@ -1,0 +1,1875 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Plan and execute interruption-safe canonical repository layout migrations."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import sqlite3
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Iterable
+
+
+PLAN_SCHEMA = "aidevops-repo-layout-plan/v1"
+RECEIPT_SCHEMA = "aidevops-repo-layout-receipt/v1"
+REMOTE_RE = re.compile(
+    r"^(?:(?:[a-z][a-z0-9+.-]*://)(?:[^/@]+@)?|[^@/]+@)?"
+    r"(?P<host>[^/:]+)[:/](?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$",
+    re.IGNORECASE,
+)
+
+
+class MigrationError(RuntimeError):
+    """A safety invariant refused the requested migration operation."""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    """Return deterministic UTF-8 JSON bytes."""
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def sha256_bytes(value: bytes) -> str:
+    """Return a lowercase SHA-256 digest."""
+    return hashlib.sha256(value).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    """Hash one regular file without following a final symlink."""
+    if path.is_symlink() or not path.is_file():
+        raise MigrationError(f"Unsafe or missing file: {path}")
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def private_directory(path: Path) -> None:
+    """Create or validate an owner-private directory."""
+    if path.exists():
+        details = path.lstat()
+        if (
+            not stat.S_ISDIR(details.st_mode)
+            or path.is_symlink()
+            or details.st_uid != os.getuid()
+        ):
+            raise MigrationError(f"Unsafe state directory: {path}")
+    else:
+        path.mkdir(parents=True, mode=0o700)
+    path.chmod(0o700)
+
+
+def atomic_write(path: Path, payload: bytes, mode: int = 0o600) -> None:
+    """Atomically replace a file on its current filesystem."""
+    if path.parent.is_symlink() or not path.parent.is_dir():
+        raise MigrationError(f"Unsafe destination directory: {path.parent}")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.chmod(mode)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def load_json(path: Path) -> Any:
+    """Load a regular JSON file."""
+    if path.is_symlink() or not path.is_file():
+        raise MigrationError(f"Unsafe or missing JSON file: {path}")
+    try:
+        with path.open(encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MigrationError(f"Malformed JSON file: {path}") from exc
+
+
+def expand_path(value: str) -> Path:
+    """Expand user syntax and return an absolute lexical path."""
+    return Path(os.path.abspath(os.path.expanduser(value)))
+
+
+def run(command: list[str], *, cwd: Path | None = None, binary: bool = False) -> Any:
+    """Run a structured local command and return stdout."""
+    try:
+        result = subprocess.run(  # nosec B603
+            command,
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=not binary,
+            timeout=30,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        detail = getattr(exc, "stderr", "")
+        if isinstance(detail, bytes):
+            detail = detail.decode(errors="replace")
+        raise MigrationError(f"Command failed: {command[0]} {str(detail).strip()}") from exc
+    return result.stdout
+
+
+def git(repo: Path, *arguments: str, binary: bool = False) -> Any:
+    """Run Git against one repository without a shell."""
+    return run(["git", "-C", str(repo), *arguments], binary=binary)
+
+
+def parse_remote(remote: str) -> tuple[str, str, str] | None:
+    """Return sanitized host/owner/repository identity for a Git remote."""
+    match = REMOTE_RE.match(remote.strip())
+    if not match:
+        return None
+    host = match.group("host").lower()
+    owner = match.group("owner")
+    repository = match.group("repo")
+    if not all(re.fullmatch(r"[A-Za-z0-9._-]+", item) for item in (host, owner, repository)):
+        return None
+    return host, owner, repository
+
+
+def discover_repositories(workspace: Path, discovery_lib: Path) -> list[Path]:
+    """Call the shared bounded shell discovery policy and parse NUL records."""
+    script = 'source "$1"; aidevops_discover_canonical_repos "$2"'
+    output = run(
+        ["bash", "-c", script, "repo-layout-discovery", str(discovery_lib), str(workspace)],
+        binary=True,
+    )
+    return sorted(Path(item.decode()) for item in output.split(b"\0") if item)
+
+
+def recommended_path(
+    workspace: Path,
+    host: str,
+    owner: str,
+    repository: str,
+    repos_json: Path,
+    discovery_lib: Path,
+) -> Path:
+    """Call the shared host-aware owner path policy."""
+    script = 'source "$1"; aidevops_recommended_repo_path "$2" "$3" "$4" "$5" "$6"'
+    output = run(
+        [
+            "bash",
+            "-c",
+            script,
+            "repo-layout-recommend",
+            str(discovery_lib),
+            str(workspace),
+            host,
+            owner,
+            repository,
+            str(repos_json),
+        ]
+    )
+    return expand_path(output.strip())
+
+
+def status_records(repo: Path) -> tuple[str, int]:
+    """Return a stable status digest and entry count."""
+    raw = git(repo, "status", "--porcelain=v1", "-z", "--untracked-files=all", binary=True)
+    return sha256_bytes(raw), len([item for item in raw.split(b"\0") if item])
+
+
+def working_tree_digest(repo: Path) -> str:
+    """Hash tracked diffs and exact untracked file content."""
+    digest = hashlib.sha256()
+    digest.update(git(repo, "diff", "--no-ext-diff", "--binary", binary=True))
+    digest.update(
+        git(repo, "diff", "--cached", "--no-ext-diff", "--binary", binary=True)
+    )
+    untracked = git(
+        repo,
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        binary=True,
+    )
+    for raw_path in sorted(item for item in untracked.split(b"\0") if item):
+        digest.update(raw_path)
+        path = repo / os.fsdecode(raw_path)
+        if path.is_symlink():
+            digest.update(b"symlink\0" + os.readlink(path).encode())
+        elif path.is_file():
+            digest.update(b"file\0" + path.read_bytes())
+        else:
+            raise MigrationError(f"Unsupported untracked path: {path}")
+    return digest.hexdigest()
+
+
+def worktree_records(repo: Path) -> list[dict[str, Any]]:
+    """Return normalized worktree identities, preserving linked paths."""
+    records: list[dict[str, Any]] = []
+    current: dict[str, Any] = {}
+    for line in git(repo, "worktree", "list", "--porcelain").splitlines() + [""]:
+        if not line:
+            if current:
+                path = Path(current.get("worktree", ""))
+                if path.is_dir():
+                    status_hash, status_count = status_records(path)
+                    current["status_sha256"] = status_hash
+                    current["status_entries"] = status_count
+                    current["working_tree_sha256"] = working_tree_digest(path)
+                # Git always lists the main worktree first. Normalize that
+                # location because its spelling changes during a move.
+                current["worktree"] = "<canonical>" if not records else str(path)
+                records.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    return records
+
+
+def repository_fingerprint(repo: Path) -> dict[str, Any]:
+    """Capture the exact local Git state that a move must preserve."""
+    status_hash, status_count = status_records(repo)
+    branches = git(
+        repo,
+        "for-each-ref",
+        "--sort=refname",
+        "--format=%(refname)%00%(objectname)",
+        "refs/heads",
+    ).splitlines()
+    stashes = git(
+        repo,
+        "for-each-ref",
+        "--sort=refname",
+        "--format=%(refname)%00%(objectname)",
+        "refs/stash",
+    ).splitlines()
+    gitmodules = repo / ".gitmodules"
+    modules_hash = file_sha256(gitmodules) if gitmodules.exists() else None
+    submodule_state: list[dict[str, str]] = []
+    index_records = git(repo, "ls-files", "--stage", "-z", binary=True)
+    for record in index_records.split(b"\0"):
+        if not record:
+            continue
+        metadata, _, raw_path = record.partition(b"\t")
+        mode, object_name, _stage = metadata.decode().split(" ", 2)
+        if mode != "160000":
+            continue
+        relative_path = raw_path.decode()
+        child = repo / relative_path
+        actual_head = "unavailable"
+        if child.exists():
+            try:
+                actual_head = git(child, "rev-parse", "HEAD").strip()
+            except MigrationError:
+                actual_head = "unavailable"
+        submodule_state.append(
+            {
+                "path": relative_path,
+                "index_head": object_name,
+                "actual_head": actual_head,
+                "working_tree_sha256": (
+                    working_tree_digest(child)
+                    if child.exists() and actual_head != "unavailable"
+                    else "unavailable"
+                ),
+            }
+        )
+    return {
+        "head": git(repo, "rev-parse", "HEAD").strip(),
+        "branch": git(repo, "symbolic-ref", "--quiet", "--short", "HEAD").strip(),
+        "branches": branches,
+        "status_sha256": status_hash,
+        "status_entries": status_count,
+        "working_tree_sha256": working_tree_digest(repo),
+        "stashes": stashes,
+        "stash_count": len(stashes),
+        "gitmodules_sha256": modules_hash,
+        "submodules_sha256": sha256_bytes(canonical_bytes(submodule_state)),
+        "worktrees": worktree_records(repo),
+    }
+
+
+def linked_pointer_records(repo: Path, records: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Record exact linked-worktree pointer content for guarded repair."""
+    pointers: list[dict[str, str]] = []
+    prefix = f"gitdir: {repo}/.git/"
+    for record in records:
+        worktree = record.get("worktree")
+        if not worktree or worktree == "<canonical>":
+            continue
+        marker = Path(worktree) / ".git"
+        if marker.is_symlink() or not marker.is_file():
+            raise MigrationError(f"Linked worktree pointer is unavailable: {marker}")
+        content = marker.read_text(encoding="utf-8")
+        if not content.startswith(prefix):
+            raise MigrationError(f"Unexpected linked worktree pointer: {marker}")
+        pointers.append(
+            {"path": str(marker), "sha256": sha256_bytes(content.encode()), "content": content}
+        )
+    return pointers
+
+
+def nearest_existing_parent(path: Path) -> Path:
+    """Find the nearest existing parent without creating anything."""
+    candidate = path
+    while not candidate.exists() and candidate != candidate.parent:
+        candidate = candidate.parent
+    if not candidate.is_dir():
+        raise MigrationError(f"No safe destination parent exists for {path}")
+    return candidate
+
+
+def safe_destination_parent(workspace: Path, destination: Path) -> Path:
+    """Reject symlink escapes and return the nearest destination parent."""
+    candidate = destination.parent
+    while candidate != workspace:
+        if candidate.exists() and candidate.is_symlink():
+            raise MigrationError(f"Destination traverses a symlink: {candidate}")
+        if candidate == candidate.parent or not path_is_inside(workspace, candidate):
+            raise MigrationError("Destination escaped the workspace")
+        candidate = candidate.parent
+    parent = nearest_existing_parent(destination.parent)
+    if parent.is_symlink() or not path_is_inside(workspace, parent.resolve()):
+        raise MigrationError("Destination parent escaped the workspace")
+    return parent
+
+
+def same_existing_path(first: Path, second: Path) -> bool:
+    """Return whether two existing names resolve to the same filesystem object."""
+    try:
+        return os.path.samefile(first, second)
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def path_is_inside(parent: Path, candidate: Path) -> bool:
+    """Return whether candidate is at or below parent lexically."""
+    try:
+        candidate.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def sqlite_schema(connection: sqlite3.Connection) -> dict[str, list[str]]:
+    """Return only the migration-relevant SQLite table columns."""
+    result: dict[str, list[str]] = {}
+    for table in ("project", "session"):
+        try:
+            rows = connection.execute(f"PRAGMA table_info({table})").fetchall()
+        except sqlite3.Error as exc:
+            raise MigrationError(f"Could not inspect SQLite table: {table}") from exc
+        if rows:
+            result[table] = [str(row[1]) for row in rows]
+    return result
+
+
+def validated_sql_target(table: str, column: str) -> tuple[str, str]:
+    """Allow only the two fixed OpenCode path columns."""
+    if (table, column) not in {("project", "worktree"), ("session", "directory")}:
+        raise MigrationError("Receipt contains an unsupported database target")
+    return table, column
+
+
+def sqlite_consumer(path: Path, mappings: dict[str, str]) -> dict[str, Any]:
+    """Capture relevant exact-path SQLite rows and schema."""
+    if path.is_symlink() or not path.is_file() or path.stat().st_uid != os.getuid():
+        raise MigrationError(f"Unsafe OpenCode database: {path}")
+    uri = f"file:{path}?mode=ro"
+    try:
+        connection = sqlite3.connect(uri, uri=True, timeout=2)
+        schema = sqlite_schema(connection)
+        rows: list[dict[str, str]] = []
+        for table, column in (("project", "worktree"), ("session", "directory")):
+            if table not in schema or "id" not in schema[table] or column not in schema[table]:
+                continue
+            parent_clause = " AND parent_id IS NULL" if table == "session" and "parent_id" in schema[table] else ""
+            for old_path in mappings:
+                query = f"SELECT id, {column} FROM {table} WHERE {column} = ?{parent_clause}"
+                for row_id, value in connection.execute(query, (old_path,)).fetchall():
+                    rows.append({"table": table, "column": column, "id": str(row_id), "value": str(value)})
+        integrity = connection.execute("PRAGMA integrity_check").fetchone()
+    except sqlite3.Error as exc:
+        raise MigrationError(f"Could not inspect OpenCode database: {path}") from exc
+    finally:
+        if "connection" in locals():
+            connection.close()
+    if not integrity or integrity[0] != "ok":
+        raise MigrationError(f"SQLite integrity check failed: {path}")
+    return {"path": str(path), "schema": schema, "rows": rows}
+
+
+def existing_optional_path(value: str | None, default: Path) -> Path | None:
+    """Resolve an optional path, returning None when it does not exist."""
+    path = expand_path(value) if value else default
+    return path if path.exists() else None
+
+
+def migration_mappings(repositories: Iterable[dict[str, Any]]) -> dict[str, str]:
+    """Build the exact old-to-new path map."""
+    return {item["source"]: item["destination"] for item in repositories}
+
+
+def plan_consumers(args: argparse.Namespace, mappings: dict[str, str]) -> dict[str, Any]:
+    """Inventory local config, terminal, runtime database, and marker consumers."""
+    home = Path.home()
+    repos_json = expand_path(args.repos_json) if args.repos_json else home / ".config/aidevops/repos.json"
+    tabby = existing_optional_path(
+        args.tabby_config,
+        home / "Library/Application Support/tabby/config.yaml",
+    )
+    opencode = existing_optional_path(
+        args.opencode_db,
+        home / ".local/share/opencode/opencode.db",
+    )
+    isolated_root = existing_optional_path(
+        args.isolated_root,
+        home / ".aidevops/.agent-workspace/work/opencode-interactive",
+    )
+    recovery_root = existing_optional_path(
+        args.recovery_root,
+        home / ".aidevops/.agent-workspace/work/opencode-tabby-recovery",
+    )
+    consumers: dict[str, Any] = {
+        "repos_json": None,
+        "tabby": None,
+        "databases": [],
+        "markers": [],
+    }
+    if repos_json.exists():
+        config = load_json(repos_json)
+        matches = []
+        for index, item in enumerate(config.get("initialized_repos", [])):
+            if isinstance(item, dict) and item.get("path") in mappings:
+                matches.append({"index": index, "path": item["path"]})
+        consumers["repos_json"] = {
+            "path": str(repos_json),
+            "sha256": file_sha256(repos_json),
+            "matches": matches,
+        }
+    if tabby:
+        tabby_text = tabby.read_text(encoding="utf-8")
+        try:
+            load_tabby_module(Path(__file__).with_name("tabby-profile-sync.py")).retarget_profile_cwds(
+                tabby_text, {}
+            )
+        except Exception as exc:  # Validation adapter normalizes parser failures.
+            raise MigrationError(f"Malformed Tabby config: {tabby}") from exc
+        consumers["tabby"] = {
+            "path": str(tabby),
+            "sha256": file_sha256(tabby),
+            "matched_paths": sorted(old for old in mappings if old in tabby_text),
+        }
+    database_paths: list[Path] = []
+    if opencode and opencode.is_file():
+        database_paths.append(opencode)
+    if isolated_root and isolated_root.is_dir():
+        database_paths.extend(sorted(isolated_root.glob("*/opencode/opencode.db")))
+    for database in dict.fromkeys(database_paths):
+        consumers["databases"].append(sqlite_consumer(database, mappings))
+    if recovery_root and recovery_root.is_dir():
+        for marker in sorted(recovery_root.glob("*/recovery.json")):
+            if marker.is_symlink() or not marker.is_file():
+                raise MigrationError(f"Unsafe recovery marker: {marker}")
+            marker_details = marker.stat()
+            directory_details = marker.parent.stat()
+            if (
+                marker_details.st_uid != os.getuid()
+                or directory_details.st_uid != os.getuid()
+                or marker_details.st_mode & 0o077
+                or directory_details.st_mode & 0o077
+            ):
+                raise MigrationError(f"Recovery marker is not owner-private: {marker}")
+            payload = load_json(marker)
+            if payload.get("schema_version") == 1 and payload.get("directory") in mappings:
+                consumers["markers"].append(
+                    {
+                        "path": str(marker),
+                        "sha256": file_sha256(marker),
+                        "directory": payload["directory"],
+                    }
+                )
+    return consumers
+
+
+def plan_command(args: argparse.Namespace) -> int:
+    """Create a deterministic, non-mutating migration plan."""
+    workspace = expand_path(args.workspace)
+    output = expand_path(args.output)
+    discovery_lib = expand_path(args.discovery_lib)
+    if workspace.is_symlink() or not workspace.is_dir():
+        raise MigrationError("Workspace must be an existing non-symlink directory")
+    workspace = workspace.resolve()
+    repos_json = expand_path(args.repos_json) if args.repos_json else Path.home() / ".config/aidevops/repos.json"
+    registrations: list[dict[str, Any]] = []
+    if repos_json.exists():
+        payload = load_json(repos_json)
+        entries = payload.get("initialized_repos", [])
+        if not isinstance(entries, list):
+            raise MigrationError("repos.json initialized_repos must be an array")
+        registrations = [item for item in entries if isinstance(item, dict)]
+
+    repositories: list[dict[str, Any]] = []
+    exclusions: list[dict[str, str]] = []
+    for source in discover_repositories(workspace, discovery_lib):
+        try:
+            remote = git(source, "remote", "get-url", "origin").strip()
+        except MigrationError:
+            exclusions.append({"path": str(source), "reason": "missing-origin"})
+            continue
+        identity = parse_remote(remote)
+        if not identity:
+            exclusions.append({"path": str(source), "reason": "unsupported-remote"})
+            continue
+        host, owner, repository = identity
+        if host != "github.com":
+            exclusions.append({"path": str(source), "reason": "non-github-remote"})
+            continue
+        destination = recommended_path(
+            workspace, host, owner, repository, repos_json, discovery_lib
+        )
+        if destination == source:
+            continue
+        if not path_is_inside(workspace, destination):
+            raise MigrationError("Recommended destination escaped the workspace")
+        registration_matches = [
+            item for item in registrations if expand_path(str(item.get("path", ""))) == source
+        ]
+        if any(item.get("local_only") is True for item in registration_matches):
+            exclusions.append({"path": str(source), "reason": "local-only-registration"})
+            continue
+        if registration_matches and not args.include_registered_paths:
+            exclusions.append({"path": str(source), "reason": "explicit-registration-not-approved"})
+            continue
+        destination_parent = safe_destination_parent(workspace, destination)
+        source_device = source.stat().st_dev
+        destination_device = destination_parent.stat().st_dev
+        worktrees = worktree_records(source)
+        stage = workspace / f".aidevops-layout-stage-{uuid.uuid4().hex[:12]}"
+        repositories.append(
+            {
+                "source": str(source),
+                "destination": str(destination),
+                "stage": str(stage),
+                "remote": {"host": host, "owner": owner, "repository": repository},
+                "fingerprint": repository_fingerprint(source),
+                "linked_pointers": linked_pointer_records(source, worktrees),
+                "registered": bool(registration_matches),
+                "registration_update_approved": bool(registration_matches),
+                "source_device": source_device,
+                "destination_device": destination_device,
+                "destination_collision": (
+                    destination.exists() and not same_existing_path(source, destination)
+                ),
+            }
+        )
+
+    mappings = migration_mappings(repositories)
+    consumers = plan_consumers(args, mappings)
+    state_dir = (
+        expand_path(args.state_dir)
+        if args.state_dir
+        else Path.home() / ".aidevops/.agent-workspace/work/repo-layout-migrations"
+    )
+    consumer_paths = []
+    for name in ("repos_json", "tabby"):
+        consumer = consumers.get(name)
+        if consumer:
+            consumer_paths.append(Path(consumer["path"]))
+    consumer_paths.extend(Path(item["path"]) for item in consumers["databases"])
+    consumer_paths.extend(Path(item["path"]) for item in consumers["markers"])
+    for item in repositories:
+        source = Path(item["source"])
+        protected_paths = [output, state_dir, *consumer_paths]
+        if any(path_is_inside(source, path) for path in protected_paths):
+            raise MigrationError(
+                "Plan, receipt, and consumer paths must remain outside moved repositories"
+            )
+    plan: dict[str, Any] = {
+        "schema": PLAN_SCHEMA,
+        "plan_id": uuid.uuid4().hex,
+        "created_at": int(time.time()),
+        "workspace": str(workspace),
+        "workspace_device": workspace.stat().st_dev,
+        "registered_paths_approved": bool(args.include_registered_paths),
+        "repositories": repositories,
+        "exclusions": exclusions,
+        "consumers": consumers,
+        "state_dir": str(state_dir),
+    }
+    plan["plan_sha256"] = sha256_bytes(canonical_bytes(plan))
+    if any(item["destination_collision"] for item in repositories):
+        raise MigrationError("Destination collision detected; no plan was written")
+    if any(item["source_device"] != item["destination_device"] for item in repositories):
+        raise MigrationError("Cross-device move detected; no plan was written")
+    atomic_write(output, canonical_bytes(plan))
+    print(
+        json.dumps(
+            {
+                "plan": str(output),
+                "plan_sha256": plan["plan_sha256"],
+                "moves": len(repositories),
+                "exclusions": len(exclusions),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def validate_plan(plan: dict[str, Any], confirmation: str) -> None:
+    """Validate schema, embedded digest, and operator confirmation."""
+    if plan.get("schema") != PLAN_SCHEMA:
+        raise MigrationError("Unsupported migration plan schema")
+    embedded = plan.get("plan_sha256")
+    unsigned = dict(plan)
+    unsigned.pop("plan_sha256", None)
+    observed = sha256_bytes(canonical_bytes(unsigned))
+    if embedded != observed or confirmation != observed:
+        raise MigrationError("Plan SHA-256 confirmation does not match")
+
+
+def receipt_paths(plan: dict[str, Any]) -> tuple[str, Path, Path]:
+    """Resolve deterministic private receipt paths for a plan."""
+    receipt_id = f"layout-{plan['plan_id']}"
+    root = expand_path(plan["state_dir"])
+    directory = root / receipt_id
+    return receipt_id, directory, directory / "receipt.jsonl"
+
+
+def append_event(journal: Path, event: dict[str, Any]) -> None:
+    """Append and fsync one receipt event."""
+    private_directory(journal.parent)
+    payload = dict(event)
+    payload.setdefault("timestamp", int(time.time()))
+    with journal.open("ab") as handle:
+        os.chmod(journal, 0o600)
+        handle.write(canonical_bytes(payload))
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def read_events(
+    journal: Path, *, repair_incomplete_tail: bool = False
+) -> list[dict[str, Any]]:
+    """Read complete JSONL records and optionally discard a torn final record."""
+    if journal.is_symlink() or not journal.is_file():
+        raise MigrationError(f"Receipt does not exist: {journal}")
+    events: list[dict[str, Any]] = []
+    try:
+        raw = journal.read_bytes()
+        valid_length = 0
+        lines = raw.splitlines(keepends=True)
+        for index, line in enumerate(lines):
+            if not line.endswith(b"\n"):
+                if index != len(lines) - 1:
+                    raise MigrationError("Receipt journal has an invalid record boundary")
+                if repair_incomplete_tail:
+                    with journal.open("r+b") as handle:
+                        handle.truncate(valid_length)
+                        handle.flush()
+                        os.fsync(handle.fileno())
+                break
+            events.append(json.loads(line))
+            valid_length += len(line)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise MigrationError("Receipt journal is malformed") from exc
+    if events and events[0].get("schema") != RECEIPT_SCHEMA:
+        raise MigrationError("Unsupported receipt schema")
+    return events
+
+
+def done_keys(events: list[dict[str, Any]]) -> set[str]:
+    """Return completed idempotency keys."""
+    return {str(event["key"]) for event in events if event.get("event") == "completed"}
+
+
+def event_for_key(events: list[dict[str, Any]], key: str) -> dict[str, Any] | None:
+    """Return the latest durable started or completed event for a key."""
+    for event in reversed(events):
+        if event.get("event") in {"started", "completed"} and event.get("key") == key:
+            return event
+    return None
+
+
+def start_step(
+    journal: Path,
+    events: list[dict[str, Any]],
+    key: str,
+    details: dict[str, Any],
+) -> dict[str, Any]:
+    """Persist recovery details before a step can mutate external state."""
+    existing = event_for_key(events, key)
+    if existing:
+        if existing.get("details") != details:
+            raise MigrationError(f"Receipt step details changed: {key}")
+        return details
+    event = {"event": "started", "key": key, "details": details}
+    append_event(journal, event)
+    events.append(event)
+    return details
+
+
+def complete_step(
+    journal: Path,
+    events: list[dict[str, Any]],
+    completed: set[str],
+    key: str,
+    details: dict[str, Any],
+) -> None:
+    """Record one verified mutation boundary as completed."""
+    event = {"event": "completed", "key": key, "details": details}
+    append_event(journal, event)
+    events.append(event)
+    completed.add(key)
+
+
+def process_identity(pid: int) -> str:
+    """Return a stable-enough process start identity when ps is available."""
+    ps = shutil.which("ps")
+    if not ps:
+        return ""
+    try:
+        observed = subprocess.run(  # nosec B603
+            [ps, "-o", "lstart=", "-p", str(pid)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return observed.stdout.strip() if observed.returncode == 0 else ""
+
+
+def lock_owner_is_live(owner: dict[str, Any]) -> bool:
+    """Return whether a lock still belongs to the same live process."""
+    try:
+        pid = int(owner["pid"])
+        os.kill(pid, 0)
+    except (KeyError, TypeError, ValueError, ProcessLookupError):
+        return False
+    except PermissionError:
+        return True
+    expected_start = str(owner.get("process_start", ""))
+    observed_start = process_identity(pid)
+    return not expected_start or not observed_start or expected_start == observed_start
+
+
+def acquire_lock(plan: dict[str, Any], receipt_id: str) -> Path:
+    """Acquire a workspace-scoped mkdir lock."""
+    state_root = expand_path(plan["state_dir"])
+    private_directory(state_root)
+    workspace_key = sha256_bytes(plan["workspace"].encode())[:20]
+    lock = state_root / f"workspace-{workspace_key}.lock"
+    try:
+        lock.mkdir(mode=0o700)
+    except FileExistsError as exc:
+        owner_path = lock / "owner.json"
+        try:
+            owner = load_json(owner_path)
+        except MigrationError:
+            raise MigrationError(f"Unverifiable workspace migration lock: {lock}") from exc
+        if lock_owner_is_live(owner):
+            raise MigrationError(
+                f"Another layout migration owns the workspace lock: {lock}"
+            ) from exc
+        owner_path.unlink()
+        try:
+            lock.rmdir()
+            lock.mkdir(mode=0o700)
+        except OSError as recovery_error:
+            raise MigrationError(f"Could not recover stale workspace lock: {lock}") from recovery_error
+    atomic_write(
+        lock / "owner.json",
+        canonical_bytes(
+            {
+                "receipt_id": receipt_id,
+                "pid": os.getpid(),
+                "process_start": process_identity(os.getpid()),
+            }
+        ),
+    )
+    return lock
+
+
+def release_lock(lock: Path) -> None:
+    """Release a lock created by acquire_lock."""
+    (lock / "owner.json").unlink(missing_ok=True)
+    try:
+        lock.rmdir()
+    except OSError:
+        pass
+
+
+def assert_no_active_path(plan: dict[str, Any]) -> None:
+    """Reject observed process working directories below a planned path."""
+    current = Path.cwd().resolve()
+    active_directories = [current]
+    lsof = shutil.which("lsof")
+    if lsof:
+        try:
+            observed = subprocess.run(  # nosec B603
+                [lsof, "-a", "-d", "cwd", "-Fpn"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if observed.returncode in (0, 1):
+                active_directories.extend(
+                    Path(line[1:]).resolve()
+                    for line in observed.stdout.splitlines()
+                    if line.startswith("n/")
+                )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    for item in plan["repositories"]:
+        source = Path(item["source"])
+        destination = Path(item["destination"])
+        for active in active_directories:
+            if path_is_inside(source, active) or path_is_inside(destination, active):
+                raise MigrationError(
+                    "Active-path ambiguity: a process cwd is inside a planned repository"
+                )
+
+
+def validate_repository_plan(
+    item: dict[str, Any], completed: bool, workspace: Path, started: bool = False
+) -> None:
+    """Verify one source or already-moved destination against the plan."""
+    source = Path(item["source"])
+    destination = Path(item["destination"])
+    stage = Path(item["stage"])
+    location = destination if completed or (not source.exists() and destination.exists()) else source
+    if not location.is_dir():
+        if stage.is_dir():
+            location = stage
+        else:
+            raise MigrationError(f"Planned repository is missing: {source}")
+    if not (started and location == stage) and repository_fingerprint(location) != item["fingerprint"]:
+        raise MigrationError(f"Repository drift detected: {source}")
+    if source.exists() and destination.exists() and not same_existing_path(source, destination):
+        raise MigrationError(f"Source and destination both exist: {source}")
+    parent = safe_destination_parent(workspace, destination)
+    if location.stat().st_dev != parent.stat().st_dev:
+        raise MigrationError(f"Cross-device move refused: {source}")
+
+
+def validate_consumers(
+    plan: dict[str, Any], completed: set[str], events: list[dict[str, Any]]
+) -> None:
+    """Reject pre-apply config, marker, and database drift."""
+    consumers = plan["consumers"]
+    for name in ("repos_json", "tabby"):
+        consumer = consumers.get(name)
+        key = f"consumer:{name}"
+        if consumer and key not in completed:
+            path = Path(consumer["path"])
+            allowed = {consumer["sha256"]}
+            started = event_for_key(events, key)
+            if started:
+                allowed.add(started["details"]["after_sha256"])
+            if file_sha256(path) not in allowed:
+                raise MigrationError(f"Consumer drift detected: {name}")
+    for index, database in enumerate(consumers.get("databases", [])):
+        key = f"consumer:database:{index}"
+        if key not in completed:
+            started = event_for_key(events, key)
+            if started:
+                path = Path(database["path"])
+                with sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=2) as connection:
+                    schema = sqlite_schema(connection)
+                if (
+                    schema != database["schema"]
+                    or database_change_state(path, started["details"]["changes"])
+                    not in {"before", "after"}
+                ):
+                    raise MigrationError(
+                        f"Database schema or row drift detected: {database['path']}"
+                    )
+            else:
+                observed = sqlite_consumer(
+                    Path(database["path"]), migration_mappings(plan["repositories"])
+                )
+                if observed["schema"] != database["schema"] or observed["rows"] != database["rows"]:
+                    raise MigrationError(
+                        f"Database schema or row drift detected: {database['path']}"
+                    )
+    for index, marker in enumerate(consumers.get("markers", [])):
+        key = f"consumer:marker:{index}"
+        if key not in completed:
+            allowed = {marker["sha256"]}
+            started = event_for_key(events, key)
+            if started:
+                allowed.add(started["details"]["after_sha256"])
+            if file_sha256(Path(marker["path"])) not in allowed:
+                raise MigrationError(f"Recovery marker drift detected: {marker['path']}")
+
+
+def create_parent_directories(path: Path, workspace: Path) -> list[str]:
+    """Create missing destination parents beneath the workspace."""
+    missing: list[Path] = []
+    candidate = path
+    while not candidate.exists():
+        if candidate == workspace or not path_is_inside(workspace, candidate):
+            raise MigrationError("Destination parent escaped workspace")
+        missing.append(candidate)
+        candidate = candidate.parent
+    for directory in reversed(missing):
+        directory.mkdir(mode=0o700)
+    return [str(item) for item in missing]
+
+
+def planned_parent_directories(path: Path, workspace: Path) -> list[str]:
+    """Describe destination parents that the migration owns before mutation."""
+    missing: list[Path] = []
+    candidate = path
+    while not candidate.exists():
+        if candidate == workspace or not path_is_inside(workspace, candidate):
+            raise MigrationError("Destination parent escaped workspace")
+        missing.append(candidate)
+        candidate = candidate.parent
+    return [str(item) for item in missing]
+
+
+def repository_step_details(
+    item: dict[str, Any], workspace: Path
+) -> dict[str, Any]:
+    """Build deterministic rollback details before moving a repository."""
+    source = Path(item["source"])
+    destination = Path(item["destination"])
+    self_nested = path_is_inside(source, destination) and source != destination
+    if self_nested:
+        created_directories = []
+        candidate = destination.parent
+        while path_is_inside(source, candidate):
+            created_directories.append(str(candidate))
+            if candidate == source:
+                break
+            candidate = candidate.parent
+    else:
+        created_directories = planned_parent_directories(
+            destination.parent, workspace
+        )
+    old_prefix = f"gitdir: {source}/.git/"
+    new_prefix = f"gitdir: {destination}/.git/"
+    pointer_changes = []
+    for pointer in item["linked_pointers"]:
+        before = pointer["content"]
+        if not before.startswith(old_prefix):
+            raise MigrationError(f"Unexpected planned linked pointer: {pointer['path']}")
+        pointer_changes.append(
+            {
+                "path": pointer["path"],
+                "before": before,
+                "after": new_prefix + before[len(old_prefix) :],
+            }
+        )
+    return {
+        "source": str(source),
+        "destination": str(destination),
+        "created_directories": created_directories,
+        "self_nested": self_nested,
+        "pointer_changes": pointer_changes,
+        "post_fingerprint": item["fingerprint"],
+    }
+
+
+def repair_linked_pointers(item: dict[str, Any], new_root: Path) -> list[dict[str, str]]:
+    """Rewrite only exact expected linked-worktree gitdir prefixes."""
+    old_root = Path(item["source"])
+    changes: list[dict[str, str]] = []
+    for pointer in item["linked_pointers"]:
+        path = Path(pointer["path"])
+        content = path.read_text(encoding="utf-8")
+        old_prefix = f"gitdir: {old_root}/.git/"
+        new_prefix = f"gitdir: {new_root}/.git/"
+        if content.startswith(new_prefix):
+            continue
+        if sha256_bytes(content.encode()) != pointer["sha256"] or not content.startswith(old_prefix):
+            raise MigrationError(f"Unexpected linked worktree pointer content: {path}")
+        updated = new_prefix + content[len(old_prefix) :]
+        atomic_write(path, updated.encode(), mode=path.stat().st_mode & 0o777)
+        changes.append({"path": str(path), "before": content, "after": updated})
+    return changes
+
+
+def move_repository(
+    item: dict[str, Any], workspace: Path, details: dict[str, Any]
+) -> dict[str, Any]:
+    """Move one repository, recover staging, repair pointers, and verify state."""
+    source = Path(item["source"])
+    destination = Path(item["destination"])
+    stage = Path(item["stage"])
+    create_parent_directories(destination.parent, workspace)
+    case_only = str(source).lower() == str(destination).lower() and source != destination
+    self_nested = path_is_inside(source, destination) and source != destination
+    if destination.exists() and not source.exists():
+        pass
+    elif stage.exists() and not source.exists():
+        create_parent_directories(destination.parent, workspace)
+        os.rename(stage, destination)
+    elif source.exists() and (
+        not destination.exists()
+        or (case_only and same_existing_path(source, destination))
+    ):
+        if case_only or self_nested:
+            if stage.exists():
+                raise MigrationError(f"Migration stage collision: {stage}")
+            os.rename(source, stage)
+            create_parent_directories(destination.parent, workspace)
+            os.rename(stage, destination)
+        else:
+            os.rename(source, destination)
+    else:
+        raise MigrationError(f"Ambiguous move state: {source}")
+    repair_linked_pointers(item, destination)
+    observed = repository_fingerprint(destination)
+    if observed != item["fingerprint"]:
+        changed_fields = sorted(
+            key
+            for key in set(observed) | set(item["fingerprint"])
+            if observed.get(key) != item["fingerprint"].get(key)
+        )
+        raise MigrationError(
+            f"Post-move repository verification failed ({','.join(changed_fields)}): "
+            f"{destination}"
+        )
+    if observed != details["post_fingerprint"]:
+        raise MigrationError(f"Receipt repository details changed: {source}")
+    return details
+
+
+def backup_regular_file(source: Path, destination: Path) -> None:
+    """Atomically copy one regular file to a private receipt backup."""
+    if source.is_symlink() or not source.is_file():
+        raise MigrationError(f"Unsafe backup source: {source}")
+    private_directory(destination.parent)
+    atomic_write(destination, source.read_bytes(), mode=0o600)
+
+
+def ensure_file_backup(source: Path, backup: Path, before_sha256: str) -> bytes:
+    """Create once and authenticate a pre-mutation regular-file backup."""
+    if backup.exists():
+        details = backup.lstat()
+        if (
+            backup.is_symlink()
+            or not backup.is_file()
+            or details.st_uid != os.getuid()
+            or details.st_mode & 0o077
+            or file_sha256(backup) != before_sha256
+        ):
+            raise MigrationError(f"Unsafe or mismatched receipt backup: {backup}")
+    else:
+        if file_sha256(source) != before_sha256:
+            raise MigrationError(f"Consumer drift detected before backup: {source}")
+        backup_regular_file(source, backup)
+    return backup.read_bytes()
+
+
+def apply_prepared_file(details: dict[str, Any], payload: bytes, mode: int) -> None:
+    """Idempotently apply a file mutation authenticated by before/after hashes."""
+    path = Path(details["path"])
+    observed = file_sha256(path)
+    if observed == details["after_sha256"]:
+        return
+    if observed != details["before_sha256"]:
+        raise MigrationError(f"Consumer drift blocks apply: {path}")
+    atomic_write(path, payload, mode=mode)
+    if file_sha256(path) != details["after_sha256"]:
+        raise MigrationError(f"Consumer verification failed after apply: {path}")
+
+
+def prepare_repos_json(
+    consumer: dict[str, Any], mappings: dict[str, str], backup: Path
+) -> tuple[dict[str, Any], bytes]:
+    """Prepare authenticated repository-registration bytes and rollback details."""
+    path = Path(consumer["path"])
+    original = ensure_file_backup(path, backup, consumer["sha256"])
+    try:
+        payload = json.loads(original)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise MigrationError(f"Malformed JSON backup: {backup}") from exc
+    changed = 0
+    for item in payload.get("initialized_repos", []):
+        if isinstance(item, dict) and item.get("path") in mappings:
+            item["path"] = mappings[item["path"]]
+            changed += 1
+    encoded = json.dumps(payload, indent=2, ensure_ascii=False).encode() + b"\n"
+    return (
+        {
+            "path": str(path),
+            "backup": str(backup),
+            "before_sha256": consumer["sha256"],
+            "after_sha256": sha256_bytes(encoded),
+            "changed": changed,
+        },
+        encoded,
+    )
+
+
+def load_tabby_module(script_path: Path) -> Any:
+    """Load the existing Tabby implementation for exact path retargeting."""
+    sys.path.insert(0, str(script_path.parent))
+    specification = importlib.util.spec_from_file_location("aidevops_tabby_profile_sync", script_path)
+    if specification is None or specification.loader is None:
+        raise MigrationError("Could not load Tabby profile sync module")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+def prepare_tabby(
+    consumer: dict[str, Any], mappings: dict[str, str], backup: Path, script_path: Path
+) -> tuple[dict[str, Any], bytes]:
+    """Prepare authenticated Tabby bytes while preserving unrelated content."""
+    path = Path(consumer["path"])
+    original_bytes = ensure_file_backup(path, backup, consumer["sha256"])
+    module = load_tabby_module(script_path)
+    original = original_bytes.decode("utf-8")
+    updated, changed = module.retarget_profile_cwds(original, mappings)
+    encoded = updated.encode()
+    return (
+        {
+            "path": str(path),
+            "backup": str(backup),
+            "before_sha256": consumer["sha256"],
+            "after_sha256": sha256_bytes(encoded),
+            "changed": changed,
+        },
+        encoded,
+    )
+
+
+def database_change_state(path: Path, changes: list[dict[str, str]]) -> str:
+    """Classify exact guarded rows as wholly before, wholly after, or drifted."""
+    states: set[str] = set()
+    try:
+        with sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=2) as connection:
+            for change in changes:
+                table, column = validated_sql_target(change["table"], change["column"])
+                row = connection.execute(
+                    f"SELECT {column} FROM {table} WHERE id = ?", (change["id"],)
+                ).fetchone()
+                if not row:
+                    return "drift"
+                if row[0] == change["value"]:
+                    states.add("before")
+                elif row[0] == change["after"]:
+                    states.add("after")
+                else:
+                    return "drift"
+    except sqlite3.Error as exc:
+        raise MigrationError(f"Could not inspect OpenCode database: {path}") from exc
+    if len(states) > 1:
+        return "drift"
+    return next(iter(states), "before")
+
+
+def prepare_database(
+    consumer: dict[str, Any], mappings: dict[str, str], backup: Path
+) -> dict[str, Any]:
+    """Prepare a database backup and deterministic guarded row changes."""
+    path = Path(consumer["path"])
+    private_directory(backup.parent)
+    changes = [
+        {**row, "after": mappings[row["value"]]}
+        for row in consumer["rows"]
+    ]
+    if backup.exists():
+        details = backup.lstat()
+        if (
+            backup.is_symlink()
+            or not backup.is_file()
+            or details.st_uid != os.getuid()
+            or details.st_mode & 0o077
+        ):
+            raise MigrationError(f"Unsafe database backup: {backup}")
+    else:
+        if database_change_state(path, changes) != "before":
+            raise MigrationError(f"OpenCode row drift detected: {path}")
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{backup.name}.", dir=backup.parent
+        )
+        os.close(descriptor)
+        temporary = Path(temporary_name)
+        temporary.unlink()
+        try:
+            with sqlite3.connect(path, timeout=2) as connection:
+                with sqlite3.connect(temporary) as backup_connection:
+                    connection.backup(backup_connection)
+            temporary.chmod(0o600)
+            with temporary.open("rb") as handle:
+                os.fsync(handle.fileno())
+            os.replace(temporary, backup)
+        except (sqlite3.Error, OSError) as exc:
+            raise MigrationError(f"OpenCode database backup failed: {path}") from exc
+        finally:
+            temporary.unlink(missing_ok=True)
+    return {
+        "path": str(path),
+        "backup": str(backup),
+        "backup_sha256": file_sha256(backup),
+        "changes": changes,
+    }
+
+
+def update_database(details: dict[str, Any]) -> None:
+    """Idempotently apply prepared exact OpenCode row changes."""
+    path = Path(details["path"])
+    state = database_change_state(path, details["changes"])
+    if state == "after":
+        return
+    if state != "before":
+        raise MigrationError(f"OpenCode row drift detected: {path}")
+    try:
+        connection = sqlite3.connect(path, timeout=2)
+        connection.execute("BEGIN IMMEDIATE")
+        for change in details["changes"]:
+            table, column = validated_sql_target(change["table"], change["column"])
+            query = f"UPDATE {table} SET {column} = ? WHERE id = ? AND {column} = ?"
+            cursor = connection.execute(
+                query, (change["after"], change["id"], change["value"])
+            )
+            if cursor.rowcount != 1:
+                raise MigrationError(f"OpenCode row drift detected: {path}")
+        integrity = connection.execute("PRAGMA integrity_check").fetchone()
+        if not integrity or integrity[0] != "ok":
+            raise MigrationError(f"SQLite integrity check failed: {path}")
+        connection.commit()
+    except (sqlite3.Error, OSError) as exc:
+        if "connection" in locals() and connection.in_transaction:
+            connection.rollback()
+        raise MigrationError(f"OpenCode database update failed: {path}") from exc
+    finally:
+        if "connection" in locals():
+            connection.close()
+    if database_change_state(path, details["changes"]) != "after":
+        raise MigrationError(f"OpenCode database verification failed: {path}")
+
+
+def prepare_marker(
+    consumer: dict[str, Any], mappings: dict[str, str], backup: Path
+) -> tuple[dict[str, Any], bytes]:
+    """Prepare authenticated schema-v1 recovery-marker bytes."""
+    path = Path(consumer["path"])
+    original = ensure_file_backup(path, backup, consumer["sha256"])
+    try:
+        payload = json.loads(original)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise MigrationError(f"Malformed JSON backup: {backup}") from exc
+    old = payload["directory"]
+    payload["directory"] = mappings[old]
+    encoded = canonical_bytes(payload)
+    return (
+        {
+            "path": str(path),
+            "backup": str(backup),
+            "before_sha256": consumer["sha256"],
+            "after_sha256": sha256_bytes(encoded),
+            "before": old,
+            "after": payload["directory"],
+        },
+        encoded,
+    )
+
+
+def maybe_inject_failure(key: str) -> None:
+    """Provide deterministic fixture-only interruption boundaries."""
+    requested = os.environ.get("AIDEVOPS_MIGRATE_FAIL_AFTER")
+    if requested and requested == key:
+        raise MigrationError(f"Injected failure after {key}")
+
+
+def maybe_inject_post_mutation_failure(key: str) -> None:
+    """Provide fixture-only termination after mutation but before completion."""
+    requested = os.environ.get("AIDEVOPS_MIGRATE_FAIL_AFTER_MUTATION")
+    if requested and requested == key:
+        raise MigrationError(f"Injected failure after mutation {key}")
+
+
+def apply_command(args: argparse.Namespace) -> int:
+    """Apply or resume a confirmed plan."""
+    plan_path = expand_path(args.plan)
+    plan = load_json(plan_path)
+    validate_plan(plan, args.confirm)
+    receipt_id, receipt_dir, journal = receipt_paths(plan)
+    private_directory(receipt_dir)
+    lock = acquire_lock(plan, receipt_id)
+    try:
+        if journal.exists():
+            events = read_events(journal, repair_incomplete_tail=True)
+            if events:
+                _stored_plan, events = validate_receipt_bundle(
+                    receipt_id, receipt_dir, journal, expected_plan=plan
+                )
+            else:
+                stored_plan_path = receipt_dir / "plan.json"
+                assert_private_owned_path(stored_plan_path, directory=False)
+                stored_plan = load_json(stored_plan_path)
+                validate_plan(stored_plan, stored_plan.get("plan_sha256", ""))
+                if canonical_bytes(stored_plan) != canonical_bytes(plan):
+                    raise MigrationError("Empty receipt does not match its stored plan")
+        else:
+            events = []
+        completed = done_keys(events)
+        if not events:
+            atomic_write(receipt_dir / "plan.json", canonical_bytes(plan))
+            created = {
+                "schema": RECEIPT_SCHEMA,
+                "event": "created",
+                "receipt_id": receipt_id,
+                "plan_sha256": plan["plan_sha256"],
+                "plan_path": str(plan_path),
+            }
+            append_event(journal, created)
+            events.append(created)
+        if "migration:complete" in completed:
+            print(json.dumps(receipt_status(receipt_id, receipt_dir, journal), sort_keys=True))
+            return 0
+        assert_no_active_path(plan)
+        workspace = Path(plan["workspace"])
+        for index, item in enumerate(plan["repositories"]):
+            key = f"repository:{index}"
+            started = event_for_key(events, key)
+            source = Path(item["source"])
+            destination = Path(item["destination"])
+            if started and key not in completed and not source.exists() and destination.exists():
+                repair_linked_pointers(item, destination)
+            validate_repository_plan(
+                item, key in completed, workspace, bool(started)
+            )
+        validate_consumers(plan, completed, events)
+        for index, item in enumerate(plan["repositories"]):
+            key = f"repository:{index}"
+            if key in completed:
+                continue
+            existing = event_for_key(events, key)
+            details = (
+                existing["details"]
+                if existing
+                else repository_step_details(item, workspace)
+            )
+            start_step(journal, events, key, details)
+            move_repository(item, workspace, details)
+            maybe_inject_post_mutation_failure(key)
+            complete_step(journal, events, completed, key, details)
+            maybe_inject_failure(key)
+
+        mappings = migration_mappings(plan["repositories"])
+        backups = receipt_dir / "backups"
+        repos_consumer = plan["consumers"].get("repos_json")
+        if repos_consumer and "consumer:repos_json" not in completed:
+            key = "consumer:repos_json"
+            details, payload = prepare_repos_json(
+                repos_consumer, mappings, backups / "repos.json"
+            )
+            start_step(journal, events, key, details)
+            apply_prepared_file(
+                details, payload, mode=Path(details["path"]).stat().st_mode & 0o777
+            )
+            maybe_inject_post_mutation_failure(key)
+            complete_step(journal, events, completed, key, details)
+            maybe_inject_failure(key)
+        tabby_consumer = plan["consumers"].get("tabby")
+        if tabby_consumer and "consumer:tabby" not in completed:
+            key = "consumer:tabby"
+            tabby_script = Path(__file__).with_name("tabby-profile-sync.py")
+            details, payload = prepare_tabby(
+                tabby_consumer, mappings, backups / "tabby.yaml", tabby_script
+            )
+            start_step(journal, events, key, details)
+            apply_prepared_file(
+                details, payload, mode=Path(details["path"]).stat().st_mode & 0o777
+            )
+            maybe_inject_post_mutation_failure(key)
+            complete_step(journal, events, completed, key, details)
+            maybe_inject_failure(key)
+        for index, consumer in enumerate(plan["consumers"].get("databases", [])):
+            key = f"consumer:database:{index}"
+            if key in completed:
+                continue
+            details = prepare_database(
+                consumer, mappings, backups / f"opencode-{index}.db"
+            )
+            start_step(journal, events, key, details)
+            update_database(details)
+            maybe_inject_post_mutation_failure(key)
+            complete_step(journal, events, completed, key, details)
+            maybe_inject_failure(key)
+        for index, consumer in enumerate(plan["consumers"].get("markers", [])):
+            key = f"consumer:marker:{index}"
+            if key in completed:
+                continue
+            details, payload = prepare_marker(
+                consumer, mappings, backups / f"recovery-{index}.json"
+            )
+            start_step(journal, events, key, details)
+            apply_prepared_file(details, payload, mode=0o600)
+            maybe_inject_post_mutation_failure(key)
+            complete_step(journal, events, completed, key, details)
+            maybe_inject_failure(key)
+        append_event(journal, {"event": "completed", "key": "migration:complete"})
+        print(json.dumps(receipt_status(receipt_id, receipt_dir, journal), sort_keys=True))
+        return 0
+    finally:
+        release_lock(lock)
+
+
+def restore_file(details: dict[str, Any]) -> None:
+    """Idempotently restore an authenticated backup without overwriting drift."""
+    path = Path(details["path"])
+    backup = Path(details["backup"])
+    if file_sha256(backup) != details["before_sha256"]:
+        raise MigrationError(f"Receipt backup drift blocks rollback: {backup}")
+    observed = file_sha256(path)
+    if observed == details["before_sha256"]:
+        return
+    if observed != details["after_sha256"]:
+        raise MigrationError(f"Post-plan drift blocks rollback: {path}")
+    atomic_write(path, backup.read_bytes(), mode=path.stat().st_mode & 0o777)
+    if file_sha256(path) != details["before_sha256"]:
+        raise MigrationError(f"File rollback verification failed: {path}")
+
+
+def rollback_database(details: dict[str, Any]) -> None:
+    """Idempotently reverse rows still holding receipt-owned after values."""
+    path = Path(details["path"])
+    state = database_change_state(path, details["changes"])
+    if state == "before":
+        return
+    if state != "after":
+        raise MigrationError(f"Post-plan database drift blocks rollback: {path}")
+    try:
+        connection = sqlite3.connect(path, timeout=2)
+        connection.execute("BEGIN IMMEDIATE")
+        for change in details["changes"]:
+            table, column = validated_sql_target(change["table"], change["column"])
+            query = f"UPDATE {table} SET {column} = ? WHERE id = ? AND {column} = ?"
+            cursor = connection.execute(query, (change["value"], change["id"], change["after"]))
+            if cursor.rowcount != 1:
+                raise MigrationError(f"Post-plan database drift blocks rollback: {path}")
+        integrity = connection.execute("PRAGMA integrity_check").fetchone()
+        if not integrity or integrity[0] != "ok":
+            raise MigrationError(f"SQLite integrity check failed: {path}")
+        connection.commit()
+    except sqlite3.Error as exc:
+        if "connection" in locals() and connection.in_transaction:
+            connection.rollback()
+        raise MigrationError(f"Database rollback failed: {path}") from exc
+    finally:
+        if "connection" in locals():
+            connection.close()
+    if database_change_state(path, details["changes"]) != "before":
+        raise MigrationError(f"Database rollback verification failed: {path}")
+
+
+def restore_linked_pointers(details: dict[str, Any]) -> None:
+    """Idempotently restore receipt-owned linked-worktree pointer content."""
+    for pointer in details["pointer_changes"]:
+        path = Path(pointer["path"])
+        content = path.read_text(encoding="utf-8")
+        if content == pointer["before"]:
+            continue
+        if content != pointer["after"]:
+            raise MigrationError(f"Linked pointer drift blocks rollback: {path}")
+        atomic_write(path, pointer["before"].encode(), mode=path.stat().st_mode & 0o777)
+
+
+def rollback_repository(item: dict[str, Any], details: dict[str, Any]) -> None:
+    """Idempotently return an unchanged repository and pointers to its source."""
+    source = Path(item["source"])
+    destination = Path(item["destination"])
+    stage = Path(item["stage"])
+    self_nested = bool(details.get("self_nested"))
+    case_only_same = (
+        source != destination
+        and str(source).lower() == str(destination).lower()
+        and same_existing_path(source, destination)
+    )
+    if source.is_dir() and not destination.exists() and not stage.exists():
+        restore_linked_pointers(details)
+    elif stage.is_dir() and not source.exists() and not destination.exists():
+        if not self_nested:
+            raise MigrationError(f"Unexpected rollback stage: {stage}")
+    elif destination.is_dir() and (
+        not source.exists() or self_nested or case_only_same
+    ):
+        if repository_fingerprint(destination) != details["post_fingerprint"]:
+            raise MigrationError(f"Post-plan repository drift blocks rollback: {destination}")
+        for pointer in details["pointer_changes"]:
+            if Path(pointer["path"]).read_text(encoding="utf-8") != pointer["after"]:
+                raise MigrationError(
+                    f"Linked pointer drift blocks rollback: {pointer['path']}"
+                )
+        if self_nested:
+            os.rename(destination, stage)
+        else:
+            os.rename(destination, source)
+    else:
+        raise MigrationError(f"Repository rollback collision or missing destination: {source}")
+    if self_nested and stage.exists():
+        for directory_name in details.get("created_directories", []):
+            directory = Path(directory_name)
+            if not directory.exists():
+                continue
+            try:
+                directory.rmdir()
+            except OSError as exc:
+                raise MigrationError(
+                    f"Unexpected content blocks nested rollback: {directory}"
+                ) from exc
+        if source.exists():
+            raise MigrationError(f"Nested rollback source remains occupied: {source}")
+        os.rename(stage, source)
+    restore_linked_pointers(details)
+    if repository_fingerprint(source) != item["fingerprint"]:
+        raise MigrationError(f"Repository rollback verification failed: {source}")
+    if not self_nested:
+        for directory_name in details.get("created_directories", []):
+            directory = Path(directory_name)
+            try:
+                directory.rmdir()
+            except OSError:
+                pass
+
+
+def assert_private_owned_path(path: Path, *, directory: bool) -> None:
+    """Require an existing non-symlink owner-private file or directory."""
+    try:
+        details = path.lstat()
+    except OSError as exc:
+        raise MigrationError(f"Receipt path is unavailable: {path}") from exc
+    expected_type = stat.S_ISDIR(details.st_mode) if directory else stat.S_ISREG(details.st_mode)
+    if (
+        path.is_symlink()
+        or not expected_type
+        or details.st_uid != os.getuid()
+        or details.st_mode & 0o077
+    ):
+        raise MigrationError(f"Receipt path is not owner-private: {path}")
+
+
+def validate_receipt_event_targets(
+    plan: dict[str, Any], directory: Path, events: list[dict[str, Any]]
+) -> None:
+    """Bind every receipt event to exact paths and rows from its stored plan."""
+    mappings = migration_mappings(plan["repositories"])
+    expected: dict[str, dict[str, Any]] = {}
+    for index, item in enumerate(plan["repositories"]):
+        expected[f"repository:{index}"] = {"kind": "repository", "item": item}
+    consumers = plan["consumers"]
+    if consumers.get("repos_json"):
+        expected["consumer:repos_json"] = {
+            "kind": "file",
+            "path": consumers["repos_json"]["path"],
+            "backup": str(directory / "backups/repos.json"),
+        }
+    if consumers.get("tabby"):
+        expected["consumer:tabby"] = {
+            "kind": "file",
+            "path": consumers["tabby"]["path"],
+            "backup": str(directory / "backups/tabby.yaml"),
+        }
+    for index, consumer in enumerate(consumers.get("databases", [])):
+        expected[f"consumer:database:{index}"] = {
+            "kind": "database",
+            "path": consumer["path"],
+            "backup": str(directory / f"backups/opencode-{index}.db"),
+            "changes": [
+                {**row, "after": mappings[row["value"]]} for row in consumer["rows"]
+            ],
+        }
+    for index, consumer in enumerate(consumers.get("markers", [])):
+        expected[f"consumer:marker:{index}"] = {
+            "kind": "file",
+            "path": consumer["path"],
+            "backup": str(directory / f"backups/recovery-{index}.json"),
+        }
+    for event in events[1:]:
+        if event.get("event") not in {"started", "completed"}:
+            raise MigrationError("Receipt contains an unsupported event")
+        key = str(event.get("key", ""))
+        base_key = key.removeprefix("rollback:")
+        if base_key in {"migration:complete", "migration:rolled-back"}:
+            continue
+        target = expected.get(base_key)
+        details = event.get("details")
+        if not target or not isinstance(details, dict):
+            raise MigrationError(f"Receipt contains an unsupported step: {key}")
+        if target["kind"] == "repository":
+            item = target["item"]
+            if (
+                details.get("source") != item["source"]
+                or details.get("destination") != item["destination"]
+                or details.get("post_fingerprint") != item["fingerprint"]
+                or bool(details.get("self_nested"))
+                != (path_is_inside(Path(item["source"]), Path(item["destination"])) and item["source"] != item["destination"])
+            ):
+                raise MigrationError(f"Receipt repository target mismatch: {key}")
+            planned_pointers = {entry["path"]: entry["content"] for entry in item["linked_pointers"]}
+            for pointer in details.get("pointer_changes", []):
+                before = planned_pointers.get(pointer.get("path"))
+                expected_after = (
+                    before.replace(
+                        f"gitdir: {item['source']}/.git/",
+                        f"gitdir: {item['destination']}/.git/",
+                        1,
+                    )
+                    if before
+                    else None
+                )
+                if pointer.get("before") != before or pointer.get("after") != expected_after:
+                    raise MigrationError(f"Receipt linked pointer target mismatch: {key}")
+            if len(details.get("pointer_changes", [])) != len(planned_pointers):
+                raise MigrationError(f"Receipt linked pointer set mismatch: {key}")
+            workspace = Path(plan["workspace"])
+            destination_parent = Path(item["destination"]).parent
+            for created in details.get("created_directories", []):
+                created_path = Path(created)
+                if (
+                    created_path == workspace
+                    or not path_is_inside(workspace, created_path)
+                    or not path_is_inside(created_path, destination_parent)
+                ):
+                    raise MigrationError(f"Receipt directory target mismatch: {key}")
+        else:
+            if details.get("path") != target["path"] or details.get("backup") != target["backup"]:
+                raise MigrationError(f"Receipt consumer target mismatch: {key}")
+            if target["kind"] == "database" and details.get("changes") != target["changes"]:
+                raise MigrationError(f"Receipt database target mismatch: {key}")
+
+
+def validate_receipt_bundle(
+    receipt_id: str,
+    directory: Path,
+    journal: Path,
+    expected_plan: dict[str, Any] | None = None,
+    repair_incomplete_tail: bool = False,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Authenticate an owner-private receipt against its immutable stored plan."""
+    assert_private_owned_path(directory.parent, directory=True)
+    assert_private_owned_path(directory, directory=True)
+    plan_path = directory / "plan.json"
+    assert_private_owned_path(plan_path, directory=False)
+    assert_private_owned_path(journal, directory=False)
+    plan = load_json(plan_path)
+    validate_plan(plan, plan.get("plan_sha256", ""))
+    expected_id, expected_directory, expected_journal = receipt_paths(plan)
+    if (
+        receipt_id != expected_id
+        or directory != expected_directory
+        or journal != expected_journal
+        or expand_path(plan["state_dir"]) != directory.parent
+        or (expected_plan is not None and canonical_bytes(expected_plan) != canonical_bytes(plan))
+    ):
+        raise MigrationError("Receipt does not match its stored plan")
+    events = read_events(journal, repair_incomplete_tail=repair_incomplete_tail)
+    if not events:
+        raise MigrationError("Receipt journal has no complete creation event")
+    created = events[0]
+    if (
+        created.get("event") != "created"
+        or created.get("receipt_id") != receipt_id
+        or created.get("plan_sha256") != plan["plan_sha256"]
+    ):
+        raise MigrationError("Receipt creation event does not match its stored plan")
+    validate_receipt_event_targets(plan, directory, events)
+    return plan, events
+
+
+def locate_receipt(receipt: str, state_dir: str | None) -> tuple[str, Path, Path]:
+    """Resolve only a strict receipt ID below the configured private state root."""
+    if not re.fullmatch(r"layout-[a-f0-9]{32}", receipt):
+        raise MigrationError("Invalid receipt ID")
+    root = (
+        expand_path(state_dir)
+        if state_dir
+        else Path.home() / ".aidevops/.agent-workspace/work/repo-layout-migrations"
+    )
+    receipt_id = receipt
+    directory = root / receipt_id
+    return receipt_id, directory, directory / "receipt.jsonl"
+
+
+def receipt_status(receipt_id: str, directory: Path, journal: Path) -> dict[str, Any]:
+    """Return machine-readable receipt state and its current confirmation hash."""
+    _plan, events = validate_receipt_bundle(receipt_id, directory, journal)
+    completed = done_keys(events)
+    if "migration:rolled-back" in completed:
+        state = "rolled-back"
+    elif "migration:complete" in completed:
+        state = "applied"
+    else:
+        state = "partial"
+    created = events[0]
+    if state == "partial":
+        next_actions = [
+            {
+                "action": "resume",
+                "plan": created.get("plan_path"),
+                "confirm": created.get("plan_sha256"),
+            },
+            {"action": "rollback", "confirm": file_sha256(journal)},
+        ]
+    elif state == "applied":
+        next_actions = [{"action": "rollback", "confirm": file_sha256(journal)}]
+    else:
+        next_actions = []
+    return {
+        "receipt_id": receipt_id,
+        "state": state,
+        "last_verified_step": next(
+            (event.get("key", event.get("event")) for event in reversed(events)), "created"
+        ),
+        "receipt_sha256": file_sha256(journal),
+        "receipt_directory": str(directory),
+        "next_actions": next_actions,
+    }
+
+
+def status_command(args: argparse.Namespace) -> int:
+    """Print current receipt state."""
+    receipt_id, directory, journal = locate_receipt(args.receipt, args.state_dir)
+    print(json.dumps(receipt_status(receipt_id, directory, journal), sort_keys=True))
+    return 0
+
+
+def run_rollback_step(
+    journal: Path,
+    events: list[dict[str, Any]],
+    completed: set[str],
+    key: str,
+    details: dict[str, Any],
+    operation: Any,
+) -> None:
+    """Persist, execute, and complete one idempotent rollback step."""
+    rollback_key = f"rollback:{key}"
+    if rollback_key in completed:
+        return
+    start_step(journal, events, rollback_key, details)
+    operation(details)
+    maybe_inject_post_mutation_failure(rollback_key)
+    complete_step(journal, events, completed, rollback_key, details)
+
+
+def rollback_command(args: argparse.Namespace) -> int:
+    """Mechanically reverse receipt-owned changes after exact confirmation."""
+    receipt_id, directory, journal = locate_receipt(args.receipt, args.state_dir)
+    plan, _events = validate_receipt_bundle(receipt_id, directory, journal)
+    lock = acquire_lock(plan, receipt_id)
+    try:
+        if file_sha256(journal) != args.confirm:
+            raise MigrationError("Receipt SHA-256 confirmation does not match")
+        plan, events = validate_receipt_bundle(
+            receipt_id, directory, journal, repair_incomplete_tail=True
+        )
+        completed = done_keys(events)
+        if "migration:rolled-back" in completed:
+            print(json.dumps(receipt_status(receipt_id, directory, journal), sort_keys=True))
+            return 0
+        assert_no_active_path(plan)
+        for index in reversed(range(len(plan["consumers"].get("markers", [])))):
+            key = f"consumer:marker:{index}"
+            event = event_for_key(events, key)
+            if event:
+                run_rollback_step(
+                    journal, events, completed, key, event["details"], restore_file
+                )
+        for index in reversed(range(len(plan["consumers"].get("databases", [])))):
+            key = f"consumer:database:{index}"
+            event = event_for_key(events, key)
+            if event:
+                run_rollback_step(
+                    journal,
+                    events,
+                    completed,
+                    key,
+                    event["details"],
+                    rollback_database,
+                )
+        for key in ("consumer:tabby", "consumer:repos_json"):
+            event = event_for_key(events, key)
+            if event:
+                run_rollback_step(
+                    journal, events, completed, key, event["details"], restore_file
+                )
+        for index in reversed(range(len(plan["repositories"]))):
+            key = f"repository:{index}"
+            event = event_for_key(events, key)
+            if event:
+                run_rollback_step(
+                    journal,
+                    events,
+                    completed,
+                    key,
+                    event["details"],
+                    lambda details, item=plan["repositories"][index]: rollback_repository(
+                        item, details
+                    ),
+                )
+        append_event(journal, {"event": "completed", "key": "migration:rolled-back"})
+        print(json.dumps(receipt_status(receipt_id, directory, journal), sort_keys=True))
+        return 0
+    finally:
+        release_lock(lock)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the versioned command-line contract."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    plan = subparsers.add_parser("plan")
+    plan.add_argument("--workspace", required=True)
+    plan.add_argument("--output", required=True)
+    plan.add_argument("--include-registered-paths", action="store_true")
+    plan.add_argument("--repos-json")
+    plan.add_argument("--tabby-config")
+    plan.add_argument("--opencode-db")
+    plan.add_argument("--isolated-root")
+    plan.add_argument("--recovery-root")
+    plan.add_argument("--state-dir")
+    plan.add_argument("--discovery-lib", required=True)
+    plan.set_defaults(handler=plan_command)
+    apply = subparsers.add_parser("apply")
+    apply.add_argument("--plan", required=True)
+    apply.add_argument("--confirm", required=True)
+    apply.add_argument("--discovery-lib", required=True)
+    apply.set_defaults(handler=apply_command)
+    rollback = subparsers.add_parser("rollback")
+    rollback.add_argument("--receipt", required=True)
+    rollback.add_argument("--confirm", required=True)
+    rollback.add_argument("--state-dir")
+    rollback.add_argument("--discovery-lib", required=True)
+    rollback.set_defaults(handler=rollback_command)
+    status = subparsers.add_parser("status")
+    status.add_argument("--receipt", required=True)
+    status.add_argument("--state-dir")
+    status.add_argument("--discovery-lib", required=True)
+    status.set_defaults(handler=status_command)
+    return parser
+
+
+def main() -> int:
+    """Run one migration command with concise fail-closed diagnostics."""
+    arguments = build_parser().parse_args()
+    try:
+        return int(arguments.handler(arguments))
+    except MigrationError as exc:
+        print(f"repo layout migration refused: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -46,6 +46,7 @@ from tabby_profile_validation import (
 )
 from tabby_shell_resolver import ShellResolutionError, resolve_login_shell
 from tabby_yaml_helpers import (
+    _parse_block_scalar,
     load_yaml_simple,
     save_yaml,
     extract_existing_cwds,
@@ -53,6 +54,7 @@ from tabby_yaml_helpers import (
     extract_profile_blocks,
     insert_profiles_block,
     remove_profile_blocks,
+    validate_yaml_document,
 )
 
 
@@ -317,6 +319,63 @@ def is_aidevops_managed_profile(profile: dict, projects_group_id: str | None) ->
         and _has_managed_profile_id(profile)
         and _has_managed_launch(profile)
     )
+
+
+def retarget_profile_cwds(
+    config_text: str, path_mappings: dict[str, str]
+) -> tuple[str, int]:
+    """Retarget exact profile cwd scalars without changing unrelated bytes."""
+    validate_yaml_document(config_text)
+    lines = config_text.splitlines(keepends=True)
+    changed = 0
+    index = 0
+    cwd_pattern = re.compile(r"^(?P<indent>\s+)cwd:\s*(?P<value>.*?)(?P<newline>\r?\n)?$")
+    while index < len(lines):
+        match = cwd_pattern.match(lines[index])
+        if not match:
+            index += 1
+            continue
+        raw_value = match.group("value").strip()
+        if raw_value and raw_value[0] in (">", "|"):
+            parent_indent = len(match.group("indent"))
+            value, next_index = _parse_block_scalar(
+                [line.rstrip("\r\n") for line in lines],
+                index + 1,
+                parent_indent,
+                raw_value[0],
+            )
+            replacement = path_mappings.get(value)
+            if replacement:
+                lines[index] = (
+                    f"{match.group('indent')}cwd: {replacement}"
+                    f"{match.group('newline') or ''}"
+                )
+                del lines[index + 1 : next_index]
+                changed += 1
+                index += 1
+                continue
+            index = next_index
+            continue
+        quote = (
+            raw_value[0]
+            if len(raw_value) >= 2
+            and raw_value[0] == raw_value[-1]
+            and raw_value[0] in ("'", '"')
+            else ""
+        )
+        value = raw_value[1:-1] if quote else raw_value
+        replacement = path_mappings.get(value)
+        if replacement:
+            rendered = f"{quote}{replacement}{quote}" if quote else replacement
+            lines[index] = (
+                f"{match.group('indent')}cwd: {rendered}"
+                f"{match.group('newline') or ''}"
+            )
+            changed += 1
+        index += 1
+    updated = "".join(lines)
+    validate_yaml_document(updated)
+    return updated, changed
 
 
 def plan_profile_reconciliation(

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ open-design-helper.sh start --https-local open-design
 
 Imported Open Design skills are not copied verbatim. They are evaluated through aidevops build-agent methodology, deduplicated against existing agents, flattened into aidevops `*-skill.md` structure, attributed to upstream, and given verification commands. See `.agents/tools/design/open-design-ingestion.md` for the full skill-value matrix.
 
-**Project tracking:** When you run `aidevops init`, the project is automatically registered in `~/.config/aidevops/repos.json`. Running `aidevops update` checks all registered projects for version updates.
+**Project tracking:** When you run `aidevops init`, the project is automatically registered in `~/.config/aidevops/repos.json`. Running `aidevops update` checks all registered projects for version updates. Repository layout changes remain separate and user-invoked: `aidevops repos migrate-layout plan` creates a non-mutating, content-hashed plan, while confirmed apply, status, resume, and rollback operations preserve private receipts and fail closed on drift.
 
 ### **Use aidevops in Any Project**
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -876,6 +876,16 @@ cmd_repos() {
 	add) _repos_add ;;
 	remove | rm) _repos_remove "${2:-}" ;;
 	clean) _repos_clean ;;
+	migrate-layout)
+		shift
+		local migrate_helper="${AIDEVOPS_CLI_MODULES_DIR%/aidevops-cli}/repo-layout-migrate-helper.sh"
+		[[ -f "$migrate_helper" ]] || migrate_helper="${AGENTS_DIR}/scripts/repo-layout-migrate-helper.sh"
+		if [[ ! -x "$migrate_helper" ]]; then
+			print_error "Repository layout migration helper is unavailable"
+			return 1
+		fi
+		"$migrate_helper" "$@"
+		;;
 	maintenance | maintain)
 		shift
 		_repos_maintenance "$@"
@@ -888,6 +898,8 @@ cmd_repos() {
 		echo "  add      Register current project"
 		echo "  remove   Remove project from registry"
 		echo "  clean    Remove entries for non-existent projects"
+		echo "  migrate-layout <plan|apply|rollback|status>"
+		echo "           Guarded owner-layout migration with durable receipts"
 		echo "  maintenance <on|off> [repo]"
 		echo "           Include/exclude a registered repo from recurring automation"
 		;;

--- a/tests/test-repo-layout-migrate.py
+++ b/tests/test-repo-layout-migrate.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Disposable end-to-end tests for guarded repository layout migration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+HELPER = REPOSITORY_ROOT / ".agents/scripts/repo-layout-migrate-helper.sh"
+
+
+class RepoLayoutMigrationTest(unittest.TestCase):
+    """Exercise plan, apply/resume, consumer updates, refusal, and rollback."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name).resolve()
+        self.home = self.root / "home"
+        self.workspace = self.home / "Git"
+        self.state = self.home / "state"
+        self.workspace.mkdir(parents=True)
+        self.source = self.workspace / "Project"
+        self.destination = self.workspace / "acme" / "Project"
+        self.worktree = self.workspace / "_worktrees" / "Project-feature"
+        self.repos_json = self.home / ".config/aidevops/repos.json"
+        self.tabby = self.home / "tabby.yaml"
+        self.database = self.home / "opencode.db"
+        self.isolated_root = self.home / "isolated"
+        self.recovery_root = self.home / "recovery"
+        self.plan = self.home / "plan.json"
+        self.environment = {**os.environ, "HOME": str(self.home)}
+        self._create_repository()
+        self._create_consumers()
+
+    def _run(
+        self,
+        *arguments: str,
+        check: bool = True,
+        cwd: Path | None = None,
+        environment: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            [str(HELPER), *arguments],
+            cwd=cwd or self.root,
+            env=environment or self.environment,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+        if check and result.returncode != 0:
+            self.fail(
+                f"migration command failed ({result.returncode}): {result.stderr.strip()}"
+            )
+        return result
+
+    def _git(self, *arguments: str, cwd: Path | None = None) -> str:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=cwd or self.source,
+            text=True,
+            capture_output=True,
+            check=True,
+            timeout=20,
+        )
+        return result.stdout.strip()
+
+    def _create_repository(self) -> None:
+        self.source.mkdir()
+        self._git("init", "-q", "-b", "main")
+        self._git("config", "user.name", "Fixture User")
+        self._git("config", "user.email", "fixture@example.invalid")
+        (self.source / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+        (self.source / ".gitmodules").write_text(
+            '[submodule "vendor/library"]\n'
+            "\tpath = vendor/library\n"
+            "\turl = ../library.git\n",
+            encoding="utf-8",
+        )
+        self._git("add", "tracked.txt", ".gitmodules")
+        self._git("commit", "-q", "-m", "initial")
+        self._git("remote", "add", "origin", "git@github.com:Acme/Project.git")
+        self.worktree.parent.mkdir()
+        self._git("worktree", "add", "-q", "-b", "feature/test", str(self.worktree))
+        (self.source / "stash.txt").write_text("stash\n", encoding="utf-8")
+        self._git("add", "stash.txt")
+        self._git("stash", "push", "-q", "-m", "fixture")
+        (self.source / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+    def _create_database(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(path) as connection:
+            connection.execute("CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT)")
+            connection.execute(
+                "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, parent_id TEXT)"
+            )
+            connection.execute(
+                "INSERT INTO project VALUES (?, ?)", ("project-1", str(self.source))
+            )
+            connection.execute(
+                "INSERT INTO session VALUES (?, ?, NULL)",
+                ("ses_fixture1", str(self.source)),
+            )
+
+    def _create_consumers(self) -> None:
+        self.repos_json.parent.mkdir(parents=True)
+        self.repos_json.write_text(
+            json.dumps(
+                {
+                    "initialized_repos": [
+                        {
+                            "path": str(self.source),
+                            "slug": "Acme/Project",
+                            "custom": "preserved",
+                        }
+                    ],
+                    "git_parent_dirs": [str(self.workspace)],
+                    "personal_owners": {"github.com": ["alice"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.tabby.write_text(
+            "profiles:\n"
+            "  - name: Custom Project\n"
+            "    color: '#ABCDEF'\n"
+            "    options:\n"
+            f"      cwd: '{self.source}'\n"
+            "      command: /bin/zsh\n"
+            "groups: []\n",
+            encoding="utf-8",
+        )
+        self._create_database(self.database)
+        isolated_db = self.isolated_root / "worker-1/opencode/opencode.db"
+        self._create_database(isolated_db)
+        marker = self.recovery_root / "ses_fixture1/recovery.json"
+        marker.parent.mkdir(parents=True)
+        self.recovery_root.chmod(0o700)
+        marker.parent.chmod(0o700)
+        marker.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "session_id": "ses_fixture1",
+                    "directory": str(self.source),
+                    "data_dir": str(isolated_db.parent.parent),
+                }
+            ),
+            encoding="utf-8",
+        )
+        marker.chmod(0o600)
+
+    def _plan(self, *, include_registered: bool = True) -> dict:
+        arguments = [
+            "plan",
+            "--workspace",
+            str(self.workspace),
+            "--output",
+            str(self.plan),
+            "--repos-json",
+            str(self.repos_json),
+            "--tabby-config",
+            str(self.tabby),
+            "--opencode-db",
+            str(self.database),
+            "--isolated-root",
+            str(self.isolated_root),
+            "--recovery-root",
+            str(self.recovery_root),
+            "--state-dir",
+            str(self.state),
+        ]
+        if include_registered:
+            arguments.append("--include-registered-paths")
+        result = self._run(*arguments)
+        return json.loads(result.stdout)
+
+    def _receipt_status(self, receipt_id: str) -> dict:
+        result = self._run(
+            "status", "--receipt", receipt_id, "--state-dir", str(self.state)
+        )
+        return json.loads(result.stdout)
+
+    def test_plan_is_non_mutating_and_reports_complete_inventory(self) -> None:
+        before = self._fixture_digest()
+        summary = self._plan()
+        payload = json.loads(self.plan.read_text(encoding="utf-8"))
+
+        self.assertEqual(before, self._fixture_digest(exclude_plan=True))
+        self.assertEqual(summary["moves"], 1)
+        repository = payload["repositories"][0]
+        self.assertEqual(repository["fingerprint"]["status_entries"], 1)
+        self.assertEqual(repository["fingerprint"]["stash_count"], 1)
+        self.assertIsNotNone(repository["fingerprint"]["gitmodules_sha256"])
+        self.assertEqual(len(repository["fingerprint"]["worktrees"]), 2)
+        self.assertEqual(len(repository["linked_pointers"]), 1)
+        self.assertEqual(len(payload["consumers"]["databases"]), 2)
+        self.assertEqual(len(payload["consumers"]["markers"]), 1)
+        self.assertFalse(self.destination.exists())
+
+    def test_apply_resume_or_rollback_preserves_exact_state(self) -> None:
+        before_repository = self._repository_snapshot(self.source)
+        marker = self.recovery_root / "ses_fixture1/recovery.json"
+        before_consumers = {
+            self.repos_json: self.repos_json.read_bytes(),
+            self.tabby: self.tabby.read_bytes(),
+            marker: marker.read_bytes(),
+        }
+        summary = self._plan()
+        interrupted_environment = {
+            **self.environment,
+            "AIDEVOPS_MIGRATE_FAIL_AFTER": "repository:0",
+        }
+        interrupted = self._run(
+            "apply",
+            "--plan",
+            str(self.plan),
+            "--confirm",
+            summary["plan_sha256"],
+            check=False,
+            environment=interrupted_environment,
+        )
+        self.assertEqual(interrupted.returncode, 2)
+        self.assertTrue(self.destination.is_dir())
+        self.assertFalse(self.source.exists())
+
+        applied = json.loads(
+            self._run(
+                "apply",
+                "--plan",
+                str(self.plan),
+                "--confirm",
+                summary["plan_sha256"],
+            ).stdout
+        )
+        self.assertEqual(applied["state"], "applied")
+        receipt_id = applied["receipt_id"]
+        self.assertEqual(self._receipt_status(receipt_id)["state"], "applied")
+        registration = json.loads(self.repos_json.read_text(encoding="utf-8"))
+        self.assertEqual(registration["initialized_repos"][0]["path"], str(self.destination))
+        self.assertEqual(registration["initialized_repos"][0]["custom"], "preserved")
+        tabby_text = self.tabby.read_text(encoding="utf-8")
+        self.assertIn(str(self.destination), tabby_text)
+        self.assertIn("color: '#ABCDEF'", tabby_text)
+        self.assertEqual(self._database_paths(self.database), {str(self.destination)})
+        linked_marker = (self.worktree / ".git").read_text(encoding="utf-8")
+        self.assertIn(str(self.destination / ".git"), linked_marker)
+        self.assertEqual(
+            self._git("rev-parse", "HEAD", cwd=self.destination),
+            self._git("rev-parse", "HEAD", cwd=self.worktree),
+        )
+
+        status = self._receipt_status(receipt_id)
+        rolled_back = json.loads(
+            self._run(
+                "rollback",
+                "--receipt",
+                receipt_id,
+                "--state-dir",
+                str(self.state),
+                "--confirm",
+                status["receipt_sha256"],
+            ).stdout
+        )
+        self.assertEqual(rolled_back["state"], "rolled-back")
+        self.assertTrue(self.source.is_dir())
+        self.assertFalse(self.destination.exists())
+        self.assertEqual(before_repository, self._repository_snapshot(self.source))
+        for path, expected in before_consumers.items():
+            self.assertEqual(path.read_bytes(), expected)
+        self.assertEqual(self._database_paths(self.database), {str(self.source)})
+
+    def test_refusal_for_unapproved_registration_and_plan_drift(self) -> None:
+        summary = self._plan(include_registered=False)
+        payload = json.loads(self.plan.read_text(encoding="utf-8"))
+        self.assertEqual(summary["moves"], 0)
+        self.assertEqual(
+            payload["exclusions"][0]["reason"], "explicit-registration-not-approved"
+        )
+
+        summary = self._plan()
+        (self.source / "dirty.txt").write_text("changed after plan\n", encoding="utf-8")
+        refused = self._run(
+            "apply",
+            "--plan",
+            str(self.plan),
+            "--confirm",
+            summary["plan_sha256"],
+            check=False,
+        )
+        self.assertEqual(refused.returncode, 2)
+        self.assertIn("drift detected", refused.stderr)
+        self.assertTrue(self.source.is_dir())
+        self.assertFalse(self.destination.exists())
+
+    def test_refusal_for_destination_collision_and_active_path(self) -> None:
+        self.destination.mkdir(parents=True)
+        refused = self._run(
+            "plan",
+            "--workspace",
+            str(self.workspace),
+            "--output",
+            str(self.plan),
+            "--repos-json",
+            str(self.repos_json),
+            "--include-registered-paths",
+            check=False,
+        )
+        self.assertEqual(refused.returncode, 2)
+        self.assertIn("Destination collision", refused.stderr)
+        self.destination.rmdir()
+        self.destination.parent.rmdir()
+
+        summary = self._plan()
+        active = self._run(
+            "apply",
+            "--plan",
+            str(self.plan),
+            "--confirm",
+            summary["plan_sha256"],
+            check=False,
+            cwd=self.source,
+        )
+        self.assertEqual(active.returncode, 2)
+        self.assertIn("Active-path ambiguity", active.stderr)
+        self.assertTrue(self.source.is_dir())
+
+    def test_refusal_for_unexpected_linked_pointer(self) -> None:
+        summary = self._plan()
+        (self.worktree / ".git").write_text("gitdir: /unexpected/location\n", encoding="utf-8")
+        refused = self._run(
+            "apply",
+            "--plan",
+            str(self.plan),
+            "--confirm",
+            summary["plan_sha256"],
+            check=False,
+        )
+        self.assertEqual(refused.returncode, 2)
+        self.assertTrue(self.source.is_dir())
+        self.assertFalse(self.destination.exists())
+
+    def test_refusal_for_malformed_config_and_database_schema_drift(self) -> None:
+        original_tabby = self.tabby.read_text(encoding="utf-8")
+        self.tabby.write_text("profiles: not-a-list\n", encoding="utf-8")
+        malformed = self._run(
+            "plan",
+            "--workspace",
+            str(self.workspace),
+            "--output",
+            str(self.plan),
+            "--repos-json",
+            str(self.repos_json),
+            "--tabby-config",
+            str(self.tabby),
+            "--include-registered-paths",
+            check=False,
+        )
+        self.assertEqual(malformed.returncode, 2)
+        self.assertFalse(self.plan.exists())
+
+        self.tabby.write_text(original_tabby, encoding="utf-8")
+        summary = self._plan()
+        with sqlite3.connect(self.database) as connection:
+            connection.execute("ALTER TABLE project ADD COLUMN later TEXT")
+        drifted = self._run(
+            "apply",
+            "--plan",
+            str(self.plan),
+            "--confirm",
+            summary["plan_sha256"],
+            check=False,
+        )
+        self.assertEqual(drifted.returncode, 2)
+        self.assertIn("Database schema or row drift", drifted.stderr)
+        self.assertTrue(self.source.is_dir())
+
+    def test_confirmation_and_post_apply_drift_block_rollback(self) -> None:
+        summary = self._plan()
+        wrong = self._run(
+            "apply",
+            "--plan",
+            str(self.plan),
+            "--confirm",
+            "0" * 64,
+            check=False,
+        )
+        self.assertEqual(wrong.returncode, 2)
+        self.assertTrue(self.source.is_dir())
+
+        applied = json.loads(
+            self._run(
+                "apply",
+                "--plan",
+                str(self.plan),
+                "--confirm",
+                summary["plan_sha256"],
+            ).stdout
+        )
+        (self.destination / "dirty.txt").write_text("newer work\n", encoding="utf-8")
+        status = self._receipt_status(applied["receipt_id"])
+        refused = self._run(
+            "rollback",
+            "--receipt",
+            applied["receipt_id"],
+            "--state-dir",
+            str(self.state),
+            "--confirm",
+            status["receipt_sha256"],
+            check=False,
+        )
+        self.assertEqual(refused.returncode, 2)
+        self.assertIn("drift blocks rollback", refused.stderr)
+        self.assertTrue(self.destination.is_dir())
+
+    def test_resume_or_rollback_from_every_consumer_boundary(self) -> None:
+        boundaries = (
+            "consumer:repos_json",
+            "consumer:tabby",
+            "consumer:database:0",
+            "consumer:database:1",
+            "consumer:marker:0",
+        )
+        for boundary in boundaries:
+            with self.subTest(boundary=boundary):
+                summary = self._plan()
+                payload = json.loads(self.plan.read_text(encoding="utf-8"))
+                receipt_id = f"layout-{payload['plan_id']}"
+                interrupted = self._run(
+                    "apply",
+                    "--plan",
+                    str(self.plan),
+                    "--confirm",
+                    summary["plan_sha256"],
+                    check=False,
+                    environment={
+                        **self.environment,
+                        "AIDEVOPS_MIGRATE_FAIL_AFTER": boundary,
+                    },
+                )
+                self.assertEqual(interrupted.returncode, 2)
+                partial = self._receipt_status(receipt_id)
+                self.assertEqual(partial["state"], "partial")
+                self.assertEqual(
+                    {item["action"] for item in partial["next_actions"]},
+                    {"resume", "rollback"},
+                )
+                applied = json.loads(
+                    self._run(
+                        "apply",
+                        "--plan",
+                        str(self.plan),
+                        "--confirm",
+                        summary["plan_sha256"],
+                    ).stdout
+                )
+                current = self._receipt_status(applied["receipt_id"])
+                rolled_back = json.loads(
+                    self._run(
+                        "rollback",
+                        "--receipt",
+                        applied["receipt_id"],
+                        "--state-dir",
+                        str(self.state),
+                        "--confirm",
+                        current["receipt_sha256"],
+                    ).stdout
+                )
+                self.assertEqual(rolled_back["state"], "rolled-back")
+                self.assertTrue(self.source.is_dir())
+                self.assertFalse(self.destination.exists())
+
+    def test_resume_after_mutation_before_completion_event(self) -> None:
+        for boundary in ("repository:0", "consumer:repos_json"):
+            with self.subTest(boundary=boundary):
+                summary = self._plan()
+                interrupted = self._run(
+                    "apply",
+                    "--plan",
+                    str(self.plan),
+                    "--confirm",
+                    summary["plan_sha256"],
+                    check=False,
+                    environment={
+                        **self.environment,
+                        "AIDEVOPS_MIGRATE_FAIL_AFTER_MUTATION": boundary,
+                    },
+                )
+                self.assertEqual(interrupted.returncode, 2)
+                applied = json.loads(
+                    self._run(
+                        "apply",
+                        "--plan",
+                        str(self.plan),
+                        "--confirm",
+                        summary["plan_sha256"],
+                    ).stdout
+                )
+                status = self._receipt_status(applied["receipt_id"])
+                self._run(
+                    "rollback",
+                    "--receipt",
+                    applied["receipt_id"],
+                    "--state-dir",
+                    str(self.state),
+                    "--confirm",
+                    status["receipt_sha256"],
+                )
+                self.assertTrue(self.source.is_dir())
+                self.assertFalse(self.destination.exists())
+                self.assertIn(
+                    str(self.source / ".git"),
+                    (self.worktree / ".git").read_text(encoding="utf-8"),
+                )
+
+    def test_resume_rollback_after_mutation_before_completion_event(self) -> None:
+        summary = self._plan()
+        applied = json.loads(
+            self._run(
+                "apply",
+                "--plan",
+                str(self.plan),
+                "--confirm",
+                summary["plan_sha256"],
+            ).stdout
+        )
+        status = self._receipt_status(applied["receipt_id"])
+        interrupted = self._run(
+            "rollback",
+            "--receipt",
+            applied["receipt_id"],
+            "--state-dir",
+            str(self.state),
+            "--confirm",
+            status["receipt_sha256"],
+            check=False,
+            environment={
+                **self.environment,
+                "AIDEVOPS_MIGRATE_FAIL_AFTER_MUTATION": "rollback:repository:0",
+            },
+        )
+        self.assertEqual(interrupted.returncode, 2)
+        partial = self._receipt_status(applied["receipt_id"])
+        resumed = json.loads(
+            self._run(
+                "rollback",
+                "--receipt",
+                applied["receipt_id"],
+                "--state-dir",
+                str(self.state),
+                "--confirm",
+                partial["receipt_sha256"],
+            ).stdout
+        )
+        self.assertEqual(resumed["state"], "rolled-back")
+        self.assertTrue(self.source.is_dir())
+        self.assertFalse(self.destination.exists())
+
+    def test_receipt_paths_and_event_targets_are_authenticated(self) -> None:
+        summary = self._plan()
+        applied = json.loads(
+            self._run(
+                "apply",
+                "--plan",
+                str(self.plan),
+                "--confirm",
+                summary["plan_sha256"],
+            ).stdout
+        )
+        receipt_directory = Path(applied["receipt_directory"])
+        refused_path = self._run(
+            "status",
+            "--receipt",
+            str(receipt_directory),
+            "--state-dir",
+            str(self.state),
+            check=False,
+        )
+        self.assertEqual(refused_path.returncode, 2)
+        self.assertIn("Invalid receipt ID", refused_path.stderr)
+
+        journal = receipt_directory / "receipt.jsonl"
+        events = [json.loads(line) for line in journal.read_text(encoding="utf-8").splitlines()]
+        consumer_event = next(
+            event
+            for event in events
+            if event.get("key") == "consumer:repos_json"
+            and event.get("event") == "started"
+        )
+        consumer_event["details"]["path"] = str(self.home / "unrelated.json")
+        journal.write_text(
+            "".join(json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n" for event in events),
+            encoding="utf-8",
+        )
+        journal.chmod(0o600)
+        refused_target = self._run(
+            "status",
+            "--receipt",
+            applied["receipt_id"],
+            "--state-dir",
+            str(self.state),
+            check=False,
+        )
+        self.assertEqual(refused_target.returncode, 2)
+        self.assertIn("target mismatch", refused_target.stderr)
+
+    def test_torn_receipt_tail_recovers_and_rollback_rejects_active_path(self) -> None:
+        summary = self._plan()
+        plan_payload = json.loads(self.plan.read_text(encoding="utf-8"))
+        receipt_id = f"layout-{plan_payload['plan_id']}"
+        receipt_directory = self.state / receipt_id
+        receipt_directory.mkdir(parents=True, mode=0o700)
+        self.state.chmod(0o700)
+        stored_plan = receipt_directory / "plan.json"
+        stored_plan.write_bytes(self.plan.read_bytes())
+        stored_plan.chmod(0o600)
+        journal = receipt_directory / "receipt.jsonl"
+        journal.write_bytes(b'{"event":"cre')
+        journal.chmod(0o600)
+
+        applied = json.loads(
+            self._run(
+                "apply",
+                "--plan",
+                str(self.plan),
+                "--confirm",
+                summary["plan_sha256"],
+            ).stdout
+        )
+        status = self._receipt_status(applied["receipt_id"])
+        active = self._run(
+            "rollback",
+            "--receipt",
+            applied["receipt_id"],
+            "--state-dir",
+            str(self.state),
+            "--confirm",
+            status["receipt_sha256"],
+            check=False,
+            cwd=self.destination,
+        )
+        self.assertEqual(active.returncode, 2)
+        self.assertIn("Active-path ambiguity", active.stderr)
+
+        with journal.open("ab") as handle:
+            handle.write(b'{"event":"com')
+        torn_status = self._receipt_status(applied["receipt_id"])
+        self.assertEqual(torn_status["state"], "applied")
+        rolled_back = json.loads(
+            self._run(
+                "rollback",
+                "--receipt",
+                applied["receipt_id"],
+                "--state-dir",
+                str(self.state),
+                "--confirm",
+                torn_status["receipt_sha256"],
+            ).stdout
+        )
+        self.assertEqual(rolled_back["state"], "rolled-back")
+        self.assertTrue(self.source.is_dir())
+        self.assertFalse(self.destination.exists())
+
+    def test_apply_and_rollback_staged_path_shapes(self) -> None:
+        cases = (
+            ("nested", Path("acme"), Path("acme/Project")),
+            ("case-only", Path("Acme/CaseProject"), Path("acme/CaseProject")),
+        )
+        for label, source_relative, destination_relative in cases:
+            with self.subTest(label=label):
+                workspace = self.home / f"Git-{label}"
+                source = workspace / source_relative
+                destination = workspace / destination_relative
+                source.mkdir(parents=True)
+                self._git("init", "-q", "-b", "main", cwd=source)
+                self._git("config", "user.name", "Fixture User", cwd=source)
+                self._git(
+                    "config", "user.email", "fixture@example.invalid", cwd=source
+                )
+                (source / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+                self._git("add", "tracked.txt", cwd=source)
+                self._git("commit", "-q", "-m", "initial", cwd=source)
+                repository_name = destination.name
+                self._git(
+                    "remote",
+                    "add",
+                    "origin",
+                    f"git@github.com:Acme/{repository_name}.git",
+                    cwd=source,
+                )
+                config = self.home / f"repos-{label}.json"
+                config.write_text(
+                    json.dumps(
+                        {
+                            "initialized_repos": [],
+                            "personal_owners": {"github.com": ["alice"]},
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                plan = self.home / f"plan-{label}.json"
+                state = self.home / f"state-{label}"
+                summary = json.loads(
+                    self._run(
+                        "plan",
+                        "--workspace",
+                        str(workspace),
+                        "--output",
+                        str(plan),
+                        "--repos-json",
+                        str(config),
+                        "--state-dir",
+                        str(state),
+                    ).stdout
+                )
+                apply_result = self._run(
+                    "apply",
+                    "--plan",
+                    str(plan),
+                    "--confirm",
+                    summary["plan_sha256"],
+                    check=False,
+                )
+                self.assertEqual(apply_result.returncode, 0, apply_result.stderr)
+                applied = json.loads(apply_result.stdout)
+                self.assertTrue(destination.is_dir())
+                status = json.loads(
+                    self._run(
+                        "status",
+                        "--receipt",
+                        applied["receipt_id"],
+                        "--state-dir",
+                        str(state),
+                    ).stdout
+                )
+                self._run(
+                    "rollback",
+                    "--receipt",
+                    applied["receipt_id"],
+                    "--state-dir",
+                    str(state),
+                    "--confirm",
+                    status["receipt_sha256"],
+                )
+                self.assertTrue(source.is_dir())
+                if str(source).lower() != str(destination).lower():
+                    self.assertFalse(destination.exists())
+
+    def _database_paths(self, path: Path) -> set[str]:
+        with sqlite3.connect(path) as connection:
+            project = connection.execute("SELECT worktree FROM project").fetchone()[0]
+            session = connection.execute("SELECT directory FROM session").fetchone()[0]
+        return {project, session}
+
+    def _repository_snapshot(self, path: Path) -> dict[str, str]:
+        return {
+            "head": self._git("rev-parse", "HEAD", cwd=path),
+            "branch": self._git("branch", "--show-current", cwd=path),
+            "branches": self._git(
+                "for-each-ref",
+                "--sort=refname",
+                "--format=%(refname) %(objectname)",
+                "refs/heads",
+                cwd=path,
+            ),
+            "status": self._git("status", "--porcelain=v1", cwd=path),
+            "stashes": self._git("stash", "list", cwd=path),
+            "linked_pointer": (self.worktree / ".git").read_text(encoding="utf-8"),
+        }
+
+    def _fixture_digest(
+        self, *, exclude_plan: bool = False, exclude_state: bool = False
+    ) -> str:
+        digest = hashlib.sha256()
+        for path in sorted(self.home.rglob("*")):
+            if exclude_plan and path == self.plan:
+                continue
+            if exclude_state and (path == self.state or self.state in path.parents):
+                continue
+            relative = path.relative_to(self.home)
+            digest.update(str(relative).encode())
+            if path.is_file() and not path.is_symlink():
+                digest.update(path.read_bytes())
+        return digest.hexdigest()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test-tabby-profile-sync.py
+++ b/tests/test-tabby-profile-sync.py
@@ -52,6 +52,35 @@ profiles:
 
         self.assertEqual(tabby_profile_sync.extract_group_id(config_text), "abc-123")
 
+    def test_retarget_profile_cwds_preserves_custom_fields(self):
+        original = """profiles:
+  - name: Custom title
+    color: '#AABBCC'
+    options:
+      cwd: '/workspace/OldRepo'
+      command: /bin/zsh
+  - name: Folded
+    options:
+      cwd: >-
+        /workspace/OldRepo
+groups: []
+"""
+
+        updated, changed = tabby_profile_sync.retarget_profile_cwds(
+            original, {"/workspace/OldRepo": "/workspace/acme/OldRepo"}
+        )
+
+        self.assertEqual(changed, 2)
+        self.assertIn("name: Custom title", updated)
+        self.assertIn("color: '#AABBCC'", updated)
+        self.assertIn("command: /bin/zsh", updated)
+        self.assertEqual(updated.count("/workspace/acme/OldRepo"), 2)
+        second, second_changed = tabby_profile_sync.retarget_profile_cwds(
+            updated, {"/workspace/OldRepo": "/workspace/acme/OldRepo"}
+        )
+        self.assertEqual(second, updated)
+        self.assertEqual(second_changed, 0)
+
 
 class TestExtractExistingCwds(unittest.TestCase):
     """Regression tests for YAML scalar parsing (t2250 root cause A).


### PR DESCRIPTION
## Summary

Adds a non-mutating plan command plus confirmed, receipt-backed apply, status,
resume, and rollback for owner-based repository layout migration. The command
updates registered paths, Tabby profiles, OpenCode databases, recovery markers,
and linked-worktree pointers with drift and collision guards.

## Files Changed

`.agents/reference/repo-organization.md`,
`.agents/reference/repos-json-fields.md`,
`.agents/scripts/repo-layout-migrate-helper.sh`,
`.agents/scripts/repo_layout_migrate.py`,
`.agents/scripts/tabby-profile-sync.py`, `README.md`, `aidevops.sh`,
`tests/test-repo-layout-migrate.py`, and `tests/test-tabby-profile-sync.py`.

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 13 disposable-repository migration tests
  exercised plan, apply, interrupted resume, status, active-path refusal,
  consumer retargeting, linked-worktree preservation, torn-receipt recovery,
  and rollback. Additionally, 48 Tabby tests, owner-layout and recovery-marker
  suites, Python compilation, Bash syntax, ShellCheck, diff checks,
  changed-file linters, and independent high-risk closeout review passed.

## New File Smell Justification

The new migration engine intentionally keeps plan validation, durable receipt
events, filesystem movement, consumer retargeting, and rollback invariants in a
single private transaction module. Splitting those state-machine boundaries in
this PR would increase recovery coupling and review risk. The flagged items are
maintainability metrics rather than observed defects; runtime interruption tests
and two independent review cycles cover the high-risk paths.

## Ratchet Bump Justification

The 13 reported smells come from the new guarded transaction engine and its
Tabby adapter. They reflect explicit fail-closed branching and receipt
validation for destructive filesystem operations. SonarCloud reports zero new
issues and all repository-required checks passed. A later focused refactor can
split stable boundaries without combining that work with first delivery of the
migration contract.

Resolves #31084
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.304 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 2h 5m and 1,211,111 tokens on this with the user in an interactive session.