### PR TITLE
GH#31167: fix: bind aggregation merge bodies to verified heads

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -1138,11 +1138,11 @@ _merge_remove_body_snapshot() {
 }
 
 # Release provenance later reads merge commit trailers with `git
-# interpret-trailers --parse`. Reject an aggregation body whose raw trailers
+# interpret-trailers --parse`. Reject aggregation content whose raw trailers
 # would be hidden by a non-terminal signature divider before it reaches any
 # merge transport.
-_merge_validate_release_aggregation_body() {
-	local body_file="$1"
+_merge_validate_release_aggregation_content() {
+	local content="$1"
 	local expected_pr="${2:-}"
 	local raw_aggregator=""
 	local raw_aggregates=""
@@ -1150,11 +1150,11 @@ _merge_validate_release_aggregation_body() {
 	local parsed_aggregator=""
 	local parsed_aggregates=""
 
-	raw_aggregator=$(awk '/^Aidevops-Release-Aggregator-PR: / { print substr($0, 33) }' "$body_file") || return 1
-	raw_aggregates=$(awk '/^Aidevops-Release-Aggregates: / { print substr($0, 30) }' "$body_file") || return 1
+	raw_aggregator=$(awk '/^Aidevops-Release-Aggregator-PR: / { print substr($0, 33) }' <<<"$content") || return 1
+	raw_aggregates=$(awk '/^Aidevops-Release-Aggregates: / { print substr($0, 30) }' <<<"$content") || return 1
 	[[ -n "$raw_aggregator" || -n "$raw_aggregates" ]] || return 0
 
-	parsed_trailers=$(git interpret-trailers --parse <"$body_file") || return 1
+	parsed_trailers=$(git interpret-trailers --parse <<<"$content") || return 1
 	parsed_aggregator=$(awk '/^Aidevops-Release-Aggregator-PR: / { print substr($0, 33) }' <<<"$parsed_trailers") || return 1
 	parsed_aggregates=$(awk '/^Aidevops-Release-Aggregates: / { print substr($0, 30) }' <<<"$parsed_trailers") || return 1
 	if ! awk '
@@ -1171,6 +1171,94 @@ _merge_validate_release_aggregation_body() {
 		! "$parsed_aggregator" =~ ^[0-9]+$ || -z "$parsed_aggregates" ||
 		(-n "$expected_pr" && "$parsed_aggregator" != "$expected_pr") ]]; then
 		print_error "Release-aggregation trailers must be a terminal parseable block; place any signature footer and --- before the Aidevops-Release trailers."
+		return 1
+	fi
+	return 0
+}
+
+_merge_validate_release_aggregation_body() {
+	local body_file="$1"
+	local expected_pr="${2:-}"
+	local content=""
+	content=$(<"$body_file") || return 1
+	_merge_validate_release_aggregation_content "$content" "$expected_pr"
+	return $?
+}
+
+_merge_release_aggregation_manifest() {
+	local content="$1"
+	awk '/^Aidevops-Release-Aggregator-PR: |^Aidevops-Release-Aggregates: / { print }' <<<"$content"
+	return 0
+}
+
+# Bind an aggregation merge body to the immutable manifest on the exact PR
+# head verified by the pre-merge gate. Reading the commit by SHA avoids trusting
+# a mutable local branch or a later branch-head lookup.
+_merge_validate_verified_head_aggregation_binding() {
+	local pr_number="$1"
+	local repo="$2"
+	local verified_head_sha="$3"
+	local merge_body_file="${4:-}"
+	local head_message=""
+	local head_manifest=""
+	local body_content=""
+	local body_manifest=""
+
+	head_message=$(_flm_gh_read gh api "repos/${repo}/git/commits/${verified_head_sha}" \
+		--jq '.message // empty' 2>/dev/null) || {
+		print_error "Merge blocked: unable to inspect the exact verified PR head commit for a release-aggregation manifest; refresh remote evidence and retry."
+		return 1
+	}
+	head_manifest=$(_merge_release_aggregation_manifest "$head_message") || return 1
+	[[ -n "$head_manifest" ]] || return 0
+
+	if ! _merge_validate_release_aggregation_content "$head_message" "$pr_number"; then
+		print_error "Merge blocked: the exact verified PR head contains an invalid release-aggregation manifest; repair the head manifest and refresh review evidence."
+		return 1
+	fi
+	if [[ -z "$merge_body_file" ]]; then
+		print_error "Merge blocked: the exact verified PR head contains a release-aggregation manifest, but no --body-file was supplied; provide the identical terminal manifest and retry."
+		return 1
+	fi
+	body_content=$(<"$merge_body_file") || {
+		print_error "Merge blocked: the immutable merge body snapshot became unreadable before manifest binding."
+		return 1
+	}
+	body_manifest=$(_merge_release_aggregation_manifest "$body_content") || return 1
+	if [[ "$head_manifest" != "$body_manifest" ]]; then
+		print_error "Merge blocked: the exact verified PR head and squash merge body release-aggregation manifests differ; regenerate --body-file from the verified head manifest and retry."
+		return 1
+	fi
+	return 0
+}
+
+_merge_prepare_verified_head_aggregation_body() {
+	local pr_number="$1"
+	local repo="$2"
+	local source_body_file="${3:-}"
+	local binding_head_sha=""
+	FULL_LOOP_MERGE_PREPARED_BODY_FILE=""
+	FULL_LOOP_MERGE_BODY_SNAPSHOT=""
+
+	if [[ -n "$source_body_file" ]]; then
+		FULL_LOOP_MERGE_BODY_SNAPSHOT=$(_merge_snapshot_body_file "$source_body_file") || return 1
+		FULL_LOOP_MERGE_PREPARED_BODY_FILE="$FULL_LOOP_MERGE_BODY_SNAPSHOT"
+		if ! _merge_validate_release_aggregation_body "$FULL_LOOP_MERGE_PREPARED_BODY_FILE" "$pr_number"; then
+			_merge_remove_body_snapshot "$FULL_LOOP_MERGE_BODY_SNAPSHOT"
+			return 1
+		fi
+	fi
+	if [[ -z "${FULL_LOOP_VERIFIED_PR_HEAD_SHA:-}" && -z "$FULL_LOOP_MERGE_PREPARED_BODY_FILE" ]]; then
+		return 0
+	fi
+	binding_head_sha=$(_merge_resolve_match_head "$pr_number" "$repo") || {
+		_merge_remove_body_snapshot "$FULL_LOOP_MERGE_BODY_SNAPSHOT"
+		print_error "Merge blocked: cannot bind the merge body to an exact remotely verified PR head."
+		return 1
+	}
+	if ! _merge_validate_verified_head_aggregation_binding \
+		"$pr_number" "$repo" "$binding_head_sha" "$FULL_LOOP_MERGE_PREPARED_BODY_FILE"; then
+		_merge_remove_body_snapshot "$FULL_LOOP_MERGE_BODY_SNAPSHOT"
 		return 1
 	fi
 	return 0
@@ -1880,15 +1968,9 @@ cmd_merge() {
 			_canonical_dir=$(_merge_current_canonical_dir_for_cleanup "$_cleanup_worktree" 2>/dev/null || true)
 		fi
 	fi
-	local _merge_body_snapshot=""
-	if [[ -n "$merge_body_file" ]]; then
-		_merge_body_snapshot=$(_merge_snapshot_body_file "$merge_body_file") || return 1
-		merge_body_file="$_merge_body_snapshot"
-		if ! _merge_validate_release_aggregation_body "$merge_body_file" "$pr_number"; then
-			_merge_remove_body_snapshot "$_merge_body_snapshot"
-			return 1
-		fi
-	fi
+	_merge_prepare_verified_head_aggregation_body "$pr_number" "$repo" "$merge_body_file" || return 1
+	local _merge_body_snapshot="$FULL_LOOP_MERGE_BODY_SNAPSHOT"
+	merge_body_file="$FULL_LOOP_MERGE_PREPARED_BODY_FILE"
 	# Retarget any open PRs stacked on this branch before the head branch is
 	# deleted post-merge. GitHub auto-closes stacked children when their base
 	# branch disappears; retargeting to the default branch prevents this.

--- a/.agents/scripts/tests/test-full-loop-merge-body-file.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-body-file.sh
@@ -9,6 +9,8 @@ AGENTS_SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 2
 TEST_ROOT=""
 TEST_MODE="normal"
 TEST_ORIGINAL_BODY_FILE=""
+TEST_HEAD_COMMIT_MESSAGE=""
+TEST_RESOLVE_HEAD_FAIL=0
 TESTS_RUN=0
 TESTS_FAILED=0
 
@@ -74,6 +76,10 @@ capture_rest_body_field() {
 gh() {
 	local command="${1:-}"
 	local subcommand="${2:-}"
+	if [[ "$command" == "api" && "$subcommand" == "repos/testorg/testrepo/git/commits/fixture-head-sha" ]]; then
+		printf '%s\n' "$TEST_HEAD_COMMIT_MESSAGE"
+		return 0
+	fi
 	if [[ "$command" == "pr" && "$subcommand" == "view" && "$*" == *"--json title,commits"* ]]; then
 		printf '%s\n' '{"title":"GH#29733: fix: preserve explicit merge bodies","commits":[{"messageHeadline":"fix: preserve explicit merge bodies"}]}'
 		return 0
@@ -131,7 +137,10 @@ setup_subject() {
 	source "${AGENTS_SCRIPTS_DIR}/shared-constants.sh"
 	# shellcheck source=../full-loop-helper-merge.sh
 	source "${AGENTS_SCRIPTS_DIR}/full-loop-helper-merge.sh"
+	FULL_LOOP_VERIFIED_PR_HEAD_SHA="fixture-head-sha"
+	set_matching_head_manifest
 	_merge_resolve_match_head() {
+		[[ "$TEST_RESOLVE_HEAD_FAIL" -eq 0 ]] || return 1
 		printf '%s\n' 'fixture-head-sha'
 		return 0
 	}
@@ -159,6 +168,7 @@ setup_subject() {
 		return 1
 	}
 	_retarget_stacked_children_interactive() {
+		: >"${TEST_ROOT}/retarget-called"
 		return 0
 	}
 	_merge_verify_completed_state() {
@@ -181,6 +191,35 @@ write_fixture_body() {
 		'' \
 		'Aidevops-Release-Aggregator-PR: 42' \
 		'Aidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f' >"$body_file"
+	return 0
+}
+
+set_matching_head_manifest() {
+	TEST_HEAD_COMMIT_MESSAGE=$'chore(release): aggregate reviewed sources\n\nAidevops-Release-Aggregator-PR: 42\nAidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f'
+	return 0
+}
+
+write_two_source_body() {
+	local body_file="$1"
+	local order="${2:-normal}"
+	printf '%s\n' \
+		'chore(release): aggregate reviewed sources' \
+		'' \
+		'Aidevops-Release-Aggregator-PR: 42' >"$body_file"
+	if [[ "$order" == "reversed" ]]; then
+		printf '%s\n' \
+			'Aidevops-Release-Aggregates: 29722@f2c7962f8b29922b44f44bd13406262569ddc374' \
+			'Aidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f' >>"$body_file"
+	else
+		printf '%s\n' \
+			'Aidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f' \
+			'Aidevops-Release-Aggregates: 29722@f2c7962f8b29922b44f44bd13406262569ddc374' >>"$body_file"
+	fi
+	return 0
+}
+
+set_two_source_head_manifest() {
+	TEST_HEAD_COMMIT_MESSAGE=$'chore(release): aggregate reviewed sources\n\nAidevops-Release-Aggregator-PR: 42\nAidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f\nAidevops-Release-Aggregates: 29722@f2c7962f8b29922b44f44bd13406262569ddc374'
 	return 0
 }
 
@@ -217,6 +256,7 @@ assert_transport_preserves_body() {
 	local rc=0
 	TEST_MODE="$mode"
 	TEST_ORIGINAL_BODY_FILE="$body_file"
+	set_matching_head_manifest
 	rm -f "${TEST_ROOT}/captured-body-"* "${TEST_ROOT}/capture-count" "${TEST_ROOT}/snapshot-paths"
 	write_fixture_body "$body_file"
 	cp "$body_file" "$expected_file"
@@ -247,6 +287,92 @@ assert_transport_preserves_body() {
 		print_result "$label preserves exact body bytes" 0
 	else
 		print_result "$label preserves exact body bytes" 1 "rc=${rc}; captures=${capture_count}; exact=${exact}; snapshots_removed=${snapshots_removed}"
+	fi
+	return 0
+}
+
+assert_head_body_mismatch_fails() {
+	local body_mode="$1"
+	local label="$2"
+	local body_file="${TEST_ROOT}/mismatched-aggregation-body"
+	local output=""
+	local rc=0
+	TEST_MODE="normal"
+	set_two_source_head_manifest
+	rm -f "${TEST_ROOT}/capture-count" "${TEST_ROOT}/snapshot-paths"
+	case "$body_mode" in
+	partial)
+		write_fixture_body "$body_file"
+		;;
+	reordered)
+		write_two_source_body "$body_file" reversed
+		;;
+	different)
+		printf '%s\n' \
+			'chore(release): aggregate reviewed sources' \
+			'' \
+			'Aidevops-Release-Aggregator-PR: 42' \
+			'Aidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f' \
+			'Aidevops-Release-Aggregates: 29723@62d328329b58fc214bfed3358ad079b1a2528289' >"$body_file"
+		;;
+	*)
+		return 1
+		;;
+	esac
+	output=$(cmd_merge 42 testorg/testrepo --squash --body-file "$body_file" 2>&1) || rc=$?
+	if [[ "$rc" -ne 0 && ! -e "${TEST_ROOT}/capture-count" &&
+		"$output" == *"manifests differ"* && "$output" == *"regenerate --body-file"* ]]; then
+		print_result "$label fails before merge write" 0
+	else
+		print_result "$label fails before merge write" 1 "rc=${rc}; output=${output}"
+	fi
+	return 0
+}
+
+test_aggregation_head_requires_body_file() {
+	local output=""
+	local rc=0
+	TEST_MODE="normal"
+	set_matching_head_manifest
+	rm -f "${TEST_ROOT}/capture-count" "${TEST_ROOT}/snapshot-paths"
+	output=$(cmd_merge 42 testorg/testrepo --squash 2>&1) || rc=$?
+	if [[ "$rc" -ne 0 && ! -e "${TEST_ROOT}/capture-count" &&
+		"$output" == *"no --body-file was supplied"* && "$output" == *"identical terminal manifest"* ]]; then
+		print_result "aggregation head without body file fails before merge write" 0
+	else
+		print_result "aggregation head without body file fails before merge write" 1 "rc=${rc}; output=${output}"
+	fi
+	return 0
+}
+
+test_non_aggregation_head_without_body_is_unchanged() {
+	local rc=0
+	TEST_MODE="normal"
+	TEST_HEAD_COMMIT_MESSAGE="fix: ordinary non-aggregation change"
+	rm -f "${TEST_ROOT}/capture-count" "${TEST_ROOT}/snapshot-paths"
+	cmd_merge 42 testorg/testrepo --squash >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -eq 0 && ! -e "${TEST_ROOT}/capture-count" ]]; then
+		print_result "non-aggregation head without body keeps normal merge behavior" 0
+	else
+		print_result "non-aggregation head without body keeps normal merge behavior" 1 "rc=${rc}"
+	fi
+	return 0
+}
+
+test_head_drift_fails_before_stacked_pr_mutation() {
+	local output=""
+	local rc=0
+	TEST_MODE="normal"
+	TEST_RESOLVE_HEAD_FAIL=1
+	set_matching_head_manifest
+	rm -f "${TEST_ROOT}/capture-count" "${TEST_ROOT}/retarget-called"
+	output=$(cmd_merge 42 testorg/testrepo --squash 2>&1) || rc=$?
+	TEST_RESOLVE_HEAD_FAIL=0
+	if [[ "$rc" -ne 0 && ! -e "${TEST_ROOT}/capture-count" && ! -e "${TEST_ROOT}/retarget-called" &&
+		"$output" == *"exact remotely verified PR head"* ]]; then
+		print_result "head drift fails before stacked PR or merge mutation" 0
+	else
+		print_result "head drift fails before stacked PR or merge mutation" 1 "rc=${rc}; output=${output}"
 	fi
 	return 0
 }
@@ -350,6 +476,12 @@ main() {
 	assert_transport_preserves_body auto-admin "interactive auto-to-admin fallback" 2 1
 	assert_transport_preserves_body stale-401 "stale-auth retry" 2
 	assert_transport_preserves_body rest "REST fallback" 1
+	test_aggregation_head_requires_body_file
+	assert_head_body_mismatch_fails partial "partial head/body manifest"
+	assert_head_body_mismatch_fails reordered "reordered head/body manifest"
+	assert_head_body_mismatch_fails different "different head/body manifest"
+	test_non_aggregation_head_without_body_is_unchanged
+	test_head_drift_fails_before_stacked_pr_mutation
 	test_invalid_body_files_fail_before_gate
 	test_hidden_aggregation_trailers_fail_before_merge_write
 	test_duplicate_aggregation_sources_fail_before_merge_write


### PR DESCRIPTION
## Summary

Bind release-aggregation squash manifests to the immutable remotely verified PR head before any merge transport or stacked-PR mutation.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh, .agents/scripts/tests/test-full-loop-merge-body-file.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Focused merge-body cases, core gh-shim merge cases, scoped linters, ShellCheck, complexity gates, and version consistency passed through executable paths.

Resolves #31167


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.307 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 41m and 254,976 tokens on this with the user in an interactive session.
