### PR TITLE
GH#31195: fix: fall back to gh auth for collaborator permissions

### DIFF
--- a/.agents/scripts/shared-gh-collaborator-permission.sh
+++ b/.agents/scripts/shared-gh-collaborator-permission.sh
@@ -9,6 +9,8 @@
 _SHARED_GH_COLLABORATOR_PERMISSION_LOADED=1
 
 _AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE="unknown"
+_AIDEVOPS_GH_COLLAB_APP_PREFERRED_ROUTE="app-preferred"
+_AIDEVOPS_GH_COLLAB_GH_FALLBACK_ROUTE="gh-fallback"
 
 #######################################
 # Decide whether an issue actor has maintainer-equivalent repository authority.
@@ -178,10 +180,40 @@ _gh_repository_owner_matches_actor() {
 }
 
 #######################################
+# Request collaborator permission with the requested authentication route.
+#
+# Args: $1=route, $2=permission endpoint path
+# Returns: status from the selected API call.
+#######################################
+_gh_collaborator_permission_request() {
+	local auth_route="$1"
+	local perm_url="$2"
+
+	if [[ "$auth_route" == "$_AIDEVOPS_GH_COLLAB_GH_FALLBACK_ROUTE" ]]; then
+		if declare -F _gh_with_timeout >/dev/null 2>&1; then
+			AIDEVOPS_GH_QUOTA_COST=1 \
+				AIDEVOPS_GH_ROUTE_DECISION="collaborator-permission-gh-fallback" \
+				_gh_with_timeout read gh api -i "$perm_url"
+			return $?
+		fi
+		AIDEVOPS_GH_QUOTA_COST=1 \
+			AIDEVOPS_GH_ROUTE_DECISION="collaborator-permission-gh-fallback" \
+			gh api -i "$perm_url"
+		return $?
+	fi
+
+	AIDEVOPS_GH_QUOTA_COST=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="collaborator-permission-rest" \
+		_rest_api_call read gh api -i "$perm_url"
+	return $?
+}
+
+#######################################
 # Look up a repository collaborator permission through App-aware REST routing.
 #
-# Auth selection stays in _rest_api_call/github_app_api_call: GitHub App
-# installation auth is preferred when configured, with normal gh/PAT fallback.
+# GitHub App installation auth is preferred when configured. If that route
+# cannot produce a trustworthy verdict, retry once with the authenticated gh
+# credential; a confirmed 404 remains a final non-collaborator verdict.
 # Callers can inspect the status globals after a non-zero return to distinguish
 # transient lookup failures from confirmed non-collaborators.
 #
@@ -189,7 +221,8 @@ _gh_repository_owner_matches_actor() {
 #   AIDEVOPS_GH_COLLAB_PERMISSION_HTTP
 #   AIDEVOPS_GH_COLLAB_PERMISSION_REASON
 #
-# Args: $1=repo_slug owner/repo, $2=user login, $3=optional output variable
+# Args: $1=repo_slug owner/repo, $2=user login, $3=optional output variable,
+#       $4=internal auth route (app-preferred|gh-fallback)
 # Output: permission value (admin|maintain|write|triage|read|none) on lookup success.
 # Returns: 0=lookup succeeded (404 maps to none), 2=lookup/API/parse failure.
 #######################################
@@ -204,6 +237,7 @@ _gh_collaborator_permission_lookup() {
 	local line=""
 	local body=""
 	local in_body=0
+	local auth_route="${4:-$_AIDEVOPS_GH_COLLAB_APP_PREFERRED_ROUTE}"
 	# Keep the internal value distinct from caller-selected output names. Bash
 	# uses dynamic scope, so a local named permission_value would shadow the
 	# common caller output variable and silently return an empty permission.
@@ -219,9 +253,7 @@ _gh_collaborator_permission_lookup() {
 		return 2
 	fi
 
-	api_response=$(AIDEVOPS_GH_QUOTA_COST=1 \
-		AIDEVOPS_GH_ROUTE_DECISION="collaborator-permission-rest" \
-		_rest_api_call read gh api -i "$perm_url" 2>&1)
+	api_response=$(_gh_collaborator_permission_request "$auth_route" "$perm_url" 2>&1)
 	rc=$?
 	while IFS= read -r line; do
 		line="${line%$'\r'}"
@@ -260,15 +292,13 @@ _gh_collaborator_permission_lookup() {
 	fi
 
 	if [[ "$rc" -ne 0 ]]; then
-		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="api-failure"
-		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
-		return 2
+		_gh_collaborator_permission_resolve_failure "$auth_route" "$repo_slug" "$user" "$out_var" "api-failure"
+		return $?
 	fi
 
 	if [[ "$http_status" != "200" ]]; then
-		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="unexpected-http"
-		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
-		return 2
+		_gh_collaborator_permission_resolve_failure "$auth_route" "$repo_slug" "$user" "$out_var" "unexpected-http"
+		return $?
 	fi
 
 	resolved_permission=$(printf '%s' "$body" | jq -r '.permission // .role_name // ""' 2>/dev/null) || resolved_permission=""
@@ -277,7 +307,11 @@ _gh_collaborator_permission_lookup() {
 	fi
 	case "$resolved_permission" in
 	admin | maintain | write | triage | read | none)
-		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="ok"
+		if [[ "$auth_route" == "$_AIDEVOPS_GH_COLLAB_GH_FALLBACK_ROUTE" ]]; then
+			AIDEVOPS_GH_COLLAB_PERMISSION_REASON="gh-fallback-ok"
+		else
+			AIDEVOPS_GH_COLLAB_PERMISSION_REASON="ok"
+		fi
 		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
 		if [[ -n "$out_var" ]]; then
 			printf -v "$out_var" '%s' "$resolved_permission"
@@ -287,11 +321,62 @@ _gh_collaborator_permission_lookup() {
 		return 0
 		;;
 	*)
-		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="malformed-response"
-		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
-		return 2
+		_gh_collaborator_permission_resolve_failure "$auth_route" "$repo_slug" "$user" "$out_var" "malformed-response"
+		return $?
 		;;
 	esac
+}
+
+#######################################
+# Retry an uncertain App-routed permission read with authenticated gh auth.
+#
+# Args: $1=repo_slug, $2=user login, $3=output variable
+# Returns: 0=retry produced a verdict, 2=both routes were uncertain,
+#          3=GitHub App routing was not configured.
+#######################################
+_gh_collaborator_permission_retry_with_gh() {
+	local repo_slug="$1"
+	local user="$2"
+	local out_var="${3:-}"
+	local retry_rc=0
+
+	if ! declare -F github_app_is_configured >/dev/null 2>&1 || ! github_app_is_configured; then
+		return 3
+	fi
+
+	_gh_collaborator_permission_lookup "$repo_slug" "$user" "$out_var" "$_AIDEVOPS_GH_COLLAB_GH_FALLBACK_ROUTE" || retry_rc=$?
+	if [[ "$retry_rc" -eq 0 ]]; then
+		return 0
+	fi
+
+	AIDEVOPS_GH_COLLAB_PERMISSION_REASON="app-and-gh-${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-api-failure}"
+	export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
+	return 2
+}
+
+#######################################
+# Resolve an uncertain permission read without weakening the fail-closed guard.
+#
+# Args: $1=route, $2=repo_slug, $3=user, $4=output variable, $5=failure reason
+# Returns: 0=confirmed fallback verdict, 2=uncertain, 3=App route unavailable.
+#######################################
+_gh_collaborator_permission_resolve_failure() {
+	local auth_route="$1"
+	local repo_slug="$2"
+	local user="$3"
+	local out_var="$4"
+	local failure_reason="$5"
+	local retry_rc=3
+
+	if [[ "$auth_route" == "$_AIDEVOPS_GH_COLLAB_APP_PREFERRED_ROUTE" ]]; then
+		retry_rc=0
+		_gh_collaborator_permission_retry_with_gh "$repo_slug" "$user" "$out_var" || retry_rc=$?
+		[[ "$retry_rc" -eq 0 || "$retry_rc" -eq 2 ]] && return "$retry_rc"
+	fi
+
+	AIDEVOPS_GH_COLLAB_PERMISSION_REASON="$failure_reason"
+	export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
+	return 2
 }
 
 #######################################

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -148,6 +148,10 @@ _stub_jq_filter_arg() {
 }
 _stub_gh_api_collaborator_permission() {
 	local status="${STUB_COLLAB_STATUS:-200}"
+	if [[ "${STUB_COLLAB_APP_FAIL:-0}" == "1" && "${GH_TOKEN:-}" == "cached-app-token" ]]; then
+		printf 'HTTP/2.0 403 Forbidden\n\n{"message":"Forbidden"}\n'
+		return 1
+	fi
 	if [[ "${STUB_COLLAB_FAIL:-0}" == "1" ]]; then
 		printf 'HTTP/2.0 %s Forbidden\n\n{"message":"Forbidden"}\n' "$status"
 		return 1
@@ -2160,6 +2164,51 @@ else
 	fail "collaborator permission lookup uses GitHub App REST route when available" \
 		"perm=${collab_perm} GH_CALLS=$(cat "$GH_CALLS") | TOKENS=$(cat "$GH_APP_TOKEN_CALLS")"
 fi
+
+: >"$GH_CALLS"
+: >"$GH_APP_TOKEN_CALLS"
+export STUB_COLLAB_PERMISSION=admin
+export STUB_COLLAB_APP_FAIL=1
+collab_perm=""
+_gh_collaborator_permission_lookup "owner/repo" "testuser" collab_perm 2>/dev/null || true
+if [[ "$collab_perm" == "admin" && "${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-}" == "gh-fallback-ok" ]] &&
+	grep -q 'cached-app-token' "$GH_APP_TOKEN_CALLS" 2>/dev/null &&
+	[[ "$(grep -cE '^api -i /repos/owner/repo/collaborators/testuser/permission' "$GH_CALLS")" -eq 2 ]]; then
+	pass "collaborator permission retries with gh auth after GitHub App denial"
+else
+	fail "collaborator permission retries with gh auth after GitHub App denial" \
+		"perm=${collab_perm} reason=${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-unset} GH_CALLS=$(cat "$GH_CALLS") | TOKENS=$(cat "$GH_APP_TOKEN_CALLS")"
+fi
+unset STUB_COLLAB_APP_FAIL
+
+: >"$GH_CALLS"
+: >"$GH_APP_TOKEN_CALLS"
+export STUB_COLLAB_STATUS=404
+collab_perm=""
+_gh_collaborator_permission_lookup "owner/repo" "outsider" collab_perm 2>/dev/null || true
+if [[ "$collab_perm" == "none" && "${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-}" == "404" ]] &&
+	[[ "$(grep -cE '^api -i /repos/owner/repo/collaborators/outsider/permission' "$GH_CALLS")" -eq 1 ]]; then
+	pass "GitHub App 404 remains a confirmed non-collaborator verdict"
+else
+	fail "GitHub App 404 remains a confirmed non-collaborator verdict" \
+		"perm=${collab_perm} http=${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unset} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_COLLAB_STATUS
+
+: >"$GH_CALLS"
+: >"$GH_APP_TOKEN_CALLS"
+export STUB_COLLAB_APP_FAIL=1
+export STUB_COLLAB_FAIL=1
+if ! _gh_collaborator_permission_lookup "owner/repo" "testuser" >/dev/null 2>&1 &&
+	[[ "${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-}" == "app-and-gh-api-failure" ]] &&
+	[[ "$(grep -cE '^api -i /repos/owner/repo/collaborators/testuser/permission' "$GH_CALLS")" -eq 2 ]]; then
+	pass "collaborator permission fails closed when App and gh auth both fail"
+else
+	fail "collaborator permission fails closed when App and gh auth both fail" \
+		"http=${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unset} reason=${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-unset} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_COLLAB_APP_FAIL STUB_COLLAB_FAIL
+export STUB_COLLAB_PERMISSION=write
 
 unset AIDEVOPS_GITHUB_APP_ENABLED AIDEVOPS_GITHUB_APP_ID AIDEVOPS_GITHUB_APP_INSTALLATION_ID AIDEVOPS_GITHUB_APP_REST_FIRST
 


### PR DESCRIPTION
## Summary

Retries uncertain GitHub App collaborator permission reads with the authenticated gh credential while preserving confirmed 404 and dual-route fail-closed outcomes.

## Files Changed

.agents/scripts/shared-gh-collaborator-permission.sh, .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; bash .agents/scripts/tests/test-gh-current-user-write-guard.sh; bash .agents/scripts/tests/test-full-loop-merge-authority-guard.sh; shellcheck .agents/scripts/shared-gh-collaborator-permission.sh .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; .agents/scripts/linters-local.sh --changed; gh api repos/marcusquinn/aidevops/collaborators/marcusquinn/permission --jq '.permission' (admin)

Resolves #31195


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 plugin for [OpenCode](https://opencode.ai) v1.18.28 with gpt-5.6-terra spent 18m and 197,797 tokens on this as a headless worker.