### PR TITLE
t18397: feat: make email facade exports explicit

### DIFF
--- a/.agents/scripts/email-to-markdown.py
+++ b/.agents/scripts/email-to-markdown.py
@@ -51,6 +51,32 @@ _parser_mod = _import_sibling('email_parser')
 _norm_mod = _import_sibling('email_normaliser')
 _summary_mod = _import_sibling('email_md_summary')
 
+__all__ = (
+    "parse_eml",
+    "parse_msg",
+    "get_email_body",
+    "extract_attachments",
+    "load_dedup_registry",
+    "save_dedup_registry",
+    "get_file_size",
+    "extract_header_safe",
+    "parse_date_safe",
+    "compute_content_hash",
+    "_parse_email_file",
+    "_extract_headers",
+    "_parse_received_date",
+    "normalise_email_sections",
+    "build_thread_map",
+    "reconstruct_thread",
+    "generate_thread_index",
+    "build_frontmatter",
+    "format_size",
+    "estimate_tokens",
+    "yaml_escape",
+    "generate_summary",
+    "strip_markdown",
+)
+
 # Re-export public API from submodules for callers that import from this file
 from email_parser import (  # noqa: E402
     parse_eml,

--- a/.agents/scripts/email_jmap_adapter.py
+++ b/.agents/scripts/email_jmap_adapter.py
@@ -33,16 +33,50 @@ Output: JSON to stdout. Errors to stderr.
 import argparse
 import sys
 
+__all__ = (
+    "INDEX_DIR",
+    "INDEX_DB",
+    "_init_index_db",
+    "_upsert_jmap_email",
+    "_first_or_empty",
+    "_get_auth",
+    "_make_auth_header",
+    "_jmap_request",
+    "_get_session",
+    "_get_primary_account",
+    "_session_context",
+    "_find_response",
+    "_resolve_mailbox_id",
+    "_build_mailbox_path",
+    "_format_email_header",
+    "_format_addresses",
+    "HEADER_PROPERTIES",
+    "BODY_PROPERTIES",
+    "KEYWORD_TAXONOMY",
+    "cmd_connect",
+    "cmd_fetch_headers",
+    "cmd_fetch_body",
+    "cmd_search",
+    "cmd_list_mailboxes",
+    "cmd_create_mailbox",
+    "cmd_move_email",
+    "cmd_set_keyword",
+    "cmd_clear_keyword",
+    "SyncContext",
+    "cmd_index_sync",
+    "cmd_push",
+)
+
 # Re-export public surface from decomposed modules for backwards compatibility.
 # Other scripts importing from email_jmap_adapter continue to work unchanged.
-from email_jmap_index import (  # noqa: F401
+from email_jmap_index import (
     INDEX_DIR,
     INDEX_DB,
     _init_index_db,
     _upsert_jmap_email,
     _first_or_empty,
 )
-from email_jmap_transport import (  # noqa: F401
+from email_jmap_transport import (
     _get_auth,
     _make_auth_header,
     _jmap_request,
@@ -50,14 +84,14 @@ from email_jmap_transport import (  # noqa: F401
     _get_primary_account,
     _session_context,
 )
-from email_jmap_helpers import (  # noqa: F401
+from email_jmap_helpers import (
     _find_response,
     _resolve_mailbox_id,
     _build_mailbox_path,
     _format_email_header,
     _format_addresses,
 )
-from email_jmap_commands import (  # noqa: F401
+from email_jmap_commands import (
     HEADER_PROPERTIES,
     BODY_PROPERTIES,
     KEYWORD_TAXONOMY,
@@ -71,9 +105,11 @@ from email_jmap_commands import (  # noqa: F401
     cmd_set_keyword,
     cmd_clear_keyword,
 )
-from email_jmap_sync import (  # noqa: F401
+from email_jmap_sync import (
     SyncContext,
     cmd_index_sync,
+)
+from email_jmap_push import (
     cmd_push,
 )
 

--- a/.agents/scripts/email_normaliser.py
+++ b/.agents/scripts/email_normaliser.py
@@ -6,9 +6,18 @@ email_normaliser.py - Email section normalisation, thread reconstruction, and fr
 Part of the email-to-markdown pipeline. Imported by email_to_markdown.py.
 """
 
-import re
+__all__ = (
+    "parse_eml",
+    "parse_msg",
+    "extract_header_safe",
+    "parse_date_safe",
+    "normalise_email_sections",
+    "build_thread_map",
+    "reconstruct_thread",
+    "generate_thread_index",
+)
 
-from email_parser import (  # noqa: F401
+from email_parser import (
     parse_eml,
     parse_msg,
     extract_header_safe,
@@ -17,7 +26,7 @@ from email_parser import (  # noqa: F401
 
 # Re-export public surface from decomposed module for backwards compatibility.
 # Other scripts importing from email_normaliser continue to work unchanged.
-from email_normaliser_sections import (  # noqa: F401
+from email_normaliser_sections import (
     normalise_email_sections,
     build_thread_map,
     reconstruct_thread,

--- a/.agents/scripts/email_thread.py
+++ b/.agents/scripts/email_thread.py
@@ -18,12 +18,10 @@ Usage (CLI):
 
 import hashlib
 import json
-import os
 import re
 import sys
 from pathlib import Path
 from collections import defaultdict
-from datetime import datetime, timezone
 from typing import Optional
 
 

--- a/tests/test-email-facade-exports.py
+++ b/tests/test-email-facade-exports.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Regression tests for public email facade exports."""
+
+import importlib
+import importlib.util
+import re
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / ".agents" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+if importlib.util.find_spec("html2text") is None:
+    sys.modules["html2text"] = types.ModuleType("html2text")
+
+
+JMAP_EXPORTS = {
+    "INDEX_DIR", "INDEX_DB", "_init_index_db", "_upsert_jmap_email",
+    "_first_or_empty", "_get_auth", "_make_auth_header", "_jmap_request",
+    "_get_session", "_get_primary_account", "_session_context", "_find_response",
+    "_resolve_mailbox_id", "_build_mailbox_path", "_format_email_header",
+    "_format_addresses", "HEADER_PROPERTIES", "BODY_PROPERTIES", "KEYWORD_TAXONOMY",
+    "cmd_connect", "cmd_fetch_headers", "cmd_fetch_body", "cmd_search",
+    "cmd_list_mailboxes", "cmd_create_mailbox", "cmd_move_email", "cmd_set_keyword",
+    "cmd_clear_keyword", "SyncContext", "cmd_index_sync", "cmd_push",
+}
+NORMALISER_EXPORTS = {
+    "parse_eml", "parse_msg", "extract_header_safe", "parse_date_safe",
+    "normalise_email_sections", "build_thread_map", "reconstruct_thread",
+    "generate_thread_index",
+}
+MARKDOWN_EXPORTS = {
+    "parse_eml", "parse_msg", "get_email_body", "extract_attachments",
+    "load_dedup_registry", "save_dedup_registry", "get_file_size",
+    "extract_header_safe", "parse_date_safe", "compute_content_hash",
+    "_parse_email_file", "_extract_headers", "_parse_received_date",
+    "normalise_email_sections", "build_thread_map", "reconstruct_thread",
+    "generate_thread_index", "build_frontmatter", "format_size", "estimate_tokens",
+    "yaml_escape", "generate_summary", "strip_markdown",
+}
+
+
+def load_markdown_facade():
+    """Load the hyphenated facade through its supported file path."""
+    spec = importlib.util.spec_from_file_location(
+        "email_to_markdown_facade", SCRIPTS_DIR / "email-to-markdown.py"
+    )
+    if not spec or not spec.loader:
+        raise RuntimeError("Unable to load email-to-markdown.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class EmailFacadeExportsTests(unittest.TestCase):
+    """Protect compatibility facades from accidental export removal."""
+
+    def assert_exports(self, module, expected):
+        self.assertEqual(set(module.__all__), expected)
+        for name in expected:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(module, name))
+
+    def test_jmap_facade_exports_remain_importable(self):
+        self.assert_exports(importlib.import_module("email_jmap_adapter"), JMAP_EXPORTS)
+
+    def test_normaliser_facade_exports_remain_importable(self):
+        self.assert_exports(importlib.import_module("email_normaliser"), NORMALISER_EXPORTS)
+
+    def test_markdown_facade_exports_remain_importable(self):
+        self.assert_exports(load_markdown_facade(), MARKDOWN_EXPORTS)
+
+    def test_dead_standard_library_imports_do_not_return(self):
+        normaliser = (SCRIPTS_DIR / "email_normaliser.py").read_text()
+        thread = (SCRIPTS_DIR / "email_thread.py").read_text()
+        self.assertNotRegex(normaliser, re.compile(r"^import re\\b", re.MULTILINE))
+        self.assertNotRegex(thread, re.compile(r"^import os\\b", re.MULTILINE))
+        self.assertNotRegex(thread, re.compile(r"^from datetime import\\b", re.MULTILINE))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implementation for issue #31148.

## Files Changed

.agents/scripts/email-to-markdown.py, .agents/scripts/email_jmap_adapter.py, .agents/scripts/email_normaliser.py, .agents/scripts/email_thread.py, tests/test-email-facade-exports.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #31148


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.306 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 5m and 82,621 tokens on this as a headless worker.