### PR TITLE
GH#31145: add policy-safe body-file support

### DIFF
--- a/.agents/scripts/framework-issue-helper.sh
+++ b/.agents/scripts/framework-issue-helper.sh
@@ -10,7 +10,7 @@
 #
 # Usage:
 #   framework-issue-helper.sh detect "title or description text"
-#   framework-issue-helper.sh log --title "Title" --body "Body" [--label "bug"]
+#   framework-issue-helper.sh log --title "Title" (--body "Body" | --body-file PATH) [--label "bug"]
 #   framework-issue-helper.sh check-repo [--repo-path PATH]
 #
 # Commands:
@@ -23,6 +23,7 @@
 #                      Options:
 #                        --title TEXT      Issue title (required)
 #                        --body TEXT       Issue body (optional, auto-generated if omitted)
+#                        --body-file PATH  Read the issue body once from a regular file
 #                        --label LABEL     GitHub label (default: "bug")
 #                        --auto-dispatch   Explicitly retain the default automatic dispatch
 #                        --tier TIER       Add tier label (default: "standard")
@@ -615,15 +616,42 @@ _log_option_value() {
 	return 0
 }
 
+# Read a caller-supplied body before any network operation. The helper keeps the
+# resulting text on the existing signing, privacy, deduplication, and creation
+# path rather than passing an unchecked path to gh.
+_read_log_body_file() {
+	local body_file="$1"
+	local body_content=""
+	local trimmed_content=""
+
+	if [[ -z "$body_file" || ! -f "$body_file" || ! -r "$body_file" ]]; then
+		log_error "--body-file requires a readable regular file"
+		return 1
+	fi
+	body_content=$(<"$body_file") || {
+		log_error "Could not read --body-file: $body_file"
+		return 1
+	}
+	trimmed_content="${body_content#"${body_content%%[![:space:]]*}"}"
+	trimmed_content="${trimmed_content%"${trimmed_content##*[![:space:]]}"}"
+	if [[ -z "$trimmed_content" ]]; then
+		log_error "--body-file must contain a substantive issue body"
+		return 1
+	fi
+
+	printf '%s' "$body_content"
+	return 0
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # _parse_log_command ARGS...
 # ─────────────────────────────────────────────────────────────────────────────
 _parse_log_command() {
-	local title="" body="" label="bug" dry_run="false" auto_dispatch="yes" tier="standard" hold_reason="" dispatch_flag=""
+	local title="" body="" body_file="" body_source="" label="bug" dry_run="false" auto_dispatch="yes" tier="standard" hold_reason="" dispatch_flag=""
 	while [[ $# -gt 0 ]]; do
 		local option="$1"
 		case "$option" in
-		--title | --title=* | --body | --body=* | --label | --label=* | --tier | --tier=* | --hold-reason | --hold-reason=*)
+		--title | --title=* | --body | --body=* | --body-file | --body-file=* | --label | --label=* | --tier | --tier=* | --hold-reason | --hold-reason=*)
 			local flag_name="${option%%=*}"
 			local option_value
 			option_value="$(_log_option_value "$flag_name" "$option" "$#" "${2-}")" || return 1
@@ -632,7 +660,20 @@ _parse_log_command() {
 				title="$option_value"
 				;;
 			--body)
+				if [[ "$body_source" == "file" ]]; then
+					log_error "--body and --body-file are mutually exclusive"
+					return 1
+				fi
 				body="$option_value"
+				body_source="argument"
+				;;
+			--body-file)
+				if [[ "$body_source" == "argument" ]]; then
+					log_error "--body and --body-file are mutually exclusive"
+					return 1
+				fi
+				body_file="$option_value"
+				body_source="file"
 				;;
 			--label)
 				label="$option_value"
@@ -692,6 +733,9 @@ _parse_log_command() {
 	if [[ -n "$hold_reason" && "$auto_dispatch" != "no" ]]; then
 		log_error "--hold-reason requires --no-auto-dispatch"
 		return 1
+	fi
+	if [[ "$body_source" == "file" ]]; then
+		body=$(_read_log_body_file "$body_file") || return 1
 	fi
 
 	log_framework_issue "$title" "$body" "$label" "$dry_run" "$auto_dispatch" "$tier" "$hold_reason"

--- a/.agents/scripts/tests/test-framework-issue-helper.sh
+++ b/.agents/scripts/tests/test-framework-issue-helper.sh
@@ -436,6 +436,61 @@ else
 	fail "explicit caller body is preserved" "$explicit_text"
 fi
 
+multiline_source_dir="${TMP_DIR}/body files"
+mkdir -p "$multiline_source_dir"
+multiline_source="${multiline_source_dir}/worker-ready report.md"
+printf '%s\n' '## What' '' 'First line.' 'Second line.' >"$multiline_source"
+multiline_capture="${TMP_DIR}/multiline-capture.md"
+multiline_output="${TMP_DIR}/multiline.out"
+if TEST_DUPLICATE_VALUE="" \
+	TEST_CREATED_URL="https://github.com/marcusquinn/aidevops/issues/9108" \
+	TEST_GH_BODY_FILE="$multiline_capture" \
+	PATH="${generated_stub_dir}:$PATH" \
+	"$HELPER" log --title "fix: body file contract" --body-file "$multiline_source" >"$multiline_output" 2>&1; then
+	multiline_body=$(<"$multiline_capture")
+	assert_contains "$multiline_body" $'## What\n\nFirst line.\nSecond line.' "body-file preserves multiline Markdown and spaces in paths"
+else
+	multiline_text=$(<"$multiline_output")
+	fail "body-file preserves multiline Markdown and spaces in paths" "$multiline_text"
+fi
+
+equals_capture="${TMP_DIR}/equals-body-file-capture.md"
+if TEST_DUPLICATE_VALUE="" \
+	TEST_CREATED_URL="https://github.com/marcusquinn/aidevops/issues/9109" \
+	TEST_GH_BODY_FILE="$equals_capture" \
+	PATH="${generated_stub_dir}:$PATH" \
+	"$HELPER" log --title "fix: equals body file contract" --body-file="$multiline_source" >/dev/null 2>&1; then
+	assert_contains "$(<"$equals_capture")" "Second line." "body-file equals syntax is supported"
+else
+	fail "body-file equals syntax is supported" "helper rejected --body-file=PATH"
+fi
+
+for invalid_body_file in "${TMP_DIR}/missing.md" "$multiline_source_dir"; do
+	invalid_body_output="${TMP_DIR}/invalid-body-file-$(basename "$invalid_body_file").out"
+	if PATH="${generated_stub_dir}:$PATH" "$HELPER" log --title "fix: invalid body file" \
+		--body-file "$invalid_body_file" --dry-run >"$invalid_body_output" 2>&1; then
+		fail "invalid body-file input is rejected" "$invalid_body_file was accepted"
+	else
+		assert_contains "$(<"$invalid_body_output")" "readable regular file" "invalid body-file input is rejected"
+	fi
+done
+
+empty_body_file="${TMP_DIR}/empty-body.md"
+: >"$empty_body_file"
+if PATH="${generated_stub_dir}:$PATH" "$HELPER" log --title "fix: empty body file" \
+	--body-file "$empty_body_file" --dry-run >"${TMP_DIR}/empty-body-file.out" 2>&1; then
+	fail "empty body-file input is rejected" "empty file was accepted"
+else
+	assert_contains "$(<"${TMP_DIR}/empty-body-file.out")" "substantive issue body" "empty body-file input is rejected"
+fi
+
+if PATH="${generated_stub_dir}:$PATH" "$HELPER" log --title "fix: conflicting body inputs" \
+	--body "inline" --body-file "$multiline_source" --dry-run >"${TMP_DIR}/body-conflict.out" 2>&1; then
+	fail "body and body-file conflict is rejected" "conflicting inputs were accepted"
+else
+	assert_contains "$(<"${TMP_DIR}/body-conflict.out")" "mutually exclusive" "body and body-file conflict is rejected"
+fi
+
 unsafe_output="${TMP_DIR}/unsafe-explicit.out"
 unsafe_trace="${TMP_DIR}/unsafe-explicit.trace"
 set +e
@@ -463,6 +518,7 @@ assert_contains "$help_text" "--auto-dispatch" "usage documents auto-dispatch fl
 assert_contains "$help_text" "--tier TIER" "usage documents tier flag"
 assert_contains "$help_text" "--no-auto-dispatch" "usage documents durable manual hold flag"
 assert_contains "$help_text" "--hold-reason TEXT" "usage documents required hold reason"
+assert_contains "$help_text" "--body-file PATH" "usage documents body-file input"
 
 printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Support --body-file PATH and --body-file=PATH while retaining the existing signing, privacy, deduplication, and issue-creation path.

## Files Changed

.agents/scripts/framework-issue-helper.sh, .agents/scripts/tests/test-framework-issue-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck and the focused framework-issue-helper suite passed, covering multiline Markdown, paths with spaces, invalid or empty files, conflicting body inputs, and help output.

Resolves #31145


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 33m and 420,606 tokens on this with the user in an interactive session.