### PR TITLE
GH#31196: Repair Codex MCP startup during setup/update

### DIFF
--- a/.agents/scripts/codex-mcp-config.py
+++ b/.agents/scripts/codex-mcp-config.py
@@ -5,21 +5,12 @@
 
 import argparse
 import copy
-import json
 import os
 from pathlib import Path
-import re
 import stat
 import tempfile
 
-try:
-    import tomllib
-except ImportError:
-    try:
-        import tomli as tomllib
-    except ImportError:
-        raise SystemExit("Codex MCP migration requires Python 3.11+ or tomli; config unchanged") from None
-
+from lib.codex_mcp_toml import render, tomllib
 
 DEFAULTS = {
     "context7": {"command": "npx", "args": ["-y", "@upstash/context7-mcp@latest"]},
@@ -45,6 +36,55 @@ def known_package(args, package):
     return any(arg == package or arg.startswith(package + "@") for arg in args)
 
 
+def migrate_npx(name, server, messages):
+    if Path(server.get("command", "")).name not in ("npx", "npx.cmd"):
+        return
+    args = server.get("args", [])
+    if name == "playwright" and known_package(args, "@anthropic-ai/mcp-server-playwright"):
+        args = [
+            "@playwright/mcp@0.0.79"
+            if arg.startswith("@anthropic-ai/mcp-server-playwright") else arg
+            for arg in args
+        ]
+        server["args"] = args
+        messages.append("playwright: replaced nonexistent legacy npm package")
+    if name not in NPX_PACKAGES or not known_package(args, NPX_PACKAGES[name]):
+        return
+    if "-y" not in args and "--yes" not in args:
+        server["args"] = ["-y", *args]
+    if "startup_timeout_sec" not in server and "startup_timeout_ms" not in server:
+        server["startup_timeout_sec"] = 60
+        messages.append(f"{name}: allow 60 seconds for npm cold start")
+
+
+def migrate_remote(name, server, messages):
+    if name not in DEFAULTS or "url" not in server:
+        return
+    if server["url"] != DEFAULTS[name].get("url"):
+        return
+    if server.get("type") == "url":
+        del server["type"]
+    # Old setup implicitly enabled OAuth without login. Preserve explicit choices.
+    if name == "cloudflare-api" and "enabled" not in server:
+        server["enabled"] = False
+        messages.append("cloudflare-api: disabled pending explicit OAuth setup")
+
+
+def migrate_unavailable(name, server, messages):
+    if not server.get("enabled", True):
+        return
+    command = server.get("command", "")
+    if name == "auggie-mcp" and Path(command).name == "auggie":
+        if server.get("args") == ["--mcp"]:
+            server["enabled"] = False
+            messages.append("auggie-mcp: disabled deprecated integration")
+    if name != "node_repl" or not command.startswith("/Applications/"):
+        return
+    if command.endswith("/cua_node/bin/node_repl") and not os.path.isfile(command):
+        server["enabled"] = False
+        messages.append("node_repl: disabled stale app executable; reinstall via the app")
+
+
 def reconcile(data):
     """Return desired config and human-readable changes, never credential values."""
     desired = copy.deepcopy(data)
@@ -55,100 +95,10 @@ def reconcile(data):
             servers[name] = dict(default, enabled=False)
             messages.append(f"{name}: added disabled; enable explicitly when needed")
     for name, server in servers.items():
-        command = server.get("command", "")
-        args = server.get("args", [])
-        is_npx = Path(command).name in ("npx", "npx.cmd")
-        if name == "playwright" and is_npx and known_package(
-            args, "@anthropic-ai/mcp-server-playwright"
-        ):
-            server["args"] = [
-                "@playwright/mcp@0.0.79"
-                if arg.startswith("@anthropic-ai/mcp-server-playwright") else arg
-                for arg in args
-            ]
-            args = server["args"]
-            messages.append("playwright: replaced nonexistent legacy npm package")
-        if is_npx and name in NPX_PACKAGES and known_package(args, NPX_PACKAGES[name]):
-            if "-y" not in args and "--yes" not in args:
-                server["args"] = ["-y", *args]
-            if "startup_timeout_sec" not in server and "startup_timeout_ms" not in server:
-                server["startup_timeout_sec"] = 60
-                messages.append(f"{name}: allow 60 seconds for npm cold start")
-        if name in DEFAULTS and "url" in server and server["url"] == DEFAULTS[name].get("url"):
-            if server.get("type") == "url":
-                del server["type"]
-            # Old setup implicitly enabled an OAuth service without a login step.
-            # Preserve explicit opt-in/opt-out decisions on subsequent updates.
-            if name == "cloudflare-api" and "enabled" not in server:
-                server["enabled"] = False
-                messages.append("cloudflare-api: disabled pending explicit OAuth setup")
-        if name == "auggie-mcp" and Path(command).name == "auggie" and args == ["--mcp"]:
-            if server.get("enabled", True):
-                server["enabled"] = False
-                messages.append("auggie-mcp: disabled deprecated integration")
-        if (name == "node_repl" and command.startswith("/Applications/")
-                and command.endswith("/cua_node/bin/node_repl")
-                and not os.path.isfile(command) and server.get("enabled", True)):
-            server["enabled"] = False
-            messages.append("node_repl: disabled stale app executable; reinstall via the app")
+        migrate_npx(name, server, messages)
+        migrate_remote(name, server, messages)
+        migrate_unavailable(name, server, messages)
     return desired, messages
-
-
-def section_span(text, name):
-    headers = list(re.finditer(r"(?m)^\s*\[[^\n]+\][ \t]*(?:#[^\n]*)?$", text))
-    for index, header in enumerate(headers):
-        try:
-            parsed = tomllib.loads(header.group() + "\n__probe__ = true\n")
-        except tomllib.TOMLDecodeError:
-            continue
-        if parsed == {"mcp_servers": {name: {"__probe__": True}}}:
-            end = headers[index + 1].start() if index + 1 < len(headers) else len(text)
-            return header.end(), end
-    raise ValueError(f"Cannot safely locate MCP table {name}")
-
-
-def change_field(block, key, old, new, remove=False):
-    match = re.search(r"(?m)^[ \t]*" + re.escape(key) + r"[ \t]*=", block)
-    if match is None:
-        if old is not None:
-            raise ValueError(f"Cannot safely locate field {key}")
-        return "\n" + key + " = " + json.dumps(new) + "\n" + block.lstrip("\n")
-    # Parse progressively to include multiline arrays without swallowing the next key.
-    end = match.end()
-    while end < len(block):
-        newline = block.find("\n", end)
-        end = len(block) if newline < 0 else newline + 1
-        try:
-            value = tomllib.loads(block[match.start():end])
-        except tomllib.TOMLDecodeError:
-            continue
-        if value != {key: old}:
-            raise ValueError(f"Cannot safely replace field {key}")
-        replacement = "" if remove else key + " = " + json.dumps(new) + "\n"
-        return block[:match.start()] + replacement + block[end:]
-    raise ValueError(f"Cannot safely parse field {key}")
-
-
-def render(text, original, desired):
-    old_servers = original.get("mcp_servers", {})
-    for name, server in desired["mcp_servers"].items():
-        if name not in old_servers:
-            text += "\n[mcp_servers." + json.dumps(name) + "]\n"
-            text += "".join(key + " = " + json.dumps(value) + "\n" for key, value in server.items())
-            continue
-        previous = old_servers[name]
-        if previous == server:
-            continue
-        start, end = section_span(text, name)
-        block = text[start:end]
-        for key in previous.keys() | server.keys():
-            if previous.get(key) != server.get(key):
-                block = change_field(block, key, previous.get(key), server.get(key), key not in server)
-        text = text[:start] + block + text[end:]
-    # Fail closed for exotic TOML layouts: no semantic change outside the plan.
-    if tomllib.loads(text) != desired:
-        raise ValueError("MCP migration would alter unrelated configuration")
-    return text
 
 
 def main():

--- a/.agents/scripts/codex-mcp-config.py
+++ b/.agents/scripts/codex-mcp-config.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Reconcile known Codex MCP defaults without rewriting unrelated TOML."""
+
+import argparse
+import copy
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import tempfile
+
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        raise SystemExit("Codex MCP migration requires Python 3.11+ or tomli; config unchanged") from None
+
+
+DEFAULTS = {
+    "context7": {"command": "npx", "args": ["-y", "@upstash/context7-mcp@latest"]},
+    "playwright": {
+        "command": "npx",
+        "args": ["-y", "@playwright/mcp@0.0.79", "--headless", "--isolated"],
+    },
+    "shadcn": {"command": "npx", "args": ["-y", "shadcn@latest", "mcp"]},
+    "openapi-search": {"url": "https://openapi-mcp.openapisearch.com/mcp"},
+    "cloudflare-api": {"url": "https://mcp.cloudflare.com/mcp"},
+}
+NPX_PACKAGES = {
+    "context7": "@upstash/context7-mcp",
+    "playwright": "@playwright/mcp",
+    "shadcn": "shadcn",
+    "macos-automator": "@steipete/macos-automator-mcp",
+    "shopify-dev-mcp": "@shopify/dev-mcp",
+}
+
+
+def known_package(args, package):
+    """Match package names exactly, including an optional version suffix."""
+    return any(arg == package or arg.startswith(package + "@") for arg in args)
+
+
+def reconcile(data):
+    """Return desired config and human-readable changes, never credential values."""
+    desired = copy.deepcopy(data)
+    servers = desired.setdefault("mcp_servers", {})
+    messages = []
+    for name, default in DEFAULTS.items():
+        if name not in servers:
+            servers[name] = dict(default, enabled=False)
+            messages.append(f"{name}: added disabled; enable explicitly when needed")
+    for name, server in servers.items():
+        command = server.get("command", "")
+        args = server.get("args", [])
+        is_npx = Path(command).name in ("npx", "npx.cmd")
+        if name == "playwright" and is_npx and known_package(
+            args, "@anthropic-ai/mcp-server-playwright"
+        ):
+            server["args"] = [
+                "@playwright/mcp@0.0.79"
+                if arg.startswith("@anthropic-ai/mcp-server-playwright") else arg
+                for arg in args
+            ]
+            args = server["args"]
+            messages.append("playwright: replaced nonexistent legacy npm package")
+        if is_npx and name in NPX_PACKAGES and known_package(args, NPX_PACKAGES[name]):
+            if "-y" not in args and "--yes" not in args:
+                server["args"] = ["-y", *args]
+            if "startup_timeout_sec" not in server and "startup_timeout_ms" not in server:
+                server["startup_timeout_sec"] = 60
+                messages.append(f"{name}: allow 60 seconds for npm cold start")
+        if name in DEFAULTS and "url" in server and server["url"] == DEFAULTS[name].get("url"):
+            if server.get("type") == "url":
+                del server["type"]
+            # Old setup implicitly enabled an OAuth service without a login step.
+            # Preserve explicit opt-in/opt-out decisions on subsequent updates.
+            if name == "cloudflare-api" and "enabled" not in server:
+                server["enabled"] = False
+                messages.append("cloudflare-api: disabled pending explicit OAuth setup")
+        if name == "auggie-mcp" and Path(command).name == "auggie" and args == ["--mcp"]:
+            if server.get("enabled", True):
+                server["enabled"] = False
+                messages.append("auggie-mcp: disabled deprecated integration")
+        if (name == "node_repl" and command.startswith("/Applications/")
+                and command.endswith("/cua_node/bin/node_repl")
+                and not os.path.isfile(command) and server.get("enabled", True)):
+            server["enabled"] = False
+            messages.append("node_repl: disabled stale app executable; reinstall via the app")
+    return desired, messages
+
+
+def section_span(text, name):
+    headers = list(re.finditer(r"(?m)^\s*\[[^\n]+\][ \t]*(?:#[^\n]*)?$", text))
+    for index, header in enumerate(headers):
+        try:
+            parsed = tomllib.loads(header.group() + "\n__probe__ = true\n")
+        except tomllib.TOMLDecodeError:
+            continue
+        if parsed == {"mcp_servers": {name: {"__probe__": True}}}:
+            end = headers[index + 1].start() if index + 1 < len(headers) else len(text)
+            return header.end(), end
+    raise ValueError(f"Cannot safely locate MCP table {name}")
+
+
+def change_field(block, key, old, new, remove=False):
+    match = re.search(r"(?m)^[ \t]*" + re.escape(key) + r"[ \t]*=", block)
+    if match is None:
+        if old is not None:
+            raise ValueError(f"Cannot safely locate field {key}")
+        return "\n" + key + " = " + json.dumps(new) + "\n" + block.lstrip("\n")
+    # Parse progressively to include multiline arrays without swallowing the next key.
+    end = match.end()
+    while end < len(block):
+        newline = block.find("\n", end)
+        end = len(block) if newline < 0 else newline + 1
+        try:
+            value = tomllib.loads(block[match.start():end])
+        except tomllib.TOMLDecodeError:
+            continue
+        if value != {key: old}:
+            raise ValueError(f"Cannot safely replace field {key}")
+        replacement = "" if remove else key + " = " + json.dumps(new) + "\n"
+        return block[:match.start()] + replacement + block[end:]
+    raise ValueError(f"Cannot safely parse field {key}")
+
+
+def render(text, original, desired):
+    old_servers = original.get("mcp_servers", {})
+    for name, server in desired["mcp_servers"].items():
+        if name not in old_servers:
+            text += "\n[mcp_servers." + json.dumps(name) + "]\n"
+            text += "".join(key + " = " + json.dumps(value) + "\n" for key, value in server.items())
+            continue
+        previous = old_servers[name]
+        if previous == server:
+            continue
+        start, end = section_span(text, name)
+        block = text[start:end]
+        for key in previous.keys() | server.keys():
+            if previous.get(key) != server.get(key):
+                block = change_field(block, key, previous.get(key), server.get(key), key not in server)
+        text = text[:start] + block + text[end:]
+    # Fail closed for exotic TOML layouts: no semantic change outside the plan.
+    if tomllib.loads(text) != desired:
+        raise ValueError("MCP migration would alter unrelated configuration")
+    return text
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=Path.home() / ".codex/config.toml")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    config = args.config.expanduser().resolve()
+    original_bytes = config.read_bytes() if config.exists() else b""
+    text = original_bytes.decode("utf-8")
+    original = tomllib.loads(text)
+    desired, messages = reconcile(original)
+    updated = render(text, original, desired)
+    if updated == text:
+        print("Codex MCP configuration already reconciled")
+        return
+    for message in messages:
+        print(message)
+    if args.dry_run:
+        print("Dry run: no files changed")
+        return
+    config.parent.mkdir(parents=True, exist_ok=True)
+    mode = stat.S_IMODE(config.stat().st_mode) if config.exists() else 0o600
+    fd, temporary = tempfile.mkstemp(prefix=".codex-mcp-", dir=config.parent)
+    try:
+        with os.fdopen(fd, "wb") as output:
+            output.write(updated.encode("utf-8"))
+            os.fchmod(output.fileno(), mode)
+        if config.exists():
+            if config.read_bytes() != original_bytes:
+                raise ValueError("Codex configuration changed concurrently; retry setup")
+            backup_fd, backup = tempfile.mkstemp(prefix="config.toml.before-mcp-", dir=config.parent)
+            with os.fdopen(backup_fd, "wb") as output:
+                output.write(original_bytes)
+            print(f"Backup saved: {Path(backup).name}")
+        os.replace(temporary, config)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ValueError, OSError) as error:
+        raise SystemExit(f"Codex MCP migration failed ({type(error).__name__}); config left unchanged") from None

--- a/.agents/scripts/lib/codex_mcp_toml.py
+++ b/.agents/scripts/lib/codex_mcp_toml.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validated, minimally invasive TOML field edits for Codex MCP migration."""
+
+import json
+import re
+
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        raise SystemExit("Codex MCP migration requires Python 3.11+ or tomli; config unchanged") from None
+
+
+def section_span(text, name):
+    headers = list(re.finditer(r"(?m)^\s*\[[^\n]+\][ \t]*(?:#[^\n]*)?$", text))
+    for index, header in enumerate(headers):
+        try:
+            parsed = tomllib.loads(header.group() + "\n__probe__ = true\n")
+        except tomllib.TOMLDecodeError:
+            continue
+        if parsed == {"mcp_servers": {name: {"__probe__": True}}}:
+            end = headers[index + 1].start() if index + 1 < len(headers) else len(text)
+            return header.end(), end
+    raise ValueError(f"Cannot safely locate MCP table {name}")
+
+
+def change_field(block, key, old, new, remove=False):
+    match = re.search(r"(?m)^[ \t]*" + re.escape(key) + r"[ \t]*=", block)
+    if match is None:
+        if old is not None:
+            raise ValueError(f"Cannot safely locate field {key}")
+        return "\n" + key + " = " + json.dumps(new) + "\n" + block.lstrip("\n")
+    # Parse progressively to include multiline arrays without swallowing the next key.
+    end = match.end()
+    while end < len(block):
+        newline = block.find("\n", end)
+        end = len(block) if newline < 0 else newline + 1
+        try:
+            value = tomllib.loads(block[match.start():end])
+        except tomllib.TOMLDecodeError:
+            continue
+        if value != {key: old}:
+            raise ValueError(f"Cannot safely replace field {key}")
+        replacement = "" if remove else key + " = " + json.dumps(new) + "\n"
+        return block[:match.start()] + replacement + block[end:]
+    raise ValueError(f"Cannot safely parse field {key}")
+
+
+def render(text, original, desired):
+    old_servers = original.get("mcp_servers", {})
+    for name, server in desired["mcp_servers"].items():
+        if name not in old_servers:
+            text += "\n[mcp_servers." + json.dumps(name) + "]\n"
+            text += "".join(key + " = " + json.dumps(value) + "\n" for key, value in server.items())
+            continue
+        previous = old_servers[name]
+        if previous == server:
+            continue
+        start, end = section_span(text, name)
+        block = text[start:end]
+        for key in previous.keys() | server.keys():
+            if previous.get(key) != server.get(key):
+                block = change_field(block, key, previous.get(key), server.get(key), key not in server)
+        text = text[:start] + block + text[end:]
+    # Fail closed for exotic TOML layouts: no semantic change outside the plan.
+    if tomllib.loads(text) != desired:
+        raise ValueError("MCP migration would alter unrelated configuration")
+    return text

--- a/.agents/scripts/setup/modules/config.sh
+++ b/.agents/scripts/setup/modules/config.sh
@@ -245,74 +245,21 @@ update_codex_config() {
 
 	# Fix broken MCP_DOCKER entry (P0 — OrbStack/Colima don't support docker mcp)
 	if type _fix_codex_docker_mcp &>/dev/null; then
-		_fix_codex_docker_mcp
+		_fix_codex_docker_mcp || return 1
 	fi
 
 	# Deploy aidevops MCP servers to Codex config.toml
-	_deploy_codex_mcps
+	_deploy_codex_mcps || return 1
 
 	print_success "Codex configuration updated"
 	return 0
 }
 
-# Deploy standard aidevops MCP servers to ~/.codex/config.toml
-# Codex uses TOML format: [mcp_servers.NAME] sections
+# Reconcile known defaults and migrations while preserving custom TOML settings.
 _deploy_codex_mcps() {
-	local config="$HOME/.codex/config.toml"
-	mkdir -p "$HOME/.codex"
-
-	# Touch config if it doesn't exist
-	[[ -f "$config" ]] || touch "$config"
-
-	local mcp_count=0
-
-	# Helper: add a TOML MCP section if not already present
-	# Args: $1=name, $2=type (stdio|url), $3=command_or_url, $4=args (optional, comma-separated)
-	_add_codex_mcp() {
-		local name="$1"
-		local mcp_type="$2"
-		local cmd_or_url="$3"
-		local args="${4:-}"
-
-		if grep -q "\\[mcp_servers\\.${name}\\]" "$config" 2>/dev/null; then
-			echo -e "  ${BLUE:-}=${NC:-} $name (already configured)"
-			return 0
-		fi
-
-		{
-			echo ""
-			echo "[mcp_servers.${name}]"
-			if [[ "$mcp_type" == "stdio" ]]; then
-				echo "command = '${cmd_or_url}'"
-				if [[ -n "$args" ]]; then
-					echo "args = [${args}]"
-				fi
-			else
-				echo "type = 'url'"
-				echo "url = '${cmd_or_url}'"
-			fi
-		} >>"$config"
-		((++mcp_count))
-		echo -e "  ${GREEN:-}+${NC:-} $name"
-		return 0
-	}
-
-	# --- context7 (library docs) ---
-	_add_codex_mcp "context7" "stdio" "npx" "'-y', '@upstash/context7-mcp@latest'"
-
-	# --- Playwright MCP ---
-	_add_codex_mcp "playwright" "stdio" "npx" "'-y', '@playwright/mcp@0.0.79', '--headless', '--isolated'"
-
-	# --- shadcn UI ---
-	_add_codex_mcp "shadcn" "stdio" "npx" "'shadcn@latest', 'mcp'"
-
-	# --- OpenAPI Search (remote, zero install) ---
-	_add_codex_mcp "openapi-search" "url" "https://openapi-mcp.openapisearch.com/mcp"
-
-	# --- Cloudflare API (remote) ---
-	_add_codex_mcp "cloudflare-api" "url" "https://mcp.cloudflare.com/mcp"
-
-	echo -e "  ${GREEN:-}Done${NC:-} -- $mcp_count new MCP servers added to Codex config"
+	local helper_dir
+	helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)" || return 1
+	python3 "$helper_dir/codex-mcp-config.py" || return 1
 	return 0
 }
 

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -2685,8 +2685,9 @@ _fix_codex_docker_mcp() {
 		return 0
 	fi
 
-	# Check if `docker mcp` subcommand is actually available
-	if docker mcp --help >/dev/null 2>&1; then
+	# Docker can return success for help on an unknown subcommand.
+	# The version command verifies that the MCP CLI plugin actually exists.
+	if docker mcp version >/dev/null 2>&1; then
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-codex-mcp-config.py
+++ b/.agents/scripts/tests/test-codex-mcp-config.py
@@ -7,11 +7,13 @@ import importlib.util
 import os
 from pathlib import Path
 import subprocess
+import sys
 import tempfile
 import unittest
 from unittest.mock import patch
 
 SCRIPT = Path(__file__).resolve().parents[1] / "codex-mcp-config.py"
+sys.path.insert(0, str(SCRIPT.parent))
 spec = importlib.util.spec_from_file_location("codex_mcp_config", SCRIPT)
 migration = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(migration)
@@ -37,15 +39,17 @@ print_info() { printf '%s\\n' "$*"; }
 docker() { [[ "$*" == "mcp --help" ]]; }
 _fix_codex_docker_mcp
 '''
-            subprocess.run(["bash", "-c", command, "test", str(module)],
-                           env={**os.environ, "HOME": directory}, check=True, capture_output=True)
+            subprocess.run(  # nosec B603 -- fixed shell, repository module, and local fixtures
+                ["/bin/bash", "-c", command, "test", str(module)],
+                env={**os.environ, "HOME": directory}, check=True, capture_output=True)
             parsed = migration.tomllib.loads(config.read_text())
             self.assertNotIn("MCP_DOCKER", parsed.get("mcp_servers", {}))
             self.assertEqual(parsed["other"], {"keep": True})
             config.write_text(original)
             command = command.replace('[[ "$*" == "mcp --help" ]]', 'return 0')
-            subprocess.run(["bash", "-c", command, "test", str(module)],
-                           env={**os.environ, "HOME": directory}, check=True, capture_output=True)
+            subprocess.run(  # nosec B603 -- fixed shell, repository module, and local fixtures
+                ["/bin/bash", "-c", command, "test", str(module)],
+                env={**os.environ, "HOME": directory}, check=True, capture_output=True)
             self.assertEqual(config.read_text(), original)
 
     def test_fresh_defaults_are_opt_in(self):

--- a/.agents/scripts/tests/test-codex-mcp-config.py
+++ b/.agents/scripts/tests/test-codex-mcp-config.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Regression coverage for setup/update Codex MCP reconciliation."""
+
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPT = Path(__file__).resolve().parents[1] / "codex-mcp-config.py"
+spec = importlib.util.spec_from_file_location("codex_mcp_config", SCRIPT)
+migration = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(migration)
+
+
+def migrate(text):
+    original = migration.tomllib.loads(text)
+    desired, _ = migration.reconcile(original)
+    return migration.render(text, original, desired)
+
+
+class CodexMCPTests(unittest.TestCase):
+    def test_docker_help_false_positive(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / ".codex").mkdir()
+            config = root / ".codex/config.toml"
+            original = "[mcp_servers.MCP_DOCKER]\ncommand = 'docker'\nargs = ['mcp', 'gateway', 'run']\n[other]\nkeep = true\n"
+            config.write_text(original)
+            module = SCRIPT.parent / "setup/modules/tool-install.sh"
+            command = '''source "$1"
+print_info() { printf '%s\\n' "$*"; }
+docker() { [[ "$*" == "mcp --help" ]]; }
+_fix_codex_docker_mcp
+'''
+            subprocess.run(["bash", "-c", command, "test", str(module)],
+                           env={**os.environ, "HOME": directory}, check=True, capture_output=True)
+            parsed = migration.tomllib.loads(config.read_text())
+            self.assertNotIn("MCP_DOCKER", parsed.get("mcp_servers", {}))
+            self.assertEqual(parsed["other"], {"keep": True})
+            config.write_text(original)
+            command = command.replace('[[ "$*" == "mcp --help" ]]', 'return 0')
+            subprocess.run(["bash", "-c", command, "test", str(module)],
+                           env={**os.environ, "HOME": directory}, check=True, capture_output=True)
+            self.assertEqual(config.read_text(), original)
+
+    def test_fresh_defaults_are_opt_in(self):
+        servers = migration.tomllib.loads(migrate(""))["mcp_servers"]
+        self.assertEqual(set(servers), set(migration.DEFAULTS))
+        self.assertTrue(all(not server["enabled"] for server in servers.values()))
+        self.assertNotIn("type", servers["cloudflare-api"])
+
+    def test_legacy_multiline_package_and_nested_env(self):
+        text = '''# User preferences
+model = "custom-model"
+[mcp_servers."playwright"] # keep this comment
+command = "npx"
+args = [
+  "-y",
+  "@anthropic-ai/mcp-server-playwright@latest",
+  "--custom-option",
+]
+enabled = true
+[mcp_servers.playwright.env]
+CUSTOM = "retained"
+[profiles.personal]
+model = "another-model"
+'''
+        result = migrate(text)
+        data = migration.tomllib.loads(result)
+        server = data["mcp_servers"]["playwright"]
+        self.assertEqual(server["args"], ["-y", "@playwright/mcp@0.0.79", "--custom-option"])
+        self.assertTrue(server["enabled"])
+        self.assertEqual(server["env"], {"CUSTOM": "retained"})
+        self.assertIn("# keep this comment", result)
+        self.assertEqual(data["profiles"], {"personal": {"model": "another-model"}})
+        self.assertEqual(migrate(result), result)
+
+    def test_preserve_custom_commands_and_explicit_settings(self):
+        text = '''[mcp_servers.playwright]
+command = "/custom/launcher"
+args = ["custom"]
+enabled = false
+startup_timeout_sec = 300
+[mcp_servers.cloudflare-api]
+url = "https://mcp.cloudflare.com/mcp"
+enabled = true
+'''
+        before = migration.tomllib.loads(text)["mcp_servers"]
+        after = migration.tomllib.loads(migrate(text))["mcp_servers"]
+        for name, value in before.items():
+            self.assertEqual(after[name], value)
+
+    def test_oauth_and_deprecated_migrations(self):
+        text = '''[mcp_servers.cloudflare-api]
+type = 'url'
+url = 'https://mcp.cloudflare.com/mcp'
+[mcp_servers.auggie-mcp]
+command = '/custom/bin/auggie'
+args = ['--mcp']
+'''
+        servers = migration.tomllib.loads(migrate(text))["mcp_servers"]
+        self.assertFalse(servers["cloudflare-api"]["enabled"])
+        self.assertNotIn("type", servers["cloudflare-api"])
+        self.assertFalse(servers["auggie-mcp"]["enabled"])
+
+    def test_missing_app_executable_only(self):
+        data = {"mcp_servers": {"node_repl": {
+            "command": "/Applications/Example.app/Contents/Resources/cua_node/bin/node_repl"
+        }, "custom": {"command": "/missing/custom"}}}
+        with patch.object(migration.os.path, "isfile", return_value=False):
+            updated, _ = migration.reconcile(data)
+        self.assertFalse(updated["mcp_servers"]["node_repl"]["enabled"])
+        self.assertEqual(updated["mcp_servers"]["custom"], data["mcp_servers"]["custom"])
+        with patch.object(migration.os.path, "isfile", return_value=True):
+            updated, _ = migration.reconcile(data)
+        self.assertNotIn("enabled", updated["mcp_servers"]["node_repl"])
+
+    def test_backups_modes_and_idempotence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "config.toml"
+            config.write_text("# retained\nmodel = 'example'\n")
+            config.chmod(0o600)
+            original = config.read_bytes()
+            with patch("sys.argv", [str(SCRIPT), "--config", str(config)]):
+                migration.main()
+                updated = config.read_bytes()
+                migration.main()
+            backups = list(Path(directory).glob("config.toml.before-mcp-*"))
+            self.assertEqual(len(backups), 1)
+            self.assertEqual(backups[0].read_bytes(), original)
+            self.assertEqual(config.read_bytes(), updated)
+            self.assertEqual(config.stat().st_mode & 0o777, 0o600)
+
+    def test_invalid_input_unchanged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "config.toml"
+            config.write_text("[invalid")
+            with patch("sys.argv", [str(SCRIPT), "--config", str(config)]):
+                with self.assertRaises(ValueError):
+                    migration.main()
+            self.assertEqual(config.read_text(), "[invalid")
+            self.assertEqual(list(Path(directory).glob("config.toml.before-mcp-*")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Setup/update now reconciles known legacy Codex MCP configuration instead of skipping existing sections. This repairs the nonexistent Playwright package, adds noninteractive npm startup defaults, disables deprecated Auggie and recognized missing app executables, and makes Cloudflare opt-in before OAuth setup. Newly installed optional servers start disabled; explicit user settings and custom commands are preserved.

The new `.agents/scripts/codex-mcp-config.py` and `.agents/scripts/lib/codex_mcp_toml.py` validate the complete TOML result, back up changed configuration, and write atomically. `.agents/scripts/setup/modules/config.sh` invokes it and propagates failure. `.agents/scripts/setup/modules/tool-install.sh` checks `docker mcp version`, because help can return success for an unavailable plugin.

Validation: eight regression tests in `.agents/scripts/tests/test-codex-mcp-config.py` pass, including Docker's false-positive help response, idempotence, backups, custom settings, and nested/multiline TOML. Changed-file quality gates, ShellCheck, and Qlty smells on both new implementation modules pass. Live initialization/tool discovery passed for Context7, Playwright, shadcn, macOS Automator, and Shopify after separately repairing its damaged local cache; OpenAPI returned a valid initialization response.

Compatibility: the migration needs Python 3.11+ or tomli and fails without changing configuration if neither parser is available. No release requested.

Resolves #31196

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 automated scan.