### PR TITLE
GH#31165: recover rejected OpenAI OAuth tokens

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool-health-check.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-health-check.mjs
@@ -36,6 +36,12 @@ function interpretValidityStatus(status, okOn403, on403msg) {
   return `HTTP ${status}`;
 }
 
+export function interpretOpenAIValidityStatus(status) {
+  if (status === 401) return "INVALID (401 -- will force refresh on next provider request)";
+  if (status === 403) return "UNVERIFIED (403 -- Platform API probe does not validate ChatGPT OAuth)";
+  return interpretValidityStatus(status, false);
+}
+
 async function checkAccountTokenValidity(prov, account) {
   try {
     if (prov === "anthropic") {
@@ -54,7 +60,7 @@ async function checkAccountTokenValidity(prov, account) {
       const r = await fetch("https://api.openai.com/v1/models", {
         headers: { "Authorization": `Bearer ${account.access}`, "User-Agent": OPENCODE_USER_AGENT },
       });
-      return interpretValidityStatus(r.status, false);
+      return interpretOpenAIValidityStatus(r.status);
     }
     if (prov === "google") {
       const r = await fetch(GOOGLE_HEALTH_CHECK_URL, {

--- a/.agents/plugins/opencode-aidevops/oauth-pool-refresh.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-refresh.mjs
@@ -196,7 +196,7 @@ export function authFailureBackoffMs(failures) {
   return Math.min(AUTH_FAILURE_MAX_COOLDOWN_MS, AUTH_FAILURE_INITIAL_COOLDOWN_MS * (2 ** (count - 1)));
 }
 
-export function markAuthRefreshFailure(provider, account) {
+function markAuthFailure(provider, account, reason) {
   const now = Date.now();
   const failures = (Number(account.authRefreshFailures) || 0) + 1;
   const cooldownMs = authFailureBackoffMs(failures);
@@ -212,10 +212,18 @@ export function markAuthRefreshFailure(provider, account) {
   account.authRefreshFailures = failures;
   account.authRefreshLastFailureAt = now;
   console.error(
-    `[aidevops] OAuth pool: ${provider} token refresh failed for ${account.email}; ` +
+    `[aidevops] OAuth pool: ${provider} ${reason} for ${account.email}; ` +
     `retry in ${Math.ceil(cooldownMs / 1000)}s (failure ${failures})`,
   );
   return cooldownMs;
+}
+
+export function markAuthRefreshFailure(provider, account) {
+  return markAuthFailure(provider, account, "token refresh failed");
+}
+
+export function markRejectedTokenFailure(provider, account) {
+  return markAuthFailure(provider, account, "refreshed token was rejected");
 }
 
 // ---------------------------------------------------------------------------
@@ -228,18 +236,7 @@ const REFRESH_FN = {
   google: refreshGoogleAccessToken,
 };
 
-/**
- * Ensure an account has a valid (non-expired) access token.
- * Routes to the correct refresh function based on provider.
- *
- * @param {string} provider
- * @param {import("./oauth-pool-storage.mjs").PoolAccount} account
- * @returns {Promise<string|null>} access token or null on failure
- */
-export async function ensureValidToken(provider, account) {
-  if (account.access && account.expires > Date.now()) {
-    return account.access;
-  }
+async function refreshAndStoreToken(provider, account) {
   const tokens = await (REFRESH_FN[provider] || refreshAccessToken)(account);
   if (!tokens) {
     markAuthRefreshFailure(provider, account);
@@ -257,7 +254,31 @@ export async function ensureValidToken(provider, account) {
   account.access = tokens.access;
   account.refresh = tokens.refresh;
   account.expires = tokens.expires;
+  account.status = "active";
+  account.cooldownUntil = null;
+  account.authRefreshFailures = 0;
+  account.authRefreshLastFailureAt = null;
   return tokens.access;
+}
+
+/** Force-refresh an OpenAI account even when its local expiry is in the future. */
+export async function forceRefreshOpenAIToken(account) {
+  return refreshAndStoreToken("openai", account);
+}
+
+/**
+ * Ensure an account has a valid (non-expired) access token.
+ * Routes to the correct refresh function based on provider.
+ *
+ * @param {string} provider
+ * @param {import("./oauth-pool-storage.mjs").PoolAccount} account
+ * @returns {Promise<string|null>} access token or null on failure
+ */
+export async function ensureValidToken(provider, account) {
+  if (account.access && account.expires > Date.now()) {
+    return account.access;
+  }
+  return refreshAndStoreToken(provider, account);
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -67,7 +67,8 @@ export {
 export {
   decodeCursorJWT, readCursorAuthJsonCredentials, readCursorStateDbCredentials,
   isCursorAgentAvailable, ensureValidToken, normalizeExpiredCooldowns,
-  authFailureBackoffMs, markAuthRefreshFailure,
+  authFailureBackoffMs, markAuthRefreshFailure, markRejectedTokenFailure,
+  forceRefreshOpenAIToken,
 } from "./oauth-pool-refresh.mjs";
 
 // Auth hooks & provider registration

--- a/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/openai-provider-auth.mjs
@@ -6,7 +6,14 @@
  * usage-limited accounts and retries once with another pooled account.
  */
 
-import { getAccounts, patchAccount, rotateOpenAIPoolToken } from "./oauth-pool.mjs";
+import {
+  applyOpenAIPoolAccount,
+  forceRefreshOpenAIToken,
+  getAccounts,
+  markRejectedTokenFailure,
+  patchAccount,
+  rotateOpenAIPoolToken,
+} from "./oauth-pool.mjs";
 import { handleOpenAITokenRefreshFailure, isOpenAITokenRefreshRequest, readOpenAITokenRefreshBody } from "./openai-auth-refresh-recovery.mjs";
 import { injectIntentSchemaProperty } from "./provider-auth-body.mjs";
 import { parseRetryAfterValue } from "./provider-auth-pool-recovery.mjs";
@@ -15,6 +22,8 @@ export { isOpenAITokenRefreshRequest } from "./openai-auth-refresh-recovery.mjs"
 
 const OPENAI_API_HOST = "api.openai.com";
 const OPENAI_API_PREFIX = "/v1/";
+const OPENAI_CODEX_HOST = "chatgpt.com";
+const OPENAI_CODEX_PREFIX = "/backend-api/codex/";
 const DEFAULT_OPENAI_COOLDOWN_MS = 300_000;
 const USAGE_LIMIT_MARKERS = [
   "usage limit",
@@ -23,6 +32,19 @@ const USAGE_LIMIT_MARKERS = [
   "quota",
   "insufficient_quota",
   "rate_limit_exceeded",
+];
+const AUTH_FAILURE_MARKERS = [
+  "authentication token is expired",
+  "access token has expired",
+  "expired token",
+  "expired access token",
+  "invalid access token",
+  "invalid token",
+  "invalid_api_key",
+  "invalid_token",
+  "sign in again",
+  "token_expired",
+  "unauthorized",
 ];
 
 let installed = false;
@@ -65,7 +87,10 @@ export function parseRetryAfterMs(response) {
 export function isOpenAIProviderRequest(input) {
   const rawUrl = typeof input === "string" || input instanceof URL ? input.toString() : input?.url;
   const url = URL.parse(rawUrl);
-  return url?.hostname === OPENAI_API_HOST && url.pathname.startsWith(OPENAI_API_PREFIX);
+  return Boolean(url && (
+    (url.hostname === OPENAI_API_HOST && url.pathname.startsWith(OPENAI_API_PREFIX))
+    || (url.hostname === OPENAI_CODEX_HOST && url.pathname.startsWith(OPENAI_CODEX_PREFIX))
+  ));
 }
 
 async function readOpenAIErrorPayload(response) {
@@ -87,6 +112,16 @@ export async function isOpenAIUsageLimitResponse(response) {
   return [code, message].some((text) => USAGE_LIMIT_MARKERS.some((marker) => text.includes(marker)));
 }
 
+export async function isOpenAIAuthFailureResponse(response) {
+  if (response.status === 401) return true;
+  if (response.status !== 403 || await isOpenAIUsageLimitResponse(response)) return false;
+  const payload = await readOpenAIErrorPayload(response);
+  const error = payload?.error || payload;
+  const code = String(error?.code || error?.type || "").toLowerCase();
+  const message = String(error?.message || error?.detail || payload?.detail || error || "").toLowerCase();
+  return [code, message].some((text) => AUTH_FAILURE_MARKERS.some((marker) => text.includes(marker)));
+}
+
 function headersFrom(input, init) {
   const requestHeaders = typeof Request !== "undefined" && input instanceof Request ? input.headers : undefined;
   return new Headers(init?.headers ?? requestHeaders);
@@ -100,8 +135,8 @@ export function extractBearerToken(input, init) {
 
 export function resolveOpenAIAccount(accessToken) {
   const accounts = getAccounts("openai");
-  const byAccess = accessToken ? accounts.find((account) => account.access === accessToken) : null;
-  return byAccess ?? [...accounts].sort((a, b) => new Date(b.lastUsed || 0) - new Date(a.lastUsed || 0))[0] ?? null;
+  if (accessToken) return accounts.find((account) => account.access === accessToken) ?? null;
+  return [...accounts].sort((a, b) => new Date(b.lastUsed || 0) - new Date(a.lastUsed || 0))[0] ?? null;
 }
 
 function isUnavailableAccount(account) {
@@ -133,28 +168,63 @@ async function prepareOpenAIRequest(input, init) {
   return { input, init: extendRequestInit(init, { body: transformedBody }) };
 }
 
-function buildRetryInit(input, init, accessToken) {
+function buildRetryInit(input, init, account) {
   const retryHeaders = headersFrom(input, init);
-  retryHeaders.set("authorization", `Bearer ${accessToken}`);
+  retryHeaders.set("authorization", `Bearer ${account.access}`);
+  retryHeaders.delete("chatgpt-account-id");
+  if (account.accountId) retryHeaders.set("chatgpt-account-id", account.accountId);
   return extendRequestInit(init, { headers: retryHeaders });
+}
+
+function retryOpenAIRequest(originalFetch, retryInput, input, init, account) {
+  const retryInit = buildRetryInit(input, init, account);
+  return originalFetch(buildRetryRequest(retryInput), retryInit);
 }
 
 async function handleOpenAIUsageLimit(ctx) {
   const { client, originalFetch, input, init, response, retryInput } = ctx;
   const current = resolveOpenAIAccount(extractBearerToken(input, init));
+  if (!current) return response;
   const currentEmail = current?.email || "unknown";
-  if (current) {
-    patchAccount("openai", current.email, {
-      status: "rate-limited",
-      cooldownUntil: Date.now() + parseRetryAfterMs(response),
-      lastUsed: new Date().toISOString(),
-    });
-  }
+  patchAccount("openai", current.email, {
+    status: "rate-limited",
+    cooldownUntil: Date.now() + parseRetryAfterMs(response),
+    lastUsed: new Date().toISOString(),
+  });
   console.error(`[aidevops] OpenAI provider: usage/rate limit for ${currentEmail} — rotating pool account`);
   const rotated = await rotateOpenAIPoolToken(client, current?.email);
   if (!rotated?.access) return response;
-  const retryInit = buildRetryInit(input, init, rotated.access);
-  return originalFetch(buildRetryRequest(retryInput), retryInit);
+  return retryOpenAIRequest(originalFetch, retryInput, input, init, rotated);
+}
+
+async function handleOpenAIAuthFailure(ctx) {
+  const { client, originalFetch, input, init, response, retryInput } = ctx;
+  const current = resolveOpenAIAccount(extractBearerToken(input, init));
+  if (!current) return response;
+  const currentEmail = current?.email || "unknown";
+  const requestAccountId = headersFrom(input, init).get("chatgpt-account-id");
+  if (!current.accountId && requestAccountId) {
+    current.accountId = requestAccountId;
+    patchAccount("openai", current.email, { accountId: requestAccountId });
+  }
+  console.error(`[aidevops] OpenAI provider: rejected token for ${currentEmail} — forcing one refresh`);
+  const refreshedAccess = await forceRefreshOpenAIToken(current);
+  if (refreshedAccess) {
+    await applyOpenAIPoolAccount(client, current);
+    const retryResponse = await retryOpenAIRequest(originalFetch, retryInput, input, init, current);
+    if (await isOpenAIAuthFailureResponse(retryResponse)) {
+      markRejectedTokenFailure("openai", current);
+    }
+    return retryResponse;
+  }
+  console.error(`[aidevops] OpenAI provider: refresh unavailable for ${currentEmail} — trying another pool account`);
+  const rotated = await rotateOpenAIPoolToken(client, current?.email);
+  if (!rotated?.access) return response;
+  const retryResponse = await retryOpenAIRequest(originalFetch, retryInput, input, init, rotated);
+  if (await isOpenAIAuthFailureResponse(retryResponse)) {
+    markRejectedTokenFailure("openai", rotated);
+  }
+  return retryResponse;
 }
 
 async function maybeRotateBeforeOpenAIFetch(client, input, init) {
@@ -164,7 +234,7 @@ async function maybeRotateBeforeOpenAIFetch(client, input, init) {
   console.error(`[aidevops] OpenAI provider: current account ${currentEmail} unavailable before request — rotating pool account`);
   const rotated = await rotateOpenAIPoolToken(client, current?.email);
   if (!rotated?.access) return init;
-  return buildRetryInit(input, init, rotated.access);
+  return buildRetryInit(input, init, rotated);
 }
 
 async function handleOpenAIFetchRequest(ctx) {
@@ -186,15 +256,20 @@ async function handleOpenAIFetchRequest(ctx) {
       response,
       bodyText: tokenRefreshBody,
     });
-  } else if (openaiRequest && await isOpenAIUsageLimitResponse(response)) {
-    result = await handleOpenAIUsageLimit({
+  } else if (openaiRequest) {
+    const responseContext = {
       client,
       originalFetch,
       input: prepared.input,
       init: firstInit,
       response,
       retryInput,
-    });
+    };
+    if (await isOpenAIUsageLimitResponse(response)) {
+      result = await handleOpenAIUsageLimit(responseContext);
+    } else if (await isOpenAIAuthFailureResponse(response)) {
+      result = await handleOpenAIAuthFailure(responseContext);
+    }
   }
   return result;
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
+import { interpretOpenAIValidityStatus } from "../oauth-pool-health-check.mjs";
+
 function loadModule() {
   return import(`../openai-provider-auth.mjs?test=${Date.now()}-${Math.random()}`);
 }
@@ -21,20 +23,42 @@ function runProviderScript(prefix, script) {
 test("detects OpenAI provider requests only", async () => {
   const { isOpenAIProviderRequest, isOpenAITokenRefreshRequest } = await loadModule();
   assert.equal(isOpenAIProviderRequest("https://api.openai.com/v1/chat/completions"), true);
+  assert.equal(isOpenAIProviderRequest("https://chatgpt.com/backend-api/codex/responses"), true);
   assert.equal(isOpenAIProviderRequest("https://api.openai.com/dashboard"), false);
+  assert.equal(isOpenAIProviderRequest("https://chatgpt.com/backend-api/accounts"), false);
   assert.equal(isOpenAIProviderRequest("https://example.com/v1/chat/completions"), false);
   assert.equal(isOpenAITokenRefreshRequest("https://auth.openai.com/oauth/token"), true);
   assert.equal(isOpenAITokenRefreshRequest("https://api.openai.com/v1/responses"), false);
 });
 
 test("detects OpenAI usage-limit responses", async () => {
-  const { isOpenAIUsageLimitResponse } = await loadModule();
+  const { isOpenAIAuthFailureResponse, isOpenAIUsageLimitResponse } = await loadModule();
   const quota = new Response(JSON.stringify({ error: { code: "insufficient_quota", message: "Usage limit reached" } }), {
     status: 403,
     headers: { "content-type": "application/json" },
   });
   assert.equal(await isOpenAIUsageLimitResponse(quota), true);
+  assert.equal(await isOpenAIAuthFailureResponse(quota), false);
+  assert.equal(await isOpenAIAuthFailureResponse(new Response("unauthorized", { status: 401 })), true);
+  assert.equal(await isOpenAIAuthFailureResponse(new Response(JSON.stringify({
+    error: { message: "Provided authentication token is expired. Please sign in again" },
+  }), {
+    status: 403,
+    headers: { "content-type": "application/json" },
+  })), true);
+  assert.equal(await isOpenAIAuthFailureResponse(new Response(JSON.stringify({
+    error: { message: "Access forbidden by workspace policy" },
+  }), {
+    status: 403,
+    headers: { "content-type": "application/json" },
+  })), false);
   assert.equal(await isOpenAIUsageLimitResponse(new Response("ok", { status: 200 })), false);
+});
+
+test("describes the Platform API probe accurately for ChatGPT OAuth", () => {
+  assert.equal(interpretOpenAIValidityStatus(200), "OK");
+  assert.match(interpretOpenAIValidityStatus(401), /force refresh/);
+  assert.match(interpretOpenAIValidityStatus(403), /does not validate ChatGPT OAuth/);
 });
 
 test("injects optional intent into OpenAI provider tool-schema variants", async () => {
@@ -69,13 +93,25 @@ test("injects optional intent into OpenAI provider tool-schema variants", async 
 test("installed fetch guard rotates on response failures and pre-request cooldowns", async () => {
   const script = String.raw`
     import assert from "node:assert/strict";
-    import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+    import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
     import { join } from "node:path";
 
     const home = process.env.HOME;
     const aidevopsDir = join(home, ".aidevops");
     mkdirSync(aidevopsDir, { recursive: true });
     const poolPath = join(aidevopsDir, "oauth-pool.json");
+    const binPath = join(home, "bin");
+    const curlPath = join(binPath, "curl");
+    mkdirSync(binPath, { recursive: true });
+    writeFileSync(curlPath, "#!/usr/bin/env node\nprocess.stdout.write(process.env.AIDEVOPS_TEST_CURL_RESPONSE || '')\n");
+    chmodSync(curlPath, 0o755);
+    process.env.PATH = binPath + ":" + process.env.PATH;
+
+    function setTokenEndpointResponse(status, payload) {
+      process.env.AIDEVOPS_TEST_CURL_RESPONSE =
+        "HTTP/1.1 " + status + " Test\r\ncontent-type: application/json\r\n\r\n" +
+        JSON.stringify(payload) + "\n" + status;
+    }
 
     async function withInstalledGuard(pool, fetchImpl, request) {
       writeFileSync(poolPath, JSON.stringify(pool));
@@ -240,6 +276,142 @@ test("installed fetch guard rotates on response failures and pre-request cooldow
 
     assert.equal(cooldownPreflight.response.status, 200);
     assert.deepEqual(cooldownPreflight.calls, ["Bearer fresh-token"]);
+
+    setTokenEndpointResponse(200, {
+      access_token: "refreshed-token",
+      refresh_token: "refreshed-refresh",
+      expires_in: 3600,
+    });
+    const rejectedFutureToken = await withInstalledGuard({
+      openai: [
+        { email: "future@example.com", access: "future-token", refresh: "future-refresh", expires: Date.now() + 9 * 86400_000, status: "active", cooldownUntil: 0 },
+      ],
+    }, async (input, init, calls) => {
+      calls.push({
+        authorization: new Headers(init?.headers).get("authorization"),
+        accountId: new Headers(init?.headers).get("chatgpt-account-id"),
+      });
+      if (calls.length === 1) {
+        return new Response(JSON.stringify({
+          error: { message: "Provided authentication token is expired. Please sign in again" },
+        }), { status: 403, headers: { "content-type": "application/json" } });
+      }
+      return new Response("ok", { status: 200 });
+    }, {
+      url: "https://chatgpt.com/backend-api/codex/responses",
+      init: {
+        method: "POST",
+        headers: { authorization: "Bearer future-token", "chatgpt-account-id": "acct_future" },
+        body: "{}",
+      },
+    });
+
+    assert.equal(rejectedFutureToken.response.status, 200);
+    assert.deepEqual(rejectedFutureToken.calls, [
+      { authorization: "Bearer future-token", accountId: "acct_future" },
+      { authorization: "Bearer refreshed-token", accountId: "acct_future" },
+    ]);
+    assert.equal(rejectedFutureToken.pool.openai[0].access, "refreshed-token");
+    assert.equal(rejectedFutureToken.pool.openai[0].refresh, "refreshed-refresh");
+    assert.equal(rejectedFutureToken.pool.openai[0].status, "active");
+    assert.equal(rejectedFutureToken.pool.openai[0].accountId, "acct_future");
+    assert.equal(rejectedFutureToken.authWrites.length, 1);
+
+    setTokenEndpointResponse(401, { error: "invalid_grant" });
+    const failedRefreshFallback = await withInstalledGuard({
+      openai: [
+        { email: "rejected@example.com", access: "rejected-token", refresh: "rejected-refresh", expires: Date.now() + 9 * 86400_000, status: "active", cooldownUntil: 0, accountId: "acct_rejected" },
+        { email: "fallback@example.com", access: "fallback-token", refresh: "fallback-refresh", expires: Date.now() + 3600_000, status: "idle", cooldownUntil: 0, accountId: "acct_fallback" },
+      ],
+    }, async (input, init, calls) => {
+      calls.push({
+        authorization: new Headers(init?.headers).get("authorization"),
+        accountId: new Headers(init?.headers).get("chatgpt-account-id"),
+      });
+      if (calls.length === 1) {
+        return new Response(JSON.stringify({ error: { code: "invalid_token" } }), {
+          status: 403,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    }, {
+      url: "https://chatgpt.com/backend-api/codex/responses",
+      init: {
+        method: "POST",
+        headers: { authorization: "Bearer rejected-token", "chatgpt-account-id": "acct_rejected" },
+        body: "{}",
+      },
+    });
+
+    assert.equal(failedRefreshFallback.response.status, 200);
+    assert.deepEqual(failedRefreshFallback.calls, [
+      { authorization: "Bearer rejected-token", accountId: "acct_rejected" },
+      { authorization: "Bearer fallback-token", accountId: "acct_fallback" },
+    ]);
+    assert.equal(failedRefreshFallback.pool.openai[0].status, "auth-error");
+    assert.equal(failedRefreshFallback.pool.openai[1].status, "active");
+
+    setTokenEndpointResponse(200, {
+      access_token: "once-refreshed-token",
+      refresh_token: "once-refreshed-refresh",
+      expires_in: 3600,
+    });
+    const boundedRetry = await withInstalledGuard({
+      openai: [
+        { email: "bounded@example.com", access: "bounded-token", refresh: "bounded-refresh", expires: Date.now() + 9 * 86400_000, status: "active", cooldownUntil: 0, accountId: "acct_bounded" },
+      ],
+    }, async (input, init, calls) => {
+      calls.push(new Headers(init?.headers).get("authorization"));
+      return new Response(JSON.stringify({ error: { message: "authentication token is expired" } }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      });
+    }, {
+      url: "https://chatgpt.com/backend-api/codex/responses",
+      init: { method: "POST", headers: { authorization: "Bearer bounded-token" }, body: "{}" },
+    });
+
+    assert.equal(boundedRetry.response.status, 401);
+    assert.deepEqual(boundedRetry.calls, ["Bearer bounded-token", "Bearer once-refreshed-token"]);
+    assert.equal(boundedRetry.pool.openai[0].status, "auth-error");
+
+    const unrelatedApiKey = await withInstalledGuard({
+      openai: [
+        { email: "pool@example.com", access: "pool-token", refresh: "pool-refresh", expires: Date.now() + 3600_000, status: "idle", cooldownUntil: 0 },
+      ],
+    }, async (input, init, calls) => {
+      calls.push(new Headers(init?.headers).get("authorization"));
+      return new Response("unauthorized", { status: 401 });
+    }, {
+      url: "https://api.openai.com/v1/responses",
+      init: { method: "POST", headers: { authorization: "Bearer unrelated-api-key" }, body: "{}" },
+    });
+
+    assert.equal(unrelatedApiKey.response.status, 401);
+    assert.deepEqual(unrelatedApiKey.calls, ["Bearer unrelated-api-key"]);
+    assert.equal(unrelatedApiKey.authWrites.length, 0);
+    assert.equal(unrelatedApiKey.pool.openai[0].status, "idle");
+
+    const unrelatedLimitedApiKey = await withInstalledGuard({
+      openai: [
+        { email: "pool@example.com", access: "pool-token", refresh: "pool-refresh", expires: Date.now() + 3600_000, status: "idle", cooldownUntil: 0 },
+      ],
+    }, async (input, init, calls) => {
+      calls.push(new Headers(init?.headers).get("authorization"));
+      return new Response(JSON.stringify({ error: { code: "insufficient_quota" } }), {
+        status: 429,
+        headers: { "content-type": "application/json" },
+      });
+    }, {
+      url: "https://api.openai.com/v1/responses",
+      init: { method: "POST", headers: { authorization: "Bearer unrelated-api-key" }, body: "{}" },
+    });
+
+    assert.equal(unrelatedLimitedApiKey.response.status, 429);
+    assert.deepEqual(unrelatedLimitedApiKey.calls, ["Bearer unrelated-api-key"]);
+    assert.equal(unrelatedLimitedApiKey.authWrites.length, 0);
+    assert.equal(unrelatedLimitedApiKey.pool.openai[0].status, "idle");
 
     const genericServerFailure = await withInstalledGuard({
       openai: [


### PR DESCRIPTION
## Summary

Recognize ChatGPT Codex requests, force-refresh locally unexpired OAuth tokens rejected by the provider, retry once, quarantine repeated failures, preserve account identity, and avoid crossing API-key billing contexts.

## Files Changed

.agents/plugins/opencode-aidevops/oauth-pool-health-check.mjs, .agents/plugins/opencode-aidevops/oauth-pool-refresh.mjs, .agents/plugins/opencode-aidevops/oauth-pool.mjs, .agents/plugins/opencode-aidevops/openai-provider-auth.mjs, .agents/plugins/opencode-aidevops/tests/test-openai-provider-auth.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: production OAuth pool and fetch-guard modules executed end to end in isolated Node subprocesses with synthetic token-endpoint and provider responses; focused OpenAI OAuth, refresh-backoff, and pool-display tests pass (12/12); Node syntax checks and local linters pass; independent closeout review reports no blocking findings. Broad plugin tests passed 760/761, with only the unrelated missing local @opencode-ai/plugin dependency failing.

Resolves #31165


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.308 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 1h 26m and 661,751 tokens on this with the user in an interactive session.