### PR TITLE
GH#31144: add audited bootstrap repository registration

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
@@ -517,11 +517,12 @@ _repo_registration_update_existing() {
 }
 
 # Register a repo in repos.json
-# Usage: register_repo <path> <version> <features>
+# Usage: register_repo <path> <version> <features> [verified-slug]
 register_repo() {
 	local repo_path="$1"
 	local version="$2"
 	local features="$3"
+	local verified_slug="${4:-}"
 
 	init_repos_file
 
@@ -553,7 +554,9 @@ register_repo() {
 	# Auto-detect GitHub slug from git remote
 	local slug=""
 	local is_local_only="false"
-	if ! slug=$(get_repo_slug "$repo_path" 2>/dev/null); then
+	if [[ -n "$verified_slug" ]]; then
+		slug="$verified_slug"
+	elif ! slug=$(get_repo_slug "$repo_path" 2>/dev/null); then
 		slug=""
 		# No remote origin — mark as local_only
 		if ! git -C "$repo_path" remote get-url origin &>/dev/null; then

--- a/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
@@ -519,9 +519,7 @@ _repo_registration_update_existing() {
 # Register a repo in repos.json
 # Usage: register_repo <path> <version> <features> [verified-slug]
 register_repo() {
-	local repo_path="$1"
-	local version="$2"
-	local features="$3"
+	local repo_path="$1" version="$2" features="$3"
 	local verified_slug="${4:-}"
 
 	init_repos_file
@@ -552,8 +550,7 @@ register_repo() {
 	fi
 
 	# Auto-detect GitHub slug from git remote
-	local slug=""
-	local is_local_only="false"
+	local slug="" is_local_only="false"
 	if [[ -n "$verified_slug" ]]; then
 		slug="$verified_slug"
 	elif ! slug=$(get_repo_slug "$repo_path" 2>/dev/null); then
@@ -577,9 +574,7 @@ register_repo() {
 
 	local has_interface
 	has_interface=$(_repo_config_has_interface_value "$repo_path")
-	local cloudron_app_type="cloudron-package"
-	local app_type_default=""
-	local cloudron_defaults='{}'
+	local cloudron_app_type="cloudron-package" app_type_default="" cloudron_defaults='{}'
 	if [[ -f "${repo_path}/CloudronManifest.json" ]]; then
 		app_type_default="$cloudron_app_type"
 		cloudron_defaults='{"manifest":"CloudronManifest.json","release_workflow":".github/workflows/cloudron-package-release.yml","monitor_compatibility":true,"upstream_tag_prefixes":["v",""]}'

--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 FAST_FORWARD_CMD="fast-forward-current"
 SYNC_MIRROR_CMD="sync-mirror"
+VERIFY_BOOTSTRAP_CMD="verify-bootstrap-registration"
 CLEAR_STALE_REBASE_CMD="clear-stale-rebase"
 CLEAR_ABANDONED_REBASE_CMD="clear-abandoned-rebase"
 AIDEVOPS_UPDATE_REASON="aidevops-update"
@@ -550,6 +551,31 @@ fetch_aidevops_release_tag() {
 	return $?
 }
 
+audit_bootstrap_identity() {
+	local repo="$1"
+	local expected_slug="$2"
+	local canonical_remote="$3"
+	local audit_helper="${SCRIPT_DIR}/audit-log-helper.sh"
+	local recovery_audit_file="${HOME}/.aidevops/logs/canonical-recovery-audit.jsonl"
+
+	[[ -x "$audit_helper" ]] || {
+		printf 'BLOCKED: tamper-evident audit helper is unavailable\n' >&2
+		return 1
+	}
+	AUDIT_LOG_FILE="$recovery_audit_file" "$audit_helper" verify --quiet || {
+		printf 'BLOCKED: audit chain verification failed\n' >&2
+		return 1
+	}
+	AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log \
+		operation.verify "Canonical bootstrap registration identity verified" \
+		--detail "repo=${repo}" --detail "operation=${VERIFY_BOOTSTRAP_CMD}" \
+		--detail "remote=${canonical_remote}" --detail "expected_slug=${expected_slug}" >/dev/null || {
+		printf 'BLOCKED: bootstrap verification audit record could not be written\n' >&2
+		return 1
+	}
+	return 0
+}
+
 usage() {
 	printf '%s\n' \
 		'Usage:' \
@@ -559,7 +585,8 @@ usage() {
 		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --issue N --confirm FAST_FORWARD_CANONICAL_BRANCH" \
 		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --reason ${AIDEVOPS_UPDATE_REASON} --confirm FAST_FORWARD_CANONICAL_BRANCH" \
 		"  canonical-recovery-helper.sh ${SYNC_MIRROR_CMD} --repo PATH --issue N --confirm SYNCHRONIZE_CANONICAL_MIRROR" \
-		"  canonical-recovery-helper.sh ${SYNC_MIRROR_CMD} --repo PATH --reason ${AIDEVOPS_UPDATE_REASON} --confirm SYNCHRONIZE_CANONICAL_MIRROR"
+		"  canonical-recovery-helper.sh ${SYNC_MIRROR_CMD} --repo PATH --reason ${AIDEVOPS_UPDATE_REASON} --confirm SYNCHRONIZE_CANONICAL_MIRROR" \
+		"  canonical-recovery-helper.sh ${VERIFY_BOOTSTRAP_CMD} --repo PATH --slug OWNER/REPO --confirm REGISTER_CANONICAL_REPOSITORY"
 	return 0
 }
 
@@ -570,6 +597,7 @@ issue_number=""
 maintenance_reason=""
 confirmation=""
 expected_branch=""
+bootstrap_slug=""
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	--repo)
@@ -590,6 +618,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--branch)
 		expected_branch="${2:-}"
+		shift 2
+		;;
+	--slug)
+		bootstrap_slug="${2:-}"
 		shift 2
 		;;
 	*)
@@ -635,16 +667,29 @@ restore-default)
 		exit 2
 	}
 	;;
+"$VERIFY_BOOTSTRAP_CMD")
+	expected_confirmation="REGISTER_CANONICAL_REPOSITORY"
+	[[ -z "$expected_branch" && "$bootstrap_slug" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || {
+		usage
+		exit 2
+	}
+	;;
 *)
 	usage
 	exit 2
 	;;
 esac
+if [[ "$cmd" != "$VERIFY_BOOTSTRAP_CMD" && -n "$bootstrap_slug" ]]; then
+	usage
+	exit 2
+fi
 [[ -d "$repo_path" ]] || {
 	usage
 	exit 2
 }
-if [[ "$issue_number" =~ ^[0-9]+$ && -z "$maintenance_reason" ]]; then
+if [[ "$cmd" == "$VERIFY_BOOTSTRAP_CMD" && -z "$issue_number" && -z "$maintenance_reason" ]]; then
+	audit_reference="bootstrap registration"
+elif [[ "$issue_number" =~ ^[0-9]+$ && -z "$maintenance_reason" ]]; then
 	audit_reference="issue ${issue_number}"
 elif [[ -z "$issue_number" && ("$cmd" == "$FAST_FORWARD_CMD" || "$cmd" == "$SYNC_MIRROR_CMD") &&
 	"$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" ]]; then
@@ -666,16 +711,12 @@ common_dir=$("$REAL_GIT" -C "$repo_path" rev-parse --path-format=absolute --git-
 	printf 'BLOCKED: recovery target is not the canonical worktree\n' >&2
 	exit 1
 }
-if [[ "$cmd" != "$SYNC_MIRROR_CMD" ]] && [[ -n "$("$REAL_GIT" -C "$repo_path" status --porcelain)" ]]; then
+if [[ "$cmd" != "$SYNC_MIRROR_CMD" && "$cmd" != "$VERIFY_BOOTSTRAP_CMD" ]] &&
+	[[ -n "$("$REAL_GIT" -C "$repo_path" status --porcelain)" ]]; then
 	printf 'BLOCKED: canonical worktree is not clean\n' >&2
 	exit 1
 fi
 
-policy_helper="${SCRIPT_DIR}/canonical-write-policy-helper.py"
-[[ -f "$policy_helper" ]] || {
-	printf 'BLOCKED: canonical branch policy helper is unavailable\n' >&2
-	exit 1
-}
 registered_slug=""
 expected_slug=""
 allow_local_mirror=true
@@ -683,7 +724,10 @@ allow_equivalent_aliases=false
 #aidevops:trust-boundary
 # Only framework self-update has an identity pinned independently of repository
 # registration, so ordinary canonical recovery keeps rejecting multiple aliases.
-if [[ "$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" ]]; then
+if [[ "$cmd" == "$VERIFY_BOOTSTRAP_CMD" ]]; then
+	expected_slug="$bootstrap_slug"
+	allow_local_mirror=false
+elif [[ "$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" ]]; then
 	expected_slug="$AIDEVOPS_FRAMEWORK_GITHUB_SLUG"
 	allow_local_mirror=false
 	allow_equivalent_aliases=true
@@ -696,13 +740,25 @@ else
 fi
 if ! canonical_remote=$(resolve_github_remote \
 	"$repo_path" "$expected_slug" "$allow_local_mirror" "$allow_equivalent_aliases"); then
-	if [[ "$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" ]]; then
+	if [[ "$cmd" == "$VERIFY_BOOTSTRAP_CMD" ]]; then
+		printf 'BLOCKED: pinned bootstrap GitHub remote is missing, mismatched, or ambiguous\n' >&2
+	elif [[ "$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" ]]; then
 		printf 'BLOCKED: official aidevops GitHub remote is missing, mismatched, or ambiguous\n' >&2
 	else
 		printf 'BLOCKED: registered GitHub remote is missing, mismatched, or ambiguous\n' >&2
 	fi
 	exit 1
 fi
+if [[ "$cmd" == "$VERIFY_BOOTSTRAP_CMD" ]]; then
+	audit_bootstrap_identity "$repo_path" "$expected_slug" "$canonical_remote" || exit 1
+	printf 'VERIFIED: canonical bootstrap identity %s via remote %s\n' "$expected_slug" "$canonical_remote"
+	exit 0
+fi
+policy_helper="${SCRIPT_DIR}/canonical-write-policy-helper.py"
+[[ -f "$policy_helper" ]] || {
+	printf 'BLOCKED: canonical branch policy helper is unavailable\n' >&2
+	exit 1
+}
 target_branch=$(AIDEVOPS_CANONICAL_REMOTE="$canonical_remote" \
 	python3 "$policy_helper" resolve-branch --cwd "$repo_path" --field branch) || exit 1
 target_branch_source=$(AIDEVOPS_CANONICAL_REMOTE="$canonical_remote" \

--- a/.agents/scripts/tests/test-repos-add-local-only-convergence.sh
+++ b/.agents/scripts/tests/test-repos-add-local-only-convergence.sh
@@ -12,10 +12,11 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 export HOME="${TEST_ROOT}/home"
 INSTALL_DIR="$REPO_ROOT"
 AGENTS_DIR="$REPO_ROOT/.agents"
+AIDEVOPS_AGENTS_DIR="$AGENTS_DIR"
 CONFIG_DIR="${HOME}/.config/aidevops"
 REPOS_FILE="${CONFIG_DIR}/repos.json"
 AIDEVOPS_REPOS_FILE="$REPOS_FILE"
-export INSTALL_DIR AGENTS_DIR CONFIG_DIR REPOS_FILE AIDEVOPS_REPOS_FILE
+export INSTALL_DIR AGENTS_DIR AIDEVOPS_AGENTS_DIR CONFIG_DIR REPOS_FILE AIDEVOPS_REPOS_FILE
 
 mkdir -p "$CONFIG_DIR"
 
@@ -54,4 +55,68 @@ register_repo "$repo_path" "1.0.1" "planning"
 [[ "$(jq -r '.initialized_repos[0].pulse' "$REPOS_FILE")" == "false" ]]
 [[ "$(_dsi_repo_path_for_slug "example/remote-backed")" == "$repo_path" ]]
 
+bootstrap_repo="${TEST_ROOT}/bootstrap-repo"
+bootstrap_remote="${TEST_ROOT}/bootstrap-remote.git"
+bootstrap_url="https://github.com/example/bootstrap-repo.git"
+linked_repo="${TEST_ROOT}/bootstrap-linked"
+git init -q --bare "$bootstrap_remote"
+git init -q -b main "$bootstrap_repo"
+git -C "$bootstrap_repo" config user.name Test
+git -C "$bootstrap_repo" config user.email test@example.invalid
+git -C "$bootstrap_repo" config commit.gpgsign false
+git -C "$bootstrap_repo" config "url.${bootstrap_remote}.insteadOf" "$bootstrap_url"
+printf 'seed\n' >"${bootstrap_repo}/README.md"
+git -C "$bootstrap_repo" add README.md
+git -C "$bootstrap_repo" commit -q -m seed
+git -C "$bootstrap_repo" remote add origin "$bootstrap_url"
+git -C "$bootstrap_repo" push -q -u origin main
+git -C "$bootstrap_remote" symbolic-ref HEAD refs/heads/main
+printf 'preserve me\n' >"${bootstrap_repo}/untracked.txt"
+
+if (
+	cd "$bootstrap_repo" || exit 1
+	AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$REPO_ROOT/aidevops.sh" repos add \
+		--slug example/bootstrap-repo
+) >/dev/null 2>&1; then
+	printf 'FAIL bootstrap registration accepted missing confirmation\n'
+	exit 1
+fi
+if jq -e --arg path "$bootstrap_repo" '.initialized_repos[] | select(.path == $path)' "$REPOS_FILE" >/dev/null; then
+	printf 'FAIL failed bootstrap registration mutated repos.json\n'
+	exit 1
+fi
+
+if (
+	cd "$bootstrap_repo" || exit 1
+	AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$REPO_ROOT/aidevops.sh" repos add \
+		--slug example/wrong-repo --confirm REGISTER_CANONICAL_REPOSITORY
+) >/dev/null 2>&1; then
+	printf 'FAIL bootstrap registration accepted a mismatched slug\n'
+	exit 1
+fi
+
+git -C "$bootstrap_repo" worktree add -q -b test/bootstrap-linked "$linked_repo"
+if (
+	cd "$linked_repo" || exit 1
+	AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$REPO_ROOT/aidevops.sh" repos add \
+		--slug example/bootstrap-repo --confirm REGISTER_CANONICAL_REPOSITORY
+) >/dev/null 2>&1; then
+	printf 'FAIL bootstrap registration accepted a linked worktree\n'
+	exit 1
+fi
+git -C "$bootstrap_repo" worktree remove "$linked_repo"
+
+if ! (
+	cd "$bootstrap_repo" || exit 1
+	AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$REPO_ROOT/aidevops.sh" repos add \
+		--slug example/bootstrap-repo --confirm REGISTER_CANONICAL_REPOSITORY
+) >/dev/null; then
+	printf 'FAIL confirmed bootstrap registration was rejected\n'
+	exit 1
+fi
+bootstrap_repo="$(cd "$bootstrap_repo" && pwd -P)"
+[[ "$(jq -r --arg path "$bootstrap_repo" '.initialized_repos[] | select(.path == $path) | .slug' "$REPOS_FILE")" == "example/bootstrap-repo" ]]
+[[ -f "${bootstrap_repo}/untracked.txt" ]]
+
 printf 'PASS repos add clears stale local_only, preserves pulse, and restores dispatch path resolution\n'
+printf 'PASS confirmed bootstrap registration validates identity without editing the canonical checkout\n'

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -772,25 +772,55 @@ _repos_list() {
 }
 
 _repos_add() {
+	local bootstrap_slug=""
+	local confirmation=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--slug)
+			bootstrap_slug="${2:-}"
+			shift 2
+			;;
+		--confirm)
+			confirmation="${2:-}"
+			shift 2
+			;;
+		*)
+			print_error "Usage: aidevops repos add [--slug OWNER/REPO --confirm REGISTER_CANONICAL_REPOSITORY]"
+			return 2
+			;;
+		esac
+	done
 	git rev-parse --is-inside-work-tree &>/dev/null || {
 		print_error "Not in a git repository"
 		return 1
 	}
 	local project_root
 	project_root=$(git rev-parse --show-toplevel)
-	[[ ! -f "$project_root/.aidevops.json" ]] && {
-		print_error "No .aidevops.json found - run 'aidevops init' first"
+	if [[ ! -f "$project_root/.aidevops.json" ]]; then
+		if [[ -z "$bootstrap_slug" || "$confirmation" != "REGISTER_CANONICAL_REPOSITORY" ]]; then
+			print_error "No .aidevops.json found - run 'aidevops init' or use the confirmed --slug bootstrap form"
+			return 1
+		fi
+		local recovery_helper="${AGENTS_DIR}/scripts/canonical-recovery-helper.sh"
+		[[ -x "$recovery_helper" ]] || {
+			print_error "Canonical bootstrap verifier is unavailable"
+			return 1
+		}
+		"$recovery_helper" verify-bootstrap-registration --repo "$project_root" \
+			--slug "$bootstrap_slug" --confirm "$confirmation" || return 1
+	elif [[ -n "$bootstrap_slug" || -n "$confirmation" ]]; then
+		print_error "The --slug bootstrap form is only valid when .aidevops.json is absent"
 		return 1
-	}
+	fi
 	local version features
-	if command -v jq &>/dev/null; then
+	if [[ -f "$project_root/.aidevops.json" ]] && command -v jq &>/dev/null; then
 		version=$(jq -r '.version' "$project_root/.aidevops.json" 2>/dev/null || echo "unknown")
 		features=$(jq -r '[.features | to_entries[] | select(.value == true) | .key] | join(",")' "$project_root/.aidevops.json" 2>/dev/null || echo "")
 	else
 		version="unknown"
 		features=""
 	fi
-	register_repo "$project_root" "$version" "$features"
+	register_repo "$project_root" "$version" "$features" "$bootstrap_slug"
 	print_success "Registered $(basename "$project_root")"
 	return 0
 }
@@ -873,7 +903,10 @@ cmd_repos() {
 	local action="${1:-list}"
 	case "$action" in
 	list | ls) _repos_list ;;
-	add) _repos_add ;;
+	add)
+		shift
+		_repos_add "$@"
+		;;
 	remove | rm) _repos_remove "${2:-}" ;;
 	clean) _repos_clean ;;
 	migrate-layout)
@@ -895,7 +928,7 @@ cmd_repos() {
 		echo ""
 		echo "Commands:"
 		echo "  list     List all registered projects (default)"
-		echo "  add      Register current project"
+		echo "  add      Register current project; confirmed --slug bootstraps config-free canonical repos"
 		echo "  remove   Remove project from registry"
 		echo "  clean    Remove entries for non-existent projects"
 		echo "  migrate-layout <plan|apply|rollback|status>"


### PR DESCRIPTION
## Summary

Add an explicit confirmation-gated repos add bootstrap path that validates canonical GitHub identity and writes a tamper-evident audit record before registration.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-repos-lib.sh, .agents/scripts/canonical-recovery-helper.sh, .agents/scripts/tests/test-repos-add-local-only-convergence.sh, aidevops.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck passed; repository convergence and canonical recovery focused suites passed, including mismatched slug, linked-worktree rejection, and untracked-file preservation.

Resolves #31144


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 32m and 417,603 tokens on this with the user in an interactive session.