### PR TITLE
GH#31136: detect and recover stale GitHub runner broker sessions

### DIFF
--- a/.agents/configs/self-hosting-files.conf
+++ b/.agents/configs/self-hosting-files.conf
@@ -31,3 +31,5 @@ worker-activity-watchdog.sh
 # its is-assigned function). Workers fixing this file run through the code
 # being fixed — same tautology as the entries above.
 dispatch-dedup-helper.sh
+# t18395: opt-in helper can restart privileged self-hosted Actions runners.
+github-runner-broker-health-helper.sh

--- a/.agents/reference/github-self-hosted-runners.md
+++ b/.agents/reference/github-self-hosted-runners.md
@@ -146,6 +146,22 @@ Expected healthy state:
 - `docker ps` shows one `github-runner-dind-N` container for each active service.
 - GitHub shows the self-hosted runners online for the target repository.
 
+These process checks are necessary but insufficient. A runner can remain
+`active`, keep its container `running`, and log `Listening for Jobs` while its
+GitHub broker session no longer accepts compatible work. Diagnose that state by
+correlating old compatible jobs that remain unassigned (`runner_id: 0` and no
+runner name), GitHub runner busy/online state, and local listener state:
+
+```bash
+BROKER_HEALTH_REPO=<OWNER>/<REPO> github-runner-broker-health-helper.sh diagnose
+```
+
+The helper distinguishes `HEALTHY`, `BUSY_CAPACITY`, `NO_MATCHING_RUNNER`,
+`STALE_BROKER_SUSPECTED`, and fail-closed `UNKNOWN_*` results. Reading runner
+inventory can require repository administration or fine-grained Actions runner
+permission. Permission, network, empty-result, or local-observability failures
+never authorize recovery. Repository values and API errors are not printed.
+
 Ephemeral runners can restart after completing a job, so a short-lived
 `activating auto-restart` state is not automatically a failure. Treat it as a
 failure only when the same instance keeps restarting without becoming online in
@@ -171,6 +187,32 @@ Restart one runner after a failed or stale job:
 ```bash
 sudo systemctl restart github-runner-dind@1.service
 ```
+
+For suspected stale broker sessions, prefer the broker helper's opt-in canary
+mode over a manual pool restart. Configure a root-owned executable adapter that
+accepts one validated runner name and maps it to the corresponding service;
+then run:
+
+```bash
+BROKER_HEALTH_REPO=<OWNER>/<REPO> \
+  BROKER_HEALTH_RESTART_ADAPTER=<APPROVED_LOCAL_ADAPTER> \
+  github-runner-broker-health-helper.sh repair
+```
+
+Recovery acquires a host-local lock, re-reads both evidence planes, rejects any
+ambiguous or busy candidate, and restarts at most one idle runner. It succeeds
+only when the runner has a fresh GitHub registration ID and the old unassigned
+queue shrinks. Cooldown, lock contention, permission loss, or failed canary
+verification stops the cycle; never continue with another runner. A new process
+or container PID alone is not proof of recovery.
+
+The default cooldown is 30 minutes and the default old-job threshold is 15
+minutes. Override them locally with `BROKER_HEALTH_COOLDOWN_SECONDS` and
+`BROKER_HEALTH_QUEUE_AGE_SECONDS`. Disable scheduled repair by removing its
+explicit adapter/configuration; diagnosis remains read-only. To reset local
+cooldown after operator review, remove
+`~/.aidevops/cache/github-runner-broker-health.json`. Reverting the helper does
+not alter existing runner services.
 
 Restart the whole pool:
 

--- a/.agents/scripts/github-runner-broker-health-helper.sh
+++ b/.agents/scripts/github-runner-broker-health-helper.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Cross-plane diagnosis and canary recovery for false-healthy GitHub Actions
+# runner broker sessions. Diagnosis is read-only; repair is explicit and
+# requires a locally configured restart adapter.
+
+set -euo pipefail
+
+BROKER_HEALTH_HELPER_DIR="${BROKER_HEALTH_HELPER_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+# shellcheck source=./shared-constants.sh
+# shellcheck disable=SC1091
+if [[ -r "${BROKER_HEALTH_HELPER_DIR}/shared-constants.sh" ]]; then
+	source "${BROKER_HEALTH_HELPER_DIR}/shared-constants.sh" 2>/dev/null || true
+fi
+
+BROKER_HEALTH_REPO="${BROKER_HEALTH_REPO:-}"
+BROKER_HEALTH_LABELS="${BROKER_HEALTH_LABELS:-self-hosted,Linux,X64,dind}"
+BROKER_HEALTH_QUEUE_AGE_SECONDS="${BROKER_HEALTH_QUEUE_AGE_SECONDS:-900}"
+BROKER_HEALTH_COOLDOWN_SECONDS="${BROKER_HEALTH_COOLDOWN_SECONDS:-1800}"
+BROKER_HEALTH_VERIFY_DELAY_SECONDS="${BROKER_HEALTH_VERIFY_DELAY_SECONDS:-15}"
+BROKER_HEALTH_CACHE_DIR="${BROKER_HEALTH_CACHE_DIR:-${HOME}/.aidevops/cache}"
+BROKER_HEALTH_STATE_FILE="${BROKER_HEALTH_STATE_FILE:-${BROKER_HEALTH_CACHE_DIR}/github-runner-broker-health.json}"
+BROKER_HEALTH_LOCK_DIR="${BROKER_HEALTH_LOCK_DIR:-${BROKER_HEALTH_CACHE_DIR}/github-runner-broker-health.lock}"
+BROKER_HEALTH_RESTART_ADAPTER="${BROKER_HEALTH_RESTART_ADAPTER:-}"
+BROKER_HEALTH_TEST_NOW_EPOCH="${BROKER_HEALTH_TEST_NOW_EPOCH:-}"
+BROKER_HEALTH_ONLINE_STATUS="online"
+
+_bh_now_epoch() {
+	if [[ "${BROKER_HEALTH_TEST_NOW_EPOCH}" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$BROKER_HEALTH_TEST_NOW_EPOCH"
+	else
+		date -u '+%s'
+	fi
+	return 0
+}
+
+_bh_require_tools() {
+	local tool
+	for tool in jq mktemp; do
+		if ! command -v "$tool" >/dev/null 2>&1; then
+			printf 'UNKNOWN_LOCAL: required tool unavailable\n' >&2
+			return 1
+		fi
+	done
+	return 0
+}
+
+_bh_labels_json() {
+	printf '%s' "$BROKER_HEALTH_LABELS" | tr ',' '\n' | jq -Rsc 'split("\n") | map(select(length > 0))'
+	return 0
+}
+
+_bh_redacted_api() {
+	local endpoint="$1"
+	local output_file="$2"
+	local error_file="$3"
+	local jq_filter="${4:-.}"
+	local pages_file="${output_file}.pages"
+	if gh api --paginate --slurp "$endpoint" >"$pages_file" 2>"$error_file"; then
+		if jq "$jq_filter" "$pages_file" >"$output_file" 2>"$error_file"; then
+			rm -f "$pages_file"
+			return 0
+		fi
+	fi
+	rm -f "$pages_file"
+	if grep -Eqi '403|forbidden|permission|resource not accessible|authentication' "$error_file"; then
+		printf 'permission\n'
+	else
+		printf 'network\n'
+	fi
+	return 1
+}
+
+_bh_collect_jobs_live() {
+	local output_file="$1"
+	local work_dir="$2"
+	local runs_file="${work_dir}/runs.json"
+	local queued_runs_file="${work_dir}/runs-queued.json"
+	local active_runs_file="${work_dir}/runs-active.json"
+	local error_file="${work_dir}/runs.err"
+	local failure=""
+	local run_id
+	[[ "$BROKER_HEALTH_REPO" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || {
+		printf 'permission\n'
+		return 1
+	}
+	failure=$(_bh_redacted_api "repos/${BROKER_HEALTH_REPO}/actions/runs?status=queued&per_page=100" "$queued_runs_file" "$error_file" '{workflow_runs: map(.workflow_runs[]) }' || true)
+	[[ -z "$failure" ]] || {
+		printf '%s\n' "$failure"
+		return 1
+	}
+	failure=$(_bh_redacted_api "repos/${BROKER_HEALTH_REPO}/actions/runs?status=in_progress&per_page=100" "$active_runs_file" "$error_file" '{workflow_runs: map(.workflow_runs[]) }' || true)
+	[[ -z "$failure" ]] || {
+		printf '%s\n' "$failure"
+		return 1
+	}
+	jq -n --slurpfile queued "$queued_runs_file" --slurpfile active "$active_runs_file" \
+		'{workflow_runs: (($queued[0].workflow_runs + $active[0].workflow_runs) | unique_by(.id))}' >"$runs_file"
+	printf '{"jobs":[' >"$output_file"
+	local first=1
+	while IFS= read -r run_id; do
+		local jobs_file="${work_dir}/jobs-${run_id}.json"
+		local jobs_error="${work_dir}/jobs-${run_id}.err"
+		failure=$(_bh_redacted_api "repos/${BROKER_HEALTH_REPO}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" "$jobs_file" "$jobs_error" '{jobs: map(.jobs[]) }' || true)
+		[[ -z "$failure" ]] || {
+			printf '%s\n' "$failure"
+			return 1
+		}
+		while IFS= read -r job; do
+			[[ "$first" -eq 1 ]] || printf ',' >>"$output_file"
+			printf '%s' "$job" >>"$output_file"
+			first=0
+		done < <(jq -c '.jobs[] | select(.status == "queued") | {id, status, labels, runner_id, runner_name, created_at}' "$jobs_file")
+	done < <(jq -r '.workflow_runs[].id' "$runs_file")
+	printf ']}\n' >>"$output_file"
+	return 0
+}
+
+_bh_collect_runners_live() {
+	local output_file="$1"
+	local work_dir="$2"
+	local error_file="${work_dir}/runners.err"
+	local failure=""
+	failure=$(_bh_redacted_api "repos/${BROKER_HEALTH_REPO}/actions/runners?per_page=100" "$output_file" "$error_file" '{runners: map(.runners[]) }' || true)
+	[[ -z "$failure" ]] || {
+		printf '%s\n' "$failure"
+		return 1
+	}
+	return 0
+}
+
+_bh_collect_local_live() {
+	local output_file="$1"
+	local units=""
+	if ! command -v systemctl >/dev/null 2>&1; then
+		printf 'local\n'
+		return 1
+	fi
+	units=$(systemctl list-units --type=service --all --no-legend --no-pager 'github-runner*' 2>/dev/null || true)
+	printf '%s\n' "$units" | jq -Rsc '
+		{runners: (split("\n") | map(select(length > 0)) | map(
+			(split(" ") | map(select(length > 0))) as $f |
+			{name: ($f[0] | sub("\\.service$"; "") | sub("@"; "-")), service: $f[0], active: ($f[2] == "active"), listener: ($f[3] == "running")}
+		))}' >"$output_file"
+	return 0
+}
+
+_bh_collect() {
+	local phase="$1"
+	local output_dir="$2"
+	local jobs_source="${BROKER_HEALTH_JOBS_FILE:-}"
+	local runners_source="${BROKER_HEALTH_RUNNERS_FILE:-}"
+	local local_source="${BROKER_HEALTH_LOCAL_FILE:-}"
+	if [[ "$phase" == "post" ]]; then
+		jobs_source="${BROKER_HEALTH_POST_JOBS_FILE:-$jobs_source}"
+		runners_source="${BROKER_HEALTH_POST_RUNNERS_FILE:-$runners_source}"
+		local_source="${BROKER_HEALTH_POST_LOCAL_FILE:-$local_source}"
+	fi
+	mkdir -p "$output_dir"
+	if [[ -n "$jobs_source" ]]; then
+		cp "$jobs_source" "${output_dir}/jobs.json"
+	else
+		local failure=""
+		failure=$(_bh_collect_jobs_live "${output_dir}/jobs.json" "$output_dir" || true)
+		[[ -z "$failure" ]] || {
+			printf 'UNKNOWN_%s\n' "$(printf '%s' "$failure" | tr '[:lower:]' '[:upper:]')"
+			return 1
+		}
+	fi
+	if [[ -n "$runners_source" ]]; then
+		cp "$runners_source" "${output_dir}/runners.json"
+	else
+		local failure=""
+		failure=$(_bh_collect_runners_live "${output_dir}/runners.json" "$output_dir" || true)
+		[[ -z "$failure" ]] || {
+			printf 'UNKNOWN_%s\n' "$(printf '%s' "$failure" | tr '[:lower:]' '[:upper:]')"
+			return 1
+		}
+	fi
+	if [[ -n "$local_source" ]]; then
+		cp "$local_source" "${output_dir}/local.json"
+	else
+		local failure=""
+		failure=$(_bh_collect_local_live "${output_dir}/local.json" || true)
+		[[ -z "$failure" ]] || {
+			printf 'UNKNOWN_LOCAL\n'
+			return 1
+		}
+	fi
+	return 0
+}
+
+_bh_evidence() {
+	local input_dir="$1"
+	local output_file="$2"
+	local now labels
+	now=$(_bh_now_epoch)
+	labels=$(_bh_labels_json)
+	jq -n \
+		--slurpfile jobs "${input_dir}/jobs.json" \
+		--slurpfile runners "${input_dir}/runners.json" \
+		--slurpfile local "${input_dir}/local.json" \
+		--argjson required "$labels" \
+		--arg online "$BROKER_HEALTH_ONLINE_STATUS" \
+		--argjson now "$now" \
+		--argjson age "$BROKER_HEALTH_QUEUE_AGE_SECONDS" '
+		def names($labels): [$labels[]? | if type == "object" then .name else . end];
+		[$jobs[0].jobs[]? | select(.status == "queued") |
+		 . + {label_names: names(.labels), created_epoch: (.created_at | fromdateiso8601? // 0)} |
+		 select(($required - .label_names | length) == 0) |
+		 select(.created_epoch > 0 and ($now - .created_epoch) >= $age) |
+		 select((.runner_id // 0) == 0 and (.runner_name // "") == "")] as $old_jobs |
+		[$runners[0].runners[]? | . + {label_names: names(.labels)} |
+		 select(($required - .label_names | length) == 0)] as $configured |
+		[$configured[] | . as $runner |
+		 select(any($old_jobs[]; .label_names as $job_labels |
+			($job_labels - $runner.label_names | length) == 0))] as $matching |
+		[$matching[] | select(.status == $online and .busy == true)] as $busy |
+		[$matching[] | select(.status == $online and .busy == false)] as $idle |
+		[$local[0].runners[]? | select(.active == true and .listener == true)] as $local_active |
+		[$idle[] as $r | $local_active[] | select(.name == $r.name or .runner_name == $r.name) |
+		 {name: $r.name, runner_id: ($r.id // 0), service: (.service // "")}] as $candidates |
+		{old_jobs: $old_jobs, runners: $configured, matching: $matching, busy: $busy, idle: $idle,
+		 local_active: $local_active, candidates: ($candidates | unique_by(.name)),
+		 queue_moving: (($jobs[0].queue_moving // false) == true)}' >"$output_file"
+	return 0
+}
+
+_bh_classify() {
+	local evidence_file="$1"
+	local old_count matching_count busy_count candidate_count queue_moving
+	old_count=$(jq '.old_jobs | length' "$evidence_file")
+	matching_count=$(jq '.matching | length' "$evidence_file")
+	busy_count=$(jq '.busy | length' "$evidence_file")
+	candidate_count=$(jq '.candidates | length' "$evidence_file")
+	queue_moving=$(jq -r '.queue_moving' "$evidence_file")
+	if [[ "$old_count" -eq 0 || "$queue_moving" == "true" ]]; then
+		printf 'HEALTHY\n'
+	elif [[ "$matching_count" -eq 0 ]]; then
+		printf 'NO_MATCHING_RUNNER\n'
+	elif [[ "$busy_count" -eq "$matching_count" ]]; then
+		printf 'BUSY_CAPACITY\n'
+	elif [[ "$candidate_count" -gt 0 ]]; then
+		printf 'STALE_BROKER_SUSPECTED\n'
+	else
+		printf 'UNKNOWN_LOCAL\n'
+	fi
+	return 0
+}
+
+_bh_emit() {
+	local finding="$1"
+	local evidence_file="${2:-}"
+	local json="${3:-0}"
+	local action="none"
+	case "$finding" in
+	STALE_BROKER_SUSPECTED) action="run repair only with an approved local restart adapter" ;;
+	BUSY_CAPACITY) action="add capacity or wait for active jobs; do not restart" ;;
+	NO_MATCHING_RUNNER) action="check labels and runner registration; do not restart" ;;
+	UNKNOWN_PERMISSION) action="grant read access to Actions jobs and runners; do not restart" ;;
+	UNKNOWN_NETWORK) action="restore GitHub API access; do not restart" ;;
+	UNKNOWN_LOCAL) action="restore local runner visibility; do not restart" ;;
+	COOLDOWN) action="wait for the recovery cooldown; do not restart" ;;
+	LOCKED) action="another recovery owns the host lock; do not restart" ;;
+	RECOVERED) action="queue movement verified after one fresh runner registration" ;;
+	FAILED_CANARY) action="inspect the canary; do not restart another runner" ;;
+	esac
+	if [[ "$json" -eq 1 ]]; then
+		local summary='{}'
+		[[ -n "$evidence_file" && -f "$evidence_file" ]] && summary=$(jq '{old_jobs:(.old_jobs|length), matching_runners:(.matching|length), busy_runners:(.busy|length), idle_candidates:(.candidates|length)}' "$evidence_file")
+		jq -n --arg finding "$finding" --arg action "$action" --argjson evidence "$summary" '{finding:$finding, action:$action, evidence:$evidence}'
+	else
+		printf 'finding: %s\naction: %s\n' "$finding" "$action"
+		if [[ -n "$evidence_file" && -f "$evidence_file" ]]; then
+			jq -r '"evidence: old_jobs=\(.old_jobs|length) matching_runners=\(.matching|length) busy_runners=\(.busy|length) idle_candidates=\(.candidates|length)"' "$evidence_file"
+		fi
+	fi
+	return 0
+}
+
+_bh_diagnose_into() {
+	local phase="$1"
+	local work_dir="$2"
+	local evidence_file="$3"
+	local failure=""
+	failure=$(_bh_collect "$phase" "${work_dir}/${phase}" || true)
+	if [[ -n "$failure" ]]; then
+		printf '%s\n' "$failure"
+		return 1
+	fi
+	_bh_evidence "${work_dir}/${phase}" "$evidence_file"
+	_bh_classify "$evidence_file"
+	return 0
+}
+
+_bh_in_cooldown() {
+	local now last
+	[[ -f "$BROKER_HEALTH_STATE_FILE" ]] || return 1
+	now=$(_bh_now_epoch)
+	last=$(jq -r '.last_restart_epoch // 0' "$BROKER_HEALTH_STATE_FILE" 2>/dev/null || printf '0')
+	[[ "$last" =~ ^[0-9]+$ ]] || last=0
+	if [[ $((now - last)) -lt "$BROKER_HEALTH_COOLDOWN_SECONDS" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_bh_write_state() {
+	local candidate="$1"
+	local outcome="$2"
+	local now tmp
+	now=$(_bh_now_epoch)
+	mkdir -p "$BROKER_HEALTH_CACHE_DIR"
+	tmp="${BROKER_HEALTH_STATE_FILE}.tmp.$$"
+	jq -n --argjson epoch "$now" --arg candidate "$candidate" --arg outcome "$outcome" \
+		'{schema:1,last_restart_epoch:$epoch,candidate:$candidate,outcome:$outcome}' >"$tmp"
+	mv "$tmp" "$BROKER_HEALTH_STATE_FILE"
+	return 0
+}
+
+_bh_verify_canary() {
+	local before="$1"
+	local after="$2"
+	local candidate="$3"
+	local old_id new_id old_jobs new_jobs
+	old_id=$(jq -r --arg name "$candidate" '.runners[] | select(.name == $name) | .id // 0' "$before" | sed -n '1p')
+	new_id=$(jq -r --arg name "$candidate" --arg online "$BROKER_HEALTH_ONLINE_STATUS" \
+		'.runners[] | select(.name == $name and .status == $online) | .id // 0' "$after" | sed -n '1p')
+	old_jobs=$(jq '.old_jobs | length' "$before")
+	new_jobs=$(jq '.old_jobs | length' "$after")
+	if [[ "${old_id:-0}" != "${new_id:-0}" && "${new_id:-0}" != "0" && "$new_jobs" -lt "$old_jobs" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+cmd_diagnose() {
+	local json="${1:-0}"
+	local work_dir evidence finding
+	work_dir=$(mktemp -d -t broker-health-XXXXXX)
+	evidence="${work_dir}/evidence.json"
+	finding=$(_bh_diagnose_into pre "$work_dir" "$evidence" || true)
+	_bh_emit "$finding" "$evidence" "$json"
+	rm -rf "$work_dir"
+	[[ "$finding" == "HEALTHY" ]] && return 0
+	return 1
+}
+
+cmd_repair() {
+	local json="${1:-0}"
+	local work_dir before after finding candidate
+	work_dir=$(mktemp -d -t broker-health-XXXXXX)
+	before="${work_dir}/before.json"
+	after="${work_dir}/after.json"
+	finding=$(_bh_diagnose_into pre "$work_dir" "$before" || true)
+	if [[ "$finding" != "STALE_BROKER_SUSPECTED" ]]; then
+		_bh_emit "$finding" "$before" "$json"
+		rm -rf "$work_dir"
+		return 1
+	fi
+	mkdir -p "$BROKER_HEALTH_CACHE_DIR"
+	if ! mkdir "$BROKER_HEALTH_LOCK_DIR" 2>/dev/null; then
+		_bh_emit LOCKED "$before" "$json"
+		rm -rf "$work_dir"
+		return 1
+	fi
+	trap 'rmdir "$BROKER_HEALTH_LOCK_DIR" 2>/dev/null || true; rm -rf "$work_dir"' EXIT
+	if _bh_in_cooldown; then
+		_bh_emit COOLDOWN "$before" "$json"
+		return 1
+	fi
+	# Re-read both planes after taking the host lock.
+	finding=$(_bh_diagnose_into pre "$work_dir" "$before" || true)
+	if [[ "$finding" != "STALE_BROKER_SUSPECTED" ]]; then
+		_bh_emit "$finding" "$before" "$json"
+		return 1
+	fi
+	candidate=$(jq -r '.candidates | sort_by(.name) | .[0].name // empty' "$before")
+	if [[ -z "$candidate" || -z "$BROKER_HEALTH_RESTART_ADAPTER" || ! -x "$BROKER_HEALTH_RESTART_ADAPTER" ]]; then
+		_bh_emit UNKNOWN_LOCAL "$before" "$json"
+		return 1
+	fi
+	_bh_write_state "$candidate" "started"
+	if ! "$BROKER_HEALTH_RESTART_ADAPTER" "$candidate" >/dev/null 2>&1; then
+		_bh_write_state "$candidate" "restart_failed"
+		_bh_emit FAILED_CANARY "$before" "$json"
+		return 1
+	fi
+	if [[ "$BROKER_HEALTH_VERIFY_DELAY_SECONDS" -gt 0 ]]; then
+		sleep "$BROKER_HEALTH_VERIFY_DELAY_SECONDS"
+	fi
+	finding=$(_bh_diagnose_into post "$work_dir" "$after" || true)
+	if [[ "$finding" == UNKNOWN_* ]] || ! _bh_verify_canary "$before" "$after" "$candidate"; then
+		_bh_write_state "$candidate" "verification_failed"
+		_bh_emit FAILED_CANARY "$after" "$json"
+		return 1
+	fi
+	_bh_write_state "$candidate" "recovered"
+	_bh_emit RECOVERED "$after" "$json"
+	return 0
+}
+
+usage() {
+	cat <<'EOF'
+Usage: github-runner-broker-health-helper.sh diagnose [--json]
+       github-runner-broker-health-helper.sh repair [--json]
+
+Diagnosis correlates old compatible unassigned jobs, GitHub runner state, and
+local active listener state. Repair requires BROKER_HEALTH_RESTART_ADAPTER to
+name an executable that accepts exactly one runner name. At most one candidate
+is restarted, followed by fresh-registration and queue-movement verification.
+EOF
+	return 0
+}
+
+main() {
+	local command="${1:-diagnose}"
+	local option="${2:-}"
+	local json=0
+	[[ "$option" == "--json" ]] && json=1
+	_bh_require_tools || return 1
+	case "$command" in
+	diagnose) cmd_diagnose "$json" ;;
+	repair) cmd_repair "$json" ;;
+	help | --help | -h) usage ;;
+	*)
+		usage >&2
+		return 2
+		;;
+	esac
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-github-runner-broker-health-helper.sh
+++ b/.agents/scripts/tests/test-github-runner-broker-health-helper.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../github-runner-broker-health-helper.sh"
+SANDBOX="$(mktemp -d -t broker-health-test-XXXXXX)"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$SANDBOX"
+	return 0
+}
+trap cleanup EXIT
+
+result() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		printf 'PASS: %s\n' "$name"
+		PASS=$((PASS + 1))
+	else
+		printf 'FAIL: %s (expected %s, got %s)\n' "$name" "$expected" "$actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+write_jobs() {
+	local path="$1"
+	local moving="$2"
+	local count="$3"
+	if [[ "$count" -eq 0 ]]; then
+		printf '{"queue_moving":%s,"jobs":[]}\n' "$moving" >"$path"
+	else
+		printf '{"queue_moving":%s,"jobs":[{"id":101,"status":"queued","labels":["self-hosted","Linux","X64","dind"],"runner_id":0,"runner_name":"","created_at":"2026-09-04T00:00:00Z"}]}\n' "$moving" >"$path"
+	fi
+	return 0
+}
+
+write_extra_label_job() {
+	local path="$1"
+	local fixture='{"queue_moving":false,"jobs":[{"id":101,"status":"queued","labels":["self-hosted","Linux","X64","dind","gpu"],"runner_id":0,"runner_name":"","created_at":"2026-09-04T00:00:00Z"}]}'
+	printf '%s\n' "$fixture" >"$path"
+	return 0
+}
+
+write_runners() {
+	local path="$1"
+	local busy="$2"
+	local id="$3"
+	printf '{"runners":[{"id":%s,"name":"runner-1","status":"online","busy":%s,"labels":[{"name":"self-hosted"},{"name":"Linux"},{"name":"X64"},{"name":"dind"}]}]}\n' "$id" "$busy" >"$path"
+	return 0
+}
+
+write_local() {
+	local path="$1"
+	printf '{"runners":[{"name":"runner-1","service":"runner@1.service","active":true,"listener":true}]}\n' >"$path"
+	return 0
+}
+
+run_finding() {
+	local command="$1"
+	local output=""
+	output=$(bash "$HELPER" "$command" --json 2>/dev/null || true)
+	printf '%s' "$output" | jq -r '.finding'
+	return 0
+}
+
+write_live_command_stubs() {
+	local bin_dir="$1"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+endpoint=""
+saw_slurp=0
+saw_jq=0
+for argument in "$@"; do
+	endpoint="$argument"
+	[[ "$argument" == "--slurp" ]] && saw_slurp=1
+	[[ "$argument" == "--jq" ]] && saw_jq=1
+done
+[[ "$saw_slurp" -eq 1 && "$saw_jq" -eq 1 ]] && exit 2
+case "$endpoint" in
+*status=queued*) printf '%s\n' '[{"workflow_runs":[{"id":7}]},{"workflow_runs":[]}]' ;;
+*status=in_progress*) printf '%s\n' '[{"workflow_runs":[]}]' ;;
+*/jobs*) printf '%s\n' '[{"jobs":[{"id":101,"status":"queued","labels":["self-hosted","Linux","X64","dind"],"runner_id":0,"runner_name":"","created_at":"2026-09-04T00:00:00Z"}]},{"jobs":[]}]' ;;
+*/runners*) printf '%s\n' '[{"runners":[{"id":11,"name":"github-runner-dind-1","status":"online","busy":false,"labels":[{"name":"self-hosted"},{"name":"Linux"},{"name":"X64"},{"name":"dind"}]}]},{"runners":[]}]' ;;
+*) exit 1 ;;
+esac
+EOF
+	cat >"${bin_dir}/systemctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'github-runner-dind@1.service loaded active running runner'
+EOF
+	chmod +x "${bin_dir}/gh" "${bin_dir}/systemctl"
+	return 0
+}
+
+export BROKER_HEALTH_TEST_NOW_EPOCH=1788483600
+export BROKER_HEALTH_QUEUE_AGE_SECONDS=900
+export BROKER_HEALTH_VERIFY_DELAY_SECONDS=0
+export BROKER_HEALTH_COOLDOWN_SECONDS=1800
+export BROKER_HEALTH_CACHE_DIR="$SANDBOX/cache"
+export BROKER_HEALTH_STATE_FILE="$BROKER_HEALTH_CACHE_DIR/state.json"
+export BROKER_HEALTH_LOCK_DIR="$BROKER_HEALTH_CACHE_DIR/lock"
+export BROKER_HEALTH_JOBS_FILE="$SANDBOX/jobs.json"
+export BROKER_HEALTH_RUNNERS_FILE="$SANDBOX/runners.json"
+export BROKER_HEALTH_LOCAL_FILE="$SANDBOX/local.json"
+export BROKER_HEALTH_POST_JOBS_FILE="$SANDBOX/post-jobs.json"
+export BROKER_HEALTH_POST_RUNNERS_FILE="$SANDBOX/post-runners.json"
+export BROKER_HEALTH_POST_LOCAL_FILE="$SANDBOX/post-local.json"
+
+write_local "$BROKER_HEALTH_LOCAL_FILE"
+write_local "$BROKER_HEALTH_POST_LOCAL_FILE"
+write_jobs "$BROKER_HEALTH_JOBS_FILE" false 1
+write_jobs "$BROKER_HEALTH_POST_JOBS_FILE" false 0
+write_runners "$BROKER_HEALTH_RUNNERS_FILE" false 11
+write_runners "$BROKER_HEALTH_POST_RUNNERS_FILE" false 22
+
+result "incident fixture is stale broker" "STALE_BROKER_SUSPECTED" "$(run_finding diagnose)"
+
+write_extra_label_job "$BROKER_HEALTH_JOBS_FILE"
+result "extra required job label is not compatible" "NO_MATCHING_RUNNER" "$(run_finding diagnose)"
+write_jobs "$BROKER_HEALTH_JOBS_FILE" false 1
+
+STUB_BIN="$SANDBOX/bin"
+write_live_command_stubs "$STUB_BIN"
+PATH_BACKUP="$PATH"
+export PATH="$STUB_BIN:$PATH"
+export BROKER_HEALTH_REPO="owner/repo"
+unset BROKER_HEALTH_JOBS_FILE BROKER_HEALTH_RUNNERS_FILE BROKER_HEALTH_LOCAL_FILE
+result "live paginated CLI response is normalized" "STALE_BROKER_SUSPECTED" "$(run_finding diagnose)"
+export PATH="$PATH_BACKUP"
+export BROKER_HEALTH_JOBS_FILE="$SANDBOX/jobs.json"
+export BROKER_HEALTH_RUNNERS_FILE="$SANDBOX/runners.json"
+export BROKER_HEALTH_LOCAL_FILE="$SANDBOX/local.json"
+
+write_runners "$BROKER_HEALTH_RUNNERS_FILE" true 11
+result "all busy is capacity pressure" "BUSY_CAPACITY" "$(run_finding diagnose)"
+write_runners "$BROKER_HEALTH_RUNNERS_FILE" false 11
+
+printf '{"runners":[]}\n' >"$BROKER_HEALTH_RUNNERS_FILE"
+result "empty runner inventory is non-recoverable" "NO_MATCHING_RUNNER" "$(run_finding diagnose)"
+write_runners "$BROKER_HEALTH_RUNNERS_FILE" false 11
+
+mkdir -p "$BROKER_HEALTH_LOCK_DIR"
+result "lock contention blocks repair" "LOCKED" "$(run_finding repair)"
+rmdir "$BROKER_HEALTH_LOCK_DIR"
+
+RESTART_LOG="$SANDBOX/restarts.log"
+export RESTART_LOG
+RESTART_ADAPTER="$SANDBOX/restart-adapter.sh"
+cat >"$RESTART_ADAPTER" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+candidate="${1:-}"
+printf '%s\n' "$candidate" >>"$RESTART_LOG"
+EOF
+chmod +x "$RESTART_ADAPTER"
+export BROKER_HEALTH_RESTART_ADAPTER="$RESTART_ADAPTER"
+
+result "one-runner canary recovers" "RECOVERED" "$(run_finding repair)"
+result "exactly one runner restarted" "1" "$(wc -l <"$RESTART_LOG" | tr -d ' ')"
+result "cooldown prevents repeat" "COOLDOWN" "$(run_finding repair)"
+result "cooldown does not restart" "1" "$(wc -l <"$RESTART_LOG" | tr -d ' ')"
+
+rm -f "$BROKER_HEALTH_STATE_FILE"
+write_runners "$BROKER_HEALTH_POST_RUNNERS_FILE" false 11
+result "unchanged registration fails canary" "FAILED_CANARY" "$(run_finding repair)"
+result "failed canary stops after one" "2" "$(wc -l <"$RESTART_LOG" | tr -d ' ')"
+
+printf 'Tests: %s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/workflows/runners-check.md
+++ b/.agents/workflows/runners-check.md
@@ -84,4 +84,30 @@ Concise dashboard, anomalies first:
 ## Arguments
 
 - No arguments: current system status
-- `--fix`: auto-fix simple issues (merge green PRs, clean stale worktrees)
+- `--fix`: auto-fix simple issues (merge green PRs, clean stale worktrees) and,
+  only when configured by the operator, invoke bounded broker recovery below.
+
+## GitHub Actions broker health
+
+Keep this separate from worker-dispatch health. Diagnose false-healthy
+self-hosted Actions runners with:
+
+```bash
+BROKER_HEALTH_REPO=<OWNER>/<REPO> github-runner-broker-health-helper.sh diagnose
+```
+
+Report its classification and action verbatim. `UNKNOWN_PERMISSION`,
+`UNKNOWN_NETWORK`, `UNKNOWN_LOCAL`, `NO_MATCHING_RUNNER`, and `BUSY_CAPACITY`
+are read-only outcomes and must never cause a restart. `active`, `running`, and
+`Listening for Jobs` are insufficient without compatible GitHub queue evidence.
+
+For `$ARGUMENTS == --fix`, run `repair` only when the operator has configured an
+executable `BROKER_HEALTH_RESTART_ADAPTER`. The helper re-checks evidence under
+a host lock, restarts at most one proven-idle candidate, enforces a cooldown,
+and requires both a fresh runner registration and queue movement:
+
+```bash
+BROKER_HEALTH_REPO=<OWNER>/<REPO> \
+  BROKER_HEALTH_RESTART_ADAPTER=<APPROVED_LOCAL_ADAPTER> \
+  github-runner-broker-health-helper.sh repair
+```


### PR DESCRIPTION
## Summary

Add cross-plane GitHub Actions runner broker diagnosis with fail-closed classifications, one-runner locked recovery, cooldowns, and fresh-registration plus queue-movement verification; expose it through runners-check and document operations.

## Files Changed

.agents/configs/self-hosting-files.conf, .agents/reference/github-self-hosted-runners.md, .agents/scripts/github-runner-broker-health-helper.sh, .agents/scripts/tests/test-github-runner-broker-health-helper.sh, .agents/workflows/runners-check.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 12 fixture and live-CLI-stub cases passed; ShellCheck passed; .agents/scripts/linters-local.sh --changed passed; independent closeout review found no remaining actionable findings.

Resolves #31136


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 24m and 139,070 tokens on this as a headless worker.