### PR TITLE
GH#31115: advance deterministic Qlty CLI to 0.643.0

### DIFF
--- a/.agents/scripts/tests/test-dependency-review-policy.sh
+++ b/.agents/scripts/tests/test-dependency-review-policy.sh
@@ -60,7 +60,7 @@ main() {
 	assert_present "Dependabot ignore is bounded to qlty action 2.3.0" \
 		'- "2.3.0"' "$DEPENDABOT_CONFIG" || true
 	assert_present "Code quality keeps the deterministic Qlty CLI version" \
-		'QLTY_VERSION: "0.636.0"' "$CODE_QUALITY_WORKFLOW" || true
+		'QLTY_VERSION: "0.643.0"' "$CODE_QUALITY_WORKFLOW" || true
 	assert_present "Code quality keeps qlty-action install v2.2.0" \
 		'qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0' \
 		"$CODE_QUALITY_WORKFLOW" || true

--- a/.agents/scripts/tests/test-post-merge-verify-report.sh
+++ b/.agents/scripts/tests/test-post-merge-verify-report.sh
@@ -107,7 +107,7 @@ else
 	fail "post-merge ripgrep bootstrap" "missing ripgrep package installation"
 fi
 
-if grep -qF 'QLTY_VERSION: "0.636.0"' "$WORKFLOW" &&
+if grep -qF 'QLTY_VERSION: "0.643.0"' "$WORKFLOW" &&
 	grep -qF 'qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899' "$WORKFLOW"; then
 	pass "post-merge verification installs the repository-pinned Qlty CLI"
 else

--- a/.agents/scripts/tests/test-qlty-workflow-version-pin.sh
+++ b/.agents/scripts/tests/test-qlty-workflow-version-pin.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-EXPECTED_VERSION="0.636.0"
+EXPECTED_VERSION="0.643.0"
 WORKFLOWS=(
 	".github/workflows/code-quality.yml"
 	".github/workflows/qlty-new-file-gate.yml"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,7 +2,7 @@ name: Code Quality Analysis
 
 # qlty-action/install otherwise resolves its moving `latest` release.
 env:
-  QLTY_VERSION: "0.636.0"
+  QLTY_VERSION: "0.643.0"
 
 on:
   push:
@@ -922,7 +922,7 @@ jobs:
     name: Qlty Smell Threshold
     runs-on: ubuntu-latest
     env:
-      QLTY_CLI_VERSION: "0.636.0"
+      QLTY_CLI_VERSION: "0.643.0"
 
     steps:
     - name: Checkout code

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -3,7 +3,7 @@ name: Post-Merge Brief Verification
 # Keep post-merge acceptance checks on the same pinned Qlty CLI as required PR
 # quality gates. Brief verify blocks may call the repository Qlty helpers.
 env:
-  QLTY_VERSION: "0.636.0"
+  QLTY_VERSION: "0.643.0"
 
 # t2135: After a PR merges to main, extract the task ID from the PR title,
 # locate the corresponding brief file, parse verify: YAML blocks from its

--- a/.github/workflows/qlty-new-file-gate.yml
+++ b/.github/workflows/qlty-new-file-gate.yml
@@ -2,7 +2,7 @@ name: Qlty New-File Gate
 
 # qlty-action/install otherwise resolves its moving `latest` release.
 env:
-  QLTY_VERSION: "0.636.0"
+  QLTY_VERSION: "0.643.0"
 
 # t2068: block PRs that add brand-new source files shipping with any
 # qlty smells.

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -3,7 +3,7 @@ name: Qlty Regression Gate
 # qlty-action/install inherits QLTY_VERSION; keep it aligned with the
 # QLTY_CLI_VERSION contract validated by the helper below.
 env:
-  QLTY_VERSION: "0.636.0"
+  QLTY_VERSION: "0.643.0"
 
 # t2065: block PRs that increase the total qlty smell count.
 #
@@ -105,7 +105,7 @@ jobs:
     name: Qlty Smell Regression
     runs-on: ubuntu-latest
     env:
-      QLTY_CLI_VERSION: "0.636.0"
+      QLTY_CLI_VERSION: "0.643.0"
     needs: detect-scope
     if: needs.detect-scope.outputs.should_scan == 'true'
     steps:

--- a/.github/workflows/ratchet-post-merge.yml
+++ b/.github/workflows/ratchet-post-merge.yml
@@ -2,7 +2,7 @@ name: Ratchet Post-Merge
 
 # qlty-action/install otherwise resolves its moving `latest` release.
 env:
-  QLTY_VERSION: "0.636.0"
+  QLTY_VERSION: "0.643.0"
 
 # GH#18775 (t2067): post-merge auto-ratchet for QLTY_SMELL_THRESHOLD.
 # When a PR merges to main and the total qlty smell count drops below


### PR DESCRIPTION
## Summary

Advance all active workflow and validator pins to Qlty CLI 0.643.0 while retaining qlty-action/install v2.2.0 for deterministic QLTY_VERSION handling.

## Files Changed

.agents/scripts/tests/test-dependency-review-policy.sh, .agents/scripts/tests/test-post-merge-verify-report.sh, .agents/scripts/tests/test-qlty-workflow-version-pin.sh, .github/workflows/code-quality.yml, .github/workflows/post-merge-verify.yml, .github/workflows/qlty-new-file-gate.yml, .github/workflows/qlty-regression.yml, .github/workflows/ratchet-post-merge.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Focused Qlty pin, post-merge verification, and dependency-policy tests passed; ShellCheck and local linters passed; exact hosted Qlty behavior is delegated to required PR checks.

Resolves #31115


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.305 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 15m and 181,035 tokens on this with the user in an interactive session.