### PR TITLE
GH#31164: fix: redact named credential assignments

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -58,9 +58,23 @@ export { checkSecretReadGate, isReadTool } from "./quality-hooks-secret-read.mjs
 
 const CREDENTIAL_PATTERN =
   /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
+const NAMED_CREDENTIAL_ASSIGNMENT_PATTERN =
+  /(^|[\s,{])((?:"?[A-Za-z_][A-Za-z0-9_]*"?))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,}\]]+)/gm;
 
 const REDACTION_TOKEN = "[redacted-credential]";
 const OPERATION_TITLE_MAX_LENGTH = 500;
+
+function isSensitiveFieldName(name) {
+  return /(?:^|_)(?:API_KEY|TOKEN|SECRET|PASSWORD)$/i.test(name.replaceAll('"', ""));
+}
+
+function redactAssignedValue(value) {
+  const quote = value.at(0);
+  if ((quote === '"' || quote === "'") && value.endsWith(quote)) {
+    return `${quote}${REDACTION_TOKEN}${quote}`;
+  }
+  return REDACTION_TOKEN;
+}
 
 /**
  * Scrub known credential token prefixes from a string value.
@@ -69,7 +83,15 @@ const OPERATION_TITLE_MAX_LENGTH = 500;
  */
 export function scrubCredentials(text) {
   let count = 0;
-  const scrubbed = text.replace(CREDENTIAL_PATTERN, (_match, boundary) => {
+  const namedScrubbed = text.replace(
+    NAMED_CREDENTIAL_ASSIGNMENT_PATTERN,
+    (match, boundary, name, separator, value) => {
+      if (!isSensitiveFieldName(name)) return match;
+      count++;
+      return `${boundary}${name}${separator}${redactAssignedValue(value)}`;
+    },
+  );
+  const scrubbed = namedScrubbed.replace(CREDENTIAL_PATTERN, (_match, boundary) => {
     count++;
     return `${boundary}${REDACTION_TOKEN}`;
   });
@@ -113,6 +135,11 @@ function scrubValue(value) {
     let total = 0;
     const result = {};
     for (const [k, v] of Object.entries(value)) {
+      if (isSensitiveFieldName(k) && typeof v === "string") {
+        result[k] = REDACTION_TOKEN;
+        total++;
+        continue;
+      }
       const { value: scrubbed, count } = scrubValue(v);
       result[k] = scrubbed;
       total += count;

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -64,6 +64,22 @@ describe("credential transcript scrub boundary", () => {
     assertScrub(`client_secret=${secret}`, `client_secret=${REDACTION_TOKEN}`, 1);
   });
 
+  test("redacts unknown-format values assigned to sensitive field names", () => {
+    assertScrub(
+      "RESEND_API_KEY=synthetic_unknown_format_1234567890",
+      `RESEND_API_KEY=${REDACTION_TOKEN}`,
+      1,
+    );
+  });
+
+  test("redacts quoted sensitive fields in colon-delimited output", () => {
+    assertScrub(
+      '"RECRAFT_API_KEY": "synthetic_unknown_format_1234567890"',
+      `"RECRAFT_API_KEY": "${REDACTION_TOKEN}"`,
+      1,
+    );
+  });
+
   test("does not redact Google OAuth prefix embedded mid-word", () => {
     const embedded = `vendor-GOCSPX-${"g".repeat(28)}`;
     assertScrub(embedded, embedded, 0);
@@ -83,6 +99,24 @@ describe("credential transcript scrub boundary", () => {
       assert.deepEqual(output.output, {
         stdout: `client_secret=${REDACTION_TOKEN}`,
         exitCode: 0,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("toolExecuteAfter scrubs named credential values in structured output", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "aidevops-named-credential-scrub-"));
+    const output = {
+      output: { environment: { RESEND_API_KEY: "synthetic_unknown_format_1234567890" } },
+      metadata: {},
+    };
+
+    try {
+      const hooks = createQualityHooks({ scriptsDir: tempDir, logsDir: tempDir });
+      await hooks.toolExecuteAfter({ tool: "grep", callID: "" }, output);
+      assert.deepEqual(output.output, {
+        environment: { RESEND_API_KEY: REDACTION_TOKEN },
       });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Redact unknown-format credential values when sensitive assignment names or structured object keys are present, while retaining existing prefix scrubbing.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified through the plugin's toolExecuteAfter integration test plus the full plugin test suite.

Resolves #31164


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.308 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-terra spent 8m and 60,677 tokens on this as a headless worker.