### PR TITLE
GH#31177: serialize mutable OAuth token refresh

### DIFF
--- a/.agents/aidevops/extension.md
+++ b/.agents/aidevops/extension.md
@@ -27,6 +27,7 @@ tools:
 - **Docs**: `.agents/[service].md`
 - **Required functions**: `check_dependencies`, `load_config`, `get_account_config`, `api_request`, `list_accounts`, `show_help`, `main`
 - **Update on add**: `.gitignore`, `README.md`, `AGENTS.md`, `aidevops/recommendations.md`, `setup-wizard-helper.sh`
+- **Rotating OAuth state**: follow `reference/oauth-token-state.md`; do not persist mutable tokens as static shell credentials
 
 <!-- AI-CONTEXT-END -->
 

--- a/.agents/plugins/opencode-aidevops/oauth-pool-constants.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-constants.mjs
@@ -23,7 +23,7 @@ const HOME = homedir();
 /** Pool credential file path */
 export const POOL_FILE = join(HOME, ".aidevops", "oauth-pool.json");
 
-/** Advisory lock file — shared with oauth-pool-helper.sh (flock-based) */
+/** Advisory lock identity shared with oauth-pool-helper.sh (`.lock.d` protocol) */
 export const POOL_LOCK_FILE = POOL_FILE + ".lock";
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/oauth-pool-refresh.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-refresh.mjs
@@ -20,7 +20,7 @@ import {
   fetchTokenEndpoint, fetchOpenAITokenEndpoint, fetchGoogleTokenEndpoint,
 } from "./oauth-pool-token-endpoint.mjs";
 import {
-  patchAccount, withPoolLock, loadPool, savePool,
+  patchAccount, withPoolLock, withPoolLockAsync, loadPool, savePool,
 } from "./oauth-pool-storage.mjs";
 
 // ---------------------------------------------------------------------------
@@ -200,22 +200,23 @@ function markAuthFailure(provider, account, reason) {
   const now = Date.now();
   const failures = (Number(account.authRefreshFailures) || 0) + 1;
   const cooldownMs = authFailureBackoffMs(failures);
-  const cooldownUntil = now + cooldownMs;
-  patchAccount(provider, account.email, {
+  const failureState = {
     status: "auth-error",
-    cooldownUntil,
+    cooldownUntil: now + cooldownMs,
     authRefreshFailures: failures,
     authRefreshLastFailureAt: now,
-  });
-  account.status = "auth-error";
-  account.cooldownUntil = cooldownUntil;
-  account.authRefreshFailures = failures;
-  account.authRefreshLastFailureAt = now;
+  };
+  patchAccount(provider, account.email, failureState);
+  Object.assign(account, failureState);
+  logAuthFailure(provider, account.email, reason, failures, cooldownMs);
+  return cooldownMs;
+}
+
+function logAuthFailure(provider, email, reason, failures, cooldownMs) {
   console.error(
-    `[aidevops] OAuth pool: ${provider} ${reason} for ${account.email}; ` +
+    `[aidevops] OAuth pool: ${provider} ${reason} for ${email}; ` +
     `retry in ${Math.ceil(cooldownMs / 1000)}s (failure ${failures})`,
   );
-  return cooldownMs;
 }
 
 export function markAuthRefreshFailure(provider, account) {
@@ -236,34 +237,87 @@ const REFRESH_FN = {
   google: refreshGoogleAccessToken,
 };
 
-async function refreshAndStoreToken(provider, account) {
-  const tokens = await (REFRESH_FN[provider] || refreshAccessToken)(account);
-  if (!tokens) {
-    markAuthRefreshFailure(provider, account);
-    return null;
-  }
-  patchAccount(provider, account.email, {
-    access: tokens.access,
-    refresh: tokens.refresh,
-    expires: tokens.expires,
-    status: "active",
-    cooldownUntil: null,
-    authRefreshFailures: 0,
-    authRefreshLastFailureAt: null,
+function tokenState(account) {
+  return {
+    access: account?.access || "",
+    refresh: account?.refresh || "",
+    expires: Number(account?.expires) || 0,
+  };
+}
+
+function sameTokenState(account, expected) {
+  const current = tokenState(account);
+  return current.access === expected.access &&
+    current.refresh === expected.refresh &&
+    current.expires === expected.expires;
+}
+
+function findStoredAccount(pool, provider, email) {
+  return (pool[provider] || []).find((candidate) => candidate.email === email) || null;
+}
+
+function syncCallerAccount(account, stored) {
+  if (stored) Object.assign(account, stored);
+  return stored?.access || null;
+}
+
+async function refreshAndStoreToken(provider, account, force = false) {
+  const requestedState = tokenState(account);
+  return withPoolLockAsync(async () => {
+    let pool = loadPool();
+    let stored = findStoredAccount(pool, provider, account.email);
+    if (!stored) return null;
+
+    if ((force && !sameTokenState(stored, requestedState)) ||
+        (!force && stored.access && stored.expires > Date.now())) {
+      return syncCallerAccount(account, stored);
+    }
+
+    const refreshState = tokenState(stored);
+    const tokens = await (REFRESH_FN[provider] || refreshAccessToken)(stored);
+
+    // Same-process synchronous writers are re-entrant while this async lock is
+    // held. Re-read and compare before publishing so a re-auth cannot be
+    // overwritten by an older in-flight refresh response.
+    pool = loadPool();
+    stored = findStoredAccount(pool, provider, account.email);
+    if (!stored || !sameTokenState(stored, refreshState)) {
+      return syncCallerAccount(account, stored);
+    }
+
+    if (!tokens) {
+      const now = Date.now();
+      const failures = (Number(stored.authRefreshFailures) || 0) + 1;
+      const cooldownMs = authFailureBackoffMs(failures);
+      Object.assign(stored, {
+        status: "auth-error",
+        cooldownUntil: now + cooldownMs,
+        authRefreshFailures: failures,
+        authRefreshLastFailureAt: now,
+      });
+      savePool(pool);
+      syncCallerAccount(account, stored);
+      logAuthFailure(provider, stored.email, "token refresh failed", failures, cooldownMs);
+      return null;
+    }
+
+    Object.assign(stored, {
+      access: tokens.access,
+      refresh: tokens.refresh || stored.refresh,
+      expires: tokens.expires,
+      status: "active",
+      cooldownUntil: null,
+      authRefreshFailures: 0,
+      authRefreshLastFailureAt: null,
+    });
+    savePool(pool);
+    return syncCallerAccount(account, stored);
   });
-  account.access = tokens.access;
-  account.refresh = tokens.refresh;
-  account.expires = tokens.expires;
-  account.status = "active";
-  account.cooldownUntil = null;
-  account.authRefreshFailures = 0;
-  account.authRefreshLastFailureAt = null;
-  return tokens.access;
 }
 
 /** Force-refresh an OpenAI account even when its local expiry is in the future. */
 export async function forceRefreshOpenAIToken(account) {
-  return refreshAndStoreToken("openai", account);
+  return refreshAndStoreToken("openai", account, true);
 }
 
 /**

--- a/.agents/plugins/opencode-aidevops/oauth-pool-storage.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-storage.mjs
@@ -9,8 +9,9 @@
 
 import {
   readFileSync, writeFileSync, existsSync, mkdirSync, rmdirSync, unlinkSync,
-  renameSync, chmodSync,
+  renameSync, chmodSync, statSync,
 } from "fs";
+import { randomUUID } from "crypto";
 import { dirname } from "path";
 import { POOL_FILE, POOL_LOCK_FILE } from "./oauth-pool-constants.mjs";
 
@@ -56,15 +57,21 @@ export function loadPool() {
  * @param {Object} data
  */
 export function savePool(data) {
+  const dir = dirname(POOL_FILE);
+  let tmp = "";
   try {
-    const dir = dirname(POOL_FILE);
-    mkdirSync(dir, { recursive: true });
-    const tmp = POOL_FILE + ".tmp." + process.pid;
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    chmodSync(dir, 0o700);
+    tmp = `${POOL_FILE}.tmp.${process.pid}.${randomUUID()}`;
     writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
     chmodSync(tmp, 0o600);
     renameSync(tmp, POOL_FILE);
   } catch (err) {
+    if (tmp) {
+      try { unlinkSync(tmp); } catch { /* absent or already renamed */ }
+    }
     console.error(`[aidevops] OAuth pool: failed to save pool file: ${err.message}`);
+    throw err;
   }
 }
 
@@ -74,33 +81,117 @@ export function savePool(data) {
 
 const LOCK_DIR = POOL_LOCK_FILE + ".d";
 const OWNER_FILE = LOCK_DIR + "/owner";
-const LOCK_STALE_MS = 10000; // 10 s — sufficient for any normal pool operation
+const LOCK_WAIT_MS = 30000;
+const OWNERLESS_LOCK_GRACE_MS = 30000;
+let activeAsyncLockToken = "";
+let asyncLockTail = Promise.resolve();
 
-/** Return true if the lock recorded in OWNER_FILE belongs to a dead or expired process. */
-function isLockStale() {
+function ensurePoolDirectory() {
+  const dir = dirname(POOL_FILE);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  chmodSync(dir, 0o700);
+}
+
+function processIsLive(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
   try {
-    const { pid, ts } = JSON.parse(readFileSync(OWNER_FILE, "utf-8"));
-    const processGone = (() => { try { process.kill(pid, 0); return false; } catch { return true; } })();
-    return processGone || (Date.now() - ts > LOCK_STALE_MS);
-  } catch {
-    return false; // unreadable — wait and retry
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === "EPERM";
   }
 }
 
-/** Remove a stale lock directory, ignoring races with other cleaners. */
-function removeStalelock() {
+/** Return a stable snapshot only when the current lock can be reclaimed. */
+function staleLockSnapshot() {
+  try {
+    const raw = readFileSync(OWNER_FILE, "utf-8");
+    const owner = JSON.parse(raw);
+    return processIsLive(owner.pid) ? null : raw;
+  } catch {
+    try {
+      return Date.now() - statSync(LOCK_DIR).mtimeMs >= OWNERLESS_LOCK_GRACE_MS ? "" : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Remove only the unchanged stale lock observed by staleLockSnapshot. */
+function removeStaleLock(snapshot) {
+  try {
+    const current = readFileSync(OWNER_FILE, "utf-8");
+    if (current !== snapshot) return;
+  } catch {
+    if (snapshot !== "") return;
+  }
   try { unlinkSync(OWNER_FILE); } catch { /* race */ }
   try { rmdirSync(LOCK_DIR); } catch { /* race */ }
 }
 
-/** Release the lock only if we still own it, preventing removal of another process's lock. */
-function releaseLock() {
+function tryAcquireLock() {
+  const token = randomUUID();
   try {
-    const { pid } = JSON.parse(readFileSync(OWNER_FILE, "utf-8"));
-    if (pid !== process.pid) return;
+    mkdirSync(LOCK_DIR, { mode: 0o700 });
+  } catch (err) {
+    if (err?.code === "EEXIST") return "";
+    throw err;
+  }
+  try {
+    chmodSync(LOCK_DIR, 0o700);
+    writeFileSync(
+      OWNER_FILE,
+      JSON.stringify({ schema: "aidevops.oauth-lock/v1", pid: process.pid, token, createdAt: Date.now() }),
+      { flag: "wx", mode: 0o600 },
+    );
+    chmodSync(OWNER_FILE, 0o600);
+    return token;
+  } catch (err) {
+    try { unlinkSync(OWNER_FILE); } catch { /* absent */ }
+    try { rmdirSync(LOCK_DIR); } catch { /* retained for diagnosis */ }
+    throw err;
+  }
+}
+
+/** Release the lock only when its unguessable owner token still matches. */
+function releaseLock(token) {
+  try {
+    const owner = JSON.parse(readFileSync(OWNER_FILE, "utf-8"));
+    if (owner.pid !== process.pid || owner.token !== token) return;
     try { unlinkSync(OWNER_FILE); } catch { /* ignore */ }
     try { rmdirSync(LOCK_DIR); } catch { /* ignore */ }
   } catch { /* lock dir already gone — that's fine */ }
+}
+
+function waitForLockSync() {
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  const sleepBuf = new Int32Array(new SharedArrayBuffer(4));
+  while (Date.now() < deadline) {
+    const token = tryAcquireLock();
+    if (token) return token;
+    const snapshot = staleLockSnapshot();
+    if (snapshot !== null) {
+      removeStaleLock(snapshot);
+      continue;
+    }
+    Atomics.wait(sleepBuf, 0, 0, 50);
+  }
+  throw new Error("[aidevops] OAuth pool: timed out waiting for pool lock");
+}
+
+async function waitForLockAsync() {
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  while (Date.now() < deadline) {
+    const token = tryAcquireLock();
+    if (token) return token;
+    const snapshot = staleLockSnapshot();
+    if (snapshot !== null) {
+      removeStaleLock(snapshot);
+      continue;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("[aidevops] OAuth pool: timed out waiting for pool lock");
 }
 
 /**
@@ -115,26 +206,39 @@ function releaseLock() {
  * @returns {T}
  */
 export function withPoolLock(fn) {
-  mkdirSync(dirname(POOL_FILE), { recursive: true });
-
-  const deadline = Date.now() + 5000;
-  const sleepBuf = new Int32Array(new SharedArrayBuffer(4));
-
-  while (true) {
-    try {
-      mkdirSync(LOCK_DIR);
-      writeFileSync(OWNER_FILE, JSON.stringify({ pid: process.pid, ts: Date.now() }), { mode: 0o600 });
-      break;
-    } catch (e) {
-      if (e.code !== "EEXIST") throw e;
-      if (Date.now() >= deadline) throw new Error("[aidevops] OAuth pool: timed out waiting for pool lock");
-      if (isLockStale()) { removeStalelock(); continue; }
-      Atomics.wait(sleepBuf, 0, 0, 50);
-    }
-  }
-
+  ensurePoolDirectory();
+  if (activeAsyncLockToken) return fn();
+  const token = waitForLockSync();
   try { return fn(); }
-  finally { releaseLock(); }
+  finally { releaseLock(token); }
+}
+
+/**
+ * Execute an async refresh transaction under the same cross-process lock.
+ * Synchronous same-process mutations remain re-entrant and complete before the
+ * awaiting refresh continuation resumes on the JavaScript event loop.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+export async function withPoolLockAsync(fn) {
+  ensurePoolDirectory();
+  const previous = asyncLockTail;
+  let advanceQueue = () => {};
+  asyncLockTail = new Promise((resolve) => { advanceQueue = resolve; });
+  await previous;
+
+  let token = "";
+  try {
+    token = await waitForLockAsync();
+    activeAsyncLockToken = token;
+    return await fn();
+  } finally {
+    activeAsyncLockToken = "";
+    if (token) releaseLock(token);
+    advanceQueue();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/tests/test-oauth-token-state.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-oauth-token-state.mjs
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+test("OAuth refreshes serialize and preserve an omitted rotating refresh token", () => {
+  const home = mkdtempSync(join(tmpdir(), "aidevops-oauth-state-"));
+  const script = String.raw`
+    import assert from "node:assert/strict";
+    import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+    import { join } from "node:path";
+
+    const home = process.env.HOME;
+    const aidevopsDir = join(home, ".aidevops");
+    const poolPath = join(aidevopsDir, "oauth-pool.json");
+    const counterPath = join(home, "refresh-count");
+    const binPath = join(home, "bin");
+    mkdirSync(aidevopsDir, { recursive: true });
+    mkdirSync(binPath, { recursive: true });
+    writeFileSync(poolPath, JSON.stringify({ openai: [{
+      email: "fixture@example.com",
+      access: "old-access",
+      refresh: "rotating-refresh",
+      expires: 1,
+      status: "active",
+      cooldownUntil: 0,
+    }] }), { mode: 0o600 });
+
+    const curlPath = join(binPath, "curl");
+    writeFileSync(curlPath, [
+      "#!/usr/bin/env node",
+      "const fs = require('node:fs');",
+      "fs.appendFileSync(process.env.AIDEVOPS_TEST_REFRESH_COUNT, '1\\n');",
+      "process.stdout.write('HTTP/1.1 200 OK\\r\\ncontent-type: application/json\\r\\n\\r\\n' +",
+      "  JSON.stringify({ access_token: 'new-access', expires_in: 3600 }) + '\\n200');",
+    ].join("\n"));
+    chmodSync(curlPath, 0o755);
+    process.env.PATH = binPath + ":" + process.env.PATH;
+    process.env.AIDEVOPS_TEST_REFRESH_COUNT = counterPath;
+
+    const { forceRefreshOpenAIToken } = await import("./oauth-pool-refresh.mjs?state=" + Math.random());
+    const original = JSON.parse(readFileSync(poolPath, "utf-8")).openai[0];
+    const first = { ...original };
+    const second = { ...original };
+    const results = await Promise.all([
+      forceRefreshOpenAIToken(first),
+      forceRefreshOpenAIToken(second),
+    ]);
+
+    const saved = JSON.parse(readFileSync(poolPath, "utf-8")).openai[0];
+    assert.deepEqual(results, ["new-access", "new-access"]);
+    assert.equal(readFileSync(counterPath, "utf-8").trim().split("\n").length, 1);
+    assert.equal(saved.access, "new-access");
+    assert.equal(saved.refresh, "rotating-refresh");
+    assert.equal(first.refresh, "rotating-refresh");
+    assert.equal(second.refresh, "rotating-refresh");
+    assert.equal(statSync(aidevopsDir).mode & 0o777, 0o700);
+    assert.equal(statSync(poolPath).mode & 0o777, 0o600);
+    assert.equal(existsSync(poolPath + ".lock.d"), false);
+  `;
+
+  execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
+    cwd: join(import.meta.dirname, ".."),
+    env: { ...process.env, HOME: home },
+    stdio: "pipe",
+  });
+});
+
+test("an in-flight refresh cannot overwrite newer durable credentials", () => {
+  const home = mkdtempSync(join(tmpdir(), "aidevops-oauth-stale-response-"));
+  const script = String.raw`
+    import assert from "node:assert/strict";
+    import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+    import { join } from "node:path";
+
+    const aidevopsDir = join(process.env.HOME, ".aidevops");
+    const poolPath = join(aidevopsDir, "oauth-pool.json");
+    const binPath = join(process.env.HOME, "bin");
+    mkdirSync(aidevopsDir, { recursive: true });
+    mkdirSync(binPath, { recursive: true });
+    writeFileSync(poolPath, JSON.stringify({ openai: [{
+      email: "fixture@example.com",
+      access: "old-access",
+      refresh: "old-refresh",
+      expires: 1,
+      status: "active",
+      cooldownUntil: 0,
+    }] }), { mode: 0o600 });
+
+    const curlPath = join(binPath, "curl");
+    writeFileSync(curlPath, [
+      "#!/usr/bin/env node",
+      "const fs = require('node:fs');",
+      "const path = process.env.AIDEVOPS_TEST_POOL_PATH;",
+      "const pool = JSON.parse(fs.readFileSync(path, 'utf-8'));",
+      "Object.assign(pool.openai[0], { access: 'reauth-access', refresh: 'reauth-refresh', expires: Date.now() + 7200000 });",
+      "fs.writeFileSync(path + '.reauth', JSON.stringify(pool), { mode: 0o600 });",
+      "fs.renameSync(path + '.reauth', path);",
+      "process.stdout.write('HTTP/1.1 200 OK\\r\\ncontent-type: application/json\\r\\n\\r\\n' +",
+      "  JSON.stringify({ access_token: 'stale-access', refresh_token: 'stale-refresh', expires_in: 3600 }) + '\\n200');",
+    ].join("\n"));
+    chmodSync(curlPath, 0o755);
+    process.env.PATH = binPath + ":" + process.env.PATH;
+    process.env.AIDEVOPS_TEST_POOL_PATH = poolPath;
+
+    const { forceRefreshOpenAIToken } = await import("./oauth-pool-refresh.mjs?stale=" + Math.random());
+    const account = { ...JSON.parse(readFileSync(poolPath, "utf-8")).openai[0] };
+    const result = await forceRefreshOpenAIToken(account);
+    const saved = JSON.parse(readFileSync(poolPath, "utf-8")).openai[0];
+
+    assert.equal(result, "reauth-access");
+    assert.equal(saved.access, "reauth-access");
+    assert.equal(saved.refresh, "reauth-refresh");
+    assert.equal(account.access, "reauth-access");
+  `;
+
+  execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
+    cwd: join(import.meta.dirname, ".."),
+    env: { ...process.env, HOME: home },
+    stdio: "pipe",
+  });
+});
+
+test("JavaScript waits for the live Python owner of the shared lock", () => {
+  const home = mkdtempSync(join(tmpdir(), "aidevops-oauth-cross-runtime-"));
+  const commonPath = join(import.meta.dirname, "../../../scripts/oauth-pool-lib/_common.py");
+  const script = String.raw`
+    import assert from "node:assert/strict";
+    import { spawn } from "node:child_process";
+    import { existsSync, mkdirSync } from "node:fs";
+    import { join } from "node:path";
+
+    const poolPath = join(process.env.HOME, ".aidevops", "oauth-pool.json");
+    mkdirSync(join(process.env.HOME, ".aidevops"), { recursive: true });
+    const python = [
+      "import importlib.util,json,os,time",
+      "spec=importlib.util.spec_from_file_location('oauth_common',os.environ['AIDEVOPS_TEST_COMMON_PATH'])",
+      "module=importlib.util.module_from_spec(spec)",
+      "spec.loader.exec_module(module)",
+      "lock=open(os.environ['AIDEVOPS_TEST_POOL_PATH']+'.lock','w')",
+      "module.acquire_lock(lock)",
+      "owner_path=lock.name+'.d/owner'",
+      "owner=json.load(open(owner_path))",
+      "owner['createdAt']=0",
+      "json.dump(owner,open(owner_path,'w'))",
+      "print('LOCKED',flush=True)",
+      "time.sleep(0.35)",
+      "module.release_lock(lock)",
+      "lock.close()",
+    ].join(";");
+    const child = spawn("python3", ["-c", python], {
+      env: { ...process.env, AIDEVOPS_TEST_POOL_PATH: poolPath },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await new Promise((resolve, reject) => {
+      child.stdout.once("data", resolve);
+      child.once("error", reject);
+      child.once("exit", (code) => { if (code !== 0) reject(new Error("python lock holder exited " + code)); });
+    });
+
+    const { withPoolLockAsync } = await import("./oauth-pool-storage.mjs?cross=" + Math.random());
+    const started = Date.now();
+    await withPoolLockAsync(async () => true);
+    assert.ok(Date.now() - started >= 250);
+    assert.equal(existsSync(poolPath + ".lock.d"), false);
+  `;
+
+  execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
+    cwd: join(import.meta.dirname, ".."),
+    env: { ...process.env, HOME: home, AIDEVOPS_TEST_COMMON_PATH: commonPath },
+    stdio: "pipe",
+  });
+});

--- a/.agents/reference/oauth-token-state.md
+++ b/.agents/reference/oauth-token-state.md
@@ -1,0 +1,71 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Mutable OAuth Token State
+
+Use this contract when an integration receives access or refresh tokens that can
+change during normal API use. Static client credentials remain in `aidevops
+secret`; mutable provider state belongs to one integration-owned runtime store.
+
+The production reference is the OAuth pool: Python primitives in
+`scripts/oauth-pool-lib/_common.py` and `pool_ops_refresh.py` coordinate with the
+OpenCode implementation in `plugins/opencode-aidevops/oauth-pool-storage.mjs`
+and `oauth-pool-refresh.mjs`.
+
+## Authority and identity
+
+- Bootstrap with a client ID/secret or authorization grant from `aidevops
+  secret`; never write rotated access or refresh tokens back to shell exports.
+- Select exactly one runtime store by provider, account, project/tenant, and
+  environment. An absent or ambiguous selector fails closed; it never falls back
+  silently to another account or project.
+- One process may cache a token only until the store generation changes or an
+  authenticated request rejects it. Re-read durable state before refresh.
+- Provider SDK behavior, browser authorization, and arbitrary application state
+  are outside this storage contract.
+
+## Refresh transaction
+
+Treat `lock → re-read → refresh → replace → unlock` as one transaction:
+
+1. Acquire the store lock with a bounded wait. The lock identity and owner schema
+   must be shared by every language that writes the store.
+2. Re-read the selected account after acquisition. If another process already
+   published a usable token, use it instead of refreshing again.
+3. Keep the lock while calling the bounded token endpoint. Never reclaim a lock
+   whose recorded process is still live merely because it is old.
+4. Require a non-empty access token. When a successful response omits
+   `refresh_token`, retain the previous refresh token.
+5. Write a unique mode-`0600` temporary file in the destination directory and
+   atomically replace the live file. The directory and lock directory are
+   mode `0700`; the owner record is mode `0600`.
+6. Release only when the recorded PID and unguessable owner token still match.
+   A timeout fails closed and leaves the last valid token state unchanged.
+
+Do not add periodic refresh scheduling as a substitute for this transaction.
+Scheduling may trigger refresh, but request-bound expiry/rejection handling and
+the single-writer contract remain authoritative.
+
+## Secret handling and diagnostics
+
+- Keep token values in memory, request bodies, standard input, or protected
+  files. Never put them in command arguments, logs, issue text, test fixtures,
+  process titles, health output, or exception messages.
+- Health output may report provider/account labels, selected authority, token
+  presence, expiry/freshness, cooldown, last successful refresh, and sanitized
+  error classes. It must not emit token-bearing objects or provider responses.
+- Tests must use obvious placeholders and injected/local responses only.
+  Coverage should prove concurrent callers make one refresh, omitted and newly
+  rotated refresh tokens persist correctly, stale results cannot replace newer
+  state, modes remain restrictive, and lock timeout/recovery is bounded.
+
+## Integration checklist
+
+- Document the exact store selector and path owner without documenting values.
+- Keep the on-disk schema backward compatible or provide an explicit migration
+  and rollback path.
+- Share the reference lock protocol rather than creating a second lock name.
+- Verify one normal API request after expiry and one forced refresh after an
+  authentication rejection.
+- Add metadata-only `status` output and a terminal reauthorization message for
+  absent/revoked refresh credentials.

--- a/.agents/scripts/oauth-pool-lib/_common.py
+++ b/.agents/scripts/oauth-pool-lib/_common.py
@@ -16,11 +16,11 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 import tempfile
 import time
 import urllib.error
 import urllib.request
+import uuid
 from typing import Any
 
 
@@ -47,53 +47,134 @@ _AUTH_ERROR_CODES = {
 
 
 # ---------------------------------------------------------------------------
-# Cross-platform exclusive file lock (stdlib only, no pip dependencies).
+# Cross-runtime exclusive lock (stdlib only, no pip dependencies).
 # ---------------------------------------------------------------------------
 
-def _acquire_lock_win(lock_fd) -> None:
-    import msvcrt
-    deadline = time.time() + 30
-    while True:
-        try:
-            lock_fd.seek(0)
-            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
-            return
-        except OSError:
-            if time.time() >= deadline:
-                raise
-            time.sleep(0.1)
+_LOCK_WAIT_SECONDS = 30.0
+_OWNERLESS_LOCK_GRACE_SECONDS = 30.0
 
 
-def _release_lock_win(lock_fd) -> None:
-    import msvcrt
+def _process_is_live(pid: object) -> bool:
+    if not isinstance(pid, int) or pid <= 0:
+        return False
     try:
-        lock_fd.seek(0)
-        msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def _stale_lock_snapshot(lock_dir: str, owner_path: str) -> str | None:
+    try:
+        with open(owner_path, encoding="utf-8") as owner_file:
+            raw = owner_file.read()
+        owner = json.loads(raw)
+        return None if _process_is_live(owner.get("pid")) else raw
+    except (OSError, ValueError, TypeError, AttributeError):
+        try:
+            age = time.time() - os.stat(lock_dir).st_mtime
+        except OSError:
+            return None
+        return "" if age >= _OWNERLESS_LOCK_GRACE_SECONDS else None
+
+
+def _remove_stale_lock(lock_dir: str, owner_path: str, snapshot: str) -> None:
+    try:
+        with open(owner_path, encoding="utf-8") as owner_file:
+            current = owner_file.read()
+        if current != snapshot:
+            return
+    except OSError:
+        if snapshot != "":
+            return
+    try:
+        os.unlink(owner_path)
+    except OSError:
+        pass
+    try:
+        os.rmdir(lock_dir)
     except OSError:
         pass
 
 
-def acquire_lock(lock_fd) -> None:
-    """Acquire an exclusive lock on the given file descriptor."""
-    if sys.platform == "win32":
-        _acquire_lock_win(lock_fd)
-        return
-    import fcntl
-    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+def acquire_lock(lock_fd, timeout: float = _LOCK_WAIT_SECONDS) -> None:
+    """Acquire the mkdir lock shared with the OpenCode OAuth pool."""
+    lock_path = os.fspath(lock_fd.name)
+    lock_dir = lock_path + ".d"
+    owner_path = os.path.join(lock_dir, "owner")
+    token = str(uuid.uuid4())
+    deadline = time.monotonic() + timeout
+    os.chmod(lock_path, 0o600)
+
+    while time.monotonic() < deadline:
+        try:
+            os.mkdir(lock_dir, 0o700)
+        except FileExistsError:
+            snapshot = _stale_lock_snapshot(lock_dir, owner_path)
+            if snapshot is not None:
+                _remove_stale_lock(lock_dir, owner_path, snapshot)
+                continue
+            time.sleep(0.05)
+            continue
+
+        try:
+            owner_fd = os.open(owner_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(owner_fd, "w", encoding="utf-8") as owner_file:
+                json.dump(
+                    {
+                        "schema": "aidevops.oauth-lock/v1",
+                        "pid": os.getpid(),
+                        "token": token,
+                        "createdAt": int(time.time() * 1000),
+                    },
+                    owner_file,
+                )
+            os.chmod(lock_dir, 0o700)
+            os.chmod(owner_path, 0o600)
+            lock_fd._aidevops_lock = (lock_dir, owner_path, token)
+            return
+        except BaseException:
+            try:
+                os.unlink(owner_path)
+            except OSError:
+                pass
+            try:
+                os.rmdir(lock_dir)
+            except OSError:
+                pass
+            raise
+
+    raise TimeoutError("timed out waiting for OAuth pool lock")
 
 
 def release_lock(lock_fd) -> None:
-    """Release an exclusive lock on the given file descriptor."""
-    if sys.platform == "win32":
-        _release_lock_win(lock_fd)
+    """Release only the mkdir lock owned by this descriptor."""
+    ownership = getattr(lock_fd, "_aidevops_lock", None)
+    if not ownership:
         return
-    import fcntl
-    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    lock_dir, owner_path, token = ownership
+    try:
+        with open(owner_path, encoding="utf-8") as owner_file:
+            owner = json.load(owner_file)
+        if owner.get("pid") != os.getpid() or owner.get("token") != token:
+            return
+        os.unlink(owner_path)
+        os.rmdir(lock_dir)
+    except (OSError, ValueError, TypeError, AttributeError):
+        pass
+    finally:
+        delattr(lock_fd, "_aidevops_lock")
 
 
 def atomic_write_json(path: str, data: Any) -> None:
     """Atomically write JSON data to a file (write-to-temp then rename)."""
-    d = os.path.dirname(path)
+    parent = os.path.dirname(path)
+    d = parent or "."
+    os.makedirs(d, mode=0o700, exist_ok=True)
+    if parent:
+        os.chmod(d, 0o700)
     fd, tmp = tempfile.mkstemp(dir=d, prefix=".tmp-", suffix=".tmp")
     try:
         with os.fdopen(fd, "w") as f:

--- a/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
+++ b/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import subprocess
 import sys
 import tempfile
@@ -653,6 +654,34 @@ class RefreshTests(PoolOpsTestCase):
         self.assertEqual(_common.token_refresh_error_label(result), "auth_invalid_grant")
         self.assertNotIn("secret-refresh", json.dumps(result))
         self.assertNotIn("do not log this", json.dumps(result))
+
+    def test_shared_lock_uses_private_directory_protocol(self) -> None:
+        lock_path = self.tmp / "oauth-pool.json.lock"
+        lock_path.touch()
+        with lock_path.open("w") as lock_file:
+            _common.acquire_lock(lock_file, timeout=1)
+            lock_dir = Path(str(lock_path) + ".d")
+            owner_path = lock_dir / "owner"
+            owner = read_json(owner_path)
+
+            self.assertEqual(owner["schema"], "aidevops.oauth-lock/v1")
+            self.assertEqual(owner["pid"], os.getpid())
+            self.assertTrue(owner["token"])
+            self.assertEqual(stat.S_IMODE(lock_dir.stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(owner_path.stat().st_mode), 0o600)
+            self.assertEqual(stat.S_IMODE(lock_path.stat().st_mode), 0o600)
+
+            _common.release_lock(lock_file)
+            self.assertFalse(lock_dir.exists())
+
+    def test_atomic_write_enforces_private_parent_and_file_modes(self) -> None:
+        private_dir = self.tmp / "private"
+        target = private_dir / "state.json"
+        _common.atomic_write_json(str(target), {"status": "active"})
+
+        self.assertEqual(read_json(target), {"status": "active"})
+        self.assertEqual(stat.S_IMODE(private_dir.stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o600)
 
     def test_unauthorized_refresh_error_is_sanitized(self) -> None:
         error = urllib.error.HTTPError(


### PR DESCRIPTION
## Summary

Define and implement one cross-runtime mutable OAuth token-state contract with serialized refresh, atomic protected writes, stale-result protection, and rotating-token preservation.

## Files Changed

.agents/aidevops/extension.md, .agents/plugins/opencode-aidevops/oauth-pool-constants.mjs, .agents/plugins/opencode-aidevops/oauth-pool-refresh.mjs, .agents/plugins/opencode-aidevops/oauth-pool-storage.mjs, .agents/plugins/opencode-aidevops/tests/test-oauth-token-state.mjs, .agents/reference/oauth-token-state.md, .agents/scripts/oauth-pool-lib/_common.py, .agents/scripts/oauth-pool-lib/tests/test_pool_ops.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified through the production refresh/storage path with synthetic local endpoint responses; 54 Python tests and focused Node OAuth tests pass; local linters pass. Full plugin suite passes 763 tests with one unrelated environment failure because @opencode-ai/plugin is not installed in this worktree.

Resolves #31177


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.308 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 49m and 419,793 tokens on this with the user in an interactive session.