### PR TITLE
GH#31119: fix(release): normalize failed legacy intent

### DIFF
--- a/.agents/reference/release-aggregation-recovery.md
+++ b/.agents/reference/release-aggregation-recovery.md
@@ -101,6 +101,13 @@ authorization and remain an ancestor of the reviewed retry. The retry may remain
 direct when main is still at that exact source, or resolve through a newer
 reviewed exact-tip aggregate after intervening merges.
 
+For legacy lanes recorded before immutable manifests were universal, a PR-only
+`<PR>` intent is resolved against that reviewed aggregate before lane,
+authorization, and failure-marker comparisons. The original lane and marker
+strings remain byte-exact until the fenced refresh transaction completes, so a
+failed migration can restore the prior representation. An unknown PR, ambiguous
+match, or differing merge SHA remains a fail-closed authorization conflict.
+
 After those checks, a compare-and-swap lane write rotates the fencing token,
 records the failed source merge, and returns the lane to `reserved` with a durable
 `prepublication_recovery` marker. That marker binds the failed and current

--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -667,6 +667,19 @@ _full_loop_recovery_resolve_lane_authorization() {
 	return $?
 }
 
+_full_loop_recovery_normalize_failed_prepublication_sources() {
+	local legacy_sources="$1"
+	local normalized_sources=""
+	normalized_sources=$(_full_loop_recovery_resolve_lane_authorization "$legacy_sources" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED") || {
+		_full_loop_recovery_failed_prepublication_refused \
+			"legacy lane intent conflicts with the reviewed aggregate"
+		return 1
+	}
+	printf '%s\n' "$normalized_sources"
+	return 0
+}
+
 _full_loop_recovery_reserved_base_authorization() {
 	local repo="$1"
 	local source_pr="$2"
@@ -778,6 +791,8 @@ _full_loop_recovery_load_reserved_lane_state() {
 	local phase=""
 	local lane_sources=""
 	local failed_sources=""
+	local normalized_lane_sources=""
+	local normalized_failed_sources=""
 	_FULL_LOOP_RESERVED_RECOVERY_PHASE=""
 	_FULL_LOOP_RESERVED_RECOVERY_LANE_SOURCES=""
 	_FULL_LOOP_RESERVED_RECOVERY_FAILED_SOURCES=""
@@ -797,13 +812,17 @@ _full_loop_recovery_load_reserved_lane_state() {
 	"$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED")
 		lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 		if _full_loop_recovery_lane_has_prepublication_marker; then
-			[[ "$lane_sources" == "$current_authorization" ]] || {
+			normalized_lane_sources=$(_full_loop_recovery_normalize_failed_prepublication_sources \
+				"$lane_sources") || return 1
+			[[ "$normalized_lane_sources" == "$current_authorization" ]] || {
 				printf 'Failed pre-publication release recovery refused: lane and persisted authorization differ\n' >&2
 				return 1
 			}
 			failed_sources=$(_full_loop_recovery_lane_prepublication_sources) || return 1
+			normalized_failed_sources=$(_full_loop_recovery_normalize_failed_prepublication_sources \
+				"$failed_sources") || return 1
 			_full_loop_recovery_validate_failed_prepublication_intent "$repo" "$source_pr" \
-				"$failed_sources" "$release_type" || return 1
+				"$normalized_failed_sources" "$release_type" || return 1
 			_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION="true"
 		fi
 		;;
@@ -814,20 +833,25 @@ _full_loop_recovery_load_reserved_lane_state() {
 		if _full_loop_recovery_lane_has_prepublication_marker; then
 			failed_sources=$(_full_loop_recovery_lane_prepublication_sources) || return 1
 			[[ "$lane_sources" == "$failed_sources" ]] || return 1
+			normalized_failed_sources=$(_full_loop_recovery_normalize_failed_prepublication_sources \
+				"$failed_sources") || return 1
 			_full_loop_recovery_validate_failed_prepublication_intent "$repo" "$source_pr" \
-				"$failed_sources" "$release_type" || return 1
+				"$normalized_failed_sources" "$release_type" || return 1
 			_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION="true"
 		fi
 		;;
 	"$_FULL_LOOP_FAILED_PREPUBLICATION_PHASE")
 		lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
-		[[ "$lane_sources" == "$current_authorization" ]] || {
+		normalized_lane_sources=$(_full_loop_recovery_normalize_failed_prepublication_sources \
+			"$lane_sources") || return 1
+		[[ "$normalized_lane_sources" == "$current_authorization" ]] || {
 			printf 'Failed pre-publication release recovery refused: lane and persisted authorization differ\n' >&2
 			return 1
 		}
 		failed_sources="$lane_sources"
+		normalized_failed_sources="$normalized_lane_sources"
 		_full_loop_recovery_validate_failed_prepublication_intent "$repo" "$source_pr" \
-			"$failed_sources" "$release_type" || return 1
+			"$normalized_failed_sources" "$release_type" || return 1
 		_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION="true"
 		;;
 	*)

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -854,6 +854,7 @@ printf 'PASS persisted replacement-tag recovery recreates its detached tag workt
 	verified_pr_merge="$failed_merge"
 	_FULL_LOOP_RESOLVED_REQUESTED_MERGE="$requested_merge"
 	_FULL_LOOP_RESOLVED_SOURCE_MERGE="$current_merge"
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$old_manifest"
 	_full_loop_release_evidence_path() {
 		printf '%s\n' "$failure_fixture_path"
 		return 0
@@ -928,6 +929,10 @@ printf 'PASS persisted replacement-tag recovery recreates its detached tag workt
 	}
 	write_failure_evidence "$requested_merge"
 	_full_loop_recovery_validate_failed_prepublication_intent test/repo 42 "$old_manifest" patch
+	[[ "$(_full_loop_recovery_normalize_failed_prepublication_sources 42)" == "42@${requested_merge}" ]]
+	if _full_loop_recovery_normalize_failed_prepublication_sources 44 >/dev/null 2>&1; then
+		exit 1
+	fi
 	[[ "$_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_PR" == "99" &&
 		"$_FULL_LOOP_FAILED_PREPUBLICATION_SOURCE_MERGE" == "$failed_merge" &&
 		"$_FULL_LOOP_FAILED_PREPUBLICATION_TAG" == "v1.2.3" ]]
@@ -1038,7 +1043,7 @@ printf 'PASS failed pre-publication preparation admits only reviewed direct or a
 	prepublication_mode=aggregate
 	prepublication_expected="$expanded_manifest"
 	prepublication_marker=false
-	prepublication_failed_sources="$old_manifest"
+	prepublication_failed_sources="$legacy_lane_intent"
 	refresh_previous_sources="$legacy_lane_intent"
 	root_authorization_record=$(jq -cn --arg merge 2222222222222222222222222222222222222222 \
 		'{schema_version:1,repository:"test/repo",requested_pr:42,
@@ -1107,7 +1112,7 @@ printf 'PASS failed pre-publication preparation admits only reviewed direct or a
 		local current_authorization="$3"
 		local release_type="$4"
 		[[ "$repo" == "test/repo" && "$source_pr" == "42" &&
-			"$current_authorization" == "$prepublication_failed_sources" &&
+			"$current_authorization" == "$old_manifest" &&
 			"$release_type" == "patch" ]] || return 1
 		printf 'verify-failure\n' >>"$RESERVED_LOG"
 		[[ "$failure_mode" == "match" ]] || return 1
@@ -1217,9 +1222,9 @@ printf 'PASS failed pre-publication preparation admits only reviewed direct or a
 	: >"$RESERVED_LOG"
 	authorization="$old_manifest"
 	lane_phase=reconcile-required
-	test_lane_sources="$old_manifest"
+	test_lane_sources="$legacy_lane_intent"
 	prepublication_marker=false
-	prepublication_failed_sources="$old_manifest"
+	prepublication_failed_sources="$legacy_lane_intent"
 	failure_mode=match
 	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null
 	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "prepare-prepublication validate verify-failure acquire reopen fence expand-auth finish " ]]
@@ -1236,9 +1241,9 @@ printf 'PASS failed pre-publication preparation admits only reviewed direct or a
 	: >"$RESERVED_LOG"
 	authorization="$old_manifest"
 	lane_phase=reconcile-required
-	test_lane_sources="$old_manifest"
+	test_lane_sources="$legacy_lane_intent"
 	prepublication_marker=false
-	prepublication_failed_sources="$old_manifest"
+	prepublication_failed_sources="$legacy_lane_intent"
 	finish_mode=failure
 	if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null 2>&1; then
 		exit 1
@@ -1282,9 +1287,9 @@ printf 'PASS failed pre-publication preparation admits only reviewed direct or a
 	: >"$RESERVED_LOG"
 	authorization="$old_manifest"
 	lane_phase=reserved
-	test_lane_sources="$old_manifest"
+	test_lane_sources="$legacy_lane_intent"
 	prepublication_marker=true
-	prepublication_failed_sources="$old_manifest"
+	prepublication_failed_sources="$legacy_lane_intent"
 	prepublication_mode=direct
 	prepublication_expected="$old_manifest"
 	_full_loop_recovery_expand_reserved_authorization test/repo 42 42 patch >/dev/null
@@ -1297,9 +1302,9 @@ printf 'PASS failed pre-publication preparation admits only reviewed direct or a
 	: >"$RESERVED_LOG"
 	authorization="$old_manifest"
 	lane_phase=reconcile-required
-	test_lane_sources="$old_manifest"
+	test_lane_sources="$legacy_lane_intent"
 	prepublication_marker=false
-	prepublication_failed_sources="$old_manifest"
+	prepublication_failed_sources="$legacy_lane_intent"
 	failure_mode=mismatch
 	if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null 2>&1; then
 		exit 1


### PR DESCRIPTION
## Summary

Normalizes legacy PR-only failed release lane and marker intent against the reviewed aggregate while preserving raw rollback state.

## Files Changed

.agents/reference/release-aggregation-recovery.md, .agents/scripts/full-loop-release-aggregate-recovery.sh, .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh; bash .agents/scripts/tests/test-release-lane.sh; bash .agents/scripts/tests/test-full-loop-release-helper.sh; bash .agents/scripts/tests/test-full-loop-release-reconcile.sh; shellcheck; shfmt; .agents/scripts/linters-local.sh --changed

Resolves #31119


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 4m and 53,992 tokens on this as a headless worker.