### PR TITLE
t18396: feat: add Codacy health telemetry

### DIFF
--- a/.agents/scripts/stats-quality-sweep-tools.sh
+++ b/.agents/scripts/stats-quality-sweep-tools.sh
@@ -330,17 +330,117 @@ _sweep_sonarcloud_diagnostics() {
 	return 0
 }
 
+_codacy_telemetry_is_valid() {
+	local grade="$1"
+	local issue_count="$2"
+	local analysed_loc="$3"
+	local complex_files="$4"
+	local analysed_sha="$5"
+	local remote_sha="$6"
+
+	[[ -n "$grade" ]] && [[ "$issue_count" =~ ^[0-9]+$ ]] &&
+		[[ "$analysed_loc" =~ ^[1-9][0-9]*$ ]] && [[ "$complex_files" =~ ^[0-9]+$ ]] &&
+		[[ "$analysed_sha" =~ ^[0-9a-fA-F]{7,40}$ ]] && [[ "$remote_sha" =~ ^[0-9a-fA-F]{7,40}$ ]]
+}
+
+_codacy_read_healthy_state() {
+	local state_file="$1"
+	local previous_loc="" previous_sha=""
+
+	if [[ -f "$state_file" ]] && jq -e . "$state_file" >/dev/null 2>&1; then
+		previous_loc=$(jq -r '.healthy_loc // empty' "$state_file" 2>/dev/null || echo "")
+		previous_sha=$(jq -r '.healthy_sha // empty' "$state_file" 2>/dev/null || echo "")
+		[[ "$previous_loc" =~ ^[1-9][0-9]*$ ]] || previous_loc=""
+		[[ "$previous_sha" =~ ^[0-9a-fA-F]{7,40}$ ]] || previous_sha=""
+	fi
+	printf '%s|%s' "$previous_loc" "$previous_sha"
+	return 0
+}
+
+_codacy_policy_drift() {
+	local issues_response="$1"
+	local json_number_type="number"
+	local drift_rules=("Bandit_B404" "ESLint8_es-x_no-modules" "ESLint8_es-x_no-block-scoped-variables" "ESLint8_es-x_no-trailing-commas")
+	local drift_output="" rule rule_count
+
+	for rule in "${drift_rules[@]}"; do
+		rule_count=$(jq -r --arg rule "$rule" --arg number_type "$json_number_type" '
+			if (.patternTotals[$rule]? | type) == $number_type then .patternTotals[$rule]
+			elif (.patterns[$rule]? | type) == $number_type then .patterns[$rule]
+			elif (.facets.patterns[$rule]? | type) == $number_type then .facets.patterns[$rule]
+			else [.data[]? | select((.patternId // .pattern // .ruleId // .rule // "") == $rule)] | length
+			end
+		' <<<"$issues_response" 2>/dev/null || echo "")
+		[[ "$rule_count" =~ ^[0-9]+$ ]] || rule_count=0
+		((rule_count > 0)) && drift_output="${drift_output}  - \`${rule}\`: ${rule_count}\n"
+	done
+	printf '%s' "$drift_output"
+	return 0
+}
+
+_codacy_classify_health() {
+	local telemetry_valid="$1"
+	local analysed_sha="$2"
+	local remote_sha="$3"
+	local previous_loc="$4"
+	local previous_sha="$5"
+	local analysed_loc="$6"
+	local drift_output="$7"
+	local health_unknown="$8"
+
+	if [[ "$telemetry_valid" != true ]]; then
+		printf '%s' "$health_unknown"
+	elif [[ "$analysed_sha" != "$remote_sha" ]]; then
+		printf '%s' "STALE_ANALYSIS"
+	elif [[ -z "$previous_loc" || -z "$previous_sha" ]]; then
+		printf '%s' "BASELINE_UNKNOWN"
+	elif ((analysed_loc * 100 < previous_loc * 80)); then
+		printf '%s' "INDEX_DEGRADED"
+	elif [[ -n "$drift_output" ]]; then
+		printf '%s' "POLICY_DRIFT"
+	else
+		printf '%s' "HEALTHY"
+	fi
+	return 0
+}
+
+_codacy_save_healthy_state() {
+	local state_file="$1"
+	local grade="$2"
+	local issue_count="$3"
+	local analysed_loc="$4"
+	local complex_files="$5"
+	local analysed_sha="$6"
+	local state_dir="${state_file%/*}"
+	local state_tmp=""
+
+	mkdir -p "$state_dir" || return 1
+	state_tmp=$(mktemp "${state_file%.json}.XXXXXX" 2>/dev/null || echo "")
+	if [[ -n "$state_tmp" ]] && jq -n \
+		--arg grade "$grade" --arg sha "$analysed_sha" \
+		--argjson issues "$issue_count" --argjson loc "$analysed_loc" --argjson complex "$complex_files" \
+		'{grade: $grade, issue_count: $issues, healthy_loc: $loc, complex_files: $complex, healthy_sha: $sha}' >"$state_tmp" &&
+		mv -f "$state_tmp" "$state_file"; then
+		return 0
+	fi
+	[[ -n "$state_tmp" ]] && rm -f "$state_tmp"
+	return 1
+}
+
 #######################################
 # Run Codacy API check for a repo.
 #
 # Arguments:
 #   $1 - repo slug
+#   $2 - local repository path (used to resolve the remote default SHA)
 # Output: codacy_section markdown to stdout (empty if unavailable)
 #######################################
 _sweep_codacy() {
 	local repo_slug="$1"
-
+	local repo_path="$2"
 	local codacy_token=""
+	local health_unknown="UNKNOWN"
+
 	if command -v gopass &>/dev/null; then
 		codacy_token=$(gopass show -o "aidevops/CODACY_API_TOKEN" 2>/dev/null || echo "")
 	fi
@@ -348,19 +448,42 @@ _sweep_codacy() {
 
 	local codacy_org="${repo_slug%%/*}"
 	local codacy_repo="${repo_slug##*/}"
-	local codacy_response
-	codacy_response=$(curl -s -H "api-token: ${codacy_token}" \
-		"https://app.codacy.com/api/v3/organizations/gh/${codacy_org}/repositories/${codacy_repo}/issues/search" \
-		-X POST -H "Content-Type: application/json" -d '{"limit":1}' 2>/dev/null || echo "")
+	local summary_response issues_response
+	summary_response=$(curl -sS --fail --connect-timeout 5 --max-time 20 -H "api-token: ${codacy_token}" \
+		"https://app.codacy.com/api/v3/analysis/organizations/gh/${codacy_org}/repositories/${codacy_repo}?branch=main" 2>/dev/null || echo "")
+	issues_response=$(curl -sS --fail --connect-timeout 5 --max-time 20 -H "api-token: ${codacy_token}" \
+		"https://app.codacy.com/api/v3/analysis/organizations/gh/${codacy_org}/repositories/${codacy_repo}/issues/search" \
+		-X POST -H "Content-Type: application/json" -d '{"limit":100}' 2>/dev/null || echo "")
 
-	if [[ -n "$codacy_response" ]] && echo "$codacy_response" | jq -e '.pagination' &>/dev/null; then
-		local codacy_total
-		codacy_total=$(echo "$codacy_response" | jq -r '.pagination.total // 0')
-		[[ "$codacy_total" =~ ^[0-9]+$ ]] || codacy_total=0
-		printf '### Codacy\n\n- **Open issues**: %s\n- **Dashboard**: https://app.codacy.com/gh/%s/%s/dashboard\n' \
-			"$codacy_total" "$codacy_org" "$codacy_repo"
+	local grade issue_count analysed_loc complex_files analysed_sha remote_sha
+	grade=$(jq -r '.grade // .quality.grade // .metrics.grade // empty' <<<"$summary_response" 2>/dev/null || echo "")
+	issue_count=$(jq -r '.pagination.total // .total // empty' <<<"$issues_response" 2>/dev/null || echo "")
+	analysed_loc=$(jq -r '.totalLinesOfCode // .analysedLinesOfCode // .analyzedLinesOfCode // .metrics.totalLinesOfCode // .metrics.loc // empty' <<<"$summary_response" 2>/dev/null || echo "")
+	complex_files=$(jq -r '.complexFiles // .complexFileCount // .metrics.complexFiles // empty' <<<"$summary_response" 2>/dev/null || echo "")
+	analysed_sha=$(jq -r '.lastAnalyzedCommit // .lastAnalysedCommit // .lastAnalysis.commit.uuid // .lastAnalysis.commit.hash // .commit.uuid // .commit.hash // empty' <<<"$summary_response" 2>/dev/null || echo "")
+	remote_sha=$(git -C "$repo_path" ls-remote origin HEAD 2>/dev/null | cut -f1)
+
+	local slug_safe="${repo_slug//\//-}"
+	local state_file="${QUALITY_SWEEP_STATE_DIR}/${slug_safe}.codacy-health.json"
+	local previous_state previous_loc previous_sha drift_output health_state
+	previous_state=$(_codacy_read_healthy_state "$state_file")
+	IFS='|' read -r previous_loc previous_sha <<<"$previous_state"
+	drift_output=$(_codacy_policy_drift "$issues_response")
+	if _codacy_telemetry_is_valid "$grade" "$issue_count" "$analysed_loc" "$complex_files" "$analysed_sha" "$remote_sha"; then
+		health_state=$(_codacy_classify_health true "$analysed_sha" "$remote_sha" "$previous_loc" "$previous_sha" "$analysed_loc" "$drift_output" "$health_unknown")
+	else
+		health_state="$health_unknown"
+	fi
+	if [[ "$health_state" == "BASELINE_UNKNOWN" || "$health_state" == "HEALTHY" ]] &&
+		! _codacy_save_healthy_state "$state_file" "$grade" "$issue_count" "$analysed_loc" "$complex_files" "$analysed_sha"; then
+		health_state="$health_unknown"
 	fi
 
+	printf '### Codacy\n\n- **Grade**: %s\n- **Open issues**: %s\n- **Analysed LOC**: %s\n- **Complex files**: %s\n- **Analysed SHA**: %s\n- **Analysis health**: %s\n' \
+		"${grade:-$health_unknown}" "${issue_count:-$health_unknown}" "${analysed_loc:-$health_unknown}" \
+		"${complex_files:-$health_unknown}" "${analysed_sha:-$health_unknown}" "$health_state"
+	[[ -n "$drift_output" ]] && printf '\n**Policy drift:**\n%b' "$drift_output"
+	printf -- '- **Dashboard**: https://app.codacy.com/gh/%s/%s/dashboard\n' "$codacy_org" "$codacy_repo"
 	return 0
 }
 

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -672,7 +672,7 @@ _run_sweep_tools() {
 	fi
 
 	local codacy_section=""
-	codacy_section=$(_sweep_codacy "$repo_slug")
+	codacy_section=$(_sweep_codacy "$repo_slug" "$repo_path")
 	[[ -n "$codacy_section" ]] && tool_count=$((tool_count + 1))
 
 	local coderabbit_section=""

--- a/.agents/scripts/tests/test-codacy-health-sweep.sh
+++ b/.agents/scripts/tests/test-codacy-health-sweep.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Hermetic Codacy health-state coverage for the quality sweep.
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_SCRIPT_DIR}/.." && pwd)" || exit 1
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export QUALITY_SWEEP_STATE_DIR="${TMP_HOME}/state"
+mkdir -p "$QUALITY_SWEEP_STATE_DIR"
+
+TESTS_FAILED=0
+
+assert_contains() {
+	local label="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == *"$expected"* ]]; then
+		printf 'PASS %s\n' "$label"
+	else
+		printf 'FAIL %s: expected %s\n' "$label" "$expected"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+assert_json_value() {
+	local label="$1"
+	local file="$2"
+	local query="$3"
+	local expected="$4"
+	local actual
+	actual=$(jq -r "$query" "$file")
+	if [[ "$actual" == "$expected" ]]; then
+		printf 'PASS %s\n' "$label"
+	else
+		printf 'FAIL %s: expected %s, got %s\n' "$label" "$expected" "$actual"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+SUMMARY_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+REMOTE_SHA="$SUMMARY_SHA"
+MODE="healthy"
+LOC=1000
+
+gopass() {
+	printf 'test-token'
+	return 0
+}
+
+git() {
+	printf '%s\tHEAD\n' "$REMOTE_SHA"
+	return 0
+}
+
+curl() {
+	local arguments="$*"
+	if [[ "$MODE" == "api-failure" ]]; then
+		return 1
+	fi
+	if [[ "$arguments" == *"issues/search"* ]]; then
+		if [[ "$MODE" == "policy-drift" ]]; then
+			printf '%s' '{"pagination":{"total":17},"patternTotals":{"Bandit_B404":69}}'
+		else
+			printf '%s' '{"pagination":{"total":17},"patternTotals":{}}'
+		fi
+		return 0
+	fi
+	if [[ "$MODE" == "malformed" ]]; then
+		printf '%s' '{"grade":"B"}'
+	else
+		printf '{"grade":"B","totalLinesOfCode":%s,"complexFiles":4,"lastAnalyzedCommit":"%s"}' "$LOC" "$SUMMARY_SHA"
+	fi
+	return 0
+}
+
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/stats-quality-sweep-tools.sh"
+
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+STATE_FILE="${QUALITY_SWEEP_STATE_DIR}/owner-repo.codacy-health.json"
+assert_contains "first valid sample is baseline unknown" "$RESULT" "**Analysis health**: BASELINE_UNKNOWN"
+assert_json_value "first valid sample stores healthy LOC" "$STATE_FILE" '.healthy_loc' "1000"
+
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "matching baseline is healthy" "$RESULT" "**Analysis health**: HEALTHY"
+
+REMOTE_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "stale SHA never renders healthy" "$RESULT" "**Analysis health**: STALE_ANALYSIS"
+assert_json_value "stale SHA retains baseline" "$STATE_FILE" '.healthy_loc' "1000"
+
+REMOTE_SHA="$SUMMARY_SHA"
+LOC=799
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "LOC below 80 percent is degraded" "$RESULT" "**Analysis health**: INDEX_DEGRADED"
+assert_json_value "degraded LOC retains baseline" "$STATE_FILE" '.healthy_loc' "1000"
+
+LOC=1000
+MODE="policy-drift"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "documented rule renders policy drift" "$RESULT" "**Analysis health**: POLICY_DRIFT"
+assert_contains "documented rule includes exact count" "$RESULT" "\`Bandit_B404\`: 69"
+
+MODE="malformed"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "malformed response is unknown" "$RESULT" "**Analysis health**: UNKNOWN"
+assert_json_value "malformed response retains baseline" "$STATE_FILE" '.healthy_loc' "1000"
+
+MODE="api-failure"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "API failure is unknown" "$RESULT" "**Analysis health**: UNKNOWN"
+assert_json_value "API failure retains baseline" "$STATE_FILE" '.healthy_loc' "1000"
+
+rm -rf "$TMP_HOME"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+printf 'All Codacy health sweep tests passed\n'
+exit 0

--- a/.agents/scripts/tests/test-quality-sweep-serialization.sh
+++ b/.agents/scripts/tests/test-quality-sweep-serialization.sh
@@ -287,12 +287,10 @@ test_grade_mapping "151 smells → F (lower bound)" 151 F
 test_grade_mapping "500 smells → F" 500 F
 test_grade_mapping "non-numeric → UNKNOWN" "not-a-number" UNKNOWN
 
-# 7. _quality_sweep_for_repo end-to-end smoke test: stub _ensure_quality_issue
-#    and gh so it doesn't hit the network, then verify the full pipeline reads
-#    every section back into a local variable. The gh wrapper writes the
-#    captured --body to a file because the real call site uses
-#    `comment_stderr=$(gh ... --body "$comment_body" ...)` which runs in a
-#    subshell — variable assignments inside it would not propagate back.
+# 7. _quality_sweep_for_repo end-to-end smoke test: stub the issue/comment
+#    helpers so it doesn't hit the network, then verify the full pipeline reads
+#    every section back into a local variable. The stub writes the captured body
+#    to a file because the real call site runs in a subshell.
 export CAPTURED_COMMENT_FILE="${TMP_HOME}/captured-comment"
 : >"$CAPTURED_COMMENT_FILE"
 
@@ -303,7 +301,7 @@ _ensure_quality_issue() {
 _update_quality_issue_body() {
 	return 0
 }
-gh() {
+gh_issue_comment() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--body)

--- a/.agents/tools/code-review/codacy.md
+++ b/.agents/tools/code-review/codacy.md
@@ -74,6 +74,28 @@ curl -s -H "api-token: $CODACY_API_TOKEN" -H "Content-Type: application/json" \
   -d '{"languages": ["Python"]}'
 ```
 
+## Quality-sweep health telemetry
+
+The daily quality sweep reads the repository summary and issue overview without
+changing Codacy settings. It renders grade, issue count, analysed LOC, complex
+files, analysed SHA, and one explicit state:
+
+| State | Meaning | Operator response |
+|-------|---------|-------------------|
+| `BASELINE_UNKNOWN` | A current analysis was recorded, but no trusted prior sample exists. | Wait for the next sweep before comparing LOC. |
+| `HEALTHY` | The analysed SHA matches the remote default head and LOC is at least 80% of the prior healthy sample. | Treat the telemetry as comparable. |
+| `STALE_ANALYSIS` | Codacy analysed a different commit from the remote default head. | Request/retry analysis; do not compare findings yet. |
+| `INDEX_DEGRADED` | Current analysed LOC is below 80% of the last healthy sample. | Investigate Codacy indexing; the healthy denominator is retained. |
+| `POLICY_DRIFT` | A documented-noise rule has a non-zero overview count. | Investigate coding-standard drift; do not change external settings from the sweep. |
+| `UNKNOWN` | An API, parse, remote-SHA, or state-write failure prevented a trustworthy classification. | Resolve telemetry failure and retain the previous baseline. |
+
+Healthy samples are stored atomically in `QUALITY_SWEEP_STATE_DIR` per repository.
+Stale, degraded, malformed, and API-failure samples never replace that baseline.
+The documented-noise rules are `Bandit_B404`, `ESLint8_es-x_no-modules`,
+`ESLint8_es-x_no-block-scoped-variables`, and
+`ESLint8_es-x_no-trailing-commas`; their counts are observational evidence, not
+permission to alter Codacy, Bandit, ESLint, or exclusions.
+
 **Updating quality gate via API:**
 
 ```bash


### PR DESCRIPTION
## Summary

Adds fail-closed Codacy telemetry, persisted healthy baselines, index and policy-drift states, focused fixtures, and serialization isolation.

## Files Changed

.agents/scripts/stats-quality-sweep-tools.sh, .agents/scripts/stats-quality-sweep.sh, .agents/scripts/tests/test-codacy-health-sweep.sh, .agents/scripts/tests/test-quality-sweep-serialization.sh, .agents/tools/code-review/codacy.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-codacy-health-sweep.sh; bash .agents/scripts/tests/test-quality-sweep-serialization.sh; shellcheck .agents/scripts/stats-quality-sweep-tools.sh .agents/scripts/stats-quality-sweep.sh .agents/scripts/tests/test-codacy-health-sweep.sh .agents/scripts/tests/test-quality-sweep-serialization.sh; .agents/scripts/linters-local.sh --changed

Resolves #31147


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-terra spent 27m and 175,741 tokens on this as a headless worker.