### PR TITLE
GH#31184: apply compatible GitHub Actions updates

### DIFF
--- a/.github/workflows/code-review-monitoring.yml
+++ b/.github/workflows/code-review-monitoring.yml
@@ -124,7 +124,7 @@ jobs:
     
     - name: 📤 Upload SARIF Results
       if: always() && hashFiles('codacy-results.sarif') != ''
-      uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+      uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
       with:
         sarif_file: codacy-results.sarif
         category: codacy

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -75,7 +75,7 @@ jobs:
             --archive "$RUNNER_TEMP/aidevops-${EXPECTED_VERSION}.tgz"
 
       - name: Upload verified candidate
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-candidate-${{ inputs.candidate_commit }}
           path: |


### PR DESCRIPTION
## Summary

Updated the approved CodeQL SARIF upload and release-candidate artifact upload action pins without changing any Qlty installer reference.

## Files Changed

.github/workflows/code-review-monitoring.yml, .github/workflows/release-candidate.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Changed-file linters, actionlint, git diff --check, code-review workflow tests, and release-publication workflow tests pass; exact diff matches the two retained changes from PR #31019; upload-artifact v7.0.1 declares Node 24 and the release-candidate job uses GitHub-hosted ubuntu-latest.

Resolves #31184


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 4m and 55,298 tokens on this with the user in an interactive session.