### PR TITLE
GH#31187: accelerate recovery archive classification

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -187,12 +187,9 @@ an exact ignored and untracked approved directory with no symlink component,
 tracked path, or hard-linked regular file. A bounded manifest records its
 device/inode identity and allocated bytes; uncertainty, deadline exhaustion,
 Git output beyond the fixed capture ceiling, or drift preserves the root.
-Ordinary recovery planning still short-circuits after proving the archive dirty.
-Automatic maintenance explicitly completes the downstream evidence for that
-state, and cache apply repeats the same complete snapshot before mutation. The
-terminal commit evidence must come from the exact merged pull request whose head
-OID matches the archive, not only a branch-name match. Approved-root sizing runs
-only after the archive satisfies this cache-retrofit eligibility predicate.
+Ordinary recovery planning short-circuits once dirty; automatic maintenance completes
+downstream evidence, and cache apply repeats the snapshot. Terminal commit evidence
+must match the exact merged PR head OID, not only its branch; root sizing waits until eligible.
 
 After reviewing a v2 plan, an operator may run:
 

--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -187,6 +187,12 @@ an exact ignored and untracked approved directory with no symlink component,
 tracked path, or hard-linked regular file. A bounded manifest records its
 device/inode identity and allocated bytes; uncertainty, deadline exhaustion,
 Git output beyond the fixed capture ceiling, or drift preserves the root.
+Ordinary recovery planning still short-circuits after proving the archive dirty.
+Automatic maintenance explicitly completes the downstream evidence for that
+state, and cache apply repeats the same complete snapshot before mutation. The
+terminal commit evidence must come from the exact merged pull request whose head
+OID matches the archive, not only a branch-name match. Approved-root sizing runs
+only after the archive satisfies this cache-retrofit eligibility predicate.
 
 After reviewing a v2 plan, an operator may run:
 
@@ -252,9 +258,10 @@ then validates and classifies at most 50 rotating inventory entries inside a
 per-archive Git validation is limited to that cursor window and bounded by the
 same deadline. Both the initial size probe and its mandatory drift-detection
 remeasurement use the remaining pass budget rather than the shorter global
-reporting timeout. A persistent cursor advances after a deadline stop so large
-inventories cannot starve later entries. Operators may tune these soft limits
-with:
+reporting timeout. Final exact archive sizing is candidate-only; protected and
+unknown entries retain their existing inventory observation without that probe.
+A persistent cursor advances after a deadline stop so large inventories cannot
+starve later entries. Operators may tune these soft limits with:
 
 - `AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_RETENTION_DAYS`
 - `AIDEVOPS_WORKTREE_RECOVERY_MAINTENANCE_MAX_SCAN`

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -202,6 +202,20 @@ PY
 	return $?
 }
 
+_worktree_proc_entry_is_zombie() {
+	local proc_dir="$1"
+	local field=""
+	local state=""
+
+	[[ -r "$proc_dir/status" ]] || return 1
+	while IFS=$' \t' read -r field state _; do
+		[[ "$field" == "State:" ]] || continue
+		[[ "$state" == Z* ]]
+		return $?
+	done <"$proc_dir/status"
+	return 1
+}
+
 _worktree_proc_entry_is_known_non_worktree_daemon() {
 	local proc_dir="$1"
 	local proc_name=""
@@ -246,6 +260,7 @@ _capture_worktree_proc_cwds() {
 			# Unknown same-user processes still degrade visibility fail-closed.
 			[[ -L "$cwd_link" || -e "$cwd_link" ]] || continue
 			proc_dir="${cwd_link%/cwd}"
+			_worktree_proc_entry_is_zombie "$proc_dir" && continue
 			_worktree_proc_entry_is_provably_foreign_uid "$proc_dir" "$current_uid" && continue
 			_worktree_proc_entry_is_known_non_worktree_daemon "$proc_dir" && continue
 			visibility_degraded=1

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -529,6 +529,104 @@ test_classification_fails_closed() {
 	return 0
 }
 
+test_recovery_issue_attribution_uses_archived_source_path() {
+	local issue="" status=0
+	local rc=0
+
+	issue=$(_worktree_recovery_plan_identity_issue_number \
+		"refs/heads/feature/auto-20260830-155046" \
+		"/worktrees/project-pr2641-review-feature-auto-20260830-155046") || rc=1
+	[[ "$issue" == "2641" ]] || rc=1
+	issue=$(_worktree_recovery_plan_identity_issue_number \
+		"refs/heads/feature/auto-20260830-155046-gh2641" \
+		"/worktrees/project-pr2641-review") || rc=1
+	[[ "$issue" == "2641" ]] || rc=1
+	status=0
+	_worktree_recovery_plan_identity_issue_number \
+		"refs/heads/feature/auto-20260830-155046-gh2641" \
+		"/worktrees/project-pr2642-review" >/dev/null 2>&1 || status=$?
+	[[ "$status" -eq 2 ]] || rc=1
+	print_result "recovery_issue_attribution_uses_archived_source_path" "$rc" \
+		"Expected archived PR worktree names to supply missing task identity while conflicts fail closed"
+	return 0
+}
+
+test_unlinked_merged_pr_is_terminal_task_evidence() {
+	local identity="" evidence=""
+	local rc=0
+
+	identity=$(jq -cn \
+		'{archive_path:"/recovery/archive",source_path:"/worktrees/project-auto-20260830",
+		branch:"refs/heads/feature/auto-20260830",head:"abc123"}') || rc=1
+	evidence=$(
+		_worktree_recovery_plan_repo_slug() {
+			local ignored_archive="$1"
+			: "$ignored_archive"
+			printf '%s\n' "example/repo"
+			return 0
+		}
+		gh() {
+			local resource="$1"
+			if [[ "$resource" == "pr" ]]; then
+				printf '%s\n' '[{"state":"MERGED","mergedAt":"2026-09-01T00:00:00Z","headRefOid":"abc123"}]'
+				return 0
+			fi
+			return 1
+		}
+		_worktree_recovery_plan_external_evidence_json "$identity"
+	) || rc=1
+	printf '%s\n' "$evidence" | jq -e \
+		'.commit == "merged" and .open_pr == "clear" and .task == "closed" and .issue_number == null' \
+		>/dev/null || rc=1
+	print_result "unlinked_merged_pr_is_terminal_task_evidence" "$rc" \
+		"Expected an exact merged PR to provide terminal task evidence without a branch-encoded issue"
+	return 0
+}
+
+test_dirty_recovery_short_circuits_expensive_probes() {
+	local bucket_path="${TEST_DIR}/dirty-short-circuit"
+	local probe_path="${TEST_DIR}/dirty-short-circuit-probe"
+	local entry=""
+	local rc=0
+
+	mkdir -p "$bucket_path" || rc=1
+	entry=$(
+		_worktree_recovery_plan_identity_json() {
+			local ignored_bucket="$1"
+			: "$ignored_bucket"
+			jq -cn --arg bucket "$bucket_path" \
+				'{bucket_path:$bucket,archive_path:($bucket + "/archive"),source_path:"/worktrees/source",
+				source_removal_outcome:"removed",branch:"refs/heads/feature/auto-20260830",head:"abc123"}'
+			return $?
+		}
+		_worktree_recovery_plan_git_state() {
+			local ignored_identity="$1"
+			: "$ignored_identity"
+			printf '%s\n' "dirty"
+			return 0
+		}
+		_worktree_recovery_plan_worktree_reference_state() {
+			local ignored_identity="$1"
+			: "$ignored_identity"
+			printf 'called\n' >"$probe_path"
+			return 1
+		}
+		_worktree_recovery_measure_path() {
+			local ignored_path="$1"
+			: "$ignored_path"
+			printf 'called\n' >"$probe_path"
+			return 1
+		}
+		_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" 1024
+	) || rc=1
+	[[ "$(printf '%s\n' "$entry" | jq -r '.disposition')" == "protected" ]] || rc=1
+	[[ "$(printf '%s\n' "$entry" | jq -r '.reasons[0]')" == "archive-worktree-dirty" ]] || rc=1
+	[[ ! -e "$probe_path" ]] || rc=1
+	print_result "dirty_recovery_short_circuits_expensive_probes" "$rc" \
+		"Expected dirty archives to remain protected without unrelated local, remote, or size probes"
+	return 0
+}
+
 test_plan_records_malformed_bucket_unknown() {
 	local home_path="${TEST_DIR}/malformed-home"
 	local recovery_root="${home_path}/recovery"
@@ -2263,6 +2361,9 @@ run_all_tests() {
 	test_archive_prunes_only_regenerable_ignored_caches
 	test_archive_pruning_preserves_tracked_codegraph_root
 	test_claim_state_uses_archive_repository
+	test_recovery_issue_attribution_uses_archived_source_path
+	test_unlinked_merged_pr_is_terminal_task_evidence
+	test_dirty_recovery_short_circuits_expensive_probes
 	test_exact_plan_writes_candidate_without_mutation
 	test_plan_output_refuses_unsafe_targets
 	test_classification_fails_closed

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -627,6 +627,50 @@ test_dirty_recovery_short_circuits_expensive_probes() {
 	return 0
 }
 
+test_active_claim_short_circuits_later_probes() {
+	local bucket_path="${TEST_DIR}/active-claim-short-circuit"
+	local probe_path="${TEST_DIR}/active-claim-short-circuit-probe"
+	local entry=""
+	local rc=0
+
+	mkdir -p "$bucket_path" || rc=1
+	entry=$(
+		_worktree_recovery_plan_identity_json() {
+			local ignored_bucket="$1"
+			: "$ignored_bucket"
+			jq -cn --arg bucket "$bucket_path" \
+				'{bucket_path:$bucket,archive_path:($bucket + "/archive"),source_path:"/worktrees/source",
+				source_removal_outcome:"removed",branch:"refs/heads/feature/auto-20260830",head:"abc123"}'
+			return $?
+		}
+		_worktree_recovery_plan_git_state() { printf 'clear\n'; return 0; }
+		_worktree_recovery_plan_worktree_reference_state() { printf 'clear\n'; return 0; }
+		_worktree_recovery_plan_registry_state() { printf 'clear\n'; return 0; }
+		_worktree_recovery_plan_claim_state() { printf 'active\n'; return 0; }
+		_worktree_recovery_plan_process_state() {
+			printf 'called\n' >"$probe_path"
+			return 1
+		}
+		_worktree_recovery_plan_external_evidence_json() {
+			printf 'called\n' >"$probe_path"
+			return 1
+		}
+		_worktree_recovery_measure_path() {
+			local ignored_path="$1"
+			: "$ignored_path"
+			printf 'called\n' >"$probe_path"
+			return 1
+		}
+		_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" 1024
+	) || rc=1
+	[[ "$(printf '%s\n' "$entry" | jq -r '.disposition')" == "protected" ]] || rc=1
+	[[ "$(printf '%s\n' "$entry" | jq -r '.reasons[0]')" == "active-session-claim" ]] || rc=1
+	[[ ! -e "$probe_path" ]] || rc=1
+	print_result "active_claim_short_circuits_later_probes" "$rc" \
+		"Expected an active claim to protect its archive without process, remote, or size probes"
+	return 0
+}
+
 test_plan_records_malformed_bucket_unknown() {
 	local home_path="${TEST_DIR}/malformed-home"
 	local recovery_root="${home_path}/recovery"
@@ -2364,6 +2408,7 @@ run_all_tests() {
 	test_recovery_issue_attribution_uses_archived_source_path
 	test_unlinked_merged_pr_is_terminal_task_evidence
 	test_dirty_recovery_short_circuits_expensive_probes
+	test_active_claim_short_circuits_later_probes
 	test_exact_plan_writes_candidate_without_mutation
 	test_plan_output_refuses_unsafe_targets
 	test_classification_fails_closed

--- a/.agents/scripts/tests/test-worktree-removal-audit-lib.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit-lib.sh
@@ -1710,6 +1710,37 @@ test_proc_snapshot_marks_same_uid_unreadable_entry_degraded() {
 }
 
 # =============================================================================
+# Zombies have no live execution context or working directory. Their cwd link
+# can remain present while readlink returns ENOENT, so they are safe to skip.
+# =============================================================================
+test_proc_snapshot_skips_zombie_cwd_denial() {
+	local proc_root="${TEST_DIR}/fake-proc-zombie"
+	local current_uid=""
+	local output=""
+	local rc=0
+	current_uid=$(id -u)
+	mkdir -p "${proc_root}/1" "${proc_root}/2"
+	ln -s /visible-cwd "${proc_root}/1/cwd"
+	ln -s /zombie-cwd "${proc_root}/2/cwd"
+	printf 'State:\tZ (zombie)\nUid:\t%s\t%s\t%s\t%s\n' \
+		"$current_uid" "$current_uid" "$current_uid" "$current_uid" >"${proc_root}/2/status"
+
+	output=$(
+		readlink() {
+			local link_path="$1"
+			[[ "$link_path" == */1/cwd ]] || return 1
+			printf '/visible-cwd\n'
+			return 0
+		}
+		_capture_worktree_proc_cwds "$proc_root"
+	) || rc=1
+	[[ "$output" == "/visible-cwd" ]] || rc=1
+	print_result "proc_snapshot_skips_zombie_cwd_denial" "$rc" \
+		"Expected a proven zombie process to be skipped without degrading visible CWD evidence"
+	return 0
+}
+
+# =============================================================================
 # Same-UID hardened login daemons can deny cwd reads indefinitely. They are not
 # worktree-scoped jobs, so they must not globally degrade every cleanup scan.
 # =============================================================================
@@ -1992,6 +2023,7 @@ test_proc_snapshot_preserves_degraded_visibility
 test_proc_snapshot_skips_foreign_uid_unreadable_entry
 test_proc_snapshot_skips_foreign_uid_when_status_unreadable
 test_proc_snapshot_marks_same_uid_unreadable_entry_degraded
+test_proc_snapshot_skips_zombie_cwd_denial
 test_proc_snapshot_skips_known_same_uid_daemon_denial
 test_degraded_visibility_preserves_positive_candidate_match
 test_proc_snapshot_requires_usable_evidence_after_foreign_skips

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -1495,7 +1495,7 @@ _worktree_recovery_cache_validate_mutable_evidence() {
 	[[ "$current_identity" == "$expected_identity" ]] || return 1
 	current_evidence=$(AIDEVOPS_WORKTREE_RECOVERY_EVIDENCE_DEADLINE_EPOCH="$deadline_epoch" \
 		_worktree_recovery_apply_run_function_before_epoch "$deadline_epoch" \
-		_worktree_recovery_plan_evidence_json "$current_identity") || return 1
+		_worktree_recovery_plan_evidence_json "$current_identity" true) || return 1
 	current_evidence=$(printf '%s\n' "$current_evidence" | jq -cS '.') || return 1
 	[[ "$current_evidence" == "$expected_evidence" ]] || return 1
 	return 0

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -773,13 +773,18 @@ _worktree_recovery_plan_partial_evidence_json() {
 
 _worktree_recovery_plan_evidence_json() {
 	local identity_json="$1"
+	local complete_dirty_evidence="${2:-false}"
 	local git_state="" worktree_state="" registry_state="" claim_state=""
 	local process_state="" external_json=""
 
+	[[ "$complete_dirty_evidence" == true || "$complete_dirty_evidence" == false ]] || return 1
 	git_state=$(_worktree_recovery_plan_git_state "$identity_json") || return 1
 	if [[ "$git_state" != "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ]]; then
-		_worktree_recovery_plan_partial_evidence_json "$git_state"
-		return $?
+		if [[ "$git_state" != "$WORKTREE_RECOVERY_PLAN_STATE_DIRTY" ||
+			"$complete_dirty_evidence" != true ]]; then
+			_worktree_recovery_plan_partial_evidence_json "$git_state"
+			return $?
+		fi
 	fi
 	worktree_state=$(_worktree_recovery_plan_worktree_reference_state "$identity_json") || return 1
 	if [[ "$worktree_state" != "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ]]; then
@@ -862,12 +867,14 @@ _worktree_recovery_plan_attributed_entry_json() {
 	local bucket_path="$2"
 	local expected_bytes="$3"
 	local measurement_timeout_tenths="${4:-}"
+	local complete_dirty_evidence="${5:-false}"
 	local identity_before="" identity_after="" evidence_json="" measured_after=""
 	local bytes_after="" confidence_after="" measure_error_after="" stable=false
 	local classification_json="" disposition="" sizing_reason="sizing-unavailable"
 
 	identity_before=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
-	evidence_json=$(_worktree_recovery_plan_evidence_json "$identity_before") || return 1
+	evidence_json=$(_worktree_recovery_plan_evidence_json \
+		"$identity_before" "$complete_dirty_evidence") || return 1
 	identity_after=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
 	if [[ "$identity_before" == "$identity_after" ]]; then
 		stable=true

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -15,6 +15,7 @@ WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED="protected"
 WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN="unknown"
 WORKTREE_RECOVERY_PLAN_STATE_ACTIVE="active"
 WORKTREE_RECOVERY_PLAN_STATE_CLEAR="clear"
+WORKTREE_RECOVERY_PLAN_STATE_DIRTY="dirty"
 WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT="exact"
 WORKTREE_RECOVERY_PLAN_JSON_NULL="null"
 WORKTREE_RECOVERY_PRODUCER="worktree-helper"
@@ -658,14 +659,39 @@ _worktree_recovery_plan_repo_slug() {
 }
 
 _worktree_recovery_plan_issue_number() {
-	local branch="$1"
-	branch="${branch#refs/heads/}"
-	if [[ "$branch" =~ gh[-]?([0-9]+) ]]; then
-		printf '%s\n' "${BASH_REMATCH[1]}"
+	local reference="$1"
+	reference="${reference#refs/heads/}"
+	if [[ "$reference" =~ (^|[/_-])gh[-]?([0-9]+)([/_-]|$) ]]; then
+		printf '%s\n' "${BASH_REMATCH[2]}"
 		return 0
 	fi
-	if [[ "$branch" =~ (^|/)fix/([0-9]{3,})([-/]|$) ]]; then
+	if [[ "$reference" =~ (^|[/_-])pr[-]?([0-9]+)([/_-]|$) ]]; then
 		printf '%s\n' "${BASH_REMATCH[2]}"
+		return 0
+	fi
+	if [[ "$reference" =~ (^|/)fix/([0-9]{3,})([-/]|$) ]]; then
+		printf '%s\n' "${BASH_REMATCH[2]}"
+		return 0
+	fi
+	return 1
+}
+
+_worktree_recovery_plan_identity_issue_number() {
+	local branch="$1"
+	local source_path="$2"
+	local branch_issue="" source_issue=""
+
+	branch_issue=$(_worktree_recovery_plan_issue_number "$branch" 2>/dev/null || true)
+	source_issue=$(_worktree_recovery_plan_issue_number "${source_path##*/}" 2>/dev/null || true)
+	if [[ -n "$branch_issue" && -n "$source_issue" && "$branch_issue" != "$source_issue" ]]; then
+		return 2
+	fi
+	if [[ -n "$branch_issue" ]]; then
+		printf '%s\n' "$branch_issue"
+		return 0
+	fi
+	if [[ -n "$source_issue" ]]; then
+		printf '%s\n' "$source_issue"
 		return 0
 	fi
 	return 1
@@ -673,12 +699,13 @@ _worktree_recovery_plan_issue_number() {
 
 _worktree_recovery_plan_external_evidence_json() {
 	local identity_json="$1"
-	local archive_path="" branch_name="" head="" repo_slug=""
+	local archive_path="" source_path="" branch_name="" head="" repo_slug=""
 	local branch=""
 	local issue_number="" pr_json="" issue_state="" issue_state_normalized=""
-	local open_count="" merged_count=""
+	local open_count="" merged_count="" issue_number_status=0
 
 	archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
+	source_path=$(printf '%s\n' "$identity_json" | jq -r '.source_path') || return 1
 	branch=$(printf '%s\n' "$identity_json" | jq -r '.branch') || return 1
 	head=$(printf '%s\n' "$identity_json" | jq -r '.head') || return 1
 	branch_name="${branch#refs/heads/}"
@@ -687,7 +714,13 @@ _worktree_recovery_plan_external_evidence_json() {
 			'{commit:$unavailable,open_pr:$unavailable,task:$unavailable,issue_number:null,repo:null}'
 		return 0
 	}
-	issue_number=$(_worktree_recovery_plan_issue_number "$branch" 2>/dev/null || true)
+	issue_number=$(_worktree_recovery_plan_identity_issue_number \
+		"$branch" "$source_path" 2>/dev/null) || issue_number_status=$?
+	if [[ "$issue_number_status" -eq 2 ]]; then
+		jq -cn --arg repo "$repo_slug" --arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
+			'{commit:$unavailable,open_pr:$unavailable,task:$unavailable,issue_number:null,repo:$repo}'
+		return 0
+	fi
 	if ! command -v gh >/dev/null 2>&1; then
 		jq -cn --arg repo "$repo_slug" --arg issue "$issue_number" \
 			--arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
@@ -708,6 +741,8 @@ _worktree_recovery_plan_external_evidence_json() {
 	if [[ -n "$issue_number" ]]; then
 		issue_state=$(gh issue view "$issue_number" --repo "$repo_slug" \
 			--json state --jq '.state // empty' 2>/dev/null) || issue_state="$WORKTREE_RECOVERY_UNAVAILABLE"
+	elif [[ "$merged_count" -gt 0 ]]; then
+		issue_state="closed"
 	else
 		issue_state="unlinked"
 	fi
@@ -720,12 +755,26 @@ _worktree_recovery_plan_external_evidence_json() {
 	return $?
 }
 
+_worktree_recovery_plan_minimal_evidence_json() {
+	local git_state="$1"
+
+	jq -cn --arg git "$git_state" --arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
+		'{git:$git,worktree:$unavailable,registry:$unavailable,claim:$unavailable,
+		process:$unavailable,external:{commit:$unavailable,open_pr:$unavailable,
+		task:$unavailable,issue_number:null,repo:null}}'
+	return $?
+}
+
 _worktree_recovery_plan_evidence_json() {
 	local identity_json="$1"
 	local git_state="" worktree_state="" registry_state="" claim_state=""
 	local process_state="" external_json=""
 
 	git_state=$(_worktree_recovery_plan_git_state "$identity_json") || return 1
+	if [[ "$git_state" == "$WORKTREE_RECOVERY_PLAN_STATE_DIRTY" ]]; then
+		_worktree_recovery_plan_minimal_evidence_json "$git_state"
+		return $?
+	fi
 	worktree_state=$(_worktree_recovery_plan_worktree_reference_state "$identity_json") || return 1
 	registry_state=$(_worktree_recovery_plan_registry_state "$identity_json") || return 1
 	claim_state=$(_worktree_recovery_plan_claim_state "$identity_json") || return 1
@@ -758,11 +807,12 @@ _worktree_recovery_plan_classification_json() {
 		--arg unknown "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
 		--arg active "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE" \
 		--arg clear "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" \
+		--arg dirty "$WORKTREE_RECOVERY_PLAN_STATE_DIRTY" \
 		--arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
 		--argjson identity "$identity_json" --argjson evidence "$evidence_json" \
 		--argjson stable "$stable" '
 		if $stable != true then {disposition:$unknown,reasons:["identity-or-size-changed"]}
-		elif $evidence.git == "dirty" then {disposition:$protected,reasons:["archive-worktree-dirty"]}
+		elif $evidence.git == $dirty then {disposition:$protected,reasons:["archive-worktree-dirty"]}
 		elif $evidence.worktree == $active then {disposition:$protected,reasons:["active-git-worktree-reference"]}
 		elif $evidence.registry == $active then {disposition:$protected,reasons:["active-registry-owner"]}
 		elif $evidence.claim == $active then {disposition:$protected,reasons:["active-session-claim"]}
@@ -789,11 +839,24 @@ _worktree_recovery_plan_attributed_entry_json() {
 	local measurement_timeout_tenths="${4:-}"
 	local identity_before="" identity_after="" evidence_json="" measured_after=""
 	local bytes_after="" confidence_after="" measure_error_after="" stable=false
-	local classification_json="" sizing_reason="sizing-unavailable"
+	local classification_json="" disposition="" sizing_reason="sizing-unavailable"
 
 	identity_before=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
 	evidence_json=$(_worktree_recovery_plan_evidence_json "$identity_before") || return 1
 	identity_after=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
+	if [[ "$identity_before" == "$identity_after" ]]; then
+		stable=true
+	fi
+	classification_json=$(_worktree_recovery_plan_classification_json \
+		"$identity_after" "$evidence_json" "$stable") || return 1
+	disposition=$(printf '%s\n' "$classification_json" | jq -r '.disposition') || return 1
+	if [[ "$disposition" != "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" ]]; then
+		jq -cn --arg role "$role" --argjson bytes "$expected_bytes" \
+			--argjson identity "$identity_after" --argjson evidence "$evidence_json" \
+			--argjson classification "$classification_json" \
+			'{role:$role,path:$identity.bucket_path,archive_path:$identity.archive_path,expected_allocated_bytes:$bytes,identity:$identity,evidence:$evidence,disposition:$classification.disposition,reasons:$classification.reasons}'
+		return $?
+	fi
 	if [[ -n "$measurement_timeout_tenths" ]]; then
 		measured_after=$(_worktree_recovery_measure_path \
 			"$bucket_path" "$measurement_timeout_tenths") || return 1
@@ -811,9 +874,7 @@ _worktree_recovery_plan_attributed_entry_json() {
 	if [[ "$expected_bytes" == "$WORKTREE_RECOVERY_PLAN_JSON_NULL" ]]; then
 		expected_bytes="$bytes_after"
 	fi
-	if [[ "$identity_before" == "$identity_after" && "$bytes_after" == "$expected_bytes" ]]; then
-		stable=true
-	fi
+	[[ "$identity_before" == "$identity_after" && "$bytes_after" == "$expected_bytes" ]] || stable=false
 	classification_json=$(_worktree_recovery_plan_classification_json \
 		"$identity_after" "$evidence_json" "$stable") || return 1
 	jq -cn --arg role "$role" --argjson bytes "$expected_bytes" \
@@ -926,7 +987,7 @@ _worktree_recovery_plan_entries_json() {
 					classified_count=$((classified_count + 1))
 					if [[ "$state" == "attributed" || "$state" == "attributed-legacy" ]]; then
 						if ! entry_json=$(_worktree_recovery_plan_attributed_entry_json \
-							"$role" "$bucket_path" "$WORKTREE_RECOVERY_PLAN_JSON_NULL"); then
+							"$role" "$bucket_path" "$bytes"); then
 							entry_json=$(_worktree_recovery_plan_unknown_entry_json \
 								"$role" "$bucket_path" "$bytes" "classification-unavailable") || result_status=1
 						fi

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -755,12 +755,18 @@ _worktree_recovery_plan_external_evidence_json() {
 	return $?
 }
 
-_worktree_recovery_plan_minimal_evidence_json() {
+_worktree_recovery_plan_partial_evidence_json() {
 	local git_state="$1"
+	local worktree_state="${2:-$WORKTREE_RECOVERY_UNAVAILABLE}"
+	local registry_state="${3:-$WORKTREE_RECOVERY_UNAVAILABLE}"
+	local claim_state="${4:-$WORKTREE_RECOVERY_UNAVAILABLE}"
+	local process_state="${5:-$WORKTREE_RECOVERY_UNAVAILABLE}"
 
-	jq -cn --arg git "$git_state" --arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
-		'{git:$git,worktree:$unavailable,registry:$unavailable,claim:$unavailable,
-		process:$unavailable,external:{commit:$unavailable,open_pr:$unavailable,
+	jq -cn --arg git "$git_state" --arg worktree "$worktree_state" \
+		--arg registry "$registry_state" --arg claim "$claim_state" \
+		--arg process "$process_state" --arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
+		'{git:$git,worktree:$worktree,registry:$registry,claim:$claim,
+		process:$process,external:{commit:$unavailable,open_pr:$unavailable,
 		task:$unavailable,issue_number:null,repo:null}}'
 	return $?
 }
@@ -771,14 +777,33 @@ _worktree_recovery_plan_evidence_json() {
 	local process_state="" external_json=""
 
 	git_state=$(_worktree_recovery_plan_git_state "$identity_json") || return 1
-	if [[ "$git_state" == "$WORKTREE_RECOVERY_PLAN_STATE_DIRTY" ]]; then
-		_worktree_recovery_plan_minimal_evidence_json "$git_state"
+	if [[ "$git_state" != "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ]]; then
+		_worktree_recovery_plan_partial_evidence_json "$git_state"
 		return $?
 	fi
 	worktree_state=$(_worktree_recovery_plan_worktree_reference_state "$identity_json") || return 1
+	if [[ "$worktree_state" != "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ]]; then
+		_worktree_recovery_plan_partial_evidence_json "$git_state" "$worktree_state"
+		return $?
+	fi
 	registry_state=$(_worktree_recovery_plan_registry_state "$identity_json") || return 1
+	if [[ "$registry_state" != "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ]]; then
+		_worktree_recovery_plan_partial_evidence_json \
+			"$git_state" "$worktree_state" "$registry_state"
+		return $?
+	fi
 	claim_state=$(_worktree_recovery_plan_claim_state "$identity_json") || return 1
+	if [[ "$claim_state" != "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ]]; then
+		_worktree_recovery_plan_partial_evidence_json \
+			"$git_state" "$worktree_state" "$registry_state" "$claim_state"
+		return $?
+	fi
 	process_state=$(_worktree_recovery_plan_process_state "$identity_json") || return 1
+	if [[ "$process_state" != "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ]]; then
+		_worktree_recovery_plan_partial_evidence_json \
+			"$git_state" "$worktree_state" "$registry_state" "$claim_state" "$process_state"
+		return $?
+	fi
 	external_json=$(_worktree_recovery_plan_external_evidence_json "$identity_json") || return 1
 	printf '%s\n' "$external_json" | jq -e \
 		--arg clear "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" \

--- a/.agents/scripts/worktree-recovery-maintenance-helper.sh
+++ b/.agents/scripts/worktree-recovery-maintenance-helper.sh
@@ -629,7 +629,7 @@ _worktree_recovery_maintenance_attributed_entry_before_epoch() {
 	[[ "$remaining_seconds" -gt 0 ]] || return 124
 	_worktree_recovery_maintenance_run_function_before_epoch "$deadline_epoch" \
 		_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" "$bytes" \
-		"$((remaining_seconds * 10))"
+		"$((remaining_seconds * 10))" true
 	return $?
 }
 


### PR DESCRIPTION
## Summary

- derive missing task identity from archived source worktree names and fail closed when branch/source identifiers conflict
- accept an exact merged pull request as terminal task evidence for archives without a linked issue
- stop ordinary recovery planning after decisive local protected/unavailable evidence and remeasure only potential deletion candidates
- let automatic maintenance complete dirty mixed-archive evidence for cache retrofit while cache apply repeats the same exact evidence snapshot before mutation
- ignore only process entries proven to be zombies, which have no live CWD, while retaining fail-closed handling for other unreadable processes
- document candidate-only sizing and exact merged-PR head evidence

## Maintainer repair

The reviewed head short-circuited all dirty archives before automatic maintenance could collect the clear worktree, registry, claim, process, task, pull-request, and exact-commit evidence required by the existing cache-retrofit selector. The repair adds an internal opt-in used only by maintenance classification and cache apply revalidation. Default/manual planning retains the performance short-circuit.

## Attribution and replacement

This replaces PR #31154 after a maintainer branch refresh exposed an unrelated base-history false positive in the task-ID collision gate. David Stone's three original commits and authorship are preserved unchanged on this clean branch; the maintainer repair is layered on top.

## Testing

- recovery lifecycle regression suite: 48 run, 0 failed, including `dirty_recovery_short_circuits_expensive_probes` and `cache_retrofit_prunes_mixed_archive_and_accounts_bytes`
- ShellCheck: all six changed shell files pass with zero findings
- `.agents/scripts/linters-local.sh --changed`: passed
- `git diff --check`: passed

## Runtime evidence

A bounded plan against 1,451 local recovery archives improved from 181 to 447 classified entries per 600-second window after decisive local-evidence short-circuiting (about 2.5x). Root-assisted diagnostics then proved the remaining unreadable CWD entries were zombies. After the zombie fix, a guarded read-only plan identified 65 exact candidates totalling 4,572,377,088 bytes; no archive was deleted.

Resolves #31187

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 plugin for [OpenCode](https://opencode.ai) v1.18.27 with gpt-5.6-sol spent 55m and 582,023 tokens on this with the user in an interactive session.