### PR TITLE
GH#31109: fix(full-loop): reconcile signed merge summary bodies

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -1817,17 +1817,24 @@ _reconcile_existing_merge_summary() {
 	local merge_summary_marker="$4"
 	local merge_summary_body="$5"
 	local existing_summary=""
-	local summary_record_jq=".[] | select(.body | test(\"${merge_summary_marker}\")) | [.id, .body] | @tsv"
+	local summary_id=""
+	local existing_body=""
+	local summary_id_jq="[.[] | select(.body | test(\$marker))] | first | .id"
+	local summary_body_jq="[.[] | select(.body | test(\$marker))] | first | .body"
 
 	existing_summary=$(_gh_with_timeout read gh api "$comments_endpoint" \
-		--jq "$summary_record_jq" 2>/dev/null) || {
+		2>/dev/null) || {
 		print_error "Could not read the canonical merge summary comment on PR #${pr_number}"
 		return 1
 	}
-	local summary_id="${existing_summary%%$'\t'*}"
-	local existing_body="${existing_summary#*$'\t'}"
-	if [[ -z "$summary_id" || "$summary_id" == "$existing_summary" ]]; then
+	if ! summary_id=$(printf '%s' "$existing_summary" |
+		jq -er --arg marker "$merge_summary_marker" "$summary_id_jq"); then
 		print_error "Could not identify the canonical merge summary comment on PR #${pr_number}"
+		return 1
+	fi
+	if ! existing_body=$(printf '%s' "$existing_summary" |
+		jq -er --arg marker "$merge_summary_marker" "$summary_body_jq"); then
+		print_error "Could not read the canonical merge summary comment body on PR #${pr_number}"
 		return 1
 	fi
 	if [[ "$existing_body" == "$merge_summary_body"* ]]; then
@@ -1840,11 +1847,15 @@ _reconcile_existing_merge_summary() {
 		return 1
 	fi
 	existing_summary=$(_gh_with_timeout read gh api "$comments_endpoint" \
-		--jq "$summary_record_jq" 2>/dev/null) || {
+		2>/dev/null) || {
 		print_error "Could not verify the updated canonical merge summary comment on PR #${pr_number}"
 		return 1
 	}
-	existing_body="${existing_summary#*$'\t'}"
+	if ! existing_body=$(printf '%s' "$existing_summary" |
+		jq -er --arg marker "$merge_summary_marker" "$summary_body_jq"); then
+		print_error "Could not read the updated canonical merge summary comment body on PR #${pr_number}"
+		return 1
+	fi
 	if [[ "$existing_body" != "$merge_summary_body"* ]]; then
 		print_error "Canonical merge summary comment on PR #${pr_number} did not reach the generated metadata postcondition"
 		return 1

--- a/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
+++ b/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
@@ -257,6 +257,9 @@ export -f _gh_recover_pr_if_exists
 GH_EXISTING_MERGE_SUMMARY_COUNT=0
 # Control variable: set to 1 to simulate only malformed plain-text MERGE_SUMMARY existing
 GH_MALFORMED_MERGE_SUMMARY_ONLY=0
+# Control variable: emulate generated origin/signature metadata appended by the
+# GitHub write wrapper after a PATCH request.
+GH_APPEND_GENERATED_METADATA=0
 # Control variables for direct origin-label readback tests.
 ORIGIN_API_FAIL=0
 ORIGIN_API_LABELS='["origin:worker"]'
@@ -281,6 +284,13 @@ gh() {
 				body=*) GH_EXISTING_MERGE_SUMMARY_BODY="${arg#body=}" ;;
 				esac
 			done
+			if [[ "$GH_APPEND_GENERATED_METADATA" -eq 1 ]]; then
+				GH_EXISTING_MERGE_SUMMARY_BODY+=$'\n<!-- aidevops:origin:interactive -->\n<!-- aidevops:sig -->'
+			fi
+			return 0
+		fi
+		if [[ "$*" == *"repos/owner/repo/issues/999/comments"* && "$*" != *"--jq"* ]]; then
+			jq -cn --arg body "$GH_EXISTING_MERGE_SUMMARY_BODY" '[{id: 77, body: $body}]'
 			return 0
 		fi
 		if [[ "$*" == *'startswith("origin:")'* ]]; then
@@ -290,7 +300,8 @@ gh() {
 		fi
 		if [[ "$*" == *'<!-- MERGE_SUMMARY -->'* ]]; then
 			if [[ "$*" == *'@tsv'* ]]; then
-				printf '77\t%s\n' "$GH_EXISTING_MERGE_SUMMARY_BODY"
+				jq -cnr --arg body "$GH_EXISTING_MERGE_SUMMARY_BODY" \
+					'[{id: 77, body: $body}] | .[] | [.id, .body] | @tsv'
 				return 0
 			fi
 			printf '%s\n' "$GH_EXISTING_MERGE_SUMMARY_COUNT"
@@ -772,6 +783,7 @@ fi
 : >"$STUB_LOG"
 GH_EXISTING_MERGE_SUMMARY_COUNT=1
 GH_EXISTING_MERGE_SUMMARY_BODY=$'<!-- MERGE_SUMMARY -->\n## Completion Summary\n\n- **What**: impl\n- **Issue**: #42\n- **Files changed**: old-file.sh\n- **Testing**: old test\n- **Key decisions**: old decision'
+GH_APPEND_GENERATED_METADATA=1
 
 stale_update_rc=0
 _post_merge_summary "999" "owner/repo" "42" "impl" "new-file.sh" "new test" "new decision" || stale_update_rc=$?
@@ -786,6 +798,7 @@ else
 	fail "stale summary: canonical comment is updated in place with retry metadata" \
 		"rc=${stale_update_rc}; body='${GH_EXISTING_MERGE_SUMMARY_BODY}'; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
 fi
+GH_APPEND_GENERATED_METADATA=0
 
 # =============================================================================
 # Test 4a: _post_merge_summary ignores malformed plain-text MERGE_SUMMARY comments


### PR DESCRIPTION
## Summary

Read full comment JSON without losing multiline bodies during merge-summary reconciliation

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/tests/test-commit-and-pr-partial-success.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-commit-and-pr-partial-success.sh; shellcheck .agents/scripts/full-loop-helper-commit.sh .agents/scripts/tests/test-commit-and-pr-partial-success.sh

Resolves #31109


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.305 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-terra spent 7m and 72,650 tokens on this as a headless worker.