### PR TITLE
t18398: fix: harden Python subprocess boundaries

### DIFF
--- a/.agents/scripts/_knowledge_collector_process.py
+++ b/.agents/scripts/_knowledge_collector_process.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import signal
 import subprocess
 import time
@@ -18,9 +19,12 @@ class CollectorInterrupted(Exception):
 
 
 def _descendant_pids(root_pid: int) -> list[int]:
+    ps = shutil.which("ps")
+    if ps is None:
+        return []
     try:
-        result = subprocess.run(
-            ["ps", "-axo", "pid=,ppid="], check=True, capture_output=True, text=True, timeout=2
+        result = subprocess.run(  # nosec B603 -- resolved system process viewer and fixed argv.
+            [ps, "-axo", "pid=,ppid="], check=True, capture_output=True, text=True, timeout=2
         )
     except (OSError, subprocess.SubprocessError):
         return []
@@ -107,6 +111,18 @@ def _restore_signals(
 def _run_bounded(
     command: list[str], working_directory: Path, environment: dict[str, str], timeout: int
 ) -> subprocess.CompletedProcess[str]:
+    if not command or not all(isinstance(argument, str) for argument in command):
+        raise ValueError("collector command must be a non-empty string argv vector")
+    executable = Path(command[0])
+    if not executable.is_absolute():
+        raise ValueError("collector command must begin with an absolute executable path")
+    executable = executable.resolve(strict=True)
+    if (
+        not executable.is_file()
+        or not os.access(executable, os.X_OK)
+    ):
+        raise ValueError("collector command must begin with an executable absolute path")
+    command = [str(executable), *command[1:]]
     interrupt_signals = (signal.SIGINT, signal.SIGTERM)
     previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, interrupt_signals)
     previous_handlers: dict[signal.Signals, Any] = {}
@@ -117,7 +133,7 @@ def _run_bounded(
     for interrupt_signal in interrupt_signals:
         previous_handlers[interrupt_signal] = signal.signal(interrupt_signal, interrupt)
     try:
-        process = subprocess.Popen(
+        process = subprocess.Popen(  # nosec B603 -- validated absolute collector entrypoint and structured argv.
             command, cwd=working_directory, env=environment, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, text=True, start_new_session=True
         )

--- a/.agents/scripts/cch-sign.py
+++ b/.agents/scripts/cch-sign.py
@@ -34,6 +34,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -71,8 +72,11 @@ def load_constants(use_cache: bool = True) -> dict:
 
     # Try live extraction
     try:
-        result = subprocess.run(
-            [str(Path.home() / ".aidevops" / "agents" / "scripts" / "cch-extract.sh")],
+        extractor = Path.home() / ".aidevops" / "agents" / "scripts" / "cch-extract.sh"
+        if not extractor.is_file() or extractor.is_symlink():
+            raise FileNotFoundError("trusted CCH extractor is unavailable")
+        result = subprocess.run(  # nosec B603 -- absolute, verified deployed helper and fixed argv.
+            [str(extractor)],
             capture_output=True,
             text=True,
             timeout=10,
@@ -86,9 +90,18 @@ def load_constants(use_cache: bool = True) -> dict:
 
     # Try claude --version for at least the version
     version = DEFAULT_VERSION
+    claude = shutil.which("claude")
+    if claude is None:
+        return {
+            "version": version,
+            "salt": DEFAULT_SALT,
+            "char_indices": DEFAULT_CHAR_INDICES,
+            "entrypoint": DEFAULT_ENTRYPOINT,
+            "has_xxhash": False,
+        }
     try:
-        result = subprocess.run(
-            ["claude", "--version"],
+        result = subprocess.run(  # nosec B603 -- resolved Claude executable and fixed version argv.
+            [claude, "--version"],
             capture_output=True,
             text=True,
             timeout=5,

--- a/.agents/scripts/deployment-copy-helper.py
+++ b/.agents/scripts/deployment-copy-helper.py
@@ -106,6 +106,22 @@ def require(condition: bool, message: str) -> None:
         raise DeploymentError(message)
 
 
+def trusted_git_bin() -> str:
+    """Resolve the configured Git executable and reject non-executable overrides."""
+    configured = os.environ.get("AIDEVOPS_REAL_GIT_BIN")
+    candidate = Path(configured) if configured else None
+    if candidate is None:
+        resolved = shutil.which("git")
+        require(resolved is not None, "Git executable is unavailable")
+        candidate = Path(resolved)
+    require(candidate.is_absolute(), "Git executable must be an absolute path")
+    require(
+        candidate.is_file() and not candidate.is_symlink() and os.access(candidate, os.X_OK),
+        "Git executable is unavailable or unsafe",
+    )
+    return str(candidate.resolve(strict=True))
+
+
 def run_git(git_bin: str, cwd: Path, *args: str) -> str:
     result = subprocess.run(  # nosec B603 -- argv array; Git data is validated separately
         [git_bin, "-C", str(cwd), *args],
@@ -816,7 +832,7 @@ def receipt_context(receipt: dict[str, Any], git_bin: str) -> dict[str, Any]:
 
 def prepare_deploy(args: argparse.Namespace) -> PreparedDeployment:
     state_root = secure_state_root()
-    git_bin = os.environ.get("AIDEVOPS_REAL_GIT_BIN", "git")
+    git_bin = trusted_git_bin()
     context = validate_source(args.source, args.expected_sha, git_bin)
     source_tree = scan_tree(context["source"])
     validate_tree_proof(context, source_tree, args.reviewed_tree_sha256, state_root)
@@ -1108,7 +1124,7 @@ def recover(args: argparse.Namespace) -> dict[str, Any]:
         raise DeploymentError("Exact recovery confirmation is required")
     state_root = secure_state_root()
     receipt_path, receipt = load_receipt(state_root, args.operation_id)
-    git_bin = os.environ.get("AIDEVOPS_REAL_GIT_BIN", "git")
+    git_bin = trusted_git_bin()
     destination, _ = validate_receipt_destination(receipt, args.allow_file, state_root, git_bin)
     rollback_path, displaced_path, stage_path = receipt_paths(receipt, destination)
     with DestinationLock(destination):
@@ -1147,7 +1163,7 @@ def rollback(args: argparse.Namespace) -> dict[str, Any]:
     receipt_path, receipt = load_receipt(state_root, args.operation_id)
     if receipt.get("status") != "success":
         raise DeploymentError("Only a verified successful deployment can be rolled back")
-    git_bin = os.environ.get("AIDEVOPS_REAL_GIT_BIN", "git")
+    git_bin = trusted_git_bin()
     destination, _ = validate_receipt_destination(receipt, args.allow_file, state_root, git_bin)
     rollback_path, displaced_path, _ = receipt_paths(receipt, destination)
     with DestinationLock(destination):
@@ -1279,7 +1295,7 @@ def main() -> int:
 
 def manifest(args: argparse.Namespace) -> dict[str, Any]:
     state_root = secure_state_root()
-    git_bin = os.environ.get("AIDEVOPS_REAL_GIT_BIN", "git")
+    git_bin = trusted_git_bin()
     context = validate_source(args.source, args.expected_sha, git_bin)
     return manifest_result(scan_tree(context["source"]))
 

--- a/.agents/scripts/managed_readme.py
+++ b/.agents/scripts/managed_readme.py
@@ -70,17 +70,24 @@ def is_managed(root: Path, slug: str) -> tuple[bool, str]:
 
 
 def run_json(command: list[str]) -> Any:
-    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    if not command or not Path(command[0]).is_absolute():
+        raise RuntimeError("managed-readme command requires a resolved executable")
+    completed = subprocess.run(  # nosec B603 -- resolved executable and fixed, validated argv.
+        command, check=True, capture_output=True, text=True
+    )
     return json.loads(completed.stdout)
 
 
 def verified_owner(slug: str) -> tuple[str, str]:
-    metadata = run_json(["gh", "repo", "view", slug, "--json", "nameWithOwner,viewerPermission"])
+    gh = shutil.which("gh")
+    if gh is None:
+        raise FileNotFoundError("gh is required to verify managed repository ownership")
+    metadata = run_json([gh, "repo", "view", slug, "--json", "nameWithOwner,viewerPermission"])
     if metadata.get("nameWithOwner") != slug:
         raise RuntimeError("GitHub repository identity did not match the requested slug")
     if metadata.get("viewerPermission") not in PERMISSIONS:
         raise RuntimeError("maintainer-equivalent GitHub access is required")
-    owner = run_json(["gh", "api", f"repos/{slug}"])
+    owner = run_json([gh, "api", f"repos/{slug}"])
     owner_url = owner.get("owner", {}).get("html_url") if isinstance(owner, dict) else None
     if not isinstance(owner_url, str) or not owner_url.startswith("https://github.com/"):
         raise RuntimeError("GitHub owner URL could not be verified")
@@ -128,12 +135,16 @@ def replace_block(readme: Path, block: str) -> bool:
 
 def generate_chart(chart: Path, slug: str, script_dir: Path) -> bool:
     before = chart.read_bytes() if chart.exists() else None
+    helper = script_dir / "star-history-helper.sh"
+    if not helper.is_file() or helper.is_symlink():
+        raise RuntimeError("managed-readme star-history helper is unavailable or unsafe")
+    helper = helper.resolve()
     base_command = [
-        "bash",
-        str(script_dir / "star-history-helper.sh"),
+        "/bin/bash",
+        str(helper),
     ]
     try:
-        subprocess.run(
+        subprocess.run(  # nosec B603 -- fixed Bash and verified helper with validated repository slug.
             base_command + ["fetch", "--repo", slug, "--output", str(chart)],
             check=True,
         )
@@ -141,7 +152,7 @@ def generate_chart(chart: Path, slug: str, script_dir: Path) -> bool:
         if chart.exists():
             print("managed-readme: live Star History refresh failed; preserving existing chart", file=sys.stderr)
             return False
-        subprocess.run(
+        subprocess.run(  # nosec B603 -- fixed Bash and verified helper with validated repository slug.
             base_command + ["seed", "--repo", slug, "--output", str(chart)],
             check=True,
         )

--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -9,6 +9,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -757,11 +758,16 @@ def _collect_daily_usage(args: argparse.Namespace) -> list[DailyUsage]:
 
 def _open_path(path: Path) -> None:
     if sys.platform == "darwin":
-        subprocess.run(["open", str(path)], check=False)
+        opener = shutil.which("open")
     elif os.name == "nt":
         os.startfile(path)  # type: ignore[attr-defined]
+        return
     else:
-        subprocess.run(["xdg-open", str(path)], check=False)
+        opener = shutil.which("xdg-open")
+    if opener is not None:
+        subprocess.run(  # nosec B603 -- resolved platform opener; path is report data only.
+            [opener, str(path)], check=False
+        )
 
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:

--- a/.agents/scripts/session-miner/extract_git.py
+++ b/.agents/scripts/session-miner/extract_git.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -14,11 +15,19 @@ from typing import Optional
 from extract_shared import extraction_scope_params, repo_scope_clause, sanitize_path, time_scope_clause
 
 
+def _git_executable() -> str | None:
+    """Resolve Git once per invocation without retaining a stale path."""
+    return shutil.which("git")
+
+
 def _find_git_root(directory: str) -> Optional[str]:
     """Find the git root for a directory, or None if not a git repo."""
+    git_bin = _git_executable()
+    if git_bin is None:
+        return None
     try:
-        result = subprocess.run(
-            ["git", "-C", directory, "rev-parse", "--show-toplevel"],
+        result = subprocess.run(  # nosec B603 -- resolved Git executable; directory is data-only argv.
+            [git_bin, "-C", directory, "rev-parse", "--show-toplevel"],
             capture_output=True, text=True, timeout=5,
         )
         if result.returncode == 0:
@@ -48,8 +57,11 @@ def _parse_commit_lines(raw_output: str) -> list[dict]:
 
 def _resolve_diff_base(repo_path: str, oldest_commit: str) -> str:
     """Return the diff base ref for aggregate diff stats."""
-    parent_check = subprocess.run(
-        ["git", "-C", repo_path, "rev-parse", "--verify", "--quiet", f"{oldest_commit}^"],
+    git_bin = _git_executable()
+    if git_bin is None:
+        return "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+    parent_check = subprocess.run(  # nosec B603 -- resolved Git executable; commit came from Git output.
+        [git_bin, "-C", repo_path, "rev-parse", "--verify", "--quiet", f"{oldest_commit}^"],
         capture_output=True,
     )
     if parent_check.returncode == 0:
@@ -59,10 +71,13 @@ def _resolve_diff_base(repo_path: str, oldest_commit: str) -> str:
 
 def _attach_aggregate_diff_stats(repo_path: str, commits: list[dict]) -> None:
     """Compute aggregate diff stats for a commit range and attach to *commits[0]*."""
+    git_bin = _git_executable()
+    if git_bin is None:
+        return
     oldest_commit = commits[-1]["hash"]
     newest_commit = commits[0]["hash"]
-    stat_result = subprocess.run(
-        ["git", "-C", repo_path, "diff", "--shortstat", _resolve_diff_base(repo_path, oldest_commit), newest_commit],
+    stat_result = subprocess.run(  # nosec B603 -- resolved Git executable; refs came from parsed Git output.
+        [git_bin, "-C", repo_path, "diff", "--shortstat", _resolve_diff_base(repo_path, oldest_commit), newest_commit],
         capture_output=True, text=True, timeout=15,
     )
     if stat_result.returncode != 0 or not stat_result.stdout.strip():
@@ -85,12 +100,15 @@ def _git_log_in_window(
     repo_path: str, start_epoch_ms: int, end_epoch_ms: int, buffer_minutes: int = 60,
 ) -> list[dict]:
     """Query git log for commits within a time window."""
+    git_bin = _git_executable()
+    if git_bin is None:
+        return []
     start_ts = datetime.fromtimestamp(start_epoch_ms / 1000).isoformat()
     end_ts = datetime.fromtimestamp(end_epoch_ms / 1000 + buffer_minutes * 60).isoformat()
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 -- resolved Git executable; time filters are data-only argv.
             [
-                "git", "-C", repo_path, "log",
+                git_bin, "-C", repo_path, "log",
                 f"--after={start_ts}", f"--before={end_ts}",
                 "--format=%H|%aI|%s",
             ],


### PR DESCRIPTION
## Summary

Resolved executables before every scoped subprocess call; validated collector and deployment command provenance while retaining graceful optional-tool handling.

## Files Changed

.agents/scripts/_knowledge_collector_process.py, .agents/scripts/cch-sign.py, .agents/scripts/deployment-copy-helper.py, .agents/scripts/managed_readme.py, .agents/scripts/report-token-use-helper.py, .agents/scripts/session-miner/extract_git.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: exercised deployment provenance, managed README fallback, token-report opening, session-miner Git scope, and knowledge-collector interruption cleanup with the focused product-path suites; compiled all six scoped Python helpers and passed changed-file lint.

Resolves #31150


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-terra spent 16m and 163,497 tokens on this as a headless worker.