### PR TITLE
t18396: Add Codacy remediation tasks for t18396-t18398

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,9 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 <!--TOON:ready[0]{id,desc,owner,tags,est,logged}:
 -->
 
+- [ ] t18396 Detect Codacy index and configuration drift before remediation #bug #quality #codacy #reliability #auto-dispatch ~4h tier:standard ref:GH#31147 logged:2026-09-04 -> [todo/tasks/t18396-brief.md]
+- [ ] t18397 Make email facade exports explicit and clear Pylint unused-import noise #quality #codacy #python #refactor #auto-dispatch ~2.5h tier:standard ref:GH#31148 logged:2026-09-04 -> [todo/tasks/t18397-brief.md]
+- [ ] t18398 Harden high-signal Python subprocess boundaries reported by Codacy #bug #security #quality #codacy #python #auto-dispatch #priority:high ~5h tier:standard ref:GH#31150 logged:2026-09-04 -> [todo/tasks/t18398-brief.md]
 - [x] t18293 Reject malformed GitHub login output before approval lifecycle mutation #bug #security #framework #reliability #interactive #auto-dispatch ~2h tier:standard ref:GH#30338 logged:2026-08-17 -> [todo/tasks/t18293-brief.md] pr:#30342 completed:2026-08-17
 
 - [x] t18193 Define provider-neutral team-interface core contracts #mission:m-20260804-5d06b1 #enhancement #framework #auto-dispatch ~4h tier:standard ref:GH#29494 logged:2026-08-04 -> [todo/tasks/t18193-brief.md] pr:#29505 completed:2026-08-04

--- a/todo/tasks/t18396-brief.md
+++ b/todo/tasks/t18396-brief.md
@@ -1,0 +1,129 @@
+<!-- aidevops:brief-schema=v2 -->
+
+# t18396: Detect Codacy index and configuration drift before remediation
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `Codacy indexing quality findings issue creation worker briefs task lifecycle` → 0 hits — no relevant reusable lesson
+- [x] Discovery pass: 0 recent target-file commits / 2 relevant merged PRs (#19637, #19647) / 0 open related PRs; neither historical PR added durable drift detection
+- [x] File refs verified: 5 existing refs plus the test parent directory checked at `c2347f0b222e6ac88804f85a6a495fc05ee51f47`
+- [x] Tier: `tier:standard` — telemetry behavior, drift thresholds, failure policy, and verification are resolved; implementation still requires bounded integration work
+- [x] Seeded draft PR decision recorded: skipped — issue-only avoids anchoring the worker before the state-file shape is implemented
+
+## Origin
+
+- **Created:** 2026-09-04
+- **Session:** OpenCode `ses_f9595a114ffe165mBLWoXbpLl2`
+- **Created by:** ai-interactive
+- **Parent task:** none
+- **Blocked by:** none
+- **Conversation context:** A manual Codacy reanalysis reached current `main` but left analysed LOC far below its historical level. The user authorized durable remediation briefs rather than code changes intended only to improve the badge.
+
+## What
+
+Make the daily quality sweep report enough Codacy state to distinguish genuine code-quality changes from stale analysis, index-denominator collapse, and documented coding-standard drift. Persist a per-repository last-healthy sample, render an explicit health classification, and prevent degraded Codacy telemetry from being described as a code regression.
+
+## Why
+
+At current `main` (`c2347f0b222e6ac88804f85a6a495fc05ee51f47`), Codacy reports grade 81/B, 2,421 issues, 371,010 analysed LOC, and 14 complex files. Historical analysed LOC was about 815,000; repeated reanalysis did not restore it. The existing `_sweep_codacy()` reports only issue count, so operators and automation cannot see denominator or coding-standard drift. It also cannot detect that B404 has returned with 69 findings despite the repository policy in `.bandit`.
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** The task changes observability and fail-closed classification, not external Codacy settings. The required states and negative guarantees are specified, while the worker must fit them into existing sweep serialization.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** The work needs a cohesive state shape and focused fixtures; speculative code would constrain that implementation unnecessarily.
+- **Status:** `not-created`
+- **Freshness evidence:** Dashboard/API state and target files were checked against current analysed `main` on 2026-09-04.
+- **Verification run:** `UNVERIFIED — brief only`
+- **Stale-assumption warning:** Re-read Codacy API response fields and the current sweep serialization if either target script changes before implementation.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/stats-quality-sweep-tools.sh:333-365` — expand `_sweep_codacy()` from issue-count-only output to repository health telemetry and rule-policy drift evidence.
+- `EDIT: .agents/scripts/stats-quality-sweep.sh:650-692,726-829` — pass the scanned repository path, persist/read Codacy health state, and preserve the multi-line section contract.
+- `EDIT: .agents/tools/code-review/codacy.md:32-55,59-91` — document the health states, thresholds, and operator response.
+- `NEW: .agents/scripts/tests/test-codacy-health-sweep.sh` — hermetic API/state fixtures for healthy, stale, index-degraded, and policy-drift states.
+
+### Complete Write Surface
+
+- **Callers/readers:** `_run_sweep_tools()` calls `_sweep_codacy()` and `_quality_sweep_for_repo()` renders its section; the persistent Code Audit Routines issue is the human reader.
+- **Writers/mutation paths:** Store Codacy state under the existing `QUALITY_SWEEP_STATE_DIR` using atomic replacement. Do not change Sonar/Qlty fields in `_save_sweep_state()` or mutate Codacy settings.
+- **Tests/fixtures:** Extend the existing per-tool stubbing/serialization pattern in `.agents/scripts/tests/test-quality-sweep-serialization.sh:107-166`; add focused JSON fixtures in the new test rather than live API calls.
+- **Schemas/config:** Preserve current quality-sweep section files and state backward compatibility. New Codacy state must tolerate missing/legacy files as `BASELINE_UNKNOWN`.
+- **Generated/deployed mirrors:** `setup.sh` deploys `.agents/scripts/**`; edit repository sources only.
+- **Migrations/backfills:** `QUALITY_SWEEP_STATE_DIR` needs no destructive migration because a first observation without a trustworthy baseline records telemetry but must not claim the index is healthy.
+- **Cleanup/rollback paths:** Reverting `.agents/scripts/stats-quality-sweep-tools.sh` and the new state fields must leave the existing issue-count-only Codacy section functional; malformed state is ignored and rebuilt.
+
+### Implementation Steps
+
+1. Fetch the repository summary already verified at `/api/v3/analysis/organizations/gh/{owner}/repositories/{repo}?branch=main` and the issue overview endpoint in bounded requests. Parse grade, issue count, analysed LOC, complex-file count, last analysed SHA, and pattern totals.
+2. Compare the last analysed SHA with the remote default SHA. Classify a mismatch as `STALE_ANALYSIS` and never advance the healthy baseline from it.
+3. Once a trustworthy baseline exists, classify analysed LOC below 80% of the last healthy value as `INDEX_DEGRADED`. Keep the previous healthy baseline so a bad sample cannot ratchet the expected denominator downward.
+4. Classify non-zero counts for repository-documented noise patterns as `POLICY_DRIFT`; initially cover `Bandit_B404`, `ESLint8_es-x_no-modules`, `ESLint8_es-x_no-block-scoped-variables`, and `ESLint8_es-x_no-trailing-commas`.
+5. Render grade, issue count, LOC, complex files, analysed SHA, health state, and drift-rule counts in the Codacy section. API, parse, or state errors must render `UNKNOWN`, not zero or healthy.
+6. Keep this task observational: do not change `.bandit`, `.codacy.yml`, external coding-standard settings, issue thresholds, or source exclusions.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** Sweep instances may overlap; write state through a same-directory temporary file and atomic rename so readers never consume partial JSON.
+- **Migration/rollback:** Missing or old state initializes as unknown. Do not overwrite a last-healthy baseline with stale, malformed, or index-degraded samples.
+- **Mixed-version/backward compatibility:** Existing callers expecting one multi-line `codacy_section` remain valid; new state fields are additive.
+- **Idempotency/retry:** Repeating the same sample produces the same classification and state. API rate limits/errors remain non-destructive.
+- **Partial failure/recovery:** If one Codacy endpoint succeeds and another fails, render available telemetry with `UNKNOWN` health and retain the prior healthy state.
+
+### Verification Before Dispatch
+
+```bash
+bash .agents/scripts/tests/test-codacy-health-sweep.sh
+bash .agents/scripts/tests/test-quality-sweep-serialization.sh
+shellcheck .agents/scripts/stats-quality-sweep-tools.sh .agents/scripts/stats-quality-sweep.sh .agents/scripts/tests/test-codacy-health-sweep.sh
+.agents/scripts/linters-local.sh --changed
+```
+
+- **Surface mapping:** The focused test covers API parsing and state transitions; serialization coverage protects the dashboard transport; ShellCheck and changed-file lint cover Bash portability and repository policy.
+- **Broad verification trigger:** Run the full stats quality-sweep test group only if shared state or section serialization changes beyond Codacy-specific fields.
+
+### Files Scope
+
+- `.agents/scripts/stats-quality-sweep-tools.sh`
+- `.agents/scripts/stats-quality-sweep.sh`
+- `.agents/tools/code-review/codacy.md`
+- `.agents/scripts/tests/test-codacy-health-sweep.sh`
+- `.agents/scripts/tests/test-quality-sweep-serialization.sh`
+
+## Acceptance Criteria
+
+- [ ] A current-head healthy fixture renders grade, issue count, LOC, complex files, analysed SHA, and `HEALTHY`, then atomically records it as the last healthy sample.
+- [ ] A stale SHA, malformed response, or API failure cannot render `HEALTHY` or overwrite the prior healthy baseline.
+- [ ] A current-head sample below 80% of the prior healthy LOC renders `INDEX_DEGRADED` while retaining the prior baseline.
+- [ ] Any configured documented-noise rule with a non-zero overview count renders `POLICY_DRIFT` and the exact rule/count without changing external settings.
+- [ ] Existing multi-line quality-sweep serialization and non-Codacy tool sections remain byte-stable.
+
+## Context & Decisions
+
+- This task improves trustworthiness; it must not hide genuine findings or weaken quality gates merely to raise the badge.
+- The current index collapse remains an external incident handled separately by t18399.
+- B404 and legacy ESLint counts are drift signals because repository policy already identifies them as noise; subprocess usage rules B603/B607 remain enabled.
+
+## Dependencies
+
+- **Blocked by:** none.
+- **Blocks:** none.
+- **External:** Read-only Codacy API access; fixtures must keep tests independent of credentials and network availability.
+
+## Estimate Breakdown
+
+| Phase | Time |
+|---|---:|
+| API/state integration | 1.5h |
+| Rendering and documentation | 45m |
+| Focused verification | 1.5h |
+| Review buffer | 15m |
+| **Total** | **~4h** |

--- a/todo/tasks/t18397-brief.md
+++ b/todo/tasks/t18397-brief.md
@@ -1,0 +1,130 @@
+<!-- aidevops:brief-schema=v2 -->
+
+# t18397: Make email facade exports explicit and clear Pylint unused-import noise
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `Codacy indexing quality findings issue creation worker briefs task lifecycle` → 0 hits — no relevant reusable lesson
+- [x] Discovery pass: 0 recent target-file commits / 0 merged related PRs / 0 open related PRs
+- [x] File refs verified: 7 existing refs plus the new-test parent directory checked at `c2347f0b222e6ac88804f85a6a495fc05ee51f47`
+- [x] Tier: `tier:standard` — compatibility behavior is fixed, but the worker must distinguish facade exports from genuinely dead imports
+- [x] Seeded draft PR decision recorded: skipped — a focused issue is sufficient and avoids speculative export lists
+
+## Origin
+
+- **Created:** 2026-09-04
+- **Session:** OpenCode `ses_f9595a114ffe165mBLWoXbpLl2`
+- **Created by:** ai-interactive
+- **Parent task:** none
+- **Blocked by:** none
+- **Conversation context:** Codacy reports 93 Pylint W0611 findings. Inspection showed that many are intentional compatibility re-exports already marked for Ruff/Pyflakes, mixed with a smaller number of genuinely unused standard-library imports.
+
+## What
+
+Express the public compatibility surfaces of the decomposed email modules with explicit export contracts and remove only imports proven to be dead. Clear the current W0611 findings in the scoped files without deleting names that downstream callers may import.
+
+## Why
+
+`# noqa: F401` documents intent for Ruff/Pyflakes but does not tell Pylint that a name is part of a module’s public API. Codacy therefore reports facade imports as dead code, obscuring real unused imports such as `re` in `email_normaliser.py` and `os`/`datetime` in `email_thread.py`.
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** The desired compatibility guarantee is resolved, but the exact public export lists must be derived from current modules and validated against import behavior.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** The worker should construct export lists from current symbols and tests rather than inherit an unverified hand-written list.
+- **Status:** `not-created`
+- **Freshness evidence:** Target files, import references, tests, recent commits, and related PRs were checked on 2026-09-04.
+- **Verification run:** `UNVERIFIED — brief only`
+- **Stale-assumption warning:** Re-run import searches if any email decomposition PR lands before implementation.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/email_jmap_adapter.py:33-78` — convert documented compatibility re-exports into an explicit public surface.
+- `EDIT: .agents/scripts/email_normaliser.py:9-25` — retain parser/section re-exports explicitly and remove the unused `re` import if still dead.
+- `EDIT: .agents/scripts/email-to-markdown.py:30-83` — preserve the compatibility API of dynamically loaded pipeline modules with an explicit export contract.
+- `EDIT: .agents/scripts/email_thread.py:19-27` — remove only standard-library imports still proven unused.
+- `NEW: tests/test-email-facade-exports.py` — verify expected facade names remain importable and dead standard-library imports do not return.
+
+### Complete Write Surface
+
+- **Callers/readers:** `email-to-markdown.py:70-79` imports the `email_normaliser` facade; shell entry points execute `email-to-markdown.py`; external users may import the documented JMAP/email facade names even where no in-repo caller exists.
+- **Writers/mutation paths:** Module-level imports and `__all__` declarations only. Do not change command parsers, email conversion output, JMAP requests, or thread index writes.
+- **Tests/fixtures:** Follow the dynamic-import setup in `tests/test-email-summary.py:296-315` and the JMAP module loading pattern in `.agents/scripts/tests/test-email-jmap-push.py:16-23`.
+- **Schemas/config:** Module `__all__` declarations are the public-symbol compatibility schema; no persisted data migration is involved.
+- **Generated/deployed mirrors:** `setup.sh` deploys `.agents/scripts/**`; edit repository sources only.
+- **Migrations/backfills:** N/A because the scoped modules do not change persisted records.
+- **Cleanup/rollback paths:** Revert `__all__` declarations and import removals together; the compatibility test must fail if a public symbol disappears.
+
+### Implementation Steps
+
+1. Search each scoped module for local and external-facing documented symbols before editing. Treat comments stating “Re-export public surface” as compatibility requirements.
+2. Add explicit module-level `__all__` declarations covering the intended facade names. Keep needed imports even when their only use is export.
+3. Remove only imports with no execution or export role. Reconfirm `re` in `email_normaliser.py` and `os`, `datetime`, and `timezone` in `email_thread.py` against current HEAD.
+4. Remove obsolete `noqa: F401` markers only when the explicit export declaration makes intent clear; retain unrelated E402 markers required by dynamic sibling loading.
+5. Add a focused test that imports each facade through its supported loading path and asserts representative compatibility names. Include negative source assertions for the proven-dead imports without coupling to formatting.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** N/A; imports initialize synchronously and no shared mutable state changes.
+- **Migration/rollback:** No data migration. Reverting restores the prior implicit facade.
+- **Mixed-version/backward compatibility:** Every currently documented/re-exported public symbol must remain importable; do not narrow the API based only on in-repo usage.
+- **Idempotency/retry:** Module imports and tests remain repeatable with no external network calls.
+- **Partial failure/recovery:** A missing facade symbol must fail focused tests before merge; no generated artifacts are written.
+
+### Verification Before Dispatch
+
+```bash
+python3 tests/test-email-facade-exports.py
+python3 tests/test-email-summary.py
+python3 .agents/scripts/tests/test-email-jmap-push.py
+python3 -m compileall -q .agents/scripts/email_jmap_adapter.py .agents/scripts/email_normaliser.py .agents/scripts/email-to-markdown.py .agents/scripts/email_thread.py
+.agents/scripts/linters-local.sh --changed
+```
+
+- **Surface mapping:** Facade tests protect public imports; existing summary/JMAP tests protect runtime behavior; compileall and changed-file lint catch syntax and lint regressions.
+- **Broad verification trigger:** Run additional email integration tests only if implementation touches behavior outside module exports/import cleanup.
+
+### Files Scope
+
+- `.agents/scripts/email_jmap_adapter.py`
+- `.agents/scripts/email_normaliser.py`
+- `.agents/scripts/email-to-markdown.py`
+- `.agents/scripts/email_thread.py`
+- `tests/test-email-facade-exports.py`
+
+## Acceptance Criteria
+
+- [ ] All compatibility names currently re-exported by the three facade modules remain importable and are represented in explicit public export contracts.
+- [ ] The scoped Codacy Pylint W0611 findings are removed or reduced only through explicit export intent and deletion of proven-dead imports, never through a global Pylint disable.
+- [ ] `email_normaliser.py` and `email_thread.py` no longer import the currently dead standard-library names unless current code proves a semantic use.
+- [ ] Email conversion and JMAP tests retain their existing behavior and output contracts.
+- [ ] Focused tests, compileall, and changed-file lint pass.
+
+## Context & Decisions
+
+- Preserve compatibility over badge cleanup: absence of an in-repo caller is not evidence that a documented facade export can be deleted.
+- Use standard Python export semantics rather than tool-specific blanket suppressions.
+- This is a bounded first batch; remaining W0611 findings should be triaged by subsystem, not mass-deleted.
+
+## Dependencies
+
+- **Blocked by:** none.
+- **Blocks:** none.
+- **External:** Codacy reanalysis is confirmation after merge, not a local test dependency.
+
+## Estimate Breakdown
+
+| Phase | Time |
+|---|---:|
+| Export inventory | 30m |
+| Implementation | 45m |
+| Focused tests | 1h |
+| Review buffer | 15m |
+| **Total** | **~2.5h** |

--- a/todo/tasks/t18398-brief.md
+++ b/todo/tasks/t18398-brief.md
@@ -1,0 +1,141 @@
+<!-- aidevops:brief-schema=v2 -->
+
+# t18398: Harden high-signal Python subprocess boundaries reported by Codacy
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `Codacy indexing quality findings issue creation worker briefs task lifecycle` → 0 hits — no relevant reusable lesson
+- [x] Discovery pass: 0 recent target-file commits / 0 merged related PRs / 0 open related PRs
+- [x] File refs verified: 12 source/test refs checked at `c2347f0b222e6ac88804f85a6a495fc05ee51f47`
+- [x] Tier: `tier:standard` — the trust boundary and no-global-suppression policy are decided; each bounded callsite still needs source-aware validation
+- [x] Seeded draft PR decision recorded: skipped — security-adjacent callsite classification should precede edits
+
+## Origin
+
+- **Created:** 2026-09-04
+- **Session:** OpenCode `ses_f9595a114ffe165mBLWoXbpLl2`
+- **Created by:** ai-interactive
+- **Parent task:** none
+- **Blocked by:** none
+- **Conversation context:** Current Codacy analysis reports 74 Opengrep dangerous-subprocess findings, 35 Bandit B603 findings, and 37 Bandit B607 findings. This brief selects the six highest-density production files rather than opening one issue per annotation or suppressing the tools globally.
+
+## What
+
+Harden or precisely document the subprocess trust boundary at the 14 unique callsites in the six scoped production files. Resolve their current 26 overlapping Codacy findings while preserving command behavior, fail-closed handling, process cleanup, and platform compatibility.
+
+## Why
+
+The selected files account for the highest-density production findings: `_knowledge_collector_process.py` (6), `session-miner/extract_git.py` (6), `managed_readme.py` (4), `report-token-use-helper.py` (4), `cch-sign.py` (3), and `deployment-copy-helper.py` (3). Some callsites already validate argv and carry Bandit rationale but remain visible to Opengrep; others invoke partial executable paths or accept command vectors whose origin must be made explicit.
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** This is a bounded security-adjacent implementation inside existing command boundaries. No trust-policy redesign is authorized, but the worker must classify each argv source before choosing validation, absolute resolution, or narrow suppression.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** Pre-writing annotations would risk blessing unverified command provenance.
+- **Status:** `not-created`
+- **Freshness evidence:** All Codacy findings were fetched for current analysed `main`; target callsites and related PR activity were then checked locally.
+- **Verification run:** `UNVERIFIED — brief only`
+- **Stale-assumption warning:** Re-query or inspect current callsites if any scoped file changes before work starts; annotation line numbers are not stable identifiers.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/_knowledge_collector_process.py:20-24,107-142` — resolve the fixed process-inspection executable and validate/document the collector command boundary without weakening termination safety.
+- `EDIT: .agents/scripts/session-miner/extract_git.py:17-27,49-67,84-99` — resolve Git safely and preserve current timeout/error semantics.
+- `EDIT: .agents/scripts/managed_readme.py:72-87,129-148` — make `gh`, `bash`, and helper-path provenance explicit.
+- `EDIT: .agents/scripts/report-token-use-helper.py:758-764` — resolve platform opener executables before invocation and retain non-fatal open behavior.
+- `EDIT: .agents/scripts/cch-sign.py:60-101` — keep the absolute helper call and resolve optional `claude` execution without changing fallback constants.
+- `EDIT: .agents/scripts/deployment-copy-helper.py:109-118,379-417,468-477` — preserve validated Git provenance and add exact Opengrep suppression only where code-level checks already prove safety.
+- Existing focused tests listed below may be updated only when assertions must reflect unchanged command resolution behavior.
+
+### Complete Write Surface
+
+- **Callers/readers:** `.agents/scripts/_knowledge_collector_process.py` and the other five scoped helpers are invoked by knowledge collection, session mining, managed README sync, token reports, CCH signing, and deployment-copy workflows. Their subprocess return codes/stdout/stderr are consumed by existing control flow.
+- **Writers/mutation paths:** Changes in `.agents/scripts/deployment-copy-helper.py` and the other scoped helpers are limited to executable resolution, argv validation, and exact finding annotations; do not alter destination files, Git operations, process-group termination, report opening, signing constants, or deployment state.
+- **Tests/fixtures:** Reuse `.agents/scripts/tests/test-deployment-copy-helper.sh`, `test-managed-readme-helper.sh`, `test-report-token-use-helper.sh`, session-miner tests, and `.agents/tests/test-knowledge-collector-routine.sh`. Add assertions to existing files rather than introduce a new harness.
+- **Schemas/config:** N/A because evidence shows the scoped subprocess boundaries change no persisted schema or global security configuration.
+- **Generated/deployed mirrors:** `setup.sh` deploys `.agents/scripts/**`; do not edit installed copies.
+- **Migrations/backfills:** N/A because the scoped helpers persist no subprocess-boundary schema or records requiring migration.
+- **Cleanup/rollback paths:** Revert each scoped `.agents/scripts/*.py` change independently if behavior regresses. Never “recover” by disabling B603, B607, or the Opengrep rule repository-wide.
+
+### Implementation Steps
+
+1. For each scoped callsite, record whether the executable is absolute, resolved through a trusted lookup, or caller-controlled; record whether each argument is fixed, validated, or data-only.
+2. Resolve partial executable names with `shutil.which()` or an existing trusted path pattern, and preserve existing optional-tool behavior when an executable is absent.
+3. Keep argv arrays and `shell=False`. Add validation before execution wherever a command or executable can cross the function boundary.
+4. Where existing validation already proves a finding false positive, use the exact tool-native suppression with an inline reason tied to that validation. Use the full Opengrep rule identifier when required; do not add blanket file/tool exclusions.
+5. Preserve all current timeouts, capture modes, return-code checks, fallback ordering, and process-tree cleanup.
+6. Run the focused product-path tests, then confirm the scoped files no longer emit the targeted rules through the available local scanner or post-merge Codacy reanalysis.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** `_knowledge_collector_process.py` signal masks and process-group cleanup are concurrency-sensitive; executable validation must occur before launch without changing cleanup ordering.
+- **Migration/rollback:** No data migration. Each file can be reverted without state conversion.
+- **Mixed-version/backward compatibility:** Preserve macOS/Linux opener behavior, optional `claude` fallback, Git CLI compatibility, and existing Python versions.
+- **Idempotency/retry:** Command invocations retain current retry/fallback behavior. Resolution must not cache stale paths across unrelated runs.
+- **Partial failure/recovery:** Missing executables must follow current graceful failure paths; deployment and signing helpers must continue to fail closed where provenance cannot be verified.
+
+### Verification Before Dispatch
+
+```bash
+bash .agents/scripts/tests/test-deployment-copy-helper.sh
+bash .agents/scripts/tests/test-managed-readme-helper.sh
+bash .agents/scripts/tests/test-report-token-use-helper.sh
+bash .agents/scripts/tests/test-session-miner-repo-scope.sh
+bash .agents/tests/test-knowledge-collector-routine.sh
+python3 -m compileall -q .agents/scripts/_knowledge_collector_process.py .agents/scripts/session-miner/extract_git.py .agents/scripts/managed_readme.py .agents/scripts/report-token-use-helper.py .agents/scripts/cch-sign.py .agents/scripts/deployment-copy-helper.py
+.agents/scripts/linters-local.sh --changed
+```
+
+- **Surface mapping:** Existing helper tests cover command behavior and failure handling; compileall checks every scoped Python source; changed-file lint covers repository quality gates.
+- **Broad verification trigger:** Run a broader subsystem suite only if the implementation changes shared command wrappers or trust policy outside these files.
+
+### Files Scope
+
+- `.agents/scripts/_knowledge_collector_process.py`
+- `.agents/scripts/session-miner/extract_git.py`
+- `.agents/scripts/managed_readme.py`
+- `.agents/scripts/report-token-use-helper.py`
+- `.agents/scripts/cch-sign.py`
+- `.agents/scripts/deployment-copy-helper.py`
+- `.agents/scripts/tests/test-deployment-copy-helper.sh`
+- `.agents/scripts/tests/test-managed-readme-helper.sh`
+- `.agents/scripts/tests/test-report-token-use-helper.sh`
+- `.agents/scripts/tests/test-session-miner-repo-scope.sh`
+- `.agents/tests/test-knowledge-collector-routine.sh`
+
+## Acceptance Criteria
+
+- [ ] Every scoped subprocess call has explicit executable and argv provenance enforced in code or documented by an exact narrow suppression after validation.
+- [ ] Partial executables are resolved safely or retain a documented graceful-absence path; no implementation introduces `shell=True` or string command execution.
+- [ ] The 26 current overlapping B603/B607/dangerous-subprocess findings in the six scoped files are eliminated without disabling those rules globally.
+- [ ] Knowledge-collector interruption cleanup, deployment provenance checks, managed README fallback, session mining, report opening, and CCH fallback behavior remain unchanged.
+- [ ] Focused tests, compileall, and changed-file lint pass.
+
+## Context & Decisions
+
+- This is the first production batch, selected by finding density. Test-only subprocess findings and the remaining lower-density files are intentionally out of scope.
+- Existing `# nosec B603` comments are evidence to verify, not proof to copy blindly.
+- Security behavior outranks badge improvement; retain a finding when safe remediation or precise justification cannot be established.
+
+## Dependencies
+
+- **Blocked by:** none.
+- **Blocks:** none.
+- **External:** Codacy reanalysis confirms remote-rule clearance after merge; local product tests remain authoritative for behavior.
+
+## Estimate Breakdown
+
+| Phase | Time |
+|---|---:|
+| Callsite classification | 1h |
+| Hardening/annotations | 2h |
+| Focused verification | 1.5h |
+| Review buffer | 30m |
+| **Total** | **~5h** |


### PR DESCRIPTION
## Planning publication

- Publishes TODO.md and todo/ planning-file changes through a PR because main does not accept direct planning pushes.
- Source branch at helper invocation: feature/auto-20260904-143609.
- Commit message: plan(t18396,t18397,t18398): add Codacy remediation tasks.

## Task and issue manifest

<!-- aidevops:planning-publication:v1 id=02aa00ba6198cc2fd2c21e2b7c0929c016dd6970 -->
<!-- aidevops:planning-task:v1 task=t18396 issue=31147 -->
<!-- aidevops:planning-task:v1 task=t18397 issue=31148 -->
<!-- aidevops:planning-task:v1 task=t18398 issue=31150 -->
- For #31147
- For #31148
- For #31150

## Security and architecture guardrails

- This PR does not update .task-counter.
- Task IDs still come from claim-task-id.sh CAS allocation on a branch that permits atomic counter pushes.
- Do not replace counter allocation with a PR-backed counter update; PR review is not an atomic ID lock.

## Merge note

- Merge this planning-only PR before expecting pulse or issue-sync to see the TODO/todo changes.
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 10h 50m and 1,458,930 tokens on this with the user in an interactive session.