### PR TITLE
GH#31146: reconcile already-closed issue tasks

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -394,6 +394,64 @@ _reopen_mark_if_completed() {
 	return 1
 }
 
+# Reconcile a mapped TODO row when the remote issue is already terminal. This
+# path deliberately performs no GitHub mutation: local state advances only from
+# verified completion evidence or an immutable not-planned closure timestamp.
+_reconcile_already_closed_task() {
+	local task_id="$1"
+	local issue_number="$2"
+	local todo_file="$3"
+	local repo="$4"
+	local task_line="$5"
+	local issue_json="$6"
+	local state_reason=""
+	local closed_at=""
+	local closed_date=""
+	local issue_labels=""
+
+	require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$issue_number" || return 1
+	state_reason=$(printf '%s' "$issue_json" | jq -r '.state_reason // .stateReason // ""' 2>/dev/null) || return 1
+	closed_at=$(printf '%s' "$issue_json" | jq -r '.closed_at // .closedAt // ""' 2>/dev/null) || return 1
+	issue_labels=$(printf '%s' "$issue_json" | jq -r \
+		'[.labels[]? | if type == "object" then (.name // "") else . end] | join(" ")' 2>/dev/null) || return 1
+
+	if _is_not_planned_state_reason "$state_reason"; then
+		[[ "$closed_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || {
+			print_warning "#$issue_number is closed as not planned but has no valid closure timestamp; TODO unchanged"
+			return 1
+		}
+		closed_date="${closed_at%%T*}"
+		if [[ "$DRY_RUN" == "true" ]]; then
+			print_info "[DRY-RUN] Would mark $task_id [-] (not_planned on #$issue_number)"
+			return 0
+		fi
+		_mark_todo_not_planned "$task_id" "$issue_number" "$todo_file" "$closed_date" || return 1
+		return 0
+	fi
+
+	case "$state_reason" in
+	COMPLETED | completed) ;;
+	*)
+		print_warning "#$issue_number is closed with ambiguous reason '${state_reason:-none}'; TODO unchanged"
+		return 1
+		;;
+	esac
+	if printf '%s\n' "$issue_labels" | grep -qw "parent-task"; then
+		print_warning "#$issue_number ($task_id) is a parent task; terminal PR linkage must reconcile it"
+		return 1
+	fi
+	if ! _is_cancelled_or_deferred "$task_line" &&
+		_has_unresolved_blocker "$task_line" "" "$task_line" "$repo" "$issue_number"; then
+		print_warning "#$issue_number ($task_id) still has an unresolved dependency; TODO unchanged"
+		return 1
+	fi
+	if _reopen_mark_if_completed "$repo" "$task_id" "$issue_number" "$todo_file"; then
+		return 0
+	fi
+	print_warning "#$issue_number is closed as completed without acceptable completion evidence; TODO unchanged"
+	return 1
+}
+
 _do_close() {
 	local task_id="$1" issue_number="$2" todo_file="$3" repo="$4"
 	require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$issue_number" || return 1
@@ -493,12 +551,22 @@ cmd_close() {
 			print_info "$target_task: no matching issue"
 			return 0
 		}
-		local st
-		st=$(gh issue view "$num" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "")
-		[[ "$st" == "CLOSED" || "$st" == "closed" ]] && {
-			log_verbose "#$num already closed"
-			return 0
+		local issue_json=""
+		local st=""
+		issue_json=$(gh api "repos/${repo}/issues/${num}" 2>/dev/null) || {
+			print_error "Could not verify #$num before close reconciliation"
+			return 1
 		}
+		st=$(printf '%s' "$issue_json" | jq -r '.state // ""' 2>/dev/null) || return 1
+		if [[ "$st" == "CLOSED" || "$st" == "closed" ]]; then
+			log_verbose "#$num already closed — reconciling TODO state"
+			_reconcile_already_closed_task "$target_task" "$num" "$todo_file" "$repo" "$task_line" "$issue_json"
+			return $?
+		fi
+		if [[ "$st" != "OPEN" && "$st" != "open" ]]; then
+			print_error "Could not determine whether #$num is open"
+			return 1
+		fi
 		_do_close "$target_task" "$num" "$todo_file" "$repo" || true
 		return 0
 	fi

--- a/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
+++ b/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
@@ -230,6 +230,10 @@ todo_file=$(mktemp)
 printf '%s\n' '- [ ] t9010 retry failed completion lookup ref:GH#125' >"$todo_file"
 todo_before=$(<"$todo_file")
 _reopen_find_merged_pr() {
+	if [[ "${TEST_COMPLETION_EVIDENCE:-0}" -eq 1 ]]; then
+		printf '%s\n' "42|https://github.com/owner/repo/pull/42"
+		return 0
+	fi
 	return 1
 }
 if _reopen_mark_if_completed "owner/repo" "t9010" "125" "$todo_file"; then
@@ -240,6 +244,81 @@ else
 	pass "failed completion lookup leaves reopened TODO content unchanged"
 fi
 rm -f "$todo_file"
+
+require_task_issue_mapping() {
+	return 0
+}
+RECONCILE_RESULT=""
+TEST_COMPLETION_EVIDENCE=0
+TEST_UNRESOLVED_BLOCKER=0
+DRY_RUN=false
+_mark_todo_not_planned() {
+	local task_id="$1"
+	local issue_number="$2"
+	local todo_path="$3"
+	local closed_date="$4"
+	: "$task_id" "$issue_number" "$todo_path" "$closed_date"
+	RECONCILE_RESULT="not-planned"
+	return 0
+}
+_mark_reopen_merged_pr_task() {
+	local repo="$1"
+	local todo_path="$2"
+	local issue_number="$3"
+	local pr_number="$4"
+	: "$repo" "$todo_path" "$issue_number" "$pr_number"
+	RECONCILE_RESULT="completed"
+	return 0
+}
+_has_unresolved_blocker() {
+	[[ "$TEST_UNRESOLVED_BLOCKER" -eq 1 ]]
+	return $?
+}
+
+terminal_task='- [ ] t9012 reconcile terminal state ref:GH#9012'
+terminal_json='{"state":"closed","state_reason":"completed","closed_at":"2026-09-04T12:00:00Z","labels":[]}'
+TEST_COMPLETION_EVIDENCE=1
+if _reconcile_already_closed_task "t9012" "9012" "/unused/TODO.md" "owner/repo" "$terminal_task" "$terminal_json" &&
+	[[ "$RECONCILE_RESULT" == "completed" ]]; then
+	pass "already-closed completed issue reconciles from verified evidence"
+else
+	fail "already-closed completed issue should reconcile from verified evidence"
+fi
+
+RECONCILE_RESULT=""
+TEST_COMPLETION_EVIDENCE=0
+not_planned_json='{"state":"closed","state_reason":"not_planned","closed_at":"2026-09-03T12:00:00Z","labels":[]}'
+if _reconcile_already_closed_task "t9012" "9012" "/unused/TODO.md" "owner/repo" "$terminal_task" "$not_planned_json" &&
+	[[ "$RECONCILE_RESULT" == "not-planned" ]]; then
+	pass "already-closed not-planned issue preserves cancellation semantics"
+else
+	fail "already-closed not-planned issue should preserve cancellation semantics"
+fi
+
+RECONCILE_RESULT=""
+ambiguous_json='{"state":"closed","state_reason":null,"closed_at":"2026-09-03T12:00:00Z","labels":[]}'
+if _reconcile_already_closed_task "t9012" "9012" "/unused/TODO.md" "owner/repo" "$terminal_task" "$ambiguous_json"; then
+	fail "ambiguous already-closed issue remains unchanged"
+elif [[ -z "$RECONCILE_RESULT" ]]; then
+	pass "ambiguous already-closed issue remains unchanged"
+else
+	fail "ambiguous already-closed issue changed local state"
+fi
+
+parent_json='{"state":"closed","state_reason":"completed","closed_at":"2026-09-03T12:00:00Z","labels":[{"name":"parent-task"}]}'
+TEST_COMPLETION_EVIDENCE=1
+if _reconcile_already_closed_task "t9012" "9012" "/unused/TODO.md" "owner/repo" "$terminal_task" "$parent_json"; then
+	fail "parent task guard blocks automatic terminal reconciliation"
+else
+	pass "parent task guard blocks automatic terminal reconciliation"
+fi
+
+TEST_UNRESOLVED_BLOCKER=1
+if _reconcile_already_closed_task "t9012" "9012" "/unused/TODO.md" "owner/repo" "$terminal_task" "$terminal_json"; then
+	fail "unresolved dependency blocks automatic terminal reconciliation"
+else
+	pass "unresolved dependency blocks automatic terminal reconciliation"
+fi
 
 if [[ "$FAIL" -eq 0 ]]; then
 	printf 'All %d tests passed\n' "$PASS"


### PR DESCRIPTION
## Summary

Replace the already-closed no-op with evidence-gated TODO reconciliation for completed and not-planned issues.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh, .agents/scripts/tests/test-issue-sync-completion-evidence.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck passed; 23 completion-evidence tests and 26 reopen/not-planned tests passed, including ambiguous state, parent-task, and unresolved-blocker fail-closed cases.

Resolves #31146


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 35m and 421,707 tokens on this with the user in an interactive session.