### PR TITLE
GH#31164: redact named credentials across transcript hooks

### DIFF
--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -64,7 +64,7 @@ CREDENTIAL_PATTERN = re.compile(
 )
 
 NAMED_CREDENTIAL_ASSIGNMENT_PATTERN = re.compile(
-    r"(^|[^A-Za-z0-9_])((?:\"[A-Za-z_][A-Za-z0-9_. -]{0,127}\"|'[A-Za-z_][A-Za-z0-9_. -]{0,127}'|(?:API[ \t]+KEY|PRIVATE[ \t]+KEY|SECRET[ \t]+KEY|ACCESS[ \t]+TOKEN|AUTH[ \t]+TOKEN|CLIENT[ \t]+SECRET|USER[ \t]+PASSWORD)|[A-Za-z_][A-Za-z0-9_.-]{0,127}))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential|redacted-private-key)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)",
+    r"(^|[^A-Za-z0-9_])((?:\"[A-Za-z_][A-Za-z0-9_. -]*\"|'[A-Za-z_][A-Za-z0-9_. -]*'|(?:API[ \t]+KEY|PRIVATE[ \t]+KEY|SECRET[ \t]+KEY|ACCESS[ \t]+TOKEN|AUTH[ \t]+TOKEN|CLIENT[ \t]+SECRET|USER[ \t]+PASSWORD)|[A-Za-z_][A-Za-z0-9_.-]*))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\[[^\r\n\s,};&|<>]*\][^\r\n\s,}\)&;|<>]*|<[^>\r\n]*>[^\r\n\s,}\)&;|<>]*|\([^()\r\n]*\)|not[ \t]+set(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -107,7 +107,10 @@ def normalize_field_name(name: str) -> str:
 
 def is_sensitive_field_name(name: str) -> bool:
     """Return whether a field name is unambiguously credential-bearing."""
-    pattern = r"(?:^|_)(?:API_?KEY|PRIVATE_KEY|SECRET_KEY|TOKEN|SECRET|PASSWORD|PASSWD)$"
+    pattern = (
+        r"(?:^|_)(?:API_?KEY|PRIVATE_KEY|SECRET_KEY|ACCESS_KEY|"
+        r"ENCRYPTION_KEY|SIGNING_KEY|TOKEN|SECRET|PASSWORD|PASSWD)$"
+    )
     return bool(re.search(pattern, normalize_field_name(name)))
 
 
@@ -127,7 +130,12 @@ def redact_named_assignment(match: re.Match) -> str:
     if not is_sensitive_field_name(name) or is_placeholder_value(value):
         return match.group(0)
     quote = value[0] if value and value[0] in {'"', "'"} and value.endswith(value[0]) else ""
-    redacted = f"{quote}{REDACTION_TOKEN}{quote}" if quote else REDACTION_TOKEN
+    if quote:
+        redacted = f"{quote}{REDACTION_TOKEN}{quote}"
+    elif value.startswith("(") and value.endswith(")"):
+        redacted = f"({REDACTION_TOKEN})"
+    else:
+        redacted = REDACTION_TOKEN
     return f"{boundary}{name}{separator}{redacted}"
 
 

--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -64,7 +64,7 @@ CREDENTIAL_PATTERN = re.compile(
 )
 
 NAMED_CREDENTIAL_ASSIGNMENT_PATTERN = re.compile(
-    r"(^|[^A-Za-z0-9_])((?:\"[A-Za-z_][A-Za-z0-9_.-]*\"|'[A-Za-z_][A-Za-z0-9_.-]*'|[A-Za-z_][A-Za-z0-9_.-]*))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;])|[^\s,}\])&;]+)",
+    r"(^|[^A-Za-z0-9_])((?:\"[A-Za-z_][A-Za-z0-9_. -]*\"|'[A-Za-z_][A-Za-z0-9_. -]*'|[A-Za-z_][A-Za-z0-9_.-]*(?:[ \t]+[A-Za-z_][A-Za-z0-9_.-]*)*?))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential|redacted-private-key)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -80,6 +80,8 @@ PLACEHOLDER_VALUES = {
     "***",
     "[redacted]",
     "[redacted-credential]",
+    "[redacted-private-key]",
+    "(not set)",
     "<redacted>",
     "missing",
     "none",

--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -64,7 +64,7 @@ CREDENTIAL_PATTERN = re.compile(
 )
 
 NAMED_CREDENTIAL_ASSIGNMENT_PATTERN = re.compile(
-    r"(^|[^A-Za-z0-9_])((?:\"[A-Za-z_][A-Za-z0-9_. -]*\"|'[A-Za-z_][A-Za-z0-9_. -]*'|[A-Za-z_][A-Za-z0-9_.-]*(?:[ \t]+[A-Za-z_][A-Za-z0-9_.-]*)*?))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential|redacted-private-key)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)",
+    r"(^|[^A-Za-z0-9_])((?:\"[A-Za-z_][A-Za-z0-9_. -]{0,127}\"|'[A-Za-z_][A-Za-z0-9_. -]{0,127}'|(?:API[ \t]+KEY|PRIVATE[ \t]+KEY|SECRET[ \t]+KEY|ACCESS[ \t]+TOKEN|AUTH[ \t]+TOKEN|CLIENT[ \t]+SECRET|USER[ \t]+PASSWORD)|[A-Za-z_][A-Za-z0-9_.-]{0,127}))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential|redacted-private-key)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)",
     re.IGNORECASE | re.MULTILINE,
 )
 

--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -64,17 +64,15 @@ CREDENTIAL_PATTERN = re.compile(
 )
 
 NAMED_CREDENTIAL_ASSIGNMENT_PATTERN = re.compile(
-    r"(^|[^A-Za-z0-9_])((?:\"[A-Za-z_][A-Za-z0-9_. -]*\"|'[A-Za-z_][A-Za-z0-9_. -]*'|(?:API[ \t]+KEY|PRIVATE[ \t]+KEY|SECRET[ \t]+KEY|ACCESS[ \t]+TOKEN|AUTH[ \t]+TOKEN|CLIENT[ \t]+SECRET|USER[ \t]+PASSWORD)|[A-Za-z_][A-Za-z0-9_.-]*))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\[[^\r\n\s,};&|<>]*\][^\r\n\s,}\)&;|<>]*|<[^>\r\n]*>[^\r\n\s,}\)&;|<>]*|\([^()\r\n]*\)|not[ \t]+set(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)",
+    r"(^|[^A-Za-z0-9_])((?:\"[A-Za-z_][A-Za-z0-9_. -]*\"|'[A-Za-z_][A-Za-z0-9_. -]*'|(?:API[ \t]+KEY|PRIVATE[ \t]+KEY|SECRET[ \t]+KEY|ACCESS[ \t]+TOKEN|AUTH[ \t]+TOKEN|CLIENT[ \t]+SECRET|USER[ \t]+PASSWORD)|[A-Za-z_][A-Za-z0-9_.-]*))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"[^\r\n\s,}\])&;|<>]*|'(?:\\.|[^'\\])*'[^\r\n\s,}\])&;|<>]*|\[[^\r\n\s,};&|<>]*\][^\r\n\s,}\])&;|<>]*|<[^>\r\n]*>[^\r\n\s,}\])&;|<>]*|\([^()\r\n]*\)[^\r\n\s,}\])&;|<>]*|not[ \t]+set(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)",
     re.IGNORECASE | re.MULTILINE,
-)
-
-PEM_PRIVATE_KEY_PATTERN = re.compile(
-    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
-    re.DOTALL,
 )
 
 REDACTION_TOKEN = "[redacted-credential]"
 PEM_REDACTION_TOKEN = "[redacted-private-key]"
+PEM_BEGIN_MARKER = "-----BEGIN "
+PEM_KEY_SUFFIX = "PRIVATE KEY-----"
+PEM_LABEL_PATTERN = re.compile(r"^[A-Z0-9 ]*$")
 PLACEHOLDER_VALUES = {
     "",
     "***",
@@ -108,7 +106,7 @@ def normalize_field_name(name: str) -> str:
 def is_sensitive_field_name(name: str) -> bool:
     """Return whether a field name is unambiguously credential-bearing."""
     pattern = (
-        r"(?:^|_)(?:API_?KEY|PRIVATE_KEY|SECRET_KEY|ACCESS_KEY|"
+        r"(?:^|_)(?:API_?KEY|PRIVATE_KEY|SECRET_KEY|ACCESS_KEY|ACCESS_KEY_ID|"
         r"ENCRYPTION_KEY|SIGNING_KEY|TOKEN|SECRET|PASSWORD|PASSWD)$"
     )
     return bool(re.search(pattern, normalize_field_name(name)))
@@ -139,6 +137,40 @@ def redact_named_assignment(match: re.Match) -> str:
     return f"{boundary}{name}{separator}{redacted}"
 
 
+def scrub_private_keys(text: str) -> tuple[str, int]:
+    """Replace complete PEM private-key blocks using a linear marker scan."""
+    chunks = []
+    cursor = 0
+    count = 0
+    while cursor < len(text):
+        start = text.find(PEM_BEGIN_MARKER, cursor)
+        if start < 0:
+            break
+        label_start = start + len(PEM_BEGIN_MARKER)
+        suffix_start = text.find(PEM_KEY_SUFFIX, label_start)
+        if suffix_start < 0:
+            break
+        label = text[label_start:suffix_start]
+        header_end = suffix_start + len(PEM_KEY_SUFFIX)
+        if not PEM_LABEL_PATTERN.fullmatch(label):
+            chunks.append(text[cursor:label_start])
+            cursor = label_start
+            continue
+        end_marker = f"-----END {label}{PEM_KEY_SUFFIX}"
+        next_start = text.find(PEM_BEGIN_MARKER, header_end)
+        segment_end = len(text) if next_start < 0 else next_start
+        end = text.find(end_marker, header_end, segment_end)
+        if end < 0:
+            chunks.append(text[cursor:header_end])
+            cursor = header_end
+            continue
+        chunks.extend((text[cursor:start], PEM_REDACTION_TOKEN))
+        cursor = end + len(end_marker)
+        count += 1
+    chunks.append(text[cursor:])
+    return "".join(chunks), count
+
+
 def scrub_credentials(text: str) -> tuple[str, int]:
     """Replace credential tokens in text. Returns (scrubbed_text, match_count)."""
     named_count = 0
@@ -150,7 +182,7 @@ def scrub_credentials(text: str) -> tuple[str, int]:
             named_count += 1
         return redacted
 
-    result, pem_count = PEM_PRIVATE_KEY_PATTERN.subn(PEM_REDACTION_TOKEN, text)
+    result, pem_count = scrub_private_keys(text)
     result = NAMED_CREDENTIAL_ASSIGNMENT_PATTERN.sub(redact_and_count, result)
     result, token_count = CREDENTIAL_PATTERN.subn(REDACTION_TOKEN, result)
     return result, pem_count + named_count + token_count
@@ -188,7 +220,7 @@ def main() -> None:
     # Fast path: no known prefix, private key, or named assignment in the payload.
     if (
         not CREDENTIAL_PATTERN.search(raw)
-        and not PEM_PRIVATE_KEY_PATTERN.search(raw)
+        and PEM_BEGIN_MARKER not in raw
         and not NAMED_CREDENTIAL_ASSIGNMENT_PATTERN.search(raw)
     ):
         return

--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -64,8 +64,8 @@ CREDENTIAL_PATTERN = re.compile(
 )
 
 NAMED_CREDENTIAL_ASSIGNMENT_PATTERN = re.compile(
-    r"(^|[\s,{])((?:\"[A-Za-z_][A-Za-z0-9_]*\"|'[A-Za-z_][A-Za-z0-9_]*'|[A-Za-z_][A-Za-z0-9_]*))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential)\]|[^\s,}\]]+)",
-    re.MULTILINE,
+    r"(^|[^A-Za-z0-9_])((?:\"[A-Za-z_][A-Za-z0-9_.-]*\"|'[A-Za-z_][A-Za-z0-9_.-]*'|[A-Za-z_][A-Za-z0-9_.-]*))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;])|[^\s,}\])&;]+)",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 PEM_PRIVATE_KEY_PATTERN = re.compile(
@@ -105,12 +105,18 @@ def normalize_field_name(name: str) -> str:
 
 def is_sensitive_field_name(name: str) -> bool:
     """Return whether a field name is unambiguously credential-bearing."""
-    return bool(re.search(r"(?:^|_)(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD)$", normalize_field_name(name)))
+    pattern = r"(?:^|_)(?:API_?KEY|PRIVATE_KEY|SECRET_KEY|TOKEN|SECRET|PASSWORD|PASSWD)$"
+    return bool(re.search(pattern, normalize_field_name(name)))
 
 
 def is_placeholder_value(value: str) -> bool:
     """Keep empty and already-redacted values unchanged."""
     return unquote(value).lower() in PLACEHOLDER_VALUES
+
+
+def preserves_sensitive_value(value) -> bool:
+    """Keep absence and explicit string placeholders under sensitive keys."""
+    return value is None or (isinstance(value, str) and is_placeholder_value(value))
 
 
 def redact_named_assignment(match: re.Match) -> str:
@@ -145,12 +151,13 @@ def scrub_value(value):
     if isinstance(value, str):
         return scrub_credentials(value)[0]
     if isinstance(value, dict):
-        return {
-            key: REDACTION_TOKEN
-            if is_sensitive_field_name(key) and isinstance(nested, str) and not is_placeholder_value(nested)
-            else scrub_value(nested)
-            for key, nested in value.items()
-        }
+        scrubbed = {}
+        for key, nested in value.items():
+            if is_sensitive_field_name(key) and not preserves_sensitive_value(nested):
+                scrubbed[key] = REDACTION_TOKEN
+            else:
+                scrubbed[key] = scrub_value(nested)
+        return scrubbed
     if isinstance(value, list):
         return [scrub_value(item) for item in value]
     return value

--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -4,8 +4,8 @@
 """
 PostToolUse hook for Claude Code: transcript-side credential scrub (GH#20207).
 
-Fires after every tool call. Scrubs known credential token prefixes from the
-tool result before it reaches the model or is persisted to disk.
+Fires after every tool call. Scrubs known credential token prefixes and values
+under sensitive field names before results reach the model or transcript.
 
 This is Layer 4 of t2458 credential sanitization:
   Layers 1-3 prevent framework helpers from emitting credentials.
@@ -23,6 +23,9 @@ Token prefix families scrubbed (mirrors shared-constants.sh scrub_credentials):
   glpat-    GitLab personal access tokens
   xoxb-     Slack bot tokens
   xoxp-     Slack user tokens
+
+Unknown token formats are also scrubbed under unambiguous API key, token,
+secret, and password field names.
 
 Exit behavior:
   - Exit 0 always — this hook MUST NOT block tool execution, only sanitize.
@@ -60,6 +63,11 @@ CREDENTIAL_PATTERN = re.compile(
     re.ASCII,
 )
 
+NAMED_CREDENTIAL_ASSIGNMENT_PATTERN = re.compile(
+    r"(^|[\s,{])((?:\"[A-Za-z_][A-Za-z0-9_]*\"|'[A-Za-z_][A-Za-z0-9_]*'|[A-Za-z_][A-Za-z0-9_]*))(\s*(?:=|:)\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential)\]|[^\s,}\]]+)",
+    re.MULTILINE,
+)
+
 PEM_PRIVATE_KEY_PATTERN = re.compile(
     r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
     re.DOTALL,
@@ -67,13 +75,69 @@ PEM_PRIVATE_KEY_PATTERN = re.compile(
 
 REDACTION_TOKEN = "[redacted-credential]"
 PEM_REDACTION_TOKEN = "[redacted-private-key]"
+PLACEHOLDER_VALUES = {
+    "",
+    "***",
+    "[redacted]",
+    "[redacted-credential]",
+    "<redacted>",
+    "missing",
+    "none",
+    "not set",
+    "null",
+    "undefined",
+}
+
+
+def unquote(value: str) -> str:
+    """Trim matching quotes from a field name or assignment value."""
+    trimmed = str(value).strip()
+    if len(trimmed) >= 2 and trimmed[0] in {'"', "'"} and trimmed[-1] == trimmed[0]:
+        return trimmed[1:-1]
+    return trimmed
+
+
+def normalize_field_name(name: str) -> str:
+    """Normalize snake, kebab, dotted, and camel-case field names."""
+    normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", unquote(name))
+    return re.sub(r"[-.\s]+", "_", normalized).upper()
+
+
+def is_sensitive_field_name(name: str) -> bool:
+    """Return whether a field name is unambiguously credential-bearing."""
+    return bool(re.search(r"(?:^|_)(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD)$", normalize_field_name(name)))
+
+
+def is_placeholder_value(value: str) -> bool:
+    """Keep empty and already-redacted values unchanged."""
+    return unquote(value).lower() in PLACEHOLDER_VALUES
+
+
+def redact_named_assignment(match: re.Match) -> str:
+    """Redact one sensitive assignment while preserving its key and quoting."""
+    boundary, name, separator, value = match.groups()
+    if not is_sensitive_field_name(name) or is_placeholder_value(value):
+        return match.group(0)
+    quote = value[0] if value and value[0] in {'"', "'"} and value.endswith(value[0]) else ""
+    redacted = f"{quote}{REDACTION_TOKEN}{quote}" if quote else REDACTION_TOKEN
+    return f"{boundary}{name}{separator}{redacted}"
 
 
 def scrub_credentials(text: str) -> tuple[str, int]:
     """Replace credential tokens in text. Returns (scrubbed_text, match_count)."""
+    named_count = 0
+
+    def redact_and_count(match: re.Match) -> str:
+        nonlocal named_count
+        redacted = redact_named_assignment(match)
+        if redacted != match.group(0):
+            named_count += 1
+        return redacted
+
     result, pem_count = PEM_PRIVATE_KEY_PATTERN.subn(PEM_REDACTION_TOKEN, text)
+    result = NAMED_CREDENTIAL_ASSIGNMENT_PATTERN.sub(redact_and_count, result)
     result, token_count = CREDENTIAL_PATTERN.subn(REDACTION_TOKEN, result)
-    return result, pem_count + token_count
+    return result, pem_count + named_count + token_count
 
 
 def scrub_value(value):
@@ -81,7 +145,12 @@ def scrub_value(value):
     if isinstance(value, str):
         return scrub_credentials(value)[0]
     if isinstance(value, dict):
-        return {k: scrub_value(v) for k, v in value.items()}
+        return {
+            key: REDACTION_TOKEN
+            if is_sensitive_field_name(key) and isinstance(nested, str) and not is_placeholder_value(nested)
+            else scrub_value(nested)
+            for key, nested in value.items()
+        }
     if isinstance(value, list):
         return [scrub_value(item) for item in value]
     return value
@@ -99,8 +168,12 @@ def main() -> None:
 
     tool_response = data.get("tool_response", "")
 
-    # Fast path: no credential/private-key pattern anywhere in the raw payload.
-    if not CREDENTIAL_PATTERN.search(raw) and not PEM_PRIVATE_KEY_PATTERN.search(raw):
+    # Fast path: no known prefix, private key, or named assignment in the payload.
+    if (
+        not CREDENTIAL_PATTERN.search(raw)
+        and not PEM_PRIVATE_KEY_PATTERN.search(raw)
+        and not NAMED_CREDENTIAL_ASSIGNMENT_PATTERN.search(raw)
+    ):
         return
 
     # Scrub the tool_response field (may be str or nested JSON object).

--- a/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
@@ -6,7 +6,10 @@
 const CREDENTIAL_PATTERN =
   /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 const NAMED_CREDENTIAL_ASSIGNMENT_PATTERN =
-  /(^|[^A-Za-z0-9_])((?:"[A-Za-z_][A-Za-z0-9_. -]*"|'[A-Za-z_][A-Za-z0-9_. -]*'|(?:API[ \t]+KEY|PRIVATE[ \t]+KEY|SECRET[ \t]+KEY|ACCESS[ \t]+TOKEN|AUTH[ \t]+TOKEN|CLIENT[ \t]+SECRET|USER[ \t]+PASSWORD)|[A-Za-z_][A-Za-z0-9_.-]*))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[[^\r\n\s,};&|<>]*\][^\r\n\s,}\)&;|<>]*|<[^>\r\n]*>[^\r\n\s,}\)&;|<>]*|\([^()\r\n]*\)|not[ \t]+set(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)/gim;
+  /(^|[^A-Za-z0-9_])((?:"[A-Za-z_][A-Za-z0-9_. -]*"|'[A-Za-z_][A-Za-z0-9_. -]*'|(?:API[ \t]+KEY|PRIVATE[ \t]+KEY|SECRET[ \t]+KEY|ACCESS[ \t]+TOKEN|AUTH[ \t]+TOKEN|CLIENT[ \t]+SECRET|USER[ \t]+PASSWORD)|[A-Za-z_][A-Za-z0-9_.-]*))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"[^\r\n\s,}\])&;|<>]*|'(?:\\.|[^'\\])*'[^\r\n\s,}\])&;|<>]*|\[[^\r\n\s,};&|<>]*\][^\r\n\s,}\])&;|<>]*|<[^>\r\n]*>[^\r\n\s,}\])&;|<>]*|\([^()\r\n]*\)[^\r\n\s,}\])&;|<>]*|not[ \t]+set(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)/gim;
+const PEM_BEGIN_MARKER = "-----BEGIN ";
+const PEM_KEY_SUFFIX = "PRIVATE KEY-----";
+const PEM_LABEL_PATTERN = /^[A-Z0-9 ]*$/;
 const PLACEHOLDER_VALUES = new Set([
   "",
   "***",
@@ -23,6 +26,42 @@ const PLACEHOLDER_VALUES = new Set([
 ]);
 
 export const REDACTION_TOKEN = "[redacted-credential]";
+export const PEM_REDACTION_TOKEN = "[redacted-private-key]";
+
+function scrubPrivateKeys(text) {
+  const chunks = [];
+  let cursor = 0;
+  let count = 0;
+  while (cursor < text.length) {
+    const start = text.indexOf(PEM_BEGIN_MARKER, cursor);
+    if (start < 0) break;
+    const labelStart = start + PEM_BEGIN_MARKER.length;
+    const suffixStart = text.indexOf(PEM_KEY_SUFFIX, labelStart);
+    if (suffixStart < 0) break;
+    const label = text.slice(labelStart, suffixStart);
+    const headerEnd = suffixStart + PEM_KEY_SUFFIX.length;
+    if (!PEM_LABEL_PATTERN.test(label)) {
+      chunks.push(text.slice(cursor, labelStart));
+      cursor = labelStart;
+      continue;
+    }
+    const endMarker = `-----END ${label}${PEM_KEY_SUFFIX}`;
+    const nextStart = text.indexOf(PEM_BEGIN_MARKER, headerEnd);
+    const segmentEnd = nextStart < 0 ? text.length : nextStart;
+    const relativeEnd = text.slice(headerEnd, segmentEnd).indexOf(endMarker);
+    if (relativeEnd < 0) {
+      chunks.push(text.slice(cursor, headerEnd));
+      cursor = headerEnd;
+      continue;
+    }
+    const end = headerEnd + relativeEnd;
+    chunks.push(text.slice(cursor, start), PEM_REDACTION_TOKEN);
+    cursor = end + endMarker.length;
+    count++;
+  }
+  chunks.push(text.slice(cursor));
+  return { scrubbed: chunks.join(""), count };
+}
 
 function unquote(value) {
   const trimmed = String(value).trim();
@@ -39,7 +78,7 @@ function normalizeFieldName(name) {
 }
 
 function isSensitiveFieldName(name) {
-  return /(?:^|_)(?:API_?KEY|PRIVATE_KEY|SECRET_KEY|ACCESS_KEY|ENCRYPTION_KEY|SIGNING_KEY|TOKEN|SECRET|PASSWORD|PASSWD)$/.test(
+  return /(?:^|_)(?:API_?KEY|PRIVATE_KEY|SECRET_KEY|ACCESS_KEY|ACCESS_KEY_ID|ENCRYPTION_KEY|SIGNING_KEY|TOKEN|SECRET|PASSWORD|PASSWD)$/.test(
     normalizeFieldName(name),
   );
 }
@@ -64,8 +103,9 @@ function redactAssignedValue(value) {
 
 /** Scrub known token prefixes and unknown-format values under sensitive names. */
 export function scrubCredentials(text) {
-  let count = 0;
-  const namedScrubbed = text.replace(
+  const { scrubbed: pemScrubbed, count: pemCount } = scrubPrivateKeys(text);
+  let count = pemCount;
+  const namedScrubbed = pemScrubbed.replace(
     NAMED_CREDENTIAL_ASSIGNMENT_PATTERN,
     (match, boundary, name, separator, value) => {
       if (!isSensitiveFieldName(name)) return match;

--- a/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
@@ -6,12 +6,14 @@
 const CREDENTIAL_PATTERN =
   /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 const NAMED_CREDENTIAL_ASSIGNMENT_PATTERN =
-  /(^|[^A-Za-z0-9_])((?:"[A-Za-z_][A-Za-z0-9_.-]*"|'[A-Za-z_][A-Za-z0-9_.-]*'|[A-Za-z_][A-Za-z0-9_.-]*))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;])|[^\s,}\])&;]+)/gim;
+  /(^|[^A-Za-z0-9_])((?:"[A-Za-z_][A-Za-z0-9_. -]*"|'[A-Za-z_][A-Za-z0-9_. -]*'|[A-Za-z_][A-Za-z0-9_.-]*(?:[ \t]+[A-Za-z_][A-Za-z0-9_.-]*)*?))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential|redacted-private-key)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)/gim;
 const PLACEHOLDER_VALUES = new Set([
   "",
   "***",
   "[redacted]",
   "[redacted-credential]",
+  "[redacted-private-key]",
+  "(not set)",
   "<redacted>",
   "missing",
   "none",

--- a/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
@@ -6,7 +6,7 @@
 const CREDENTIAL_PATTERN =
   /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 const NAMED_CREDENTIAL_ASSIGNMENT_PATTERN =
-  /(^|[^A-Za-z0-9_])((?:"[A-Za-z_][A-Za-z0-9_. -]*"|'[A-Za-z_][A-Za-z0-9_. -]*'|[A-Za-z_][A-Za-z0-9_.-]*(?:[ \t]+[A-Za-z_][A-Za-z0-9_.-]*)*?))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential|redacted-private-key)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)/gim;
+  /(^|[^A-Za-z0-9_])((?:"[A-Za-z_][A-Za-z0-9_. -]{0,127}"|'[A-Za-z_][A-Za-z0-9_. -]{0,127}'|(?:API[ \t]+KEY|PRIVATE[ \t]+KEY|SECRET[ \t]+KEY|ACCESS[ \t]+TOKEN|AUTH[ \t]+TOKEN|CLIENT[ \t]+SECRET|USER[ \t]+PASSWORD)|[A-Za-z_][A-Za-z0-9_.-]{0,127}))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential|redacted-private-key)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)/gim;
 const PLACEHOLDER_VALUES = new Set([
   "",
   "***",

--- a/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
@@ -6,7 +6,7 @@
 const CREDENTIAL_PATTERN =
   /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 const NAMED_CREDENTIAL_ASSIGNMENT_PATTERN =
-  /(^|[^A-Za-z0-9_])((?:"[A-Za-z_][A-Za-z0-9_. -]{0,127}"|'[A-Za-z_][A-Za-z0-9_. -]{0,127}'|(?:API[ \t]+KEY|PRIVATE[ \t]+KEY|SECRET[ \t]+KEY|ACCESS[ \t]+TOKEN|AUTH[ \t]+TOKEN|CLIENT[ \t]+SECRET|USER[ \t]+PASSWORD)|[A-Za-z_][A-Za-z0-9_.-]{0,127}))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential|redacted-private-key)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)/gim;
+  /(^|[^A-Za-z0-9_])((?:"[A-Za-z_][A-Za-z0-9_. -]*"|'[A-Za-z_][A-Za-z0-9_. -]*'|(?:API[ \t]+KEY|PRIVATE[ \t]+KEY|SECRET[ \t]+KEY|ACCESS[ \t]+TOKEN|AUTH[ \t]+TOKEN|CLIENT[ \t]+SECRET|USER[ \t]+PASSWORD)|[A-Za-z_][A-Za-z0-9_.-]*))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[[^\r\n\s,};&|<>]*\][^\r\n\s,}\)&;|<>]*|<[^>\r\n]*>[^\r\n\s,}\)&;|<>]*|\([^()\r\n]*\)|not[ \t]+set(?=$|[\s,}\])&;|<>])|[^\s,}\])&;|<>]+)/gim;
 const PLACEHOLDER_VALUES = new Set([
   "",
   "***",
@@ -39,7 +39,7 @@ function normalizeFieldName(name) {
 }
 
 function isSensitiveFieldName(name) {
-  return /(?:^|_)(?:API_?KEY|PRIVATE_KEY|SECRET_KEY|TOKEN|SECRET|PASSWORD|PASSWD)$/.test(
+  return /(?:^|_)(?:API_?KEY|PRIVATE_KEY|SECRET_KEY|ACCESS_KEY|ENCRYPTION_KEY|SIGNING_KEY|TOKEN|SECRET|PASSWORD|PASSWD)$/.test(
     normalizeFieldName(name),
   );
 }
@@ -58,6 +58,7 @@ function redactAssignedValue(value) {
   if ((quote === '"' || quote === "'") && value.endsWith(quote)) {
     return `${quote}${REDACTION_TOKEN}${quote}`;
   }
+  if (quote === "(" && value.endsWith(")")) return `(${REDACTION_TOKEN})`;
   return REDACTION_TOKEN;
 }
 

--- a/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/** Credential transcript scrubbing shared by OpenCode post-tool hooks. */
+
+const CREDENTIAL_PATTERN =
+  /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
+const NAMED_CREDENTIAL_ASSIGNMENT_PATTERN =
+  /(^|[\s,{])((?:"[A-Za-z_][A-Za-z0-9_]*"|'[A-Za-z_][A-Za-z0-9_]*'|[A-Za-z_][A-Za-z0-9_]*))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential)\]|[^\s,}\]]+)/gm;
+const PLACEHOLDER_VALUES = new Set([
+  "",
+  "***",
+  "[redacted]",
+  "[redacted-credential]",
+  "<redacted>",
+  "missing",
+  "none",
+  "not set",
+  "null",
+  "undefined",
+]);
+
+export const REDACTION_TOKEN = "[redacted-credential]";
+
+function unquote(value) {
+  const trimmed = String(value).trim();
+  const quote = trimmed.at(0);
+  if ((quote === '"' || quote === "'") && trimmed.endsWith(quote)) return trimmed.slice(1, -1);
+  return trimmed;
+}
+
+function normalizeFieldName(name) {
+  return unquote(name)
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[-.\s]+/g, "_")
+    .toUpperCase();
+}
+
+function isSensitiveFieldName(name) {
+  return /(?:^|_)(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD)$/.test(normalizeFieldName(name));
+}
+
+function isPlaceholderValue(value) {
+  return PLACEHOLDER_VALUES.has(unquote(value).toLowerCase());
+}
+
+function redactAssignedValue(value) {
+  if (isPlaceholderValue(value)) return value;
+  const quote = value.at(0);
+  if ((quote === '"' || quote === "'") && value.endsWith(quote)) {
+    return `${quote}${REDACTION_TOKEN}${quote}`;
+  }
+  return REDACTION_TOKEN;
+}
+
+/** Scrub known token prefixes and unknown-format values under sensitive names. */
+export function scrubCredentials(text) {
+  let count = 0;
+  const namedScrubbed = text.replace(
+    NAMED_CREDENTIAL_ASSIGNMENT_PATTERN,
+    (match, boundary, name, separator, value) => {
+      if (!isSensitiveFieldName(name)) return match;
+      const redacted = redactAssignedValue(value);
+      if (redacted === value) return match;
+      count++;
+      return `${boundary}${name}${separator}${redacted}`;
+    },
+  );
+  const scrubbed = namedScrubbed.replace(CREDENTIAL_PATTERN, (_match, boundary) => {
+    count++;
+    return `${boundary}${REDACTION_TOKEN}`;
+  });
+  return { scrubbed, count };
+}
+
+function scrubValue(value) {
+  if (typeof value === "string") {
+    const { scrubbed, count } = scrubCredentials(value);
+    return { value: scrubbed, count };
+  }
+  if (Array.isArray(value)) {
+    let total = 0;
+    const result = value.map((item) => {
+      const { value: scrubbed, count } = scrubValue(item);
+      total += count;
+      return scrubbed;
+    });
+    return { value: result, count: total };
+  }
+  if (value !== null && typeof value === "object") {
+    let total = 0;
+    const result = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (isSensitiveFieldName(key) && typeof nestedValue === "string" && !isPlaceholderValue(nestedValue)) {
+        result[key] = REDACTION_TOKEN;
+        total++;
+        continue;
+      }
+      const { value: scrubbed, count } = scrubValue(nestedValue);
+      result[key] = scrubbed;
+      total += count;
+    }
+    return { value: result, count: total };
+  }
+  return { value, count: 0 };
+}
+
+/** Scrub credentials from any JSON-serialisable tool output. */
+export function scrubToolOutput(output) {
+  const { value, count } = scrubValue(output);
+  return { output: value, redacted: count > 0 };
+}

--- a/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
@@ -6,7 +6,7 @@
 const CREDENTIAL_PATTERN =
   /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 const NAMED_CREDENTIAL_ASSIGNMENT_PATTERN =
-  /(^|[\s,{])((?:"[A-Za-z_][A-Za-z0-9_]*"|'[A-Za-z_][A-Za-z0-9_]*'|[A-Za-z_][A-Za-z0-9_]*))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential)\]|[^\s,}\]]+)/gm;
+  /(^|[^A-Za-z0-9_])((?:"[A-Za-z_][A-Za-z0-9_.-]*"|'[A-Za-z_][A-Za-z0-9_.-]*'|[A-Za-z_][A-Za-z0-9_.-]*))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[(?:redacted|redacted-credential)\]|<redacted>|\(?not[ \t]+set\)?(?=$|[\s,}\])&;])|[^\s,}\])&;]+)/gim;
 const PLACEHOLDER_VALUES = new Set([
   "",
   "***",
@@ -37,11 +37,17 @@ function normalizeFieldName(name) {
 }
 
 function isSensitiveFieldName(name) {
-  return /(?:^|_)(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD)$/.test(normalizeFieldName(name));
+  return /(?:^|_)(?:API_?KEY|PRIVATE_KEY|SECRET_KEY|TOKEN|SECRET|PASSWORD|PASSWD)$/.test(
+    normalizeFieldName(name),
+  );
 }
 
 function isPlaceholderValue(value) {
   return PLACEHOLDER_VALUES.has(unquote(value).toLowerCase());
+}
+
+function preservesSensitiveValue(value) {
+  return value == null || (typeof value === "string" && isPlaceholderValue(value));
 }
 
 function redactAssignedValue(value) {
@@ -91,7 +97,7 @@ function scrubValue(value) {
     let total = 0;
     const result = {};
     for (const [key, nestedValue] of Object.entries(value)) {
-      if (isSensitiveFieldName(key) && typeof nestedValue === "string" && !isPlaceholderValue(nestedValue)) {
+      if (isSensitiveFieldName(key) && !preservesSensitiveValue(nestedValue)) {
         result[key] = REDACTION_TOKEN;
         total++;
         continue;

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -47,9 +47,9 @@ import { validateBashWorkingDirectory } from "./quality-hooks-workdir.mjs";
 import {
   scrubCredentials,
   scrubToolOutput,
-} from "./quality-hooks-credential-scrub.mjs";
+} from "./quality-hooks-output-scrub.mjs";
 
-export { scrubCredentials } from "./quality-hooks-credential-scrub.mjs";
+export { scrubCredentials } from "./quality-hooks-output-scrub.mjs";
 
 // Re-export for consumers that import from this module
 export { scanForSecrets } from "./quality-logging.mjs";

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -44,59 +44,18 @@ import {
   isDirectFileMutationTool,
 } from "./quality-hooks-git-safety.mjs";
 import { validateBashWorkingDirectory } from "./quality-hooks-workdir.mjs";
+import {
+  scrubCredentials,
+  scrubToolOutput,
+} from "./quality-hooks-credential-scrub.mjs";
+
+export { scrubCredentials } from "./quality-hooks-credential-scrub.mjs";
 
 // Re-export for consumers that import from this module
 export { scanForSecrets } from "./quality-logging.mjs";
 export { checkSecretReadGate, isReadTool } from "./quality-hooks-secret-read.mjs";
 
-// ---------------------------------------------------------------------------
-// Credential transcript scrub (GH#20207, Layer 4 of t2458)
-// Mirrors shared-constants.sh scrub_credentials regex.
-// Applied in handleToolAfter to redact tokens before they reach the model
-// or are persisted to the SQLite transcript store.
-// ---------------------------------------------------------------------------
-
-const CREDENTIAL_PATTERN =
-  /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
-const NAMED_CREDENTIAL_ASSIGNMENT_PATTERN =
-  /(^|[\s,{])((?:"?[A-Za-z_][A-Za-z0-9_]*"?))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,}\]]+)/gm;
-
-const REDACTION_TOKEN = "[redacted-credential]";
 const OPERATION_TITLE_MAX_LENGTH = 500;
-
-function isSensitiveFieldName(name) {
-  return /(?:^|_)(?:API_KEY|TOKEN|SECRET|PASSWORD)$/i.test(name.replaceAll('"', ""));
-}
-
-function redactAssignedValue(value) {
-  const quote = value.at(0);
-  if ((quote === '"' || quote === "'") && value.endsWith(quote)) {
-    return `${quote}${REDACTION_TOKEN}${quote}`;
-  }
-  return REDACTION_TOKEN;
-}
-
-/**
- * Scrub known credential token prefixes from a string value.
- * @param {string} text
- * @returns {{ scrubbed: string, count: number }}
- */
-export function scrubCredentials(text) {
-  let count = 0;
-  const namedScrubbed = text.replace(
-    NAMED_CREDENTIAL_ASSIGNMENT_PATTERN,
-    (match, boundary, name, separator, value) => {
-      if (!isSensitiveFieldName(name)) return match;
-      count++;
-      return `${boundary}${name}${separator}${redactAssignedValue(value)}`;
-    },
-  );
-  const scrubbed = namedScrubbed.replace(CREDENTIAL_PATTERN, (_match, boundary) => {
-    count++;
-    return `${boundary}${REDACTION_TOKEN}`;
-  });
-  return { scrubbed, count };
-}
 
 /**
  * Prepare an untrusted tool title for bounded, single-line telemetry storage.
@@ -110,54 +69,6 @@ export function sanitizeOperationTitle(title) {
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, OPERATION_TITLE_MAX_LENGTH);
-}
-
-/**
- * Recursively scrub credentials from any JSON-serialisable value.
- * @param {unknown} value
- * @returns {{ value: unknown, count: number }}
- */
-function scrubValue(value) {
-  if (typeof value === "string") {
-    const { scrubbed, count } = scrubCredentials(value);
-    return { value: scrubbed, count };
-  }
-  if (Array.isArray(value)) {
-    let total = 0;
-    const result = value.map((item) => {
-      const { value: v, count } = scrubValue(item);
-      total += count;
-      return v;
-    });
-    return { value: result, count: total };
-  }
-  if (value !== null && typeof value === "object") {
-    let total = 0;
-    const result = {};
-    for (const [k, v] of Object.entries(value)) {
-      if (isSensitiveFieldName(k) && typeof v === "string") {
-        result[k] = REDACTION_TOKEN;
-        total++;
-        continue;
-      }
-      const { value: scrubbed, count } = scrubValue(v);
-      result[k] = scrubbed;
-      total += count;
-    }
-    return { value: result, count: total };
-  }
-  return { value, count: 0 };
-}
-
-/**
- * Scrub credentials from tool output. Returns the sanitised output and a
- * boolean indicating whether any redaction occurred.
- * @param {unknown} output
- * @returns {{ output: unknown, redacted: boolean }}
- */
-function scrubToolOutput(output) {
-  const { value, count } = scrubValue(output);
-  return { output: value, redacted: count > 0 };
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -58,9 +58,23 @@ export { checkSecretReadGate, isReadTool } from "./quality-hooks-secret-read.mjs
 
 const CREDENTIAL_PATTERN =
   /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
+const NAMED_CREDENTIAL_ASSIGNMENT_PATTERN =
+  /(^|[\s,{])((?:"?[A-Za-z_][A-Za-z0-9_]*"?))(\s*(?:=|:)\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,}\]]+)/gm;
 
 const REDACTION_TOKEN = "[redacted-credential]";
 const OPERATION_TITLE_MAX_LENGTH = 500;
+
+function isSensitiveFieldName(name) {
+  return /(?:^|_)(?:API_KEY|TOKEN|SECRET|PASSWORD)$/i.test(name.replaceAll('"', ""));
+}
+
+function redactAssignedValue(value) {
+  const quote = value.at(0);
+  if ((quote === '"' || quote === "'") && value.endsWith(quote)) {
+    return `${quote}${REDACTION_TOKEN}${quote}`;
+  }
+  return REDACTION_TOKEN;
+}
 
 /**
  * Scrub known credential token prefixes from a string value.
@@ -69,7 +83,15 @@ const OPERATION_TITLE_MAX_LENGTH = 500;
  */
 export function scrubCredentials(text) {
   let count = 0;
-  const scrubbed = text.replace(CREDENTIAL_PATTERN, (_match, boundary) => {
+  const namedScrubbed = text.replace(
+    NAMED_CREDENTIAL_ASSIGNMENT_PATTERN,
+    (match, boundary, name, separator, value) => {
+      if (!isSensitiveFieldName(name)) return match;
+      count++;
+      return `${boundary}${name}${separator}${redactAssignedValue(value)}`;
+    },
+  );
+  const scrubbed = namedScrubbed.replace(CREDENTIAL_PATTERN, (_match, boundary) => {
     count++;
     return `${boundary}${REDACTION_TOKEN}`;
   });
@@ -113,6 +135,11 @@ function scrubValue(value) {
     let total = 0;
     const result = {};
     for (const [k, v] of Object.entries(value)) {
+      if (isSensitiveFieldName(k) && typeof v === "string") {
+        result[k] = REDACTION_TOKEN;
+        total++;
+        continue;
+      }
       const { value: scrubbed, count } = scrubValue(v);
       result[k] = scrubbed;
       total += count;

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -87,6 +87,8 @@ describe("credential transcript scrub boundary", () => {
     assertScrub("userPassword=opaque-value", `userPassword=${REDACTION_TOKEN}`, 1);
     assertScrub("SECRET_KEY=opaque-value", `SECRET_KEY=${REDACTION_TOKEN}`, 1);
     assertScrub("SSH_PRIVATE_KEY=opaque-value", `SSH_PRIVATE_KEY=${REDACTION_TOKEN}`, 1);
+    assertScrub("AWS_SECRET_ACCESS_KEY=opaque-value", `AWS_SECRET_ACCESS_KEY=${REDACTION_TOKEN}`, 1);
+    assertScrub("ARTIFACT_SIGNING_KEY=opaque-value", `ARTIFACT_SIGNING_KEY=${REDACTION_TOKEN}`, 1);
   });
 
   test("preserves delimiters around unquoted sensitive assignments", () => {
@@ -94,6 +96,8 @@ describe("credential transcript scrub boundary", () => {
     assertScrub(`API_KEY=opaque-value&other=value`, `API_KEY=${REDACTION_TOKEN}&other=value`, 1);
     assertScrub(`TOKEN=opaque-value|other`, `TOKEN=${REDACTION_TOKEN}|other`, 1);
     assertScrub(`PASSWORD=opaque-value>file`, `PASSWORD=${REDACTION_TOKEN}>file`, 1);
+    assertScrub(`(API_KEY=not set)`, `(API_KEY=not set)`, 0);
+    assertScrub(`API_KEY=(opaque-value)`, `API_KEY=(${REDACTION_TOKEN})`, 1);
   });
 
   test("redacts quoted and unquoted sensitive names containing spaces", () => {
@@ -109,6 +113,8 @@ describe("credential transcript scrub boundary", () => {
     assertScrub("CLIENT_SECRET=not set", "CLIENT_SECRET=not set", 0);
     assertScrub("CLIENT_SECRET=(not set)", "CLIENT_SECRET=(not set)", 0);
     assertScrub("PRIVATE_KEY=[redacted-private-key]", "PRIVATE_KEY=[redacted-private-key]", 0);
+    assertScrub("API_KEY=[redacted]opaque", `API_KEY=${REDACTION_TOKEN}`, 1);
+    assertScrub("API_KEY=<redacted>opaque", `API_KEY=${REDACTION_TOKEN}`, 1);
   });
 
   test("does not redact non-sensitive field-name substrings", () => {
@@ -125,6 +131,11 @@ describe("credential transcript scrub boundary", () => {
     for (let run = 0; run < runs; run++) scrubCredentials(input);
     const averageMs = Number(process.hrtime.bigint() - start) / runs / 1_000_000;
     assert.ok(averageMs < 5, `named-field scan averaged ${averageMs.toFixed(3)}ms per 10KB`);
+  });
+
+  test("redacts sensitive field names longer than 128 characters", () => {
+    const name = `${"A".repeat(129)}_API_KEY`;
+    assertScrub(`${name}=opaque-value`, `${name}=${REDACTION_TOKEN}`, 1);
   });
 
   test("does not redact Google OAuth prefix embedded mid-word", () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -117,6 +117,16 @@ describe("credential transcript scrub boundary", () => {
     assertScrub("MONKEY_TOKENIZER=enabled", "MONKEY_TOKENIZER=enabled", 0);
   });
 
+  test("scans adversarial 10KB named-field input within the performance budget", () => {
+    const input = "A ".repeat(5_000);
+    const runs = 100;
+    scrubCredentials(input);
+    const start = process.hrtime.bigint();
+    for (let run = 0; run < runs; run++) scrubCredentials(input);
+    const averageMs = Number(process.hrtime.bigint() - start) / runs / 1_000_000;
+    assert.ok(averageMs < 5, `named-field scan averaged ${averageMs.toFixed(3)}ms per 10KB`);
+  });
+
   test("does not redact Google OAuth prefix embedded mid-word", () => {
     const embedded = `vendor-GOCSPX-${"g".repeat(28)}`;
     assertScrub(embedded, embedded, 0);

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -92,6 +92,13 @@ describe("credential transcript scrub boundary", () => {
   test("preserves delimiters around unquoted sensitive assignments", () => {
     assertScrub(`(RESEND-API-KEY=opaque-value)`, `(RESEND-API-KEY=${REDACTION_TOKEN})`, 1);
     assertScrub(`API_KEY=opaque-value&other=value`, `API_KEY=${REDACTION_TOKEN}&other=value`, 1);
+    assertScrub(`TOKEN=opaque-value|other`, `TOKEN=${REDACTION_TOKEN}|other`, 1);
+    assertScrub(`PASSWORD=opaque-value>file`, `PASSWORD=${REDACTION_TOKEN}>file`, 1);
+  });
+
+  test("redacts quoted and unquoted sensitive names containing spaces", () => {
+    assertScrub(`API KEY=opaque-value`, `API KEY=${REDACTION_TOKEN}`, 1);
+    assertScrub(`"PRIVATE KEY": opaque-value`, `"PRIVATE KEY": ${REDACTION_TOKEN}`, 1);
   });
 
   test("preserves empty and explicit placeholder values", () => {
@@ -100,6 +107,8 @@ describe("credential transcript scrub boundary", () => {
     assertScrub("CLIENT_SECRET=[redacted]", "CLIENT_SECRET=[redacted]", 0);
     assertScrub("CLIENT_SECRET=[REDACTED]", "CLIENT_SECRET=[REDACTED]", 0);
     assertScrub("CLIENT_SECRET=not set", "CLIENT_SECRET=not set", 0);
+    assertScrub("CLIENT_SECRET=(not set)", "CLIENT_SECRET=(not set)", 0);
+    assertScrub("PRIVATE_KEY=[redacted-private-key]", "PRIVATE_KEY=[redacted-private-key]", 0);
   });
 
   test("does not redact non-sensitive field-name substrings", () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -80,6 +80,25 @@ describe("credential transcript scrub boundary", () => {
     );
   });
 
+  test("redacts exact and camel-case sensitive field names", () => {
+    assertScrub("TOKEN=opaque-value", `TOKEN=${REDACTION_TOKEN}`, 1);
+    assertScrub("apiKey: opaque-value", `apiKey: ${REDACTION_TOKEN}`, 1);
+    assertScrub("clientSecret='opaque-value'", `clientSecret='${REDACTION_TOKEN}'`, 1);
+    assertScrub("userPassword=opaque-value", `userPassword=${REDACTION_TOKEN}`, 1);
+  });
+
+  test("preserves empty and explicit placeholder values", () => {
+    assertScrub('API_KEY=""', 'API_KEY=""', 0);
+    assertScrub("ACCESS_TOKEN=null", "ACCESS_TOKEN=null", 0);
+    assertScrub("CLIENT_SECRET=[redacted]", "CLIENT_SECRET=[redacted]", 0);
+  });
+
+  test("does not redact non-sensitive field-name substrings", () => {
+    assertScrub("TOKEN_COUNT=3", "TOKEN_COUNT=3", 0);
+    assertScrub("PASSWORD_POLICY=strict", "PASSWORD_POLICY=strict", 0);
+    assertScrub("MONKEY_TOKENIZER=enabled", "MONKEY_TOKENIZER=enabled", 0);
+  });
+
   test("does not redact Google OAuth prefix embedded mid-word", () => {
     const embedded = `vendor-GOCSPX-${"g".repeat(28)}`;
     assertScrub(embedded, embedded, 0);
@@ -117,6 +136,24 @@ describe("credential transcript scrub boundary", () => {
       await hooks.toolExecuteAfter({ tool: "grep", callID: "" }, output);
       assert.deepEqual(output.output, {
         environment: { RESEND_API_KEY: REDACTION_TOKEN },
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("structured output preserves sensitive placeholders", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "aidevops-placeholder-scrub-"));
+    const output = {
+      output: { environment: { RESEND_API_KEY: "[redacted]", API_TOKEN: "" } },
+      metadata: {},
+    };
+
+    try {
+      const hooks = createQualityHooks({ scriptsDir: tempDir, logsDir: tempDir });
+      await hooks.toolExecuteAfter({ tool: "grep", callID: "" }, output);
+      assert.deepEqual(output.output, {
+        environment: { RESEND_API_KEY: "[redacted]", API_TOKEN: "" },
       });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -64,6 +64,22 @@ describe("credential transcript scrub boundary", () => {
     assertScrub(`client_secret=${secret}`, `client_secret=${REDACTION_TOKEN}`, 1);
   });
 
+  test("redacts unknown-format values assigned to sensitive field names", () => {
+    assertScrub(
+      "RESEND_API_KEY=synthetic_unknown_format_1234567890",
+      `RESEND_API_KEY=${REDACTION_TOKEN}`,
+      1,
+    );
+  });
+
+  test("redacts quoted sensitive fields in colon-delimited output", () => {
+    assertScrub(
+      '"RECRAFT_API_KEY": "synthetic_unknown_format_1234567890"',
+      `"RECRAFT_API_KEY": "${REDACTION_TOKEN}"`,
+      1,
+    );
+  });
+
   test("does not redact Google OAuth prefix embedded mid-word", () => {
     const embedded = `vendor-GOCSPX-${"g".repeat(28)}`;
     assertScrub(embedded, embedded, 0);
@@ -83,6 +99,24 @@ describe("credential transcript scrub boundary", () => {
       assert.deepEqual(output.output, {
         stdout: `client_secret=${REDACTION_TOKEN}`,
         exitCode: 0,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("toolExecuteAfter scrubs named credential values in structured output", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "aidevops-named-credential-scrub-"));
+    const output = {
+      output: { environment: { RESEND_API_KEY: "synthetic_unknown_format_1234567890" } },
+      metadata: {},
+    };
+
+    try {
+      const hooks = createQualityHooks({ scriptsDir: tempDir, logsDir: tempDir });
+      await hooks.toolExecuteAfter({ tool: "grep", callID: "" }, output);
+      assert.deepEqual(output.output, {
+        environment: { RESEND_API_KEY: REDACTION_TOKEN },
       });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -85,12 +85,21 @@ describe("credential transcript scrub boundary", () => {
     assertScrub("apiKey: opaque-value", `apiKey: ${REDACTION_TOKEN}`, 1);
     assertScrub("clientSecret='opaque-value'", `clientSecret='${REDACTION_TOKEN}'`, 1);
     assertScrub("userPassword=opaque-value", `userPassword=${REDACTION_TOKEN}`, 1);
+    assertScrub("SECRET_KEY=opaque-value", `SECRET_KEY=${REDACTION_TOKEN}`, 1);
+    assertScrub("SSH_PRIVATE_KEY=opaque-value", `SSH_PRIVATE_KEY=${REDACTION_TOKEN}`, 1);
+  });
+
+  test("preserves delimiters around unquoted sensitive assignments", () => {
+    assertScrub(`(RESEND-API-KEY=opaque-value)`, `(RESEND-API-KEY=${REDACTION_TOKEN})`, 1);
+    assertScrub(`API_KEY=opaque-value&other=value`, `API_KEY=${REDACTION_TOKEN}&other=value`, 1);
   });
 
   test("preserves empty and explicit placeholder values", () => {
     assertScrub('API_KEY=""', 'API_KEY=""', 0);
     assertScrub("ACCESS_TOKEN=null", "ACCESS_TOKEN=null", 0);
     assertScrub("CLIENT_SECRET=[redacted]", "CLIENT_SECRET=[redacted]", 0);
+    assertScrub("CLIENT_SECRET=[REDACTED]", "CLIENT_SECRET=[REDACTED]", 0);
+    assertScrub("CLIENT_SECRET=not set", "CLIENT_SECRET=not set", 0);
   });
 
   test("does not redact non-sensitive field-name substrings", () => {
@@ -127,7 +136,14 @@ describe("credential transcript scrub boundary", () => {
   test("toolExecuteAfter scrubs named credential values in structured output", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "aidevops-named-credential-scrub-"));
     const output = {
-      output: { environment: { RESEND_API_KEY: "synthetic_unknown_format_1234567890" } },
+      output: {
+        environment: {
+          RESEND_API_KEY: "synthetic_unknown_format_1234567890",
+          TOKEN: 1234567890,
+          PRIVATE_KEY: { material: "synthetic_unknown_format_1234567890" },
+          SECRET_KEY: null,
+        },
+      },
       metadata: {},
     };
 
@@ -135,7 +151,12 @@ describe("credential transcript scrub boundary", () => {
       const hooks = createQualityHooks({ scriptsDir: tempDir, logsDir: tempDir });
       await hooks.toolExecuteAfter({ tool: "grep", callID: "" }, output);
       assert.deepEqual(output.output, {
-        environment: { RESEND_API_KEY: REDACTION_TOKEN },
+        environment: {
+          RESEND_API_KEY: REDACTION_TOKEN,
+          TOKEN: REDACTION_TOKEN,
+          PRIVATE_KEY: REDACTION_TOKEN,
+          SECRET_KEY: null,
+        },
       });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -19,6 +19,7 @@ import { join } from "node:path";
 import { createQualityHooks, scrubCredentials } from "../quality-hooks.mjs";
 
 const REDACTION_TOKEN = "[redacted-credential]";
+const PEM_REDACTION_TOKEN = "[redacted-private-key]";
 
 function assertScrub(input, expected, expectedCount) {
   const { scrubbed, count } = scrubCredentials(input);
@@ -88,6 +89,8 @@ describe("credential transcript scrub boundary", () => {
     assertScrub("SECRET_KEY=opaque-value", `SECRET_KEY=${REDACTION_TOKEN}`, 1);
     assertScrub("SSH_PRIVATE_KEY=opaque-value", `SSH_PRIVATE_KEY=${REDACTION_TOKEN}`, 1);
     assertScrub("AWS_SECRET_ACCESS_KEY=opaque-value", `AWS_SECRET_ACCESS_KEY=${REDACTION_TOKEN}`, 1);
+    assertScrub("AWS_ACCESS_KEY_ID=opaque-value", `AWS_ACCESS_KEY_ID=${REDACTION_TOKEN}`, 1);
+    assertScrub("AccessKeyId=opaque-value", `AccessKeyId=${REDACTION_TOKEN}`, 1);
     assertScrub("ARTIFACT_SIGNING_KEY=opaque-value", `ARTIFACT_SIGNING_KEY=${REDACTION_TOKEN}`, 1);
   });
 
@@ -115,6 +118,9 @@ describe("credential transcript scrub boundary", () => {
     assertScrub("PRIVATE_KEY=[redacted-private-key]", "PRIVATE_KEY=[redacted-private-key]", 0);
     assertScrub("API_KEY=[redacted]opaque", `API_KEY=${REDACTION_TOKEN}`, 1);
     assertScrub("API_KEY=<redacted>opaque", `API_KEY=${REDACTION_TOKEN}`, 1);
+    assertScrub('API_KEY=""opaque', `API_KEY=${REDACTION_TOKEN}`, 1);
+    assertScrub("API_KEY=(not set)opaque", `API_KEY=${REDACTION_TOKEN}`, 1);
+    assertScrub("API_KEY=(redacted)opaque", `API_KEY=${REDACTION_TOKEN}`, 1);
   });
 
   test("does not redact non-sensitive field-name substrings", () => {
@@ -136,6 +142,25 @@ describe("credential transcript scrub boundary", () => {
   test("redacts sensitive field names longer than 128 characters", () => {
     const name = `${"A".repeat(129)}_API_KEY`;
     assertScrub(`${name}=opaque-value`, `${name}=${REDACTION_TOKEN}`, 1);
+  });
+
+  test("redacts standalone PEM private keys", () => {
+    const privateKey = [
+      "-----BEGIN OPENSSH PRIVATE KEY-----",
+      "synthetic-material",
+      "-----END OPENSSH PRIVATE KEY-----",
+    ].join("\n");
+    assertScrub(privateKey, PEM_REDACTION_TOKEN, 1);
+  });
+
+  test("scans unmatched PEM headers within the performance budget", () => {
+    const input = "-----BEGIN OPENSSH PRIVATE KEY-----\n".repeat(250);
+    const runs = 100;
+    scrubCredentials(input);
+    const start = process.hrtime.bigint();
+    for (let run = 0; run < runs; run++) scrubCredentials(input);
+    const averageMs = Number(process.hrtime.bigint() - start) / runs / 1_000_000;
+    assert.ok(averageMs < 5, `PEM scan averaged ${averageMs.toFixed(3)}ms per 10KB`);
   });
 
   test("does not redact Google OAuth prefix embedded mid-word", () => {

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -316,6 +316,7 @@ _verify_deployed_core_plugin_freshness() {
 		"hooks/git_safety_guard.py"
 		"plugins/opencode-aidevops/model-limits.mjs"
 		"plugins/opencode-aidevops/quality-hooks-git-safety.mjs"
+		"plugins/opencode-aidevops/quality-hooks-output-scrub.mjs"
 		"plugins/opencode-aidevops/quality-hooks.mjs"
 		"scripts/canonical_branch_policy.py"
 		"scripts/canonical-write-policy-helper.py"

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -203,12 +203,13 @@ else
 	fail "14. Nested dict tool_response scrubbed recursively — got: $output14"
 fi
 
-NAMED_TEXT_PAYLOAD='{"tool_response": "(RESEND-API-KEY=synthetic_unknown_format_1234567890) API_KEY=opaque-value&other=value TOKEN=opaque-value|next PASSWORD=opaque-value>file API KEY=opaque-value SECRET_KEY=not set"}'
+LONG_NAMED_KEY=$(python3 -c "print('A' * 129 + '_API_KEY')")
+NAMED_TEXT_PAYLOAD="{\"tool_response\": \"(RESEND-API-KEY=synthetic_unknown_format_1234567890) API_KEY=opaque-value&other=value TOKEN=opaque-value|next PASSWORD=opaque-value>file API KEY=opaque-value AWS_SECRET_ACCESS_KEY=opaque-value SIGNING_KEY=[redacted]opaque API_KEY=(opaque-value) (SECRET_KEY=not set) ${LONG_NAMED_KEY}=opaque-value\"}"
 output15=$(run_hook "$NAMED_TEXT_PAYLOAD")
 if echo "$output15" | python3 -c "
 import json, sys
 response = json.load(sys.stdin).get('tool_response', '')
-assert response == '(RESEND-API-KEY=[redacted-credential]) API_KEY=[redacted-credential]&other=value TOKEN=[redacted-credential]|next PASSWORD=[redacted-credential]>file API KEY=[redacted-credential] SECRET_KEY=not set'
+assert response == '(RESEND-API-KEY=[redacted-credential]) API_KEY=[redacted-credential]&other=value TOKEN=[redacted-credential]|next PASSWORD=[redacted-credential]>file API KEY=[redacted-credential] AWS_SECRET_ACCESS_KEY=[redacted-credential] SIGNING_KEY=[redacted-credential] API_KEY=([redacted-credential]) (SECRET_KEY=not set) ${LONG_NAMED_KEY}=[redacted-credential]'
 " 2>/dev/null; then
 	pass "15. Named secrets scrubbed without consuming delimiters"
 else

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -203,32 +203,35 @@ else
 	fail "14. Nested dict tool_response scrubbed recursively — got: $output14"
 fi
 
-NAMED_TEXT_PAYLOAD='{"tool_response": "RESEND_API_KEY=synthetic_unknown_format_1234567890"}'
+NAMED_TEXT_PAYLOAD='{"tool_response": "(RESEND-API-KEY=synthetic_unknown_format_1234567890) API_KEY=opaque-value&other=value SECRET_KEY=not set"}'
 output15=$(run_hook "$NAMED_TEXT_PAYLOAD")
 if echo "$output15" | python3 -c "
 import json, sys
 response = json.load(sys.stdin).get('tool_response', '')
-assert response == 'RESEND_API_KEY=[redacted-credential]'
+assert response == '(RESEND-API-KEY=[redacted-credential]) API_KEY=[redacted-credential]&other=value SECRET_KEY=not set'
 " 2>/dev/null; then
-	pass "15. Unknown-format named API key scrubbed in text"
+	pass "15. Named secrets scrubbed without consuming delimiters"
 else
-	fail "15. Unknown-format named API key scrubbed in text — got: $output15"
+	fail "15. Named secrets scrubbed without consuming delimiters — got: $output15"
 fi
 
-NAMED_OBJECT_PAYLOAD='{"tool_response": {"environment": {"RECRAFT_API_KEY": "synthetic_unknown_format_1234567890"}}}'
+NAMED_OBJECT_PAYLOAD='{"tool_response": {"environment": {"RECRAFT_API_KEY": "synthetic_unknown_format_1234567890", "TOKEN": 1234567890, "PRIVATE_KEY": {"material": "synthetic_unknown_format_1234567890"}, "SECRET_KEY": null}}}'
 output16=$(run_hook "$NAMED_OBJECT_PAYLOAD")
 if echo "$output16" | python3 -c "
 import json, sys
 response = json.load(sys.stdin).get('tool_response', {})
 assert response['environment']['RECRAFT_API_KEY'] == '[redacted-credential]'
+assert response['environment']['TOKEN'] == '[redacted-credential]'
+assert response['environment']['PRIVATE_KEY'] == '[redacted-credential]'
+assert response['environment']['SECRET_KEY'] is None
 " 2>/dev/null; then
-	pass "16. Unknown-format named API key scrubbed in nested output"
+	pass "16. Sensitive structured values scrubbed regardless of type"
 else
-	fail "16. Unknown-format named API key scrubbed in nested output — got: $output16"
+	fail "16. Sensitive structured values scrubbed regardless of type — got: $output16"
 fi
 
 assert_no_output "17. Sensitive placeholders remain unchanged" \
-	'{"tool_response": {"API_KEY": "[redacted]", "ACCESS_TOKEN": ""}}'
+	'{"tool_response": "API_KEY=[REDACTED] SECRET_KEY=not set ACCESS_TOKEN=null"}'
 
 assert_no_output "18. Sensitive-name substrings remain unchanged" \
 	'{"tool_response": "TOKEN_COUNT=3 PASSWORD_POLICY=strict MONKEY_TOKENIZER=enabled"}'

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -26,7 +26,7 @@
 #   15-18. Named-field positive and conservative negative cases
 #   19. Malformed JSON produces no output and exits 0 (fail-open)
 #   20-26. Word-boundary false-positive regression cases
-#   27. Performance: <5ms per 10KB tool result
+#   27-28. Known-prefix and named-field performance: <5ms per 10KB
 #
 # Usage: bash test-credential-transcript-scrub.sh
 
@@ -326,6 +326,29 @@ if python3 -c "import sys; sys.exit(0 if float('$BENCH_MS') < 5 else 1)" 2>/dev/
 	pass "27. Performance: ${BENCH_MS}ms per 10KB in-process (budget: <5ms)"
 else
 	fail "27. Performance: ${BENCH_MS}ms per 10KB in-process exceeds 5ms budget"
+fi
+
+NAMED_BENCH_MS=$(python3 -c "
+import runpy, time
+
+scrub_credentials = runpy.run_path('$HOOK_SCRIPT')['scrub_credentials']
+payload_str = 'A ' * 5000
+runs = 100
+scrub_credentials(payload_str)
+start = time.monotonic_ns()
+for _ in range(runs):
+    scrubbed, count = scrub_credentials(payload_str)
+end = time.monotonic_ns()
+assert scrubbed == payload_str and count == 0
+avg_ms = (end - start) / runs / 1_000_000
+print(round(avg_ms, 4))
+")
+
+printf '  In-process named scrub per 10KB (%d runs): %sms\n' 100 "$NAMED_BENCH_MS"
+if python3 -c "import sys; sys.exit(0 if float('$NAMED_BENCH_MS') < 5 else 1)" 2>/dev/null; then
+	pass "28. Named-field performance: ${NAMED_BENCH_MS}ms per 10KB (budget: <5ms)"
+else
+	fail "28. Named-field performance: ${NAMED_BENCH_MS}ms per 10KB exceeds 5ms budget"
 fi
 printf '  Note: subprocess launch adds ~50ms Python startup; in-process cost shown above.\n'
 

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -24,9 +24,10 @@
 #   13. Multiple tokens in one payload all redacted
 #   14. Nested JSON object tool_response scrubbed recursively
 #   15-18. Named-field positive and conservative negative cases
+#   18b. Standalone PEM private-key redaction
 #   19. Malformed JSON produces no output and exits 0 (fail-open)
 #   20-26. Word-boundary false-positive regression cases
-#   27-28. Known-prefix and named-field performance: <5ms per 10KB
+#   27-29. Known-prefix, named-field, and unmatched-PEM performance
 #
 # Usage: bash test-credential-transcript-scrub.sh
 
@@ -204,12 +205,12 @@ else
 fi
 
 LONG_NAMED_KEY=$(python3 -c "print('A' * 129 + '_API_KEY')")
-NAMED_TEXT_PAYLOAD="{\"tool_response\": \"(RESEND-API-KEY=synthetic_unknown_format_1234567890) API_KEY=opaque-value&other=value TOKEN=opaque-value|next PASSWORD=opaque-value>file API KEY=opaque-value AWS_SECRET_ACCESS_KEY=opaque-value SIGNING_KEY=[redacted]opaque API_KEY=(opaque-value) (SECRET_KEY=not set) ${LONG_NAMED_KEY}=opaque-value\"}"
+NAMED_TEXT_PAYLOAD="{\"tool_response\": \"(RESEND-API-KEY=synthetic_unknown_format_1234567890) API_KEY=opaque-value&other=value TOKEN=opaque-value|next PASSWORD=opaque-value>file API KEY=opaque-value AWS_SECRET_ACCESS_KEY=opaque-value AWS_ACCESS_KEY_ID=opaque-value AccessKeyId=opaque-value SIGNING_KEY=[redacted]opaque API_KEY=(opaque-value) API_KEY=(not set)opaque (SECRET_KEY=not set) ${LONG_NAMED_KEY}=opaque-value\"}"
 output15=$(run_hook "$NAMED_TEXT_PAYLOAD")
 if echo "$output15" | python3 -c "
 import json, sys
 response = json.load(sys.stdin).get('tool_response', '')
-assert response == '(RESEND-API-KEY=[redacted-credential]) API_KEY=[redacted-credential]&other=value TOKEN=[redacted-credential]|next PASSWORD=[redacted-credential]>file API KEY=[redacted-credential] AWS_SECRET_ACCESS_KEY=[redacted-credential] SIGNING_KEY=[redacted-credential] API_KEY=([redacted-credential]) (SECRET_KEY=not set) ${LONG_NAMED_KEY}=[redacted-credential]'
+assert response == '(RESEND-API-KEY=[redacted-credential]) API_KEY=[redacted-credential]&other=value TOKEN=[redacted-credential]|next PASSWORD=[redacted-credential]>file API KEY=[redacted-credential] AWS_SECRET_ACCESS_KEY=[redacted-credential] AWS_ACCESS_KEY_ID=[redacted-credential] AccessKeyId=[redacted-credential] SIGNING_KEY=[redacted-credential] API_KEY=([redacted-credential]) API_KEY=[redacted-credential] (SECRET_KEY=not set) ${LONG_NAMED_KEY}=[redacted-credential]'
 " 2>/dev/null; then
 	pass "15. Named secrets scrubbed without consuming delimiters"
 else
@@ -236,6 +237,17 @@ assert_no_output "17. Sensitive placeholders remain unchanged" \
 
 assert_no_output "18. Sensitive-name substrings remain unchanged" \
 	'{"tool_response": "TOKEN_COUNT=3 PASSWORD_POLICY=strict MONKEY_TOKENIZER=enabled"}'
+
+PEM_PAYLOAD='{"tool_response": "-----BEGIN OPENSSH PRIVATE KEY-----\nsynthetic-material\n-----END OPENSSH PRIVATE KEY-----"}'
+output_pem=$(run_hook "$PEM_PAYLOAD")
+if echo "$output_pem" | python3 -c "
+import json, sys
+assert json.load(sys.stdin).get('tool_response') == '[redacted-private-key]'
+" 2>/dev/null; then
+	pass "18b. Standalone PEM private key scrubbed"
+else
+	fail "18b. Standalone PEM private key scrubbed — got: $output_pem"
+fi
 
 # Test 19: malformed JSON exits 0
 assert_exit_zero "19. Malformed JSON exits 0 (fail-open)" \
@@ -350,6 +362,29 @@ if python3 -c "import sys; sys.exit(0 if float('$NAMED_BENCH_MS') < 5 else 1)" 2
 	pass "28. Named-field performance: ${NAMED_BENCH_MS}ms per 10KB (budget: <5ms)"
 else
 	fail "28. Named-field performance: ${NAMED_BENCH_MS}ms per 10KB exceeds 5ms budget"
+fi
+
+PEM_BENCH_MS=$(python3 -c "
+import runpy, time
+
+scrub_credentials = runpy.run_path('$HOOK_SCRIPT')['scrub_credentials']
+payload_str = '-----BEGIN OPENSSH PRIVATE KEY-----\n' * 250
+runs = 100
+scrub_credentials(payload_str)
+start = time.monotonic_ns()
+for _ in range(runs):
+    scrubbed, count = scrub_credentials(payload_str)
+end = time.monotonic_ns()
+assert scrubbed == payload_str and count == 0
+avg_ms = (end - start) / runs / 1_000_000
+print(round(avg_ms, 4))
+")
+
+printf '  In-process unmatched PEM scan per 10KB (%d runs): %sms\n' 100 "$PEM_BENCH_MS"
+if python3 -c "import sys; sys.exit(0 if float('$PEM_BENCH_MS') < 5 else 1)" 2>/dev/null; then
+	pass "29. Unmatched-PEM performance: ${PEM_BENCH_MS}ms per 10KB (budget: <5ms)"
+else
+	fail "29. Unmatched-PEM performance: ${PEM_BENCH_MS}ms per 10KB exceeds 5ms budget"
 fi
 printf '  Note: subprocess launch adds ~50ms Python startup; in-process cost shown above.\n'
 

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -4,9 +4,9 @@
 #
 # test-credential-transcript-scrub.sh — GH#20207 regression guard.
 #
-# Verifies that credential-transcript-scrub.py correctly redacts all 9 known
-# token-prefix families from tool result payloads and meets the <5ms/10KB
-# performance budget.
+# Verifies that credential-transcript-scrub.py redacts all 10 known token-prefix
+# families and unknown-format values under sensitive field names, while meeting
+# the <5ms/10KB performance budget.
 #
 # Tests:
 #   1.  gho_ token redacted in plain string tool_response
@@ -18,12 +18,15 @@
 #   7.  glpat- token redacted (GitLab PAT)
 #   8.  xoxb- token redacted (Slack bot token)
 #   9.  xoxp- token redacted (Slack user token)
-#   10. Clean input produces no output (fast-path, no redaction)
-#   11. Token shorter than 10 chars NOT redacted (below minimum body length)
-#   12. Multiple tokens in one payload all redacted
-#   13. Nested JSON object tool_response scrubbed recursively
-#   14. Malformed JSON produces no output and exits 0 (fail-open)
-#   15. Performance: <5ms per 10KB tool result
+#   10. GOCSPX- token redacted (Google OAuth client secret)
+#   11. Clean input produces no output (fast-path, no redaction)
+#   12. Token shorter than 10 chars NOT redacted (below minimum body length)
+#   13. Multiple tokens in one payload all redacted
+#   14. Nested JSON object tool_response scrubbed recursively
+#   15-18. Named-field positive and conservative negative cases
+#   19. Malformed JSON produces no output and exits 0 (fail-open)
+#   20-26. Word-boundary false-positive regression cases
+#   27. Performance: <5ms per 10KB tool result
 #
 # Usage: bash test-credential-transcript-scrub.sh
 
@@ -46,21 +49,24 @@ TESTS_RUN=0
 TESTS_FAILED=0
 
 pass() {
+	local label="$1"
 	TESTS_RUN=$((TESTS_RUN + 1))
-	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
 	return 0
 }
 
 fail() {
+	local label="$1"
 	TESTS_RUN=$((TESTS_RUN + 1))
 	TESTS_FAILED=$((TESTS_FAILED + 1))
-	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$label"
 	return 0
 }
 
 # Helpers
 run_hook() {
-	echo "$1" | python3 "$HOOK_SCRIPT"
+	local payload="$1"
+	echo "$payload" | python3 "$HOOK_SCRIPT"
 	return 0
 }
 
@@ -197,8 +203,38 @@ else
 	fail "14. Nested dict tool_response scrubbed recursively — got: $output14"
 fi
 
-# Test 15: malformed JSON exits 0
-assert_exit_zero "15. Malformed JSON exits 0 (fail-open)" \
+NAMED_TEXT_PAYLOAD='{"tool_response": "RESEND_API_KEY=synthetic_unknown_format_1234567890"}'
+output15=$(run_hook "$NAMED_TEXT_PAYLOAD")
+if echo "$output15" | python3 -c "
+import json, sys
+response = json.load(sys.stdin).get('tool_response', '')
+assert response == 'RESEND_API_KEY=[redacted-credential]'
+" 2>/dev/null; then
+	pass "15. Unknown-format named API key scrubbed in text"
+else
+	fail "15. Unknown-format named API key scrubbed in text — got: $output15"
+fi
+
+NAMED_OBJECT_PAYLOAD='{"tool_response": {"environment": {"RECRAFT_API_KEY": "synthetic_unknown_format_1234567890"}}}'
+output16=$(run_hook "$NAMED_OBJECT_PAYLOAD")
+if echo "$output16" | python3 -c "
+import json, sys
+response = json.load(sys.stdin).get('tool_response', {})
+assert response['environment']['RECRAFT_API_KEY'] == '[redacted-credential]'
+" 2>/dev/null; then
+	pass "16. Unknown-format named API key scrubbed in nested output"
+else
+	fail "16. Unknown-format named API key scrubbed in nested output — got: $output16"
+fi
+
+assert_no_output "17. Sensitive placeholders remain unchanged" \
+	'{"tool_response": {"API_KEY": "[redacted]", "ACCESS_TOKEN": ""}}'
+
+assert_no_output "18. Sensitive-name substrings remain unchanged" \
+	'{"tool_response": "TOKEN_COUNT=3 PASSWORD_POLICY=strict MONKEY_TOKENIZER=enabled"}'
+
+# Test 19: malformed JSON exits 0
+assert_exit_zero "19. Malformed JSON exits 0 (fail-open)" \
 	"not-valid-json"
 
 # ── Word-boundary anchor regression (t2892, GH#21026) ──────────────────────
@@ -215,26 +251,26 @@ printf '\n%s\n' "${TEST_BLUE}Word-boundary anchor (t2892)${TEST_NC}"
 # in `shared-constants.sh::scrub_credentials` corrupts source files at
 # write-time. All three locations must agree on the boundary anchor.
 
-assert_no_output "16. task-failure-handler NOT scrubbed (mid-word sk-)" \
+assert_no_output "20. task-failure-handler NOT scrubbed (mid-word sk-)" \
 	'{"tool_response": "import { handler } from \"./task-failure-handler\""}'
 
-assert_no_output "17. task-decompose-helper NOT scrubbed (mid-word sk-)" \
+assert_no_output "21. task-decompose-helper NOT scrubbed (mid-word sk-)" \
 	'{"tool_response": "Calling task-decompose-helper.sh now"}'
 
-assert_no_output "18. agent-task-failure-handler id NOT scrubbed" \
+assert_no_output "22. agent-task-failure-handler id NOT scrubbed" \
 	'{"tool_response": "inngest function id: agent-task-failure-handler"}'
 
-assert_no_output "19. task-id-collision-guard NOT scrubbed" \
+assert_no_output "23. task-id-collision-guard NOT scrubbed" \
 	'{"tool_response": "workflow: task-id-collision-guard.yml"}'
 
 # Real credentials must still be redacted across boundary contexts.
-assert_redacted "20. real sk- after space still redacted (control)" \
+assert_redacted "24. real sk- after space still redacted (control)" \
 	'{"tool_response": "API key sk-abcdefghij1234567890 invalid"}'
 
-assert_redacted "21. real sk- at start of string still redacted" \
+assert_redacted "25. real sk- at start of string still redacted" \
 	'{"tool_response": "sk-abcdefghij1234567890"}'
 
-assert_redacted "22. real ghp_ after colon still redacted" \
+assert_redacted "26. real ghp_ after colon still redacted" \
 	'{"tool_response": "token:ghp_abcdefghij1234567890"}'
 
 # ── Performance budget ─────────────────────────────────────────────────────
@@ -284,9 +320,9 @@ print(round(avg_ms, 4))
 printf '  In-process regex per 10KB (%d runs): %sms\n' 500 "$BENCH_MS"
 
 if python3 -c "import sys; sys.exit(0 if float('$BENCH_MS') < 5 else 1)" 2>/dev/null; then
-	pass "23. Performance: ${BENCH_MS}ms per 10KB in-process (budget: <5ms)"
+	pass "27. Performance: ${BENCH_MS}ms per 10KB in-process (budget: <5ms)"
 else
-	fail "23. Performance: ${BENCH_MS}ms per 10KB in-process exceeds 5ms budget"
+	fail "27. Performance: ${BENCH_MS}ms per 10KB in-process exceeds 5ms budget"
 fi
 printf '  Note: subprocess launch adds ~50ms Python startup; in-process cost shown above.\n'
 

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -203,12 +203,12 @@ else
 	fail "14. Nested dict tool_response scrubbed recursively — got: $output14"
 fi
 
-NAMED_TEXT_PAYLOAD='{"tool_response": "(RESEND-API-KEY=synthetic_unknown_format_1234567890) API_KEY=opaque-value&other=value SECRET_KEY=not set"}'
+NAMED_TEXT_PAYLOAD='{"tool_response": "(RESEND-API-KEY=synthetic_unknown_format_1234567890) API_KEY=opaque-value&other=value TOKEN=opaque-value|next PASSWORD=opaque-value>file API KEY=opaque-value SECRET_KEY=not set"}'
 output15=$(run_hook "$NAMED_TEXT_PAYLOAD")
 if echo "$output15" | python3 -c "
 import json, sys
 response = json.load(sys.stdin).get('tool_response', '')
-assert response == '(RESEND-API-KEY=[redacted-credential]) API_KEY=[redacted-credential]&other=value SECRET_KEY=not set'
+assert response == '(RESEND-API-KEY=[redacted-credential]) API_KEY=[redacted-credential]&other=value TOKEN=[redacted-credential]|next PASSWORD=[redacted-credential]>file API KEY=[redacted-credential] SECRET_KEY=not set'
 " 2>/dev/null; then
 	pass "15. Named secrets scrubbed without consuming delimiters"
 else
@@ -231,7 +231,7 @@ else
 fi
 
 assert_no_output "17. Sensitive placeholders remain unchanged" \
-	'{"tool_response": "API_KEY=[REDACTED] SECRET_KEY=not set ACCESS_TOKEN=null"}'
+	'{"tool_response": "API_KEY=[REDACTED] PRIVATE_KEY=[redacted-private-key] SECRET_KEY=(not set) ACCESS_TOKEN=null"}'
 
 assert_no_output "18. Sensitive-name substrings remain unchanged" \
 	'{"tool_response": "TOKEN_COUNT=3 PASSWORD_POLICY=strict MONKEY_TOKENIZER=enabled"}'


### PR DESCRIPTION
## Summary

Redact unknown-format credentials under unambiguous field names in OpenCode and Claude Code tool output, preserve delimiters/placeholders, recursively protect structured values, and scrub PEM private keys with linear scans.

## Files Changed

.agents/hooks/credential-transcript-scrub.py, .agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs, .agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs, .agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/tests/test-credential-transcript-scrub.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: OpenCode credential scrub suite 23/23; Claude transcript scrub suite 44/44; named and unmatched-PEM scans under 5ms per 10KB; local lint, ShellCheck, secret, portability, and complexity gates pass.

Resolves #31164


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.308 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 3h 29m and 1,064,281 tokens on this with the user in an interactive session.