### PR TITLE
GH#31191: fix: classify GitHub API deletions

### DIFF
--- a/.agents/scripts/tests/test-verify-operation-classification.sh
+++ b/.agents/scripts/tests/test-verify-operation-classification.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#31191: classify GitHub REST DELETE commands by
+# endpoint risk while preserving standard classification for read-only calls.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="${REPO_ROOT}/.agents/scripts/verify-operation-helper.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+	printf 'FAIL: cannot execute %s\n' "$HELPER" >&2
+	exit 1
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_classification() {
+	local name="$1"
+	local operation="$2"
+	local expected_type="$3"
+	local expected_tier="$4"
+	local output
+	output=$("$HELPER" check --operation "$operation")
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$output" == *"type: ${expected_type}"* && "$output" == *"risk_tier: ${expected_tier}"* ]]; then
+		printf 'PASS: %s\n' "$name"
+		return 0
+	fi
+
+	printf 'FAIL: %s\n%s\n' "$name" "$output" >&2
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 1
+}
+
+assert_classification \
+	'long --method issue-comment deletion is critical' \
+	'gh api --method DELETE repos/owner/repo/issues/comments/5543339491' \
+	'destructive_delete' 'critical' || true
+assert_classification \
+	'short -X issue-comment deletion is critical' \
+	'gh api -X DELETE repos/owner/repo/issues/comments/5543339491' \
+	'destructive_delete' 'critical' || true
+assert_classification \
+	'endpoint before method flag remains critical' \
+	'gh api "repos/owner/repo/issues/comments/5543339491" --method DELETE' \
+	'destructive_delete' 'critical' || true
+assert_classification \
+	'quoted endpoint remains critical' \
+	"gh api --method DELETE 'repos/owner/repo/issues/comments/5543339491'" \
+	'destructive_delete' 'critical' || true
+assert_classification \
+	'other DELETE endpoints are high risk' \
+	'gh api --method DELETE repos/owner/repo/issues/31191' \
+	'github_api_delete' 'high' || true
+assert_classification \
+	'read-only GitHub API call remains standard' \
+	'gh api repos/owner/repo/issues/comments/5543339491' \
+	'unknown' 'standard' || true
+
+printf '%s tests run, %s failures\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/verify-operation-helper.sh
+++ b/.agents/scripts/verify-operation-helper.sh
@@ -186,12 +186,43 @@ readonly -a RISK_PATTERNS=(
 	"chown|permission_change|high"
 )
 
+# Classify GitHub REST API deletion commands that need endpoint-aware handling.
+# Arguments: $1 — operation string
+# Output: "type|tier" when the operation is a GitHub API DELETE
+# Returns: 0 when classified, 1 when the operation is not a GitHub API DELETE
+_classify_github_api_delete() {
+	local operation="$1"
+
+	if ! printf '%s\n' "$operation" | grep -qiE '(^|[[:space:]])gh[[:space:]]+api([[:space:]]|$)'; then
+		return 1
+	fi
+
+	if ! printf '%s\n' "$operation" | grep -qiE '(^|[[:space:]])(--method|-X)[[:space:]]+DELETE([[:space:]]|$)'; then
+		return 1
+	fi
+
+	# Deleting an issue comment is irreversible; other DELETE endpoints remain
+	# high risk until their reversibility is explicitly understood and tested.
+	if printf '%s\n' "$operation" | grep -qE "(^|[[:space:]/\\\"'])issues/comments/[0-9]+([[:space:]\\\"']|$)"; then
+		echo "destructive_delete|critical"
+		return 0
+	fi
+
+	echo "github_api_delete|high"
+	return 0
+}
+
 # Classify an operation string into a risk tier.
 # Arguments: $1 — operation string
 # Output: "type|tier" on stdout (e.g., "git_force_push|critical")
 classify_operation() {
 	local operation="$1"
-	local entry pattern op_type tier
+	local entry pattern op_type tier github_api_classification
+
+	if github_api_classification=$(_classify_github_api_delete "$operation"); then
+		echo "$github_api_classification"
+		return 0
+	fi
 
 	for entry in "${RISK_PATTERNS[@]}"; do
 		pattern="${entry%%|*}"


### PR DESCRIPTION
## Summary

Classified GitHub REST DELETE operations by endpoint risk, making issue-comment deletion critical and all other DELETE requests high risk.

## Files Changed

.agents/scripts/tests/test-verify-operation-classification.sh, .agents/scripts/verify-operation-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-verify-operation-classification.sh; shellcheck .agents/scripts/verify-operation-helper.sh .agents/scripts/tests/test-verify-operation-classification.sh

Resolves #31191


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 4m and 56,731 tokens on this as a headless worker.