### PR TITLE
GH#31096: Report requested and native GPT image dimensions

### DIFF
--- a/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-tool.mjs
@@ -120,7 +120,8 @@ async function executeImageGeneration(rawArgs, options, context) {
   const versionNote = saved.versioned ? " Existing output was preserved with a versioned filename." : "";
   const cleanupNote = saved.cleanupWarning ? " Temporary-file cleanup reported a filesystem warning." : "";
   const rootNote = project.linked ? " in the validated session-owned linked worktree" : "";
-  return `Generated image saved to ${saved.projectPath}${rootNote}. Native dimensions: ${saved.width}x${saved.height}. Billing route: ${billingLabel(auth.mode)}.${versionNote}${cleanupNote}`;
+  const dimensions = `${saved.width}x${saved.height}`;
+  return `Generated image saved to ${saved.projectPath}${rootNote}. Requested size: ${args.size}; native dimensions: ${dimensions}. Billing route: ${billingLabel(auth.mode)}.${versionNote}${cleanupNote}`;
 }
 
 export function createGptImageTool(tool, z, options = {}) {

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs
@@ -78,6 +78,8 @@ describe("GPT image file safety", () => {
       const second = await saveGeneratedImage(requested, root, bytes.toString("base64"), format);
       assert.equal(first.versioned, false);
       assert.equal(second.versioned, true);
+      assert.deepEqual({ width: first.width, height: first.height }, { width: 1, height: 1 });
+      assert.deepEqual({ width: second.width, height: second.height }, { width: 1, height: 1 });
       assert.equal(first.projectPath, requested);
       assert.equal(second.projectPath, `assets/result-v2.${extension}`);
       assert.deepEqual(await readFile(join(root, first.projectPath)), bytes);

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
@@ -49,8 +49,27 @@ describe("GPT image provider requests", () => {
     assert.equal(captured.init.headers.Authorization, "Bearer oauth-test-token");
     assert.equal(body.tools[0].type, "image_generation");
     assert.equal(body.tools[0].output_format, "webp");
+    assert.equal(body.tools[0].size, "1024x1024");
     assert.equal(body.input[0].content[1].type, "input_image");
     assert.equal(result.base64, IMAGE_RESULT);
+  });
+
+  test("leaves OAuth hosted-tool size automatic when auto is requested", async () => {
+    let captured;
+    const event = `data: ${JSON.stringify({
+      type: "response.output_item.done",
+      item: { type: "image_generation_call", result: IMAGE_RESULT },
+    })}\n\n`;
+    await requestOAuthImage(
+      { accessToken: "oauth-test-token" },
+      { prompt: "draw a test", quality: "auto", size: "auto", format: "png" },
+      [],
+      async (_url, init) => {
+        captured = JSON.parse(init.body);
+        return new Response(event, { status: 200 });
+      },
+    );
+    assert.equal(Object.hasOwn(captured.tools[0], "size"), false);
   });
 
   test("uses the explicit GPT Image 2 generations endpoint for API auth", async () => {
@@ -80,11 +99,13 @@ describe("GPT image provider requests", () => {
     };
     await requestApiImage(
       { accessToken: "unit-test-credential-value" },
-      { prompt: "draw a test", quality: "auto", size: "auto", format: "jpeg" },
+      { prompt: "draw a test", quality: "auto", size: "1536x864", format: "jpeg" },
       [],
       fetchImpl,
     );
-    assert.equal(JSON.parse(captured.init.body).output_format, "jpeg");
+    const body = JSON.parse(captured.init.body);
+    assert.equal(body.output_format, "jpeg");
+    assert.equal(body.size, "1536x864");
   });
 
   test("uses multipart GPT Image 2 edits when API references are present", async () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs
@@ -89,8 +89,8 @@ describe("GPT image OpenCode tool", () => {
     assert.equal(calls, 1);
     assert.match(output, /ChatGPT subscription OAuth/);
     assert.match(output, /generated\/test\.png/);
+    assert.match(output, /Requested size: auto; native dimensions: 1x1/);
     assert.doesNotMatch(output, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-    assert.match(output, /Native dimensions: 1x1/);
   });
 
   test("routes outputs and references into a validated session-owned linked worktree", async () => {

--- a/.agents/tools/vision/image-generation.md
+++ b/.agents/tools/vision/image-generation.md
@@ -105,6 +105,14 @@ worktree, pass that worktree as `workdir`. Output and reference paths remain
 relative to the validated worktree; absolute image paths and parent traversal
 remain rejected. Every success receipt reports the native raster dimensions.
 
+The public Platform API documents `size` as the requested output geometry and
+supports constrained flexible dimensions for GPT Image 2 generation. The
+ChatGPT OAuth route uses a private hosted-tool endpoint without the same stable
+contract and may return different native geometry. The tool therefore decodes
+PNG, JPEG, and WebP dimensions before writing: an explicit-size mismatch fails
+without creating a file, while `auto` accepts the provider-selected size. Every
+successful result reports both the requested size and observed native dimensions.
+
 ### Midjourney
 
 No REST API — use Discord `/imagine` or [midjourney.com](https://www.midjourney.com/).


### PR DESCRIPTION
## Summary

Build on the merged native-dimension enforcement by reporting requested and observed dimensions, testing OAuth and Platform request contracts separately, and documenting the private OAuth endpoint behavior.

## Files Changed

.agents/plugins/opencode-aidevops/gpt-image-tool.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt-image-io.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt-image-tool.mjs, .agents/tools/vision/image-generation.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: Focused GPT Image tests passed (23/23); changed-file lint and secret checks passed; live OAuth smoke caught the observed 1254x1254 response for a 1024x1024 request before writing. Broad plugin suite passed 753/754 before rebase, with only the pre-existing missing @opencode-ai/plugin dependency affecting the unrelated V2 adapter test in a fresh worktree.

Resolves #31096


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.304 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 47m and 388,588 tokens on this with the user in an interactive session.