### PR TITLE
GH#31093: Harden GPT image worktree and dimension checks

### DIFF
--- a/.agents/plugins/opencode-aidevops/gpt-image-dimensions.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-dimensions.mjs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const JPEG_FRAME_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7,
+  0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf,
+]);
+
+function pngDimensions(buffer) {
+  if (buffer.length < 24) throw new Error("Image provider returned a PNG without dimensions.");
+  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+}
+
+function jpegDimensions(buffer) {
+  let offset = 2;
+  while (offset + 1 < buffer.length) {
+    if (buffer[offset] !== 0xff) throw new Error("Image provider returned a JPEG without dimensions.");
+    while (offset < buffer.length && buffer[offset] === 0xff) offset += 1;
+    const marker = buffer[offset];
+    offset += 1;
+    if (marker === 0xd9) break;
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+    if (offset + 2 > buffer.length) break;
+    const segmentLength = buffer.readUInt16BE(offset);
+    const segmentEnd = offset + segmentLength;
+    if (segmentLength < 2 || segmentEnd > buffer.length) break;
+    if (JPEG_FRAME_MARKERS.has(marker) && segmentLength >= 7) {
+      return { width: buffer.readUInt16BE(offset + 5), height: buffer.readUInt16BE(offset + 3) };
+    }
+    offset = segmentEnd;
+  }
+  throw new Error("Image provider returned a JPEG without dimensions.");
+}
+
+function webpChunkDimensions(type, chunk) {
+  if (type === "VP8X" && chunk.length === 10) {
+    return { width: 1 + chunk.readUIntLE(4, 3), height: 1 + chunk.readUIntLE(7, 3) };
+  }
+  if (type === "VP8 " && chunk.length >= 10 && chunk.subarray(3, 6).equals(Buffer.from([0x9d, 0x01, 0x2a]))) {
+    return { width: chunk.readUInt16LE(6) & 0x3fff, height: chunk.readUInt16LE(8) & 0x3fff };
+  }
+  if (type === "VP8L" && chunk.length >= 5 && chunk[0] === 0x2f) {
+    const bits = chunk.readUInt32LE(1);
+    return { width: 1 + (bits & 0x3fff), height: 1 + ((bits >>> 14) & 0x3fff) };
+  }
+  return null;
+}
+
+function webpDimensions(buffer) {
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const type = buffer.subarray(offset, offset + 4).toString("ascii");
+    const length = buffer.readUInt32LE(offset + 4);
+    const end = offset + 8 + length;
+    if (end > buffer.length) break;
+    const dimensions = webpChunkDimensions(type, buffer.subarray(offset + 8, end));
+    if (dimensions) return dimensions;
+    offset = end + (length % 2);
+  }
+  throw new Error("Image provider returned a WebP without dimensions.");
+}
+
+export function generatedImageDimensions(buffer, format) {
+  if (format === "png") return pngDimensions(buffer);
+  if (format === "jpeg") return jpegDimensions(buffer);
+  if (format === "webp") return webpDimensions(buffer);
+  throw new Error("Unsupported generated image format.");
+}

--- a/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-io.mjs
@@ -10,6 +10,7 @@ import {
   requireRelativePath,
 } from "./gpt-image-paths.mjs";
 import { secureWriteGeneratedImage } from "./gpt-image-secure-write.mjs";
+import { generatedImageDimensions } from "./gpt-image-dimensions.mjs";
 
 const MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -80,6 +81,25 @@ function validateGeneratedImageBase64(base64, format) {
   return buffer;
 }
 
+export function inspectGeneratedImageBase64(base64, format) {
+  const selected = requireImageFormat(format);
+  const buffer = validateGeneratedImageBase64(base64, selected);
+  const dimensions = generatedImageDimensions(buffer, selected);
+  if (dimensions.width < 1 || dimensions.height < 1) {
+    throw new Error(`Image provider returned invalid ${selected} dimensions.`);
+  }
+  return { buffer, ...dimensions };
+}
+
+function enforceRequestedDimensions(dimensions, requestedSize, format) {
+  if (!requestedSize || requestedSize === "auto") return;
+  const observed = `${dimensions.width}x${dimensions.height}`;
+  if (observed === requestedSize) return;
+  throw new Error(
+    `Image provider returned ${observed} ${format.toUpperCase()} for requested ${requestedSize}; no artifact was written.`,
+  );
+}
+
 export async function validateImageOutputPath(out, projectRoot, format = "png") {
   const requested = requireRelativePath(out, "Image output");
   const selected = requireImageFormat(format);
@@ -98,8 +118,10 @@ export async function validateImageOutputPath(out, projectRoot, format = "png") 
 }
 
 export async function saveGeneratedImage(out, projectRoot, base64, format = "png", options = {}) {
-  const buffer = validateGeneratedImageBase64(base64, format);
+  const image = inspectGeneratedImageBase64(base64, format);
+  enforceRequestedDimensions(image, options.requestedSize, format);
   const requestedPath = await validateImageOutputPath(out, projectRoot, format);
   const root = await requireProjectRoot(projectRoot);
-  return secureWriteGeneratedImage(buffer, requestedPath, root, options);
+  const saved = await secureWriteGeneratedImage(image.buffer, requestedPath, root, options);
+  return { ...saved, width: image.width, height: image.height };
 }

--- a/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
@@ -9,6 +9,7 @@ import {
 } from "./gpt-image-auth.mjs";
 import { readReferenceImages, saveGeneratedImage, validateImageOutputPath } from "./gpt-image-io.mjs";
 import { requestApiImage, requestOAuthImage } from "./gpt-image-request.mjs";
+import { resolveGptImageProjectRoot } from "./gpt-image-worktree.mjs";
 
 const IMAGE_QUALITIES = new Set(["low", "medium", "high", "auto"]);
 const IMAGE_FORMATS = new Set(["png", "jpeg", "webp"]);
@@ -20,6 +21,7 @@ function validateOutputArgs(args) {
   if (args.quality !== undefined && !IMAGE_QUALITIES.has(args.quality)) throw new Error("Unsupported image quality.");
   if (args.format !== undefined && !IMAGE_FORMATS.has(args.format)) throw new Error("Unsupported image format.");
   if (args.size !== undefined && typeof args.size !== "string") throw new Error("Image size must be a string.");
+  if (args.workdir !== undefined && typeof args.workdir !== "string") throw new Error("Image workdir must be a string.");
 }
 
 function validateReferenceArgs(args) {
@@ -87,7 +89,7 @@ function billingLabel(mode) {
   return mode === "oauth" ? "ChatGPT subscription OAuth" : "OpenAI Platform API";
 }
 
-async function executeImageGeneration(rawArgs, options) {
+async function executeImageGeneration(rawArgs, options, context) {
   validateRawArgs(rawArgs);
   const args = {
     ...rawArgs,
@@ -96,8 +98,9 @@ async function executeImageGeneration(rawArgs, options) {
     quality: rawArgs.quality || "auto",
     format: rawArgs.format || "png",
   };
-  await validateImageOutputPath(args.out, options.projectRoot, args.format);
-  const images = await readReferenceImages(args.images, options.projectRoot);
+  const project = await resolveGptImageProjectRoot(args.workdir, options.projectRoot, context, options);
+  await validateImageOutputPath(args.out, project.root, args.format);
+  const images = await readReferenceImages(args.images, project.root);
   let auth = await resolveGptImageAuth(args, options);
   let result;
 
@@ -108,14 +111,16 @@ async function executeImageGeneration(rawArgs, options) {
   }
   if (!result.response.ok) throw result.error;
 
-  const saved = await saveGeneratedImage(args.out, options.projectRoot, result.base64, args.format, {
+  const saved = await saveGeneratedImage(args.out, project.root, result.base64, args.format, {
+    requestedSize: args.size,
     scriptsDir: options.scriptsDir,
     spawnImpl: options.imageWriterSpawn,
   });
   if (auth.mode === "oauth") (options.markOAuthSuccess || markOAuthImageSuccess)(auth);
   const versionNote = saved.versioned ? " Existing output was preserved with a versioned filename." : "";
   const cleanupNote = saved.cleanupWarning ? " Temporary-file cleanup reported a filesystem warning." : "";
-  return `Generated image saved to ${saved.projectPath}. Billing route: ${billingLabel(auth.mode)}.${versionNote}${cleanupNote}`;
+  const rootNote = project.linked ? " in the validated session-owned linked worktree" : "";
+  return `Generated image saved to ${saved.projectPath}${rootNote}. Native dimensions: ${saved.width}x${saved.height}. Billing route: ${billingLabel(auth.mode)}.${versionNote}${cleanupNote}`;
 }
 
 export function createGptImageTool(tool, z, options = {}) {
@@ -124,19 +129,20 @@ export function createGptImageTool(tool, z, options = {}) {
   const executionOptions = { ...options, fetchImpl, projectRoot: options.projectRoot || process.cwd() };
   return tool({
     description:
-      "Generate or reference-edit a PNG, JPEG, or WebP with GPT Image 2. Uses ChatGPT OAuth by default; API billing must be selected explicitly with auth=api and a named account alias. Writes only inside the OpenCode project and never overwrites an existing image.",
+      "Generate or reference-edit a PNG, JPEG, or WebP with GPT Image 2. Uses ChatGPT OAuth by default; API billing must be selected explicitly with auth=api and a named account alias. Writes only inside the OpenCode project or a validated session-owned linked worktree and never overwrites an existing image.",
     args: {
       prompt: z.string().describe("Description of the image to generate or edit."),
       out: z.string().describe("Project-relative output path with an extension matching format."),
       format: z.enum(["png", "jpeg", "webp"]).optional().describe("Native output format; defaults to png."),
       quality: z.enum(["low", "medium", "high", "auto"]).optional().describe("GPT Image 2 quality; defaults to auto."),
       size: z.string().optional().describe("auto or WIDTHxHEIGHT satisfying GPT Image 2 constraints."),
+      workdir: z.string().optional().describe("Optional absolute path to the current session-owned linked worktree."),
       images: z.array(z.string()).optional().describe("Optional project-relative PNG, JPEG, or WebP reference image paths."),
       auth: z.enum(["oauth", "api"]).optional().describe("Billing route; defaults to ChatGPT OAuth. API must be explicit."),
       account: z.string().optional().describe("OAuth pool email when auth=oauth, or named API-key alias when auth=api."),
     },
-    async execute(args) {
-      return executeImageGeneration(args && typeof args === "object" ? args : {}, executionOptions);
+    async execute(args, context) {
+      return executeImageGeneration(args && typeof args === "object" ? args : {}, executionOptions, context);
     },
   });
 }

--- a/.agents/plugins/opencode-aidevops/gpt-image-worktree.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-worktree.mjs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { execFile } from "node:child_process";
+import { lstat, realpath } from "node:fs/promises";
+import { isAbsolute, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { requireProjectRoot } from "./gpt-image-paths.mjs";
+
+const execFileAsync = promisify(execFile);
+
+async function gitPath(root, argument) {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", root, "rev-parse", argument], {
+      encoding: "utf8",
+      timeout: 5_000,
+    });
+    const value = stdout.trim();
+    if (!value) throw new Error("missing Git path");
+    return realpath(isAbsolute(value) ? value : resolve(root, value));
+  } catch {
+    throw new Error("Image workdir must be an existing Git worktree root.");
+  }
+}
+
+async function gitWorktreeIdentity(root) {
+  const topLevel = await gitPath(root, "--show-toplevel");
+  if (topLevel !== root) throw new Error("Image workdir must name the Git worktree root.");
+  return {
+    commonDir: await gitPath(root, "--git-common-dir"),
+    gitDir: await gitPath(root, "--git-dir"),
+  };
+}
+
+async function verifyRegisteredOwnership({ root, sessionID, scriptsDir }) {
+  if (!scriptsDir) throw new Error("Image worktree ownership verification is unavailable.");
+  try {
+    const { stdout } = await execFileAsync(
+      join(scriptsDir, "worktree-helper.sh"),
+      ["registry", "verify-owner", root, sessionID],
+      { encoding: "utf8", timeout: 10_000 },
+    );
+    if (stdout.trim() !== "VERIFIED") throw new Error("unexpected verification receipt");
+  } catch {
+    throw new Error("Image workdir is not owned by the current OpenCode session.");
+  }
+}
+
+export async function resolveGptImageProjectRoot(requestedWorkdir, projectRoot, context, options = {}) {
+  const startupRoot = await requireProjectRoot(projectRoot);
+  if (requestedWorkdir === undefined) return { root: startupRoot, linked: false };
+  if (typeof requestedWorkdir !== "string" || !isAbsolute(requestedWorkdir)) {
+    throw new Error("Image workdir must be an absolute linked-worktree path.");
+  }
+
+  let requestedStats;
+  try {
+    requestedStats = await lstat(requestedWorkdir);
+  } catch {
+    throw new Error("Image workdir is unavailable or unsafe.");
+  }
+  if (!requestedStats.isDirectory() || requestedStats.isSymbolicLink()) {
+    throw new Error("Image workdir is unavailable or unsafe.");
+  }
+  const root = await requireProjectRoot(requestedWorkdir);
+  const sessionID = String(context?.sessionID || "");
+  if (!/^ses_[A-Za-z0-9_-]+$/.test(sessionID)) {
+    throw new Error("Image workdir requires a current OpenCode session identity.");
+  }
+
+  const startupIdentity = await gitWorktreeIdentity(await gitPath(startupRoot, "--show-toplevel"));
+  const requestedIdentity = await gitWorktreeIdentity(root);
+  if (startupIdentity.commonDir !== requestedIdentity.commonDir) {
+    throw new Error("Image workdir belongs to an unrelated Git repository.");
+  }
+  if (requestedIdentity.gitDir === requestedIdentity.commonDir) {
+    throw new Error("Image workdir must be a linked Git worktree, not a canonical checkout.");
+  }
+
+  const verifyOwnership = options.verifyWorktreeOwnership || verifyRegisteredOwnership;
+  await verifyOwnership({ root, sessionID, scriptsDir: options.scriptsDir });
+  return { root, linked: true };
+}

--- a/.agents/plugins/opencode-aidevops/pre-edit-check-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/pre-edit-check-tool.mjs
@@ -232,7 +232,7 @@ export function createPreEditCheckTool(tool, z, scriptsDir, timeoutMs = 120000) 
       workdir: z.string().optional().describe('Optional target Git worktree to validate'),
       targetPaths: z.array(z.string()).optional().describe('Optional intended write paths, resolved relative to workdir'),
     },
-    async execute(args) {
+    async execute(args, context) {
       const normalizedArgs = args && typeof args === "object" ? args : {};
       let invocation;
       try {
@@ -245,7 +245,7 @@ export function createPreEditCheckTool(tool, z, scriptsDir, timeoutMs = 120000) 
       const taskArgs = repositoryTarget
         ? [...(normalizedArgs.task ? ["--loop-mode"] : []), "--file", repositoryTarget]
         : (normalizedArgs.task ? ["--loop-mode", "--task", normalizedArgs.task] : []);
-      const result = await runPreEditCheck(script, taskArgs, targetWorkdir, timeoutMs);
+      const result = await runPreEditCheck(script, taskArgs, targetWorkdir, timeoutMs, context);
       return formatPreEditCheckResult(result, timeoutMs);
     },
   });
@@ -258,13 +258,24 @@ export function createPreEditCheckTool(tool, z, scriptsDir, timeoutMs = 120000) 
  * @param {string[]} args
  * @param {string} cwd
  * @param {number} timeoutMs
+ * @param {object} [context] - OpenCode tool context
  * @returns {Promise<{code: number|null, stdout: string, stderr: string, timedOut: boolean, error?: Error}>}
  */
-function runPreEditCheck(script, args, cwd, timeoutMs) {
+function runPreEditCheck(script, args, cwd, timeoutMs, context) {
   return new Promise((resolve) => {
+    const sessionID = String(context?.sessionID || "");
+    const sessionEnv = /^ses_[A-Za-z0-9_-]+$/.test(sessionID)
+      ? {
+          OPENCODE: "1",
+          OPENCODE_PID: String(process.pid),
+          OPENCODE_SESSION_ID: sessionID,
+          AIDEVOPS_OPENCODE_SESSION_ID: sessionID,
+        }
+      : {};
     const child = spawn("bash", [script, ...args], {
       cwd,
       detached: true,
+      env: { ...process.env, ...sessionEnv },
       stdio: ["ignore", "pipe", "pipe"],
     });
     let stdout = "";

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs
@@ -7,7 +7,12 @@ import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { readReferenceImages, saveGeneratedImage, validateImageOutputPath } from "../gpt-image-io.mjs";
+import {
+  inspectGeneratedImageBase64,
+  readReferenceImages,
+  saveGeneratedImage,
+  validateImageOutputPath,
+} from "../gpt-image-io.mjs";
 
 const PNG_BYTES = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
@@ -29,6 +34,30 @@ const OUTPUT_CASES = [
   { bytes: WEBP_BYTES, extension: "webp", format: "webp" },
 ];
 const roots = [];
+
+function crc32(buffer) {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function rasterWithDimensions(bytes, format, width, height) {
+  const result = Buffer.from(bytes);
+  if (format === "png") {
+    result.writeUInt32BE(width, 16);
+    result.writeUInt32BE(height, 20);
+    result.writeUInt32BE(crc32(result.subarray(12, 29)), 29);
+  } else if (format === "jpeg") {
+    result.writeUInt16BE(height, 7);
+    result.writeUInt16BE(width, 9);
+  } else {
+    result.writeUInt32LE((width - 1) | ((height - 1) << 14), 21);
+  }
+  return result;
+}
 
 async function projectRoot() {
   const root = await mkdtemp(join(process.env.AIDEVOPS_TEMP_DIR || tmpdir(), "aidevops-gpt-image-"));
@@ -53,6 +82,35 @@ describe("GPT image file safety", () => {
       assert.equal(second.projectPath, `assets/result-v2.${extension}`);
       assert.deepEqual(await readFile(join(root, first.projectPath)), bytes);
       assert.equal((await lstat(join(root, first.projectPath))).mode & 0o777, 0o600);
+    }
+  });
+
+  test("inspects native dimensions and enforces explicit requests before publication", async () => {
+    const root = await projectRoot();
+    for (const { bytes, extension, format } of OUTPUT_CASES) {
+      const native = rasterWithDimensions(bytes, format, 1024, 1024);
+      const inspected = inspectGeneratedImageBase64(native.toString("base64"), format);
+      assert.deepEqual({ width: inspected.width, height: inspected.height }, { width: 1024, height: 1024 });
+      const saved = await saveGeneratedImage(
+        `assets/exact.${extension}`,
+        root,
+        native.toString("base64"),
+        format,
+        { requestedSize: "1024x1024" },
+      );
+      assert.equal(saved.width, 1024);
+      assert.equal(saved.height, 1024);
+      await assert.rejects(
+        saveGeneratedImage(
+          `assets/mismatch.${extension}`,
+          root,
+          bytes.toString("base64"),
+          format,
+          { requestedSize: "1024x1024" },
+        ),
+        new RegExp(`returned 1x1 ${format.toUpperCase()} for requested 1024x1024; no artifact was written`),
+      );
+      await assert.rejects(readFile(join(root, "assets", `mismatch.${extension}`)), /ENOENT/);
     }
   });
 
@@ -102,7 +160,7 @@ describe("GPT image file safety", () => {
     );
     await assert.rejects(
       saveGeneratedImage("assets/truncated.jpg", root, Buffer.from([0xff, 0xd8, 0xff, 0xd9]).toString("base64"), "jpeg"),
-      /without a terminal marker|invalid terminal JPEG marker/,
+      /without dimensions|without a terminal marker|invalid terminal JPEG marker/,
     );
   });
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs
@@ -3,7 +3,8 @@
 
 import { afterEach, describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -25,6 +26,26 @@ const z = {
   enum: () => schemaNode,
   string: () => schemaNode,
 };
+
+function git(cwd, args) {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+async function gitProject() {
+  const root = await projectRoot();
+  const canonical = join(root, "canonical");
+  const linked = join(root, "linked");
+  await mkdir(canonical);
+  git(canonical, ["init", "--initial-branch=main"]);
+  git(canonical, ["config", "user.email", "test@example.invalid"]);
+  git(canonical, ["config", "user.name", "Test"]);
+  git(canonical, ["config", "commit.gpgsign", "false"]);
+  await writeFile(join(canonical, "README.md"), "fixture\n");
+  git(canonical, ["add", "README.md"]);
+  git(canonical, ["commit", "--no-gpg-sign", "-m", "fixture"]);
+  git(canonical, ["worktree", "add", "-b", "feature/image-fixture", linked]);
+  return { canonical, linked };
+}
 
 async function projectRoot() {
   const root = await mkdtemp(join(process.env.AIDEVOPS_TEMP_DIR || tmpdir(), "aidevops-gpt-tool-"));
@@ -69,6 +90,99 @@ describe("GPT image OpenCode tool", () => {
     assert.match(output, /ChatGPT subscription OAuth/);
     assert.match(output, /generated\/test\.png/);
     assert.doesNotMatch(output, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.match(output, /Native dimensions: 1x1/);
+  });
+
+  test("routes outputs and references into a validated session-owned linked worktree", async () => {
+    const { canonical, linked } = await gitProject();
+    await mkdir(join(linked, "refs"));
+    await writeFile(join(linked, "refs", "source.png"), PNG_BYTES);
+    let ownershipChecks = 0;
+    let requestBody;
+    const tool = createTool({
+      projectRoot: canonical,
+      verifyWorktreeOwnership: async ({ root, sessionID }) => {
+        ownershipChecks += 1;
+        assert.equal(root, linked);
+        assert.equal(sessionID, "ses_image_fixture");
+      },
+      resolveOAuthAccount: async () => ({ email: "person@example.test", access: "oauth-test-token" }),
+      fetchImpl: async (_url, init) => {
+        requestBody = JSON.parse(init.body);
+        return oauthSuccess();
+      },
+    });
+    const args = {
+      prompt: "edit the reference",
+      out: "generated/test.png",
+      images: ["refs/source.png"],
+      workdir: linked,
+    };
+    const context = { sessionID: "ses_image_fixture" };
+    const first = await tool.execute(args, context);
+    const second = await tool.execute(args, context);
+
+    assert.equal(ownershipChecks, 2);
+    assert.match(first, /generated\/test\.png in the validated session-owned linked worktree/);
+    assert.match(second, /versioned filename/);
+    assert.equal(requestBody.input[0].content[1].type, "input_image");
+    assert.deepEqual(await readFile(join(linked, "generated", "test.png")), PNG_BYTES);
+    assert.deepEqual(await readFile(join(linked, "generated", "test-v2.png")), PNG_BYTES);
+    await assert.rejects(access(join(canonical, "generated", "test.png")), /ENOENT/);
+    assert.equal(git(canonical, ["status", "--porcelain"]), "");
+  });
+
+  test("rejects unsafe, unrelated, and incorrectly owned worktree roots", async () => {
+    const first = await gitProject();
+    const second = await gitProject();
+    const alias = join(first.canonical, "linked-alias");
+    await symlink(first.linked, alias, "dir");
+    let calls = 0;
+    const tool = createTool({
+      projectRoot: first.canonical,
+      verifyWorktreeOwnership: async ({ sessionID }) => {
+        if (sessionID !== "ses_image_fixture") throw new Error("wrong session");
+      },
+      fetchImpl: async () => {
+        calls += 1;
+        return oauthSuccess();
+      },
+    });
+    const args = { prompt: "draw", out: "generated/test.png" };
+    await assert.rejects(tool.execute({ ...args, workdir: first.linked }, { sessionID: "ses_other" }), /wrong session/);
+    await assert.rejects(tool.execute({ ...args, workdir: second.linked }, { sessionID: "ses_image_fixture" }), /unrelated Git repository/);
+    await assert.rejects(tool.execute({ ...args, workdir: alias }, { sessionID: "ses_image_fixture" }), /unavailable or unsafe/);
+    await assert.rejects(tool.execute({ ...args, workdir: first.linked }, {}), /current OpenCode session identity/);
+    await assert.rejects(
+      tool.execute({ ...args, out: "../escape.png", workdir: first.linked }, { sessionID: "ses_image_fixture" }),
+      /parent traversal/,
+    );
+    assert.equal(calls, 0);
+  });
+
+  test("surfaces OAuth and Platform API dimension mismatches without writing artifacts", async () => {
+    const root = await projectRoot();
+    const oauthTool = createTool({
+      projectRoot: root,
+      resolveOAuthAccount: async () => ({ email: "person@example.test", access: "oauth-test-token" }),
+      fetchImpl: async () => oauthSuccess(),
+    });
+    await assert.rejects(
+      oauthTool.execute({ prompt: "draw", out: "oauth.png", size: "1024x1024" }),
+      /returned 1x1 PNG for requested 1024x1024; no artifact was written/,
+    );
+
+    const apiTool = createTool({
+      projectRoot: root,
+      readSecret: () => "unit-test-credential-value",
+      fetchImpl: async () => Response.json({ data: [{ b64_json: PNG_BASE64 }] }),
+    });
+    await assert.rejects(
+      apiTool.execute({ prompt: "draw", out: "api.png", size: "1024x1024", auth: "api", account: "work" }),
+      /returned 1x1 PNG for requested 1024x1024; no artifact was written/,
+    );
+    await assert.rejects(access(join(root, "oauth.png")), /ENOENT/);
+    await assert.rejects(access(join(root, "api.png")), /ENOENT/);
   });
 
   test("requests and writes a selected native WebP", async () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
@@ -156,6 +156,8 @@ test("slow loop-mode creation is reported exactly once beyond the former timeout
     git(repo, ["commit", "--no-gpg-sign", "-m", "init"]);
     writeFileSync(join(fixtureScripts, "pre-edit-check.sh"), `#!/usr/bin/env bash
 set -eu
+[[ "\${OPENCODE_SESSION_ID:-}" == "ses_pre_edit_fixture" ]] || exit 9
+[[ "\${OPENCODE_PID:-}" =~ ^[0-9]+$ ]] || exit 10
 linked=${JSON.stringify(linked)}
 if ! /usr/bin/git -C "$PWD" show-ref --verify --quiet refs/heads/bugfix/slow-fixture; then
   sleep 10.1
@@ -165,8 +167,9 @@ printf 'LOOP_DECISION=worktree_created\\nWORKTREE_PATH=%s\\nNEXT_STEP: cd to the
 `);
 
     const preEditTool = createTools(fixtureScripts, () => "").aidevops_pre_edit_check;
-    const firstResult = await preEditTool.execute({ workdir: repo, task: "fix slow fixture" });
-    const secondResult = await preEditTool.execute({ workdir: repo, task: "fix slow fixture" });
+    const context = { sessionID: "ses_pre_edit_fixture" };
+    const firstResult = await preEditTool.execute({ workdir: repo, task: "fix slow fixture" }, context);
+    const secondResult = await preEditTool.execute({ workdir: repo, task: "fix slow fixture" }, context);
 
     assert.match(firstResult, /Pre-edit check PASSED \(exit 0\)/);
     assert.match(firstResult, new RegExp(`WORKTREE_PATH=${linked.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));

--- a/.agents/scripts/tests/test-worktree-registry-session-claim.sh
+++ b/.agents/scripts/tests/test-worktree-registry-session-claim.sh
@@ -8,6 +8,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 REGISTRY_LIB="${SCRIPT_DIR}/../shared-worktree-registry.sh"
+WORKTREE_HELPER="${SCRIPT_DIR}/../worktree-helper.sh"
 TEST_ROOT=$(mktemp -d)
 WORKTREE_REGISTRY_DIR="${TEST_ROOT}/registry"
 WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DIR}/worktree-registry.db"
@@ -82,6 +83,30 @@ create_linked_worktree_fixture() {
 	/usr/bin/git -C "$canonical_path" add README.md || return 1
 	/usr/bin/git -C "$canonical_path" commit -q -m seed || return 1
 	/usr/bin/git -C "$canonical_path" worktree add -q -b "$branch" "$linked_path" || return 1
+	return 0
+}
+
+test_registry_owner_verification_command() {
+	reset_registry
+	local canonical_path="${TEST_ROOT}/verify-canonical"
+	local linked_path="${TEST_ROOT}/verify-linked"
+	local session_id="ses_image_worktree"
+	create_linked_worktree_fixture "$canonical_path" "$linked_path" "feature/verify-linked" || {
+		print_result "registry command verifies exact live session owner" 1
+		return 0
+	}
+	register_worktree "$linked_path" "feature/verify-linked" --owner-pid "$OWNER_PID" --session "$session_id"
+
+	local rc=0 output=""
+	output=$("$WORKTREE_HELPER" registry verify-owner "$linked_path" "$session_id") || rc=1
+	[[ "$output" == "VERIFIED" ]] || rc=1
+	if "$WORKTREE_HELPER" registry verify-owner "$linked_path" "ses_other" >/dev/null 2>&1; then
+		rc=1
+	fi
+	if "$WORKTREE_HELPER" registry verify-owner "$canonical_path" "$session_id" >/dev/null 2>&1; then
+		rc=1
+	fi
+	print_result "registry command verifies exact live session owner" "$rc"
 	return 0
 }
 
@@ -483,6 +508,7 @@ test_owner_writers_fail_when_process_generation_is_unavailable() {
 
 main() {
 	start_live_pids
+	test_registry_owner_verification_command
 	test_same_opencode_session_rolls_owner_pid
 	test_parameterized_claim_preserves_metacharacters
 	test_legacy_equivalent_registry_path_resolves

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -572,6 +572,27 @@ cmd_switch() {
 # --- cmd_registry ---
 
 # Manage the worktree ownership registry (list or prune stale entries).
+_registry_verify_owner() {
+	local wt_path="${1:-}"
+	local session_id="${2:-}"
+	[[ -n "$wt_path" && "$session_id" == ses_* ]] || return 1
+
+	local registry_path=""
+	registry_path=$(_wt_registry_lookup_path "$wt_path") || return 1
+	_wt_path_is_canonical "$registry_path" && return 1
+
+	local snapshot="" owner_pid="" owner_session="" owner_process_start=""
+	local owner_batch="" owner_task="" owner_created="" current_process_start=""
+	snapshot=$(check_worktree_owner_snapshot "$registry_path" 2>/dev/null) || return 1
+	IFS='|' read -r owner_pid owner_session owner_batch owner_task owner_created owner_process_start <<<"$snapshot"
+	[[ "$owner_session" == "$session_id" && "$owner_pid" =~ ^[0-9]+$ ]] || return 1
+	kill -0 "$owner_pid" 2>/dev/null || return 1
+	current_process_start=$(_wt_process_start_token_for_pid "$owner_pid") || return 1
+	[[ -n "$owner_process_start" && "$current_process_start" == "$owner_process_start" ]] || return 1
+	printf 'VERIFIED\n'
+	return 0
+}
+
 cmd_registry() {
 	local subcmd="${1:-list}"
 
@@ -635,8 +656,13 @@ cmd_registry() {
 
 		echo -e "${GREEN}Done: pruned $pruned of $before_count entries ($after_count remaining)${NC}"
 		;;
+	verify-owner)
+		shift
+		_registry_verify_owner "$@"
+		return $?
+		;;
 	*)
-		echo "Usage: worktree-helper.sh registry [list|prune]"
+		echo "Usage: worktree-helper.sh registry [list|prune|verify-owner <path> <session>]"
 		;;
 	esac
 	return 0

--- a/.agents/tools/vision/image-generation.md
+++ b/.agents/tools/vision/image-generation.md
@@ -89,7 +89,8 @@ from a subscription to API credits. Never paste an API key into chat.
 |-----------|---------|-------|
 | `format` | png, jpeg, webp | `png` is the default; output extension must match |
 | `quality` | low, medium, high, auto | `auto` is the default; use low for drafts |
-| `size` | auto or WIDTHxHEIGHT | Edges must be multiples of 16, max 3840px, ratio ≤3:1, total 655,360-8,294,400px |
+| `size` | auto or WIDTHxHEIGHT | Edges must be multiples of 16, max 3840px, ratio ≤3:1, total 655,360-8,294,400px; explicit requests fail before publication if native dimensions differ |
+| `workdir` | absolute linked-worktree path | Optional; must be registered to the current OpenCode session and belong to the startup repository |
 | `images` | 0-8 project-relative paths | Reference-guided generation/editing; PNG, JPEG, or WebP, 20 MiB each |
 | `auth` | oauth, api | OAuth is the default; API billing must be explicit |
 | `account` | OAuth email or API alias | Exact selection only; no silent account substitution |
@@ -98,6 +99,11 @@ OAuth uses OpenCode's Codex channel and is therefore runtime-specific and
 experimental. The public API route calls `gpt-image-2` directly. OpenCode V2
 remains fail-closed until the aidevops V2 adapter implements equivalent tool,
 permission, credential, and session contracts.
+
+When OpenCode starts in a canonical checkout and aidevops creates a linked
+worktree, pass that worktree as `workdir`. Output and reference paths remain
+relative to the validated worktree; absolute image paths and parent traversal
+remain rejected. Every success receipt reports the native raster dimensions.
 
 ### Midjourney
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Since the last README feature refresh, aidevops has added or expanded:
 - **Worker and PR observability**: worker diagnostic failure families, runtime observability signals, review-thread response scanning, required-check validation, orphan-recovery base handling, and safer automated GitHub write guards.
 - **Runtime-neutral safety and evidence contracts**: shared command decisions across supported runtimes, commit-pinned plugin provenance with explicit hook authorization, recognized-client network checks, causal worker lineage, and redacted state snapshots/deltas in the existing observability database.
 - **OpenCode runtime polish**: versioned session title suffixes, session archive retention, OAuth pool hardening, debug-error preservation, and reusable shell-env version lookup in the OpenCode plugin.
+- **Safer GPT image generation**: native raster dimensions are verified before publication, while canonical-root OpenCode sessions can route output and references into the current session-owned linked worktree without weakening path confinement (`.agents/tools/vision/image-generation.md`).
 
 <!-- AI-CONTEXT-END -->
 


### PR DESCRIPTION
## Summary

Allow validated session-owned linked worktrees for GPT image generation and reject requested/native dimension mismatches before publication. Resolves #31094.

## Files Changed

.agents/plugins/opencode-aidevops/gpt-image-dimensions.mjs, .agents/plugins/opencode-aidevops/gpt-image-io.mjs, .agents/plugins/opencode-aidevops/gpt-image-tool.mjs, .agents/plugins/opencode-aidevops/gpt-image-worktree.mjs, .agents/plugins/opencode-aidevops/pre-edit-check-tool.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs, .agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs, .agents/scripts/tests/test-worktree-registry-session-claim.sh, .agents/scripts/worktree-helper-cmds.sh, .agents/tools/vision/image-generation.md, README.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified live worktree ownership; OpenCode plugin tests 757/757 pass; focused GPT image tests 17/17 pass; registry shell tests 16/16 pass; local linters and ShellCheck pass; independent closeout review clean.

Resolves #31093


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.304 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 53m and 410,593 tokens on this with the user in an interactive session.