### PR TITLE
t18316: fix cross-host claim expiry and registry reconciliation

### DIFF
--- a/.agents/scripts/cleanup-worktrees-async-helper.sh
+++ b/.agents/scripts/cleanup-worktrees-async-helper.sh
@@ -204,6 +204,18 @@ _update_last_run() {
 	return 0
 }
 
+_reconcile_worktree_registry() {
+	if ! declare -F prune_worktree_registry >/dev/null 2>&1; then
+		echo "[cleanup-worktrees-async] registry prune unavailable; skipping reconciliation" >>"$LOGFILE"
+		return 0
+	fi
+	if ! prune_worktree_registry >>"$LOGFILE" 2>&1; then
+		echo "[cleanup-worktrees-async] registry reconciliation failed closed; continuing guarded cleanup" >>"$LOGFILE"
+		return 0
+	fi
+	return 0
+}
+
 _prune_dirty_worktree_backups() {
 	local helper_path="${SCRIPT_DIR}/dirty-worktree-backup-helper.sh"
 	local retention_days="${DIRTY_WORKTREE_BACKUP_RETENTION_DAYS:-30}"
@@ -290,6 +302,7 @@ main() {
 	fi
 
 	echo "[cleanup-worktrees-async] Starting cleanup_worktrees (cadence OK)" >>"$LOGFILE"
+	_reconcile_worktree_registry
 
 	local rc=0
 	local outcome="success"

--- a/.agents/scripts/interactive-session-helper-stamp.sh
+++ b/.agents/scripts/interactive-session-helper-stamp.sh
@@ -104,6 +104,34 @@ _isc_delete_stamp() {
 	return 0
 }
 
+# Cross-host PIDs cannot be verified locally, so remote authority is bounded by
+# a renewable stamp age. Return 0 while fresh, 1 when conclusively expired or
+# implausibly future-dated, and 2 when timestamp parsing is unavailable or
+# malformed (callers fail closed).
+_isc_cross_host_claim_freshness() {
+	local claimed_at="$1"
+	local ttl_hours="${AIDEVOPS_CROSS_HOST_CLAIM_TTL_HOURS:-168}"
+	local future_skew_seconds="${AIDEVOPS_CROSS_HOST_CLAIM_FUTURE_SKEW_SECONDS:-300}"
+	[[ "$ttl_hours" =~ ^[1-9][0-9]*$ && "$ttl_hours" -le 8760 ]] || ttl_hours=168
+	[[ "$future_skew_seconds" =~ ^[0-9]+$ && "$future_skew_seconds" -le 86400 ]] || future_skew_seconds=300
+	[[ -n "$claimed_at" ]] || return 2
+
+	local claimed_epoch=""
+	local now_epoch=""
+	claimed_epoch=$(jq -nr --arg value "$claimed_at" \
+		'try ($value | fromdateiso8601) catch empty' 2>/dev/null || true)
+	now_epoch=$(date +%s 2>/dev/null || true)
+	[[ "$claimed_epoch" =~ ^[0-9]+$ && "$now_epoch" =~ ^[0-9]+$ ]] || return 2
+
+	if [[ "$claimed_epoch" -gt $((now_epoch + future_skew_seconds)) ]]; then
+		return 1
+	fi
+	if [[ $((now_epoch - claimed_epoch)) -gt $((ttl_hours * 3600)) ]]; then
+		return 1
+	fi
+	return 0
+}
+
 # List stampless origin:interactive claims for a single repo (t2148).
 #
 # Detection rule: an issue is a "stampless interactive claim" when all of:
@@ -243,8 +271,8 @@ _isc_extract_issue_from_branch() {
 # pass it via --worktree.
 #
 # Exit:
-#   0 — active claim exists (stamp present, PID alive, hostname matches)
-#   1 — no active claim (no stamp, or stamp is stale/cross-host/dead-PID)
+#   0 — active claim exists (local PID alive, or fresh/unknown cross-host age)
+#   1 — no active claim (no stamp, dead PID, or conclusively stale cross-host)
 #
 # Fail-open contract: any error in slug derivation, branch parsing, or
 # stamp parsing returns 1 (no claim). The caller treats "no claim" as
@@ -305,19 +333,22 @@ _isc_branch_has_active_claim() {
 	[[ -f "$stamp_file" ]] || return 1
 
 	# Read stamp fields. Treat any jq error as "no claim" (fail-open).
-	local pid hostname stored_hash
+	local pid hostname stored_hash claimed_at
 	pid=$(jq -r '.pid // empty' "$stamp_file" 2>/dev/null || echo "")
 	hostname=$(jq -r '.hostname // empty' "$stamp_file" 2>/dev/null || echo "")
 	stored_hash=$(jq -r '.owner_argv_hash // empty' "$stamp_file" 2>/dev/null || echo "")
+	claimed_at=$(jq -r '.claimed_at // empty' "$stamp_file" 2>/dev/null || echo "")
 
-	# Cross-host stamps cannot have their PID verified. Other hosts are
-	# assumed to be the authority for their own claims — if a remote
-	# session is alive on a different machine, we still want to skip
-	# cleanup of its worktree; if it's dead, scan-stale on that host
-	# will reap it. Trust the stamp existence.
+	# Cross-host stamps cannot have their PID verified. Trust remote authority
+	# only within a bounded renewable lease. Missing or malformed timestamps stay
+	# active (fail closed); expired or implausibly future timestamps release only
+	# this gate so the remaining cleanup protections still decide.
 	local local_host
 	local_host=$(_isc_hostname_or_fallback)
 	if [[ -n "$hostname" && "$hostname" != "$local_host" ]]; then
+		local freshness_rc=0
+		_isc_cross_host_claim_freshness "$claimed_at" || freshness_rc=$?
+		[[ "$freshness_rc" -eq 1 ]] && return 1
 		return 0
 	fi
 

--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -1423,14 +1423,46 @@ _wt_registry_entry_count() {
 	return 0
 }
 
-# Prune stale registry entries (dead PIDs, missing directories, corrupted paths)
+# Reconcile ownership rows whose worktree directories still exist. Missing
+# directories are handled by the batch path below; surviving worktrees need the
+# generation-aware owner checks so dead runtimes and recycled PIDs do not leave
+# permanent registry locks. This updates registry metadata only and never
+# removes a worktree directory or bypasses downstream cleanup gates.
+_wt_registry_reconcile_existing_owners() {
+	local reconcile_limit="${WORKTREE_REGISTRY_RECONCILE_LIMIT:-500}"
+	[[ "$reconcile_limit" =~ ^[1-9][0-9]*$ && "$reconcile_limit" -le 5000 ]] || reconcile_limit=500
+
+	local separator=$'\x1f'
+	local entries=""
+	entries=$(sqlite3 -separator "$separator" "$WORKTREE_REGISTRY_DB" "
+        SELECT worktree_path, owner_pid
+        FROM worktree_owners
+        ORDER BY CASE WHEN COALESCE(owner_dead_seen_at, '') = '' THEN 1 ELSE 0 END,
+                 owner_dead_seen_at, created_at
+        LIMIT ${reconcile_limit};
+    " 2>/dev/null) || return 1
+	[[ -z "$entries" ]] && return 0
+
+	local my_pid="$$"
+	local wt_path=""
+	local _owner_pid=""
+	while IFS="$separator" read -r wt_path _owner_pid; do
+		[[ -n "$wt_path" && -d "$wt_path" ]] || continue
+		_wt_is_worktree_owned_by_others_for_resolved_pid "$wt_path" "$my_pid" \
+			>/dev/null 2>&1 || true
+	done <<<"$entries"
+	return 0
+}
+
+# Prune stale registry entries and reconcile dead or recycled owners.
 # (t197) Enhanced to handle:
-#   - Dead PIDs with missing directories
+#   - Dead or recycled owner processes for surviving worktree directories
+#   - Missing worktree directories
 #   - Paths with ANSI escape codes (corrupted entries)
 #   - Test artifacts in /tmp or /var/folders
 prune_worktree_registry() {
 	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 0
-	_init_registry_db
+	_init_registry_db || return 1
 
 	local pruned_count=0
 
@@ -1475,6 +1507,11 @@ prune_worktree_registry() {
 			[[ -n "${VERBOSE:-}" ]] && _wt_registry_print_pruned_entries "$stale_entries"
 		fi
 	fi
+
+	# Existing directories may still have abandoned ownership after runtime
+	# crashes. Reconcile those rows independently; deletion remains the normal
+	# guarded cleanup pipeline's responsibility.
+	_wt_registry_reconcile_existing_owners || return 1
 
 	[[ -n "${VERBOSE:-}" ]] && echo "Pruned $pruned_count entries total"
 	return 0

--- a/.agents/scripts/tests/test-cleanup-worktrees-async.sh
+++ b/.agents/scripts/tests/test-cleanup-worktrees-async.sh
@@ -88,6 +88,8 @@ STUB
 	# Use literal return 0 / return 1 (not a variable) so the pre-commit
 	# return-statement ratchet doesn't flag the heredoc-embedded function.
 	local mock_ran_file="${TEST_DIR}/mock-ran"
+	local lifecycle_file="${TEST_DIR}/cleanup-lifecycle"
+	local registry_reconcile_file="${TEST_DIR}/registry-reconcile-ran"
 	local maintenance_ran_file="${TEST_DIR}/maintenance-ran"
 	local metadata_prune_ran_file="${TEST_DIR}/metadata-prune-ran"
 	local maintenance_result="${MOCK_MAINTENANCE_RESULT:-{\"schema\":\"test\",\"outcome\":\"no-candidates\"}}"
@@ -95,6 +97,7 @@ STUB
 		cat >"${stub_dir}/pulse-cleanup.sh" <<STUB
 # stub pulse-cleanup.sh
 cleanup_worktrees() {
+	printf 'CLEANUP\n' >>"${lifecycle_file}"
 	printf 'MOCK_RAN\n' >>"${mock_ran_file}"
 	CLEANUP_WORKTREES_SKIPPED=1
 	return 0
@@ -104,6 +107,7 @@ STUB
 		cat >"${stub_dir}/pulse-cleanup.sh" <<STUB
 # stub pulse-cleanup.sh
 _mock_cleanup_worktrees() {
+	printf 'CLEANUP\n' >>"${lifecycle_file}"
 	printf 'MOCK_RAN\n' >>"${mock_ran_file}"
 	return 1
 }
@@ -114,6 +118,7 @@ STUB
 		cat >"${stub_dir}/pulse-cleanup.sh" <<STUB
 # stub pulse-cleanup.sh
 cleanup_worktrees() {
+	printf 'CLEANUP\n' >>"${lifecycle_file}"
 	printf 'MOCK_RAN\n' >>"${mock_ran_file}"
 	return 0
 }
@@ -124,6 +129,23 @@ CLEANUP_WORKTREES_REMOVED_COUNT="${MOCK_REMOVED_COUNT:-0}"
 CLEANUP_WORKTREES_ARCHIVED_COUNT="${MOCK_ARCHIVED_COUNT:-0}"
 CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT="${MOCK_ARCHIVE_FAILED_COUNT:-0}"
 STUB
+	if [[ "${MOCK_REGISTRY_RECONCILE_EXIT:-0}" -ne 0 ]]; then
+		cat >>"${stub_dir}/pulse-cleanup.sh" <<STUB
+prune_worktree_registry() {
+	printf 'REGISTRY_RECONCILE_RAN\n' >>"${registry_reconcile_file}"
+	printf 'REGISTRY_RECONCILE\n' >>"${lifecycle_file}"
+	return 1
+}
+STUB
+	else
+		cat >>"${stub_dir}/pulse-cleanup.sh" <<STUB
+prune_worktree_registry() {
+	printf 'REGISTRY_RECONCILE_RAN\n' >>"${registry_reconcile_file}"
+	printf 'REGISTRY_RECONCILE\n' >>"${lifecycle_file}"
+	return 0
+}
+STUB
+	fi
 
 	# Copy the helper into stub_dir so that when it runs, BASH_SOURCE[0] points
 	# to stub_dir and dirname "${BASH_SOURCE[0]}" resolves to stub_dir. This
@@ -187,7 +209,9 @@ STUB
 # ============================================================
 test_cold_start() {
 	local mock_ran="${TEST_DIR}/mock-ran"
-	rm -f "$mock_ran"
+	local registry_reconcile_ran="${TEST_DIR}/registry-reconcile-ran"
+	local lifecycle_file="${TEST_DIR}/cleanup-lifecycle"
+	rm -f "$mock_ran" "$registry_reconcile_ran" "$lifecycle_file"
 
 	MOCK_CLEANUP_EXIT=0 run_helper_in_isolation || true
 
@@ -196,6 +220,32 @@ test_cold_start() {
 	else
 		print_result "cold-start: cleanup_worktrees runs on first invocation" 1 \
 			"mock-ran marker not created; cleanup_worktrees was not called"
+	fi
+	local lifecycle=""
+	lifecycle=$(tr '\n' ' ' <"$lifecycle_file" 2>/dev/null || true)
+	if [[ -f "$registry_reconcile_ran" ]] && grep -q "REGISTRY_RECONCILE_RAN" "$registry_reconcile_ran" &&
+		[[ "$lifecycle" == "REGISTRY_RECONCILE CLEANUP " ]]; then
+		print_result "cold-start: registry ownership reconciles before cleanup" 0
+	else
+		print_result "cold-start: registry ownership reconciles before cleanup" 1 \
+			"registry reconciliation order was '${lifecycle}'"
+	fi
+	return 0
+}
+
+test_registry_reconciliation_failure_is_isolated() {
+	local mock_ran="${TEST_DIR}/mock-ran"
+	local last_run_file="${TEST_DIR}/.aidevops/logs/cleanup_worktrees.last-run"
+	local cleanup_log="${TEST_DIR}/.aidevops/logs/cleanup_worktrees.log"
+	rm -f "$mock_ran" "$last_run_file" "$cleanup_log"
+
+	MOCK_REGISTRY_RECONCILE_EXIT=1 MOCK_CLEANUP_EXIT=0 run_helper_in_isolation || true
+	if [[ -f "$mock_ran" && -f "$last_run_file" ]] &&
+		grep -q "registry reconciliation failed closed; continuing guarded cleanup" "$cleanup_log" 2>/dev/null; then
+		print_result "registry-reconcile: failure is logged and guarded cleanup continues" 0
+	else
+		print_result "registry-reconcile: failure is logged and guarded cleanup continues" 1 \
+			"cleanup marker, last-run, or failure diagnostic missing"
 	fi
 	return 0
 }
@@ -563,6 +613,11 @@ main() {
 	setup
 
 	test_cold_start
+	teardown
+	setup
+	test_registry_reconciliation_failure_is_isolated
+	teardown
+	setup
 	test_last_run_updated
 
 	# Must re-setup between tests that share state

--- a/.agents/scripts/tests/test-worktree-cleanup-claim-guard.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-claim-guard.sh
@@ -15,14 +15,15 @@
 #   2. _isc_branch_has_active_claim — live PID + matching hostname → 0
 #   3. _isc_branch_has_active_claim — dead PID → 1
 #   4. _isc_branch_has_active_claim — no stamp → 1
-#   5. _isc_branch_has_active_claim — cross-host stamp → 0 (trust remote
-#      authority for own claims)
-#   6. _isc_branch_has_active_claim — unparseable branch (no issue) → 1
-#   7. should_skip_cleanup — active claim → skip (regression guard)
-#   8. should_skip_cleanup — dead-PID stamp → no skip from claim check
+#   5. _isc_branch_has_active_claim — recent cross-host stamp → 0
+#   6. _isc_branch_has_active_claim — expired/future cross-host stamp → 1
+#   7. _isc_branch_has_active_claim — malformed cross-host timestamp → 0
+#   8. _isc_branch_has_active_claim — unparseable branch (no issue) → 1
+#   9. should_skip_cleanup — active claim → skip (regression guard)
+#   10. should_skip_cleanup — dead-PID stamp → no skip from claim check
 #      (falls through to existing checks)
-#   9. should_skip_cleanup — no stamp → existing behaviour preserved
-#   10. CLI subcommand `branch-has-active-claim` round-trips correctly
+#   11. should_skip_cleanup — no stamp → existing behaviour preserved
+#   12. CLI subcommand `branch-has-active-claim` round-trips correctly
 #
 # All tests stub `gh` via PATH shim and write real stamp JSON files in a
 # sandboxed HOME so no network or real claim state is touched.
@@ -249,16 +250,18 @@ test_no_stamp() {
 test_no_stamp
 
 # =============================================================================
-# Test 5 — cross-host stamp → trust remote authority (active claim)
+# Test 5 — recent cross-host stamp → trust remote authority (active claim)
 # =============================================================================
 test_cross_host_active() {
 	local issue=99004
 	local stamp="${CLAIM_DIR}/testowner-testrepo-${issue}.json"
-	jq -n '{
+	local claimed_at
+	claimed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	jq -n --arg claimed_at "$claimed_at" '{
 		issue: 99004,
 		slug: "testowner/testrepo",
 		worktree_path: "/tmp/wt-claim-99004",
-		claimed_at: "2026-04-29T00:00:00Z",
+		claimed_at: $claimed_at,
 		pid: 999998,
 		hostname: "different-host-machine-xyz",
 		user: "testuser"
@@ -275,8 +278,82 @@ test_cross_host_active() {
 }
 test_cross_host_active
 
+test_cross_host_expired() {
+	local issue=99006
+	local stamp="${CLAIM_DIR}/testowner-testrepo-${issue}.json"
+	jq -n '{
+		issue: 99006,
+		slug: "testowner/testrepo",
+		worktree_path: "/tmp/wt-claim-99006",
+		claimed_at: "2020-01-01T00:00:00Z",
+		pid: 999997,
+		hostname: "different-host-machine-xyz",
+		user: "testuser"
+	}' >"$stamp"
+
+	AIDEVOPS_CROSS_HOST_CLAIM_TTL_HOURS=24 \
+		_isc_branch_has_active_claim "feature/gh-${issue}-test" --worktree "$FAKE_REPO" >/dev/null 2>&1
+	local rc=$?
+	rm -f "$stamp"
+	if [[ $rc -eq 1 ]]; then
+		print_result "expired cross-host stamp → no claim (exit 1)" 0
+	else
+		print_result "expired cross-host stamp → no claim (exit 1)" 1 "(rc=$rc)"
+	fi
+}
+test_cross_host_expired
+
+test_cross_host_future_dated() {
+	local issue=99007
+	local stamp="${CLAIM_DIR}/testowner-testrepo-${issue}.json"
+	jq -n '{
+		issue: 99007,
+		slug: "testowner/testrepo",
+		worktree_path: "/tmp/wt-claim-99007",
+		claimed_at: "2100-01-01T00:00:00Z",
+		pid: 999996,
+		hostname: "different-host-machine-xyz",
+		user: "testuser"
+	}' >"$stamp"
+
+	AIDEVOPS_CROSS_HOST_CLAIM_FUTURE_SKEW_SECONDS=300 \
+		_isc_branch_has_active_claim "feature/gh-${issue}-test" --worktree "$FAKE_REPO" >/dev/null 2>&1
+	local rc=$?
+	rm -f "$stamp"
+	if [[ $rc -eq 1 ]]; then
+		print_result "future-dated cross-host stamp → no claim (exit 1)" 0
+	else
+		print_result "future-dated cross-host stamp → no claim (exit 1)" 1 "(rc=$rc)"
+	fi
+}
+test_cross_host_future_dated
+
+test_cross_host_malformed_timestamp() {
+	local issue=99008
+	local stamp="${CLAIM_DIR}/testowner-testrepo-${issue}.json"
+	jq -n '{
+		issue: 99008,
+		slug: "testowner/testrepo",
+		worktree_path: "/tmp/wt-claim-99008",
+		claimed_at: "not-a-timestamp",
+		pid: 999995,
+		hostname: "different-host-machine-xyz",
+		user: "testuser"
+	}' >"$stamp"
+
+	_isc_branch_has_active_claim "feature/gh-${issue}-test" --worktree "$FAKE_REPO" >/dev/null 2>&1
+	local rc=$?
+	rm -f "$stamp"
+	if [[ $rc -eq 0 ]]; then
+		print_result "malformed cross-host timestamp stays fail-closed (exit 0)" 0
+	else
+		print_result "malformed cross-host timestamp stays fail-closed (exit 0)" 1 "(rc=$rc)"
+	fi
+}
+test_cross_host_malformed_timestamp
+
 # =============================================================================
-# Test 6 — unparseable branch (no issue derivable) → no claim
+# Test 8 — unparseable branch (no issue derivable) → no claim
 # =============================================================================
 test_unparseable_branch() {
 	# `t2916-foo` — t-NNN structural-only path returns no issue; treat as no claim

--- a/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
+++ b/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
@@ -479,6 +479,47 @@ test_legacy_registry_schema_migrates_on_owner_check() {
 	return 0
 }
 
+test_existing_owner_reconciliation_quarantines_then_unregisters() {
+	local wt_path
+	wt_path=$(make_worktree_dir "reconcile-existing-dead-owner")
+	register_dead_owner_fixture "$wt_path" "feature/reconcile-existing-dead-owner"
+
+	local rc=0
+	_wt_registry_reconcile_existing_owners || rc=1
+	assert_owner_exists "$wt_path" || rc=1
+	[[ -n "$(worktree_owner_dead_seen_at "$wt_path")" ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+
+	local registry_path=""
+	registry_path=$(_wt_registry_lookup_path "$wt_path")
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+        UPDATE worktree_owners
+        SET owner_dead_seen_at = '2020-01-01T00:00:00Z'
+        WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
+    "
+	export WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES=1
+	_wt_registry_reconcile_existing_owners || rc=1
+	assert_owner_missing "$wt_path" || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	print_result "existing-owner reconciliation quarantines then unregisters without deleting directory" "$rc"
+	return 0
+}
+
+test_existing_owner_reconciliation_preserves_live_generation() {
+	local wt_path
+	wt_path=$(make_worktree_dir "reconcile-existing-live-owner")
+	local owner_pid
+	owner_pid=$(live_other_pid)
+	register_worktree "$wt_path" "feature/reconcile-existing-live-owner" --owner-pid "$owner_pid"
+
+	local rc=0
+	_wt_registry_reconcile_existing_owners || rc=1
+	assert_owner_exists "$wt_path" || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	print_result "existing-owner reconciliation preserves live generation and directory" "$rc"
+	return 0
+}
+
 test_inconclusive_dead_pid_probe_fails_closed() {
 	local wt_path
 	wt_path=$(make_worktree_dir "inconclusive-dead-pid-probe")
@@ -561,6 +602,8 @@ main() {
 	test_explicit_cleanup_lease_identity
 	test_matching_pid_requires_matching_process_generation
 	test_legacy_registry_schema_migrates_on_owner_check
+	test_existing_owner_reconciliation_quarantines_then_unregisters
+	test_existing_owner_reconciliation_preserves_live_generation
 	test_inconclusive_dead_pid_probe_fails_closed
 	test_unavailable_process_generation_fails_closed
 	test_should_skip_cleanup_branch_merged_within_grace

--- a/TODO.md
+++ b/TODO.md
@@ -1319,6 +1319,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18314 Document npm v12 install controls and bypass-2FA token deprecation #auto-dispatch #feat #priority:medium #security ref:GH#31090
 
+- [ ] t18316 Fix cross-host claim expiry and worktree registry reconciliation #auto-dispatch #bug ref:GH#31117
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Bound cross-host interactive claim authority by a renewable seven-day timestamp, reject implausible future timestamps, and reconcile dead or recycled registry owners for surviving worktree directories without adding unused lease schema. Adapted from @superdav42's PR #31023 with project-owned fixes for the review blockers.

## Files Changed

.agents/scripts/cleanup-worktrees-async-helper.sh, .agents/scripts/interactive-session-helper-stamp.sh, .agents/scripts/shared-worktree-registry.sh, .agents/scripts/tests/test-cleanup-worktrees-async.sh, .agents/scripts/tests/test-worktree-cleanup-claim-guard.sh, .agents/scripts/tests/test-worktree-registry-dead-owner.sh, TODO.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: claim guard 13/13, registry dead-owner 19/19, async cleanup 17/17, session ownership 16/16, prune batching 5/5, removal audit 50/50, ShellCheck clean, changed-file lint clean, and zero new function-complexity violations.

Resolves #31117


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 34m and 522,205 tokens on this with the user in an interactive session.