### PR TITLE
GH#31122: fix(issue-sync): preserve protected publication result

### DIFF
--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -22,6 +22,7 @@ ISSUE_SYNC_PR_MARKER="<!-- aidevops:issue-sync-todo-pr -->"
 ISSUE_SYNC_COMMIT_SUBJECT="chore: sync GitHub issue state to TODO.md"
 ISSUE_SYNC_DEFAULT_COMMIT_MESSAGE="${ISSUE_SYNC_COMMIT_SUBJECT} [skip ci]"
 ISSUE_SYNC_LAST_PUBLISH_OUTPUT=""
+ISSUE_SYNC_LAST_PUBLISH_RESULT=""
 ISSUE_SYNC_BASE_SHA=""
 ISSUE_SYNC_SOURCE_BASE_SHA=""
 ISSUE_SYNC_EXPECTED_TARGET_SHA=""
@@ -147,8 +148,10 @@ issue_sync_capture_planning_publish() {
 	local output_file="$6"
 	local rc=0
 	: >"$output_file" || return 1
+	ISSUE_SYNC_LAST_PUBLISH_RESULT=""
 	planning_publish "$repo_path" "$commit_msg" "$remote_name" "$branch_name" "$paths" >"$output_file" 2>&1 || rc=$?
 	ISSUE_SYNC_LAST_PUBLISH_OUTPUT=$(<"$output_file")
+	ISSUE_SYNC_LAST_PUBLISH_RESULT="$PLANNING_PUBLISH_RESULT"
 	if [[ -n "$ISSUE_SYNC_LAST_PUBLISH_OUTPUT" ]]; then
 		printf '%s\n' "$ISSUE_SYNC_LAST_PUBLISH_OUTPUT"
 	fi
@@ -621,7 +624,8 @@ issue_sync_publish_todo() {
 			rm -rf "$state_dir"
 			return 0
 		fi
-		if issue_sync_is_gh006 "$ISSUE_SYNC_LAST_PUBLISH_OUTPUT"; then
+		if [[ "$ISSUE_SYNC_LAST_PUBLISH_RESULT" == "protected_branch_publication_deferred" ]] ||
+			issue_sync_is_gh006 "$ISSUE_SYNC_LAST_PUBLISH_OUTPUT"; then
 			echo "::notice::Direct TODO.md publication is protected; routing through one deterministic PR"
 			rc=0
 			issue_sync_publish_via_pr "$repo_path" "$default_branch" "$attempts" "$commit_msg" "$source_file" "$state_dir" || rc=$?

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -143,6 +143,20 @@ if [[ "${1:-}" == "api" && "${2:-}" == "repos/example/repo" ]]; then
 	exit 0
 fi
 
+if [[ "${1:-}" == "api" && "${2:-}" == "/repos/example/repo/pulls?"* ]]; then
+	if [[ -f "${GH_STUB_PR_MARKER:?}" ]]; then
+		printf '[{"number":1,"html_url":"https://github.com/example/repo/pull/1"}]\n'
+	else
+		printf '[]\n'
+	fi
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == */repos/example/repo/issues/1 ]]; then
+	printf 'origin:worker\n'
+	exit 0
+fi
+
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
 	if [[ -f "${GH_STUB_PR_MARKER:?}" ]]; then
 		printf 'https://github.com/example/repo/pull/1\n'
@@ -421,6 +435,8 @@ test_protected_branch_uses_one_rebased_pr() {
 		fail "issue-sync PR title preserves merge-loop prevention"
 	elif [[ "$(<"${title_file}.body")" != *"Ref #9001"* ]]; then
 		fail "issue-sync PR body preserves changed-task linkage"
+	elif [[ "$(<"$output_a")" == *"GH006: Protected branch update failed"* ]]; then
+		fail "typed protected-branch result survives captured provider output"
 	elif [[ "$(<"$output_a")" != *"repository-scoped CI privacy and write-policy inventory"* ]]; then
 		fail "GitHub Actions publication declares its scoped CI inventory"
 	elif ! jq -e '.initialized_repos == [{"slug":"example/repo","role":"maintainer"}]' \
@@ -429,10 +445,10 @@ test_protected_branch_uses_one_rebased_pr() {
 	elif [[ "$branch_message" == *"[skip ci]"* ]]; then
 		fail "issue-sync PR branch still runs required checks"
 	elif [[ "$(git -C "$work_a" status --short)" != *"TODO.md"* ||
-	"$(git -C "$work_b" status --short)" != *"TODO.md"* ]]; then
+		"$(git -C "$work_b" status --short)" != *"TODO.md"* ]]; then
 		fail "PR fallback preserves each caller's local TODO projection"
 	else
-		pass "GH006 converges through one rebased deterministic PR"
+		pass "typed protected-branch result routes through one rebased deterministic PR"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Preserved planning publisher's typed protected-branch deferral result across captured output and routed it to the deterministic issue-sync PR fallback.

## Files Changed

.agents/scripts/issue-sync-git-push-helper.sh, .agents/scripts/tests/test-issue-sync-git-push-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-issue-sync-git-push-helper.sh; bash .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh; shellcheck .agents/scripts/issue-sync-git-push-helper.sh .agents/scripts/planning-publisher.sh .agents/scripts/tests/test-issue-sync-git-push-helper.sh

Resolves #31122


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-terra spent 20m and 102,575 tokens on this as a headless worker.