### PR TITLE
GH#31183: fix: preserve authorization-gap evidence

### DIFF
--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -422,7 +422,7 @@ _full_loop_release_resolve_tag_expected_sources() {
 	local expected_sources="$4"
 	local resolver="${SCRIPT_DIR}/release-provenance-helper.sh"
 	local authorization_json=""
-	local resolver_args=(resolve-tag-authorization --tag "$tag_name" --source-pr "$requested_pr" --repo "$repo" --branch main)
+	local resolver_args=(resolve-tag-expected-sources --tag "$tag_name" --source-pr "$requested_pr" --repo "$repo" --branch main)
 	[[ -x "$resolver" ]] || return 1
 	[[ -n "$expected_sources" ]] && resolver_args+=(--expected-sources "$expected_sources")
 	_full_loop_release_prepare_tag_worktree "$tag_name" || return 1

--- a/.agents/scripts/release-provenance-helper.sh
+++ b/.agents/scripts/release-provenance-helper.sh
@@ -26,6 +26,7 @@ Usage:
   release-provenance-helper.sh verify-local-source --tag TAG --repo OWNER/REPO [--branch BRANCH]
   release-provenance-helper.sh resolve-authorization --source-pr PR --repo OWNER/REPO [--branch BRANCH] [--expected-sources PR[,PR...]]
   release-provenance-helper.sh resolve-tag-authorization --tag TAG --source-pr PR --repo OWNER/REPO [--branch BRANCH] [--expected-sources PR@SHA[,PR@SHA...]]
+  release-provenance-helper.sh resolve-tag-expected-sources --tag TAG --source-pr PR --repo OWNER/REPO [--branch BRANCH] [--expected-sources PR@SHA[,PR@SHA...]]
   release-provenance-helper.sh resolve-source --source-pr PR --repo OWNER/REPO [--branch BRANCH] [--expected-sources PR[,PR...]]
 
 Verifies that a release tag is signed, version-consistent, reachable from the
@@ -184,6 +185,29 @@ _release_provenance_resolve_tag_authorization() {
 		"$expected_sources_json" "$source_json") || return 1
 	_release_provenance_assert_expected_sources "$expected_sources_json" "$observed_sources_json" || return 1
 	jq -c --argjson expected "$expected_sources_json" '. + {expected_sources:$expected}' <<<"$source_json"
+	return $?
+}
+
+_release_provenance_resolve_tag_expected_sources() {
+	local tag_name="$1"
+	local requested_pr="$2"
+	local raw_sources="$3"
+	local repo_slug="$4"
+	local branch_name="$5"
+	local release_head=""
+	local tag_commit=""
+	local expected_sources_json=""
+
+	[[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && "$requested_pr" =~ ^[0-9]+$ ]] || return 1
+	[[ "$repo_slug" =~ ^[^/]+/[^/]+$ && "$branch_name" =~ ^[A-Za-z0-9._/-]+$ ]] || return 1
+	release_head=$(git rev-parse HEAD 2>/dev/null) || return 1
+	tag_commit=$(git rev-parse "refs/tags/${tag_name}^{commit}" 2>/dev/null) || return 1
+	[[ "$release_head" == "$tag_commit" ]] || return 1
+	_release_provenance_verify "$tag_name" "$repo_slug" "$branch_name" \
+		"$_RELEASE_PROVENANCE_SCOPE_LOCAL_SOURCE" >/dev/null || return 1
+	expected_sources_json=$(_release_provenance_expected_sources "$requested_pr" "$raw_sources" \
+		"$repo_slug" "$branch_name" "$tag_commit") || return 1
+	jq -cn --argjson expected "$expected_sources_json" '{expected_sources:$expected}'
 	return $?
 }
 
@@ -608,7 +632,7 @@ main() {
 	local expected_sources=""
 
 	case "$command" in
-	verify | verify-local-source | resolve-authorization | resolve-tag-authorization | resolve-source) ;;
+	verify | verify-local-source | resolve-authorization | resolve-tag-authorization | resolve-tag-expected-sources | resolve-source) ;;
 	help | --help | -h)
 		_release_provenance_usage
 		return 0
@@ -656,6 +680,11 @@ main() {
 	if [[ "$command" == "resolve-tag-authorization" ]]; then
 		[[ -n "$tag_name" && -n "$source_pr" ]] || return 1
 		_release_provenance_resolve_tag_authorization "$tag_name" "$source_pr" "$expected_sources" "$repo_slug" "$branch_name"
+		return $?
+	fi
+	if [[ "$command" == "resolve-tag-expected-sources" ]]; then
+		[[ -n "$tag_name" && -n "$source_pr" ]] || return 1
+		_release_provenance_resolve_tag_expected_sources "$tag_name" "$source_pr" "$expected_sources" "$repo_slug" "$branch_name"
 		return $?
 	fi
 	if [[ "$command" == "resolve-source" ]]; then

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -217,6 +217,13 @@ printf 'PASS signed tag trailers reconstruct release provenance\n'
 		exit 1
 	fi
 	cmp -s "$gap_path" "${TEST_ROOT}/gap-evidence-original.json"
+	gap_observed="$gap_expected"
+	if _full_loop_release_record_authorization_gap test/repo 29010 v3.32.200 "$gap_expected" \
+		'no authorization mismatch' >/dev/null 2>&1; then
+		printf 'FAIL matching authorization manifests wrote gap evidence\n'
+		exit 1
+	fi
+	cmp -s "$gap_path" "${TEST_ROOT}/gap-evidence-original.json"
 	[[ ! -f "${AIDEVOPS_FULL_LOOP_RECEIPT_DIR}/test_repo-29010.status" ]]
 )
 printf 'PASS historical authorization gaps use idempotent detached production evidence\n'

--- a/.agents/scripts/tests/test-release-provenance-helper.sh
+++ b/.agents/scripts/tests/test-release-provenance-helper.sh
@@ -331,6 +331,30 @@ if (
 	exit 1
 fi
 printf 'PASS immutable-tag authorization rejects incomplete persisted source sets\n'
+gap_expected_json=$(
+	cd "$AGG_REPO" || exit 1
+	PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
+		bash "$HELPER" resolve-tag-expected-sources --tag v2.0.0 --source-pr 42 --repo test/aggregate \
+		--expected-sources 42@"$AGG_ORIGINAL",43@"$AGG_SECOND",44@"$AGG_THIRD"
+)
+jq -e --arg original "$AGG_ORIGINAL" --arg second "$AGG_SECOND" --arg third "$AGG_THIRD" '
+	.expected_sources == [
+		{pr:42,merge:$original},
+		{pr:43,merge:$second},
+		{pr:44,merge:$third}
+	]
+' <<<"$gap_expected_json" >/dev/null
+printf 'PASS immutable-tag expected sources validate independently of the signed aggregate manifest\n'
+if (
+	cd "$AGG_REPO" || exit 1
+	PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
+		bash "$HELPER" resolve-tag-expected-sources --tag v2.0.0 --source-pr 42 --repo test/aggregate \
+		--expected-sources 42@0000000000000000000000000000000000000000
+) >/dev/null 2>&1; then
+	printf 'FAIL immutable-tag expected-source validation accepted a mismatched merge SHA\n'
+	exit 1
+fi
+printf 'PASS immutable-tag expected-source validation rejects a mismatched merge SHA\n'
 (
 	cd "$AGG_REPO" || exit 1
 	PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \


### PR DESCRIPTION
## Summary

Validate trusted expected PR@SHA sources against immutable tag ancestry independently of the signed observed manifest before recording authorization-gap evidence.

## Files Changed

.agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/release-provenance-helper.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh, .agents/scripts/tests/test-release-provenance-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with isolated immutable-tag Git and GitHub API fixture runs: bash .agents/scripts/tests/test-full-loop-release-reconcile.sh; bash .agents/scripts/tests/test-release-provenance-helper.sh; bash .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh; bash .agents/scripts/tests/test-full-loop-release-helper.sh; shellcheck changed shell files

Resolves #31183


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 7m and 93,513 tokens on this as a headless worker.