### PR TITLE
t18401: restore profile activity reporting

### DIFF
--- a/.agents/scripts/commands/auto-reason.md
+++ b/.agents/scripts/commands/auto-reason.md
@@ -24,7 +24,7 @@ Arguments: $ARGUMENTS
 | One-liner | `/auto-reason "decide the best architecture for X"` | Build a temporary program and run now |
 | `--program <path>` | `/auto-reason --program todo/research/reason-product-strategy.md` | Run from a saved program |
 | `--incumbent <path>` | `/auto-reason --incumbent draft.md "improve this argument"` | Use existing answer as A |
-| `--judges <list>` | `/auto-reason --judges simple,standard,openai/gpt-5.5 "..."` | Override judge tiers/models |
+| `--judges <list>` | `/auto-reason --judges simple,standard,thinking "..."` | Override judge tiers/models |
 | Bare | `/auto-reason` | Interactive setup |
 
 ## Step 1: Resolve Invocation
@@ -73,7 +73,7 @@ Accept free-form model labels. Do not require Claude names.
 author:       standard
 critic:       simple
 synthesizer:  standard
-judges:       simple,standard,openai/gpt-5.5
+judges:       simple,standard,thinking
 ```
 
 Allowed forms include canonical workload tiers (`simple`, `standard`, `thinking`)
@@ -127,7 +127,7 @@ name: auto-reason-{slug}
 author: standard
 critic: simple
 synthesizer: standard
-judges: simple,standard,openai/gpt-5.5
+judges: simple,standard,thinking
 
 ## Budget
 
@@ -160,7 +160,7 @@ Return a concise summary to the user:
 ```text
 Decision: changed | unchanged
 Reason: A won after 2 rounds | AB won round 3 | budget reached
-Judges: simple, standard, openai/gpt-5.5
+Judges: simple, standard, thinking
 Artifacts: ~/.aidevops/.agent-workspace/work/auto-reason/{slug}/summary.md
 ```
 

--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -314,8 +314,8 @@ _get_model_usage_from_opencode() {
 				COALESCE(json_extract(data, '\$.tokens.cache.read'), 0) AS cache_read_tokens,
 				COALESCE(json_extract(data, '\$.tokens.cache.write'), 0) AS cache_write_tokens,
 				CASE
-					WHEN json_extract(data, '\$.time.created') IS NOT NULL
-					  AND json_extract(data, '\$.time.completed') IS NOT NULL
+					WHEN json_type(data, '\$.time.created') IN ('integer', 'real')
+					  AND json_type(data, '\$.time.completed') IN ('integer', 'real')
 					  AND json_extract(data, '\$.time.completed') >= json_extract(data, '\$.time.created')
 					THEN json_extract(data, '\$.time.completed') - json_extract(data, '\$.time.created')
 					ELSE NULL
@@ -430,7 +430,8 @@ _get_model_usage_from_obs_db() {
 				COUNT(*) AS requests,
 				COUNT(DISTINCT NULLIF(session_id, '')) AS session_count,
 				(SELECT COUNT(DISTINCT NULLIF(session_id, '')) FROM filtered_requests) AS total_session_count,
-				CASE WHEN COUNT(duration_ms) = COUNT(*) AND MIN(duration_ms) >= 0
+				CASE WHEN COUNT(duration_ms) = COUNT(*)
+					  AND SUM(CASE WHEN TYPEOF(duration_ms) IN ('integer', 'real') AND duration_ms >= 0 THEN 0 ELSE 1 END) = 0
 					THEN ROUND(SUM(duration_ms) / 3600000.0, 3)
 					ELSE NULL
 				END AS session_hours,
@@ -475,7 +476,7 @@ _get_model_usage_from_jsonl() {
 			requests: length,
 			session_count: ([.[] | .session_id // empty | select(length > 0)] | unique | length),
 			total_session_count: $total_sessions,
-			session_hours: (if any(.[]; .duration_ms != null) then ([.[].duration_ms // 0] | add) / 3600000 else null end),
+			session_hours: (if all(.[]; ((.duration_ms | type) == "number") and .duration_ms >= 0) then ([.[].duration_ms] | add) / 3600000 else null end),
 			input_tokens: ([.[].input_tokens // 0] | add),
 			output_tokens: ([.[].output_tokens // 0] | add),
 			cache_read_tokens: ([.[].cache_read_tokens // 0] | add),

--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -225,7 +225,7 @@ _get_profile_session_times() {
 
 # --- Compute cost from token counts using _model_cost_rates ---
 # Takes JSON array with model/input_tokens/output_tokens/cache_read_tokens,
-# adds cost_total field computed from pricing table, sorts by cost desc.
+# adds cost_total field computed from pricing table, sorts by request count.
 _compute_costs_from_tokens() {
 	local raw_json="$1"
 	local result="[]"
@@ -250,7 +250,7 @@ _compute_costs_from_tokens() {
 			'. + [$row + {cost_total: $cost}]')
 	done < <(echo "$raw_json" | jq -c '.[]')
 
-	echo "$result" | jq -c 'sort_by(-.cost_total)'
+	echo "$result" | jq -c 'sort_by(-.requests)'
 	return 0
 }
 
@@ -280,7 +280,9 @@ _model_usage_undercuts_reference() {
 }
 
 # --- Gather model usage from OpenCode session DB (full history) ---
-# Returns JSON array with cost_total computed, or empty string if unavailable.
+# Returns JSON array with token, session, and generation-time totals, or empty
+# string if unavailable. Cost remains available for compatibility with older
+# consumers but is not rendered in the profile README.
 _get_model_usage_from_opencode() {
 	if ! command -v sqlite3 &>/dev/null || [[ ! -f "$OPENCODE_DB_FILE" ]]; then
 		echo ""
@@ -295,26 +297,36 @@ _get_model_usage_from_opencode() {
 	if [[ -f "$OPENCODE_ARCHIVE_DB_FILE" ]]; then
 		attach_clause="ATTACH DATABASE '${OPENCODE_ARCHIVE_DB_FILE}' AS archive;"
 		union_clause="UNION ALL
-			SELECT
-				json_extract(data, '\$.modelID') AS model,
-				COUNT(*) AS requests,
-				COALESCE(SUM(json_extract(data, '\$.tokens.input')), 0) AS input_tokens,
-				COALESCE(SUM(json_extract(data, '\$.tokens.output')), 0) AS output_tokens,
-				COALESCE(SUM(json_extract(data, '\$.tokens.cache.read')), 0) AS cache_read_tokens,
-				COALESCE(SUM(json_extract(data, '\$.tokens.cache.write')), 0) AS cache_write_tokens
-			FROM archive.message
-			WHERE json_extract(data, '\$.role') = 'assistant'
-			  AND json_extract(data, '\$.modelID') IS NOT NULL
-			  AND json_extract(data, '\$.modelID') != ''
-			GROUP BY model"
+			SELECT session_id, data FROM archive.message"
 	fi
 	raw_json=$(sqlite3 "$OPENCODE_DB_FILE" "
 		${attach_clause}
+		WITH all_messages AS (
+			SELECT session_id, data FROM message
+			${union_clause}
+		),
+		assistant_messages AS (
+			SELECT
+				session_id,
+				json_extract(data, '\$.modelID') AS model,
+				COALESCE(json_extract(data, '\$.tokens.input'), 0) AS input_tokens,
+				COALESCE(json_extract(data, '\$.tokens.output'), 0) AS output_tokens,
+				COALESCE(json_extract(data, '\$.tokens.cache.read'), 0) AS cache_read_tokens,
+				COALESCE(json_extract(data, '\$.tokens.cache.write'), 0) AS cache_write_tokens,
+				MAX(0, COALESCE(json_extract(data, '\$.time.completed'), 0) - COALESCE(json_extract(data, '\$.time.created'), 0)) AS duration_ms
+			FROM all_messages
+			WHERE json_extract(data, '\$.role') = 'assistant'
+			  AND json_extract(data, '\$.modelID') IS NOT NULL
+			  AND json_extract(data, '\$.modelID') != ''
+		)
 		SELECT COALESCE(
 			json_group_array(
 				json_object(
 					'model', model,
 					'requests', requests,
+					'session_count', session_count,
+					'total_session_count', total_session_count,
+					'session_hours', session_hours,
 					'input_tokens', input_tokens,
 					'output_tokens', output_tokens,
 					'cache_read_tokens', cache_read_tokens,
@@ -324,25 +336,19 @@ _get_model_usage_from_opencode() {
 			'[]'
 		)
 		FROM (
-			SELECT model, SUM(requests) AS requests,
-				SUM(input_tokens) AS input_tokens, SUM(output_tokens) AS output_tokens,
-				SUM(cache_read_tokens) AS cache_read_tokens, SUM(cache_write_tokens) AS cache_write_tokens
-			FROM (
-				SELECT
-					json_extract(data, '\$.modelID') AS model,
-					COUNT(*) AS requests,
-					COALESCE(SUM(json_extract(data, '\$.tokens.input')), 0) AS input_tokens,
-					COALESCE(SUM(json_extract(data, '\$.tokens.output')), 0) AS output_tokens,
-					COALESCE(SUM(json_extract(data, '\$.tokens.cache.read')), 0) AS cache_read_tokens,
-					COALESCE(SUM(json_extract(data, '\$.tokens.cache.write')), 0) AS cache_write_tokens
-				FROM message
-				WHERE json_extract(data, '\$.role') = 'assistant'
-				  AND json_extract(data, '\$.modelID') IS NOT NULL
-				  AND json_extract(data, '\$.modelID') != ''
-				GROUP BY model
-				${union_clause}
-			)
+			SELECT
+				model,
+				COUNT(*) AS requests,
+				COUNT(DISTINCT session_id) AS session_count,
+				(SELECT COUNT(DISTINCT session_id) FROM assistant_messages) AS total_session_count,
+				ROUND(COALESCE(SUM(duration_ms), 0) / 3600000.0, 3) AS session_hours,
+				COALESCE(SUM(input_tokens), 0) AS input_tokens,
+				COALESCE(SUM(output_tokens), 0) AS output_tokens,
+				COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+				COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens
+			FROM assistant_messages
 			GROUP BY model
+			ORDER BY requests DESC
 		);
 	" 2>/dev/null || true)
 
@@ -359,6 +365,9 @@ _get_model_usage_from_opencode() {
 		| map({
 			model: .[0].model,
 			requests: ([.[].requests] | add),
+			session_count: ([.[].session_count // 0] | add),
+			total_session_count: ([.[].total_session_count // 0] | max // 0),
+			session_hours: ([.[].session_hours // 0] | add),
 			input_tokens: ([.[].input_tokens] | add),
 			output_tokens: ([.[].output_tokens] | add),
 			cache_read_tokens: ([.[].cache_read_tokens] | add),
@@ -369,7 +378,7 @@ _get_model_usage_from_opencode() {
 	return 0
 }
 
-# --- Gather model usage from observability DB (accurate cost data) ---
+# --- Gather model usage from observability DB (accurate activity data) ---
 # date_filter: optional SQL WHERE clause fragment (e.g. "AND timestamp >= ...")
 # Returns JSON array or empty string if unavailable.
 _get_model_usage_from_obs_db() {
@@ -391,26 +400,36 @@ _get_model_usage_from_obs_db() {
 					'output_tokens', output_tokens,
 					'cache_read_tokens', cache_read_tokens,
 					'cache_write_tokens', cache_write_tokens,
+					'session_count', session_count,
+					'total_session_count', total_session_count,
+					'session_hours', session_hours,
 					'cost_total', ROUND(cost_total, 2)
 				)
 			),
 			'[]'
 		)
 		FROM (
+			WITH filtered_requests AS (
+				SELECT *
+				FROM llm_requests
+				WHERE model_id IS NOT NULL
+				  AND model_id != ''
+				  ${date_filter}
+			)
 			SELECT
 				model_id,
 				COUNT(*) AS requests,
+				COUNT(DISTINCT NULLIF(session_id, '')) AS session_count,
+				(SELECT COUNT(DISTINCT NULLIF(session_id, '')) FROM filtered_requests) AS total_session_count,
+				ROUND(COALESCE(SUM(duration_ms), 0) / 3600000.0, 3) AS session_hours,
 				COALESCE(SUM(tokens_input), 0) AS input_tokens,
 				COALESCE(SUM(tokens_output), 0) AS output_tokens,
 				COALESCE(SUM(tokens_cache_read), 0) AS cache_read_tokens,
 				COALESCE(SUM(tokens_cache_write), 0) AS cache_write_tokens,
 				COALESCE(SUM(cost), 0.0) AS cost_total
-			FROM llm_requests
-			WHERE model_id IS NOT NULL
-			  AND model_id != ''
-			  ${date_filter}
+			FROM filtered_requests
 			GROUP BY model_id
-			ORDER BY cost_total DESC
+			ORDER BY requests DESC
 		);
 	" 2>/dev/null || true)
 
@@ -435,18 +454,23 @@ _get_model_usage_from_jsonl() {
 		cutoff=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d 2>/dev/null || echo "$PROFILE_EPOCH_DATE")
 	fi
 	jq -s --arg cutoff "$cutoff" --arg period "$period" '
-		(if $period == "all" then . else [.[] | select(.recorded_at >= $cutoff)] end)
+		(if $period == "all" then . else [.[] | select(.recorded_at >= $cutoff)] end) as $rows
+		| ($rows | [.[] | .session_id // empty | select(length > 0)] | unique | length) as $total_sessions
+		| $rows
 		| group_by(.model)
 		| map({
 			model: .[0].model,
 			requests: length,
+			session_count: ([.[] | .session_id // empty | select(length > 0)] | unique | length),
+			total_session_count: $total_sessions,
+			session_hours: (if any(.[]; .duration_ms != null) then ([.[].duration_ms // 0] | add) / 3600000 else null end),
 			input_tokens: ([.[].input_tokens // 0] | add),
 			output_tokens: ([.[].output_tokens // 0] | add),
 			cache_read_tokens: ([.[].cache_read_tokens // 0] | add),
 			cache_write_tokens: ([.[].cache_write_tokens // 0] | add),
 			cost_total: ([.[].cost_total // 0] | add | . * 100 | round / 100)
 		})
-		| sort_by(-.cost_total)
+		| sort_by(-.requests)
 	' "$METRICS_FILE" 2>/dev/null || echo "[]"
 	return 0
 }

--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -283,6 +283,8 @@ _model_usage_undercuts_reference() {
 # Returns JSON array with token, session, and generation-time totals, or empty
 # string if unavailable. Cost remains available for compatibility with older
 # consumers but is not rendered in the profile README.
+# GH#17549: query both the active and archive DBs because sessions older than
+# 30 days move to the archive.
 _get_model_usage_from_opencode() {
 	if ! command -v sqlite3 &>/dev/null || [[ ! -f "$OPENCODE_DB_FILE" ]]; then
 		echo ""
@@ -290,8 +292,6 @@ _get_model_usage_from_opencode() {
 	fi
 
 	local raw_json
-	# GH#17549: Query both active and archive DBs for all-time stats.
-	# The archive DB contains sessions >30 days old, moved by opencode-db-archive.sh.
 	local attach_clause=""
 	local union_clause=""
 	if [[ -f "$OPENCODE_ARCHIVE_DB_FILE" ]]; then
@@ -305,7 +305,7 @@ _get_model_usage_from_opencode() {
 			SELECT session_id, data FROM message
 			${union_clause}
 		),
-		assistant_messages AS (
+		assistant_messages_raw AS (
 			SELECT
 				session_id,
 				json_extract(data, '\$.modelID') AS model,
@@ -313,11 +313,34 @@ _get_model_usage_from_opencode() {
 				COALESCE(json_extract(data, '\$.tokens.output'), 0) AS output_tokens,
 				COALESCE(json_extract(data, '\$.tokens.cache.read'), 0) AS cache_read_tokens,
 				COALESCE(json_extract(data, '\$.tokens.cache.write'), 0) AS cache_write_tokens,
-				MAX(0, COALESCE(json_extract(data, '\$.time.completed'), 0) - COALESCE(json_extract(data, '\$.time.created'), 0)) AS duration_ms
+				CASE
+					WHEN json_extract(data, '\$.time.created') IS NOT NULL
+					  AND json_extract(data, '\$.time.completed') IS NOT NULL
+					  AND json_extract(data, '\$.time.completed') >= json_extract(data, '\$.time.created')
+					THEN json_extract(data, '\$.time.completed') - json_extract(data, '\$.time.created')
+					ELSE NULL
+				END AS duration_ms
 			FROM all_messages
 			WHERE json_extract(data, '\$.role') = 'assistant'
 			  AND json_extract(data, '\$.modelID') IS NOT NULL
 			  AND json_extract(data, '\$.modelID') != ''
+		),
+		assistant_messages AS (
+			SELECT
+				session_id,
+				CASE
+					WHEN LENGTH(model) > 9
+					  AND SUBSTR(model, -9, 1) = '-'
+					  AND SUBSTR(model, -8) NOT GLOB '*[^0-9]*'
+					THEN SUBSTR(model, 1, LENGTH(model) - 9)
+					ELSE model
+				END AS model,
+				input_tokens,
+				output_tokens,
+				cache_read_tokens,
+				cache_write_tokens,
+				duration_ms
+			FROM assistant_messages_raw
 		)
 		SELECT COALESCE(
 			json_group_array(
@@ -341,7 +364,10 @@ _get_model_usage_from_opencode() {
 				COUNT(*) AS requests,
 				COUNT(DISTINCT session_id) AS session_count,
 				(SELECT COUNT(DISTINCT session_id) FROM assistant_messages) AS total_session_count,
-				ROUND(COALESCE(SUM(duration_ms), 0) / 3600000.0, 3) AS session_hours,
+				CASE WHEN COUNT(duration_ms) = COUNT(*)
+					THEN ROUND(SUM(duration_ms) / 3600000.0, 3)
+					ELSE NULL
+				END AS session_hours,
 				COALESCE(SUM(input_tokens), 0) AS input_tokens,
 				COALESCE(SUM(output_tokens), 0) AS output_tokens,
 				COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
@@ -357,24 +383,7 @@ _get_model_usage_from_opencode() {
 		return 0
 	fi
 
-	# Merge model variants (e.g., claude-opus-4-5-20251101 -> claude-opus-4-5)
-	local merged_json
-	merged_json=$(echo "$raw_json" | jq -c '
-		[.[] | .model = (.model | gsub("-[0-9]{8}$"; ""))]
-		| group_by(.model)
-		| map({
-			model: .[0].model,
-			requests: ([.[].requests] | add),
-			session_count: ([.[].session_count // 0] | add),
-			total_session_count: ([.[].total_session_count // 0] | max // 0),
-			session_hours: ([.[].session_hours // 0] | add),
-			input_tokens: ([.[].input_tokens] | add),
-			output_tokens: ([.[].output_tokens] | add),
-			cache_read_tokens: ([.[].cache_read_tokens] | add),
-			cache_write_tokens: ([.[].cache_write_tokens] | add)
-		})
-	')
-	_compute_costs_from_tokens "$merged_json"
+	_compute_costs_from_tokens "$raw_json"
 	return 0
 }
 
@@ -421,7 +430,10 @@ _get_model_usage_from_obs_db() {
 				COUNT(*) AS requests,
 				COUNT(DISTINCT NULLIF(session_id, '')) AS session_count,
 				(SELECT COUNT(DISTINCT NULLIF(session_id, '')) FROM filtered_requests) AS total_session_count,
-				ROUND(COALESCE(SUM(duration_ms), 0) / 3600000.0, 3) AS session_hours,
+				CASE WHEN COUNT(duration_ms) = COUNT(*) AND MIN(duration_ms) >= 0
+					THEN ROUND(SUM(duration_ms) / 3600000.0, 3)
+					ELSE NULL
+				END AS session_hours,
 				COALESCE(SUM(tokens_input), 0) AS input_tokens,
 				COALESCE(SUM(tokens_output), 0) AS output_tokens,
 				COALESCE(SUM(tokens_cache_read), 0) AS cache_read_tokens,
@@ -556,7 +568,7 @@ _get_profile_model_usage_bundle() {
 # --- Token totals: shared jq expression for computing total_all and cache_hit_pct ---
 _token_totals_jq_expr() {
 	echo '. + {total_all: (.total_input + .total_output + .total_cache_read + .total_cache_write)}
-		| . + {cache_hit_pct: (if .total_all > 0 then ((.total_cache_read / .total_all * 1000 | round) / 10) else 0 end)}'
+		| . + {cache_hit_pct: (if (.total_cache_read + .total_input) > 0 then ((.total_cache_read / (.total_cache_read + .total_input) * 1000 | round) / 10) else 0 end)}'
 	return 0
 }
 

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -806,7 +806,7 @@ _build_readme_connect() {
 
 # --- Build the commit-history chart for a user ---
 # Usage: _build_commit_history_chart <gh_user>
-# Outputs a centered light/dark picture without a clickable provider backlink.
+# Outputs a centered light/dark picture linked to the user's activity profile.
 _build_commit_history_chart() {
 	local gh_user="$1"
 	gh_user="${gh_user//[^a-zA-Z0-9-]/}"
@@ -816,10 +816,12 @@ _build_commit_history_chart() {
 
 	cat <<EOF
 <div align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://commit-history.com/embed/${gh_user}?theme=dark" />
-    <img alt="${gh_user}'s commit history" src="https://commit-history.com/embed/${gh_user}" />
-  </picture>
+  <a href="https://commit-history.com/${gh_user}">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://commit-history.com/embed/${gh_user}?theme=dark" />
+      <img alt="${gh_user}'s commit history" src="https://commit-history.com/embed/${gh_user}" />
+    </picture>
+  </a>
 </div>
 EOF
 	return 0
@@ -834,6 +836,42 @@ _ensure_commit_history_chart() {
 		return 0
 	fi
 	if grep -Fq 'https://commit-history.com/embed/' "$readme_path" 2>/dev/null; then
+		if grep -Fq "<a href=\"https://commit-history.com/${gh_user}\">" "$readme_path" 2>/dev/null; then
+			return 0
+		fi
+		local migrate_tmp
+		migrate_tmp=$(mktemp)
+		if ! awk -v href="https://commit-history.com/${gh_user}" '
+			function emit_picture() {
+				if (picture_block ~ /commit-history[.]com\/embed\//) {
+					print "  <a href=\"" href "\">"
+					printf "%s", picture_block
+					print "  </a>"
+				} else {
+					printf "%s", picture_block
+				}
+				picture_block = ""
+			}
+			/^[[:space:]]*<picture>[[:space:]]*$/ {
+				in_picture = 1
+				picture_block = $0 ORS
+				next
+			}
+			in_picture {
+				picture_block = picture_block $0 ORS
+				if ($0 ~ /<\/picture>/) {
+					emit_picture()
+					in_picture = 0
+				}
+				next
+			}
+			{ print }
+			END { if (in_picture) printf "%s", picture_block }
+		' "$readme_path" >"$migrate_tmp"; then
+			rm -f "$migrate_tmp"
+			return 1
+		fi
+		mv "$migrate_tmp" "$readme_path" || return 1
 		return 0
 	fi
 
@@ -1348,7 +1386,10 @@ _cmd_update_in_repo() {
 	' "$readme_path" >"$tmp_file"
 	local gh_user
 	gh_user=$(_resolve_profile_user "$profile_repo")
-	_ensure_commit_history_chart "$tmp_file" "$gh_user"
+	if ! _ensure_commit_history_chart "$tmp_file" "$gh_user"; then
+		rm -f "$tmp_file"
+		return 1
+	fi
 
 	# Check if content changed, ignoring UPDATED marker block
 	local old_normalized new_normalized
@@ -1774,12 +1815,12 @@ _cmd_update_contributions_in_repo() {
 _profile_assert_canonical_clean() {
 	local canonical_repo="$1"
 	local status_output=""
-	if ! status_output=$(git -C "$canonical_repo" status --porcelain --untracked-files=all); then
+	if ! status_output=$(git -C "$canonical_repo" status --porcelain --untracked-files=no); then
 		echo "Error: could not verify canonical profile checkout state" >&2
 		return 1
 	fi
 	if [[ -n "$status_output" ]]; then
-		echo "Error: canonical profile checkout is not clean; refusing automated publication" >&2
+		echo "Error: canonical profile checkout has tracked changes; refusing automated publication" >&2
 		return 1
 	fi
 	local default_branch=""

--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -134,7 +134,7 @@ _get_top_apps() {
 
 # --- Render a model usage table ---
 # Usage: _render_model_usage_table <heading> <model_json> <token_totals_json>
-# Outputs a markdown table with model usage stats, savings calculations, and footer.
+# Outputs a markdown table with model usage, cache efficiency, and session totals.
 _render_model_usage_table() {
 	local heading="$1"
 	local model_json="$2"
@@ -142,72 +142,74 @@ _render_model_usage_table() {
 
 	# Skip entirely if no model data
 	local model_count
-	model_count=$(echo "$model_json" | jq -r 'if type == "array" then [.[] | select(.cost_total >= 0.05)] | length else 0 end' 2>/dev/null)
+	model_count=$(echo "$model_json" | jq -r 'if type == "array" then [.[] | select((.requests // 0) > 0)] | length else 0 end' 2>/dev/null)
 	if [[ "${model_count:-0}" == "0" ]]; then
 		return 0
 	fi
 
-	local total_requests=0 total_input=0 total_output=0 total_cache=0 total_cost=0
-	local total_cache_savings="0" total_model_savings="0"
+	local total_requests=0 total_input=0 total_output=0 total_cache=0
+	local total_session_hours="0" session_hours_complete=true total_sessions=0
 	local model_rows=""
+	total_sessions=$(echo "$model_json" | jq -r '[.[] | .total_session_count // 0] | max // 0' 2>/dev/null || printf '0\n')
+	if [[ "$total_sessions" -eq 0 ]]; then
+		total_sessions=$(echo "$model_json" | jq -r '[.[] | .session_count // 0] | add // 0' 2>/dev/null || printf '0\n')
+	fi
 
 	while IFS= read -r row; do
-		local model requests input output cache cost
+		local model requests input output cache cache_write session_count session_hours
 		model=$(echo "$row" | jq -r '.model')
-		requests=$(echo "$row" | jq -r '.requests')
-		input=$(echo "$row" | jq -r '.input_tokens')
-		output=$(echo "$row" | jq -r '.output_tokens')
-		cache=$(echo "$row" | jq -r '.cache_read_tokens')
-		cost=$(echo "$row" | jq -r '.cost_total')
+		requests=$(echo "$row" | jq -r '.requests // 0')
+		input=$(echo "$row" | jq -r '.input_tokens // 0')
+		output=$(echo "$row" | jq -r '.output_tokens // 0')
+		cache=$(echo "$row" | jq -r '.cache_read_tokens // 0')
+		cache_write=$(echo "$row" | jq -r '.cache_write_tokens // 0')
+		session_count=$(echo "$row" | jq -r '.session_count // 0')
+		session_hours=$(echo "$row" | jq -r '.session_hours // empty')
 
 		total_requests=$((total_requests + requests))
 		total_input=$((total_input + input))
 		total_output=$((total_output + output))
 		total_cache=$((total_cache + cache))
-		total_cost=$(echo "$total_cost + $cost" | bc)
+		if [[ "$session_hours" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+			total_session_hours=$(echo "$total_session_hours + $session_hours" | bc)
+		else
+			session_hours_complete=false
+		fi
 
-		# Compute per-row savings (cache + model routing vs all-Opus baseline)
-		local savings row_cache_savings row_model_savings
-		savings=$(_compute_model_row_savings "$model" "$input" "$output" "$cache")
-		row_cache_savings=$(echo "$savings" | cut -d'|' -f1)
-		row_model_savings=$(echo "$savings" | cut -d'|' -f2)
-		total_cache_savings=$(echo "$total_cache_savings + $row_cache_savings" | bc)
-		total_model_savings=$(echo "$total_model_savings + $row_model_savings" | bc)
-
-		local clean_model
+		local clean_model cache_hit_pct
 		clean_model=$(_clean_model_name "$model")
-		local f_requests f_input f_output f_cache
+		cache_hit_pct=$(echo "$row" | jq -r '
+			((.input_tokens // 0) + (.output_tokens // 0) + (.cache_read_tokens // 0) + (.cache_write_tokens // 0)) as $total
+			| if $total > 0 then (((.cache_read_tokens // 0) / $total * 1000 | round) / 10) else 0 end')
+		local f_requests f_input f_output f_cache f_cache_hit f_session_count f_session_hours
 		f_requests=$(_format_number "$requests")
 		f_input=$(_format_tokens "$input")
 		f_output=$(_format_tokens "$output")
 		f_cache=$(_format_tokens "$cache")
+		f_cache_hit=$(_format_hours "$cache_hit_pct")
+		f_session_count=$(_format_number "$session_count")
+		if [[ "$session_hours" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+			f_session_hours="$(_format_number "$(_format_hours "$session_hours")")h"
+		else
+			f_session_hours="—"
+		fi
 
-		# Format cost and both savings with commas and 2 decimal places
-		local f_cost f_csavings f_msavings
-		f_cost=$(_format_cost "$cost")
-		f_csavings=$(_format_cost "$row_cache_savings")
-		f_msavings=$(_format_cost "$row_model_savings")
-
-		model_rows="${model_rows}| ${clean_model} | ${f_requests} | ${f_input} | ${f_output} | ${f_cache} | \$${f_cost} | \$${f_csavings} | \$${f_msavings} |
+		model_rows="${model_rows}| ${clean_model} | ${f_requests} | ${f_input} | ${f_output} | ${f_cache} | ${f_cache_hit}% | ${f_session_count} | ${f_session_hours} |
 "
-	done < <(echo "$model_json" | jq -c '.[] | select(.cost_total >= 0.05)')
+	done < <(echo "$model_json" | jq -c 'sort_by(-(.requests // 0)) | .[] | select((.requests // 0) > 0)')
 
 	# Format totals
-	local f_total_req f_total_in f_total_out f_total_cache
-	local f_total_csavings f_total_msavings
+	local f_total_req f_total_in f_total_out f_total_cache f_total_sessions f_total_session_hours
 	f_total_req=$(_format_number "$total_requests")
 	f_total_in=$(_format_tokens "$total_input")
 	f_total_out=$(_format_tokens "$total_output")
 	f_total_cache=$(_format_tokens "$total_cache")
-	local f_total_cost
-	f_total_cost=$(_format_cost "$total_cost")
-	f_total_csavings=$(_format_cost "$total_cache_savings")
-	f_total_msavings=$(_format_cost "$total_model_savings")
-
-	# Combined savings for footer
-	local combined_savings f_combined_savings
-	combined_savings=$(echo "$total_cache_savings + $total_model_savings" | bc)
-	f_combined_savings=$(_format_cost "$combined_savings")
+	f_total_sessions=$(_format_number "$total_sessions")
+	if [[ "$session_hours_complete" == true ]]; then
+		f_total_session_hours="$(_format_number "$(_format_hours "$total_session_hours")")h"
+	else
+		f_total_session_hours="—"
+	fi
 
 	# Token totals for footer
 	local all_tokens cache_pct
@@ -220,15 +222,11 @@ _render_model_usage_table() {
 
 ## ${heading}
 
-| Model | Requests | Input | Output | Cache read | API Cost | Cache savings | Model savings |
+| Model | Requests | Input | Output | Cache read | Cache Hit-Rate % | Session Count | Session Hours |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-${model_rows}| **Total** | **${f_total_req}** | **${f_total_in}** | **${f_total_out}** | **${f_total_cache}** | **\$${f_total_cost}** | **\$${f_total_csavings}** | **\$${f_total_msavings}** |
+${model_rows}| **Total** | **${f_total_req}** | **${f_total_in}** | **${f_total_out}** | **${f_total_cache}** | **${cache_pct}%** | **${f_total_sessions}** | **${f_total_session_hours}** |
 
 _${f_all_tokens} total tokens processed. ${cache_pct}% cache hit rate._
-
-_\$${f_combined_savings} total saved (\$${f_total_csavings} caching + \$${f_total_msavings} model routing vs all-Opus)._
-
-_Model savings are modest because ~${cache_pct}% of tokens are cache reads, where price differences between models are small._
 EOF
 
 	return 0

--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -179,7 +179,7 @@ _render_model_usage_table() {
 		local clean_model cache_hit_pct
 		clean_model=$(_clean_model_name "$model")
 		cache_hit_pct=$(echo "$row" | jq -r '
-			((.input_tokens // 0) + (.output_tokens // 0) + (.cache_read_tokens // 0) + (.cache_write_tokens // 0)) as $total
+			((.input_tokens // 0) + (.cache_read_tokens // 0)) as $total
 			| if $total > 0 then (((.cache_read_tokens // 0) / $total * 1000 | round) / 10) else 0 end')
 		local f_requests f_input f_output f_cache f_cache_hit f_session_count f_session_hours
 		f_requests=$(_format_number "$requests")

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -1077,14 +1077,14 @@ test_model_usage_renders_activity_metrics_without_costs() {
 	# shellcheck source=../profile-readme-render-lib.sh
 	source "$SOURCE_RENDER_LIB"
 	local model_json token_totals output_file
-	model_json='[{"model":"model-a","requests":2,"input_tokens":100,"output_tokens":100,"cache_read_tokens":800,"cache_write_tokens":0,"session_count":2,"total_session_count":2,"session_hours":1.5,"cost_total":0}]'
-	token_totals='{"total_all":1000,"cache_hit_pct":80.0}'
+	model_json='[{"model":"model-a","requests":2,"input_tokens":100,"output_tokens":900,"cache_read_tokens":900,"cache_write_tokens":100,"session_count":2,"total_session_count":2,"session_hours":1.5,"cost_total":0}]'
+	token_totals=$(_token_totals_from_model_usage "$model_json")
 	output_file="${TEST_DIR}/model-usage.md"
 	_render_model_usage_table "AI Model Usage" "$model_json" "$token_totals" >"$output_file"
 
 	if ! grep -Fq '| Model | Requests | Input | Output | Cache read | Cache Hit-Rate % | Session Count | Session Hours |' "$output_file" ||
-		! grep -Fq '| model-a | 2 | 100 | 100 | 800 | 80.0% | 2 | 1.5h |' "$output_file" ||
-		! grep -Fq '| **Total** | **2** | **100** | **100** | **800** | **80.0%** | **2** | **1.5h** |' "$output_file"; then
+		! grep -Fq '| model-a | 2 | 100 | 900 | 900 | 90.0% | 2 | 1.5h |' "$output_file" ||
+		! grep -Fq '| **Total** | **2** | **100** | **900** | **900** | **90%** | **2** | **1.5h** |' "$output_file"; then
 		print_result "$test_name" 1 "activity metric columns or values are missing"
 		return 0
 	fi
@@ -1126,6 +1126,37 @@ test_observability_model_usage_calculates_sessions_and_hours() {
 		and ($models["model-b"].session_hours == 1)
 	' >/dev/null; then
 		print_result "$test_name" 1 "unexpected observability aggregation: ${result}"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+test_opencode_model_usage_deduplicates_variants_and_rejects_partial_duration() {
+	local test_name="OpenCode model usage deduplicates normalized sessions and leaves incomplete duration unavailable"
+	TEST_DIR=$(mktemp -d)
+	# shellcheck source=../profile-readme-data-lib.sh
+	source "$SOURCE_DATA_LIB"
+	OPENCODE_DB_FILE="${TEST_DIR}/opencode.db"
+	OPENCODE_ARCHIVE_DB_FILE="${TEST_DIR}/missing-archive.db"
+	sqlite3 "$OPENCODE_DB_FILE" "
+		CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+		INSERT INTO message VALUES
+			('message-1', 'session-1', 0, 0, json_object('role', 'assistant', 'modelID', 'model-a-20260101', 'tokens', json_object('input', 10, 'output', 1, 'cache', json_object('read', 100, 'write', 0)), 'time', json_object('created', 0, 'completed', 3600000))),
+			('message-2', 'session-1', 0, 0, json_object('role', 'assistant', 'modelID', 'model-a-20260202', 'tokens', json_object('input', 20, 'output', 2, 'cache', json_object('read', 200, 'write', 0)), 'time', json_object('created', 3600000, 'completed', 7200000))),
+			('message-3', 'session-1', 0, 0, json_object('role', 'assistant', 'modelID', 'model-b', 'tokens', json_object('input', 30, 'output', 3, 'cache', json_object('read', 300, 'write', 0)), 'time', json_object('created', 7200000)));"
+
+	local result
+	result=$(_get_model_usage_from_opencode)
+	if ! printf '%s' "$result" | jq -e '
+		(INDEX(.model)) as $models
+		| ($models["model-a"].requests == 2)
+		and ($models["model-a"].session_count == 1)
+		and ($models["model-a"].total_session_count == 1)
+		and ($models["model-a"].session_hours == 2)
+		and ($models["model-b"].session_hours == null)
+	' >/dev/null; then
+		print_result "$test_name" 1 "unexpected OpenCode aggregation: ${result}"
 		return 0
 	fi
 	print_result "$test_name" 0
@@ -1504,6 +1535,8 @@ main() {
 	test_model_usage_renders_activity_metrics_without_costs
 	teardown
 	test_observability_model_usage_calculates_sessions_and_hours
+	teardown
+	test_opencode_model_usage_deduplicates_variants_and_rejects_partial_duration
 	teardown
 	test_screen_json_paths_are_optional_and_fail_visibly
 	teardown

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -1112,7 +1112,8 @@ test_observability_model_usage_calculates_sessions_and_hours() {
 			("2026-09-01T00:00:00Z", "session-1", "model-a", 3600000, 10, 1, 100, 0, 1.0),
 			("2026-09-01T01:00:00Z", "session-1", "model-a", 1800000, 20, 2, 200, 0, 1.0),
 			("2026-09-01T02:00:00Z", "session-2", "model-a", 1800000, 30, 3, 300, 0, 1.0),
-			("2026-09-01T03:00:00Z", "session-2", "model-b", 3600000, 40, 4, 400, 0, 1.0);'
+			("2026-09-01T03:00:00Z", "session-2", "model-b", 3600000, 40, 4, 400, 0, 1.0),
+			("2026-09-01T04:00:00Z", "session-2", "model-c", "corrupt", 50, 5, 500, 0, 1.0);'
 
 	local result
 	result=$(_get_model_usage_from_obs_db "")
@@ -1124,6 +1125,7 @@ test_observability_model_usage_calculates_sessions_and_hours() {
 		and ($models["model-a"].session_hours == 2)
 		and ($models["model-b"].session_count == 1)
 		and ($models["model-b"].session_hours == 1)
+		and ($models["model-c"].session_hours == null)
 	' >/dev/null; then
 		print_result "$test_name" 1 "unexpected observability aggregation: ${result}"
 		return 0
@@ -1144,7 +1146,8 @@ test_opencode_model_usage_deduplicates_variants_and_rejects_partial_duration() {
 		INSERT INTO message VALUES
 			('message-1', 'session-1', 0, 0, json_object('role', 'assistant', 'modelID', 'model-a-20260101', 'tokens', json_object('input', 10, 'output', 1, 'cache', json_object('read', 100, 'write', 0)), 'time', json_object('created', 0, 'completed', 3600000))),
 			('message-2', 'session-1', 0, 0, json_object('role', 'assistant', 'modelID', 'model-a-20260202', 'tokens', json_object('input', 20, 'output', 2, 'cache', json_object('read', 200, 'write', 0)), 'time', json_object('created', 3600000, 'completed', 7200000))),
-			('message-3', 'session-1', 0, 0, json_object('role', 'assistant', 'modelID', 'model-b', 'tokens', json_object('input', 30, 'output', 3, 'cache', json_object('read', 300, 'write', 0)), 'time', json_object('created', 7200000)));"
+			('message-3', 'session-1', 0, 0, json_object('role', 'assistant', 'modelID', 'model-b', 'tokens', json_object('input', 30, 'output', 3, 'cache', json_object('read', 300, 'write', 0)), 'time', json_object('created', 7200000))),
+			('message-4', 'session-1', 0, 0, json_object('role', 'assistant', 'modelID', 'model-c', 'tokens', json_object('input', 40, 'output', 4, 'cache', json_object('read', 400, 'write', 0)), 'time', json_object('created', 'corrupt', 'completed', 'corrupt')));"
 
 	local result
 	result=$(_get_model_usage_from_opencode)
@@ -1155,8 +1158,30 @@ test_opencode_model_usage_deduplicates_variants_and_rejects_partial_duration() {
 		and ($models["model-a"].total_session_count == 1)
 		and ($models["model-a"].session_hours == 2)
 		and ($models["model-b"].session_hours == null)
+		and ($models["model-c"].session_hours == null)
 	' >/dev/null; then
 		print_result "$test_name" 1 "unexpected OpenCode aggregation: ${result}"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+test_jsonl_model_usage_rejects_partial_duration() {
+	local test_name="JSONL model usage leaves partial duration unavailable"
+	TEST_DIR=$(mktemp -d)
+	# shellcheck source=../profile-readme-data-lib.sh
+	source "$SOURCE_DATA_LIB"
+	METRICS_FILE="${TEST_DIR}/metrics.jsonl"
+	cat >"$METRICS_FILE" <<'EOF'
+{"model":"model-a","session_id":"session-1","duration_ms":3600000,"input_tokens":10,"output_tokens":1,"cache_read_tokens":100,"cache_write_tokens":0,"cost_total":1,"recorded_at":"2026-09-01T00:00:00Z"}
+{"model":"model-a","session_id":"session-2","input_tokens":20,"output_tokens":2,"cache_read_tokens":200,"cache_write_tokens":0,"cost_total":1,"recorded_at":"2026-09-01T01:00:00Z"}
+EOF
+
+	local result
+	result=$(_get_model_usage_from_jsonl all)
+	if ! printf '%s' "$result" | jq -e '.[0].session_count == 2 and .[0].total_session_count == 2 and .[0].session_hours == null' >/dev/null; then
+		print_result "$test_name" 1 "unexpected JSONL aggregation: ${result}"
 		return 0
 	fi
 	print_result "$test_name" 0
@@ -1537,6 +1562,8 @@ main() {
 	test_observability_model_usage_calculates_sessions_and_hours
 	teardown
 	test_opencode_model_usage_deduplicates_variants_and_rejects_partial_duration
+	teardown
+	test_jsonl_model_usage_rejects_partial_duration
 	teardown
 	test_screen_json_paths_are_optional_and_fail_visibly
 	teardown

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -451,6 +451,40 @@ test_internal_override_rejects_canonical_checkout() {
 	return 0
 }
 
+test_canonical_cleanliness_ignores_untracked_files() {
+	local test_name="profile publication ignores untracked canonical files but rejects tracked changes"
+	TEST_DIR=$(mktemp -d)
+	local fixture_home="${TEST_DIR}/home"
+	local fixture_repo="${TEST_DIR}/profile-repo"
+	local fixture_remote="${TEST_DIR}/profile-remote.git"
+	mkdir -p "$fixture_home"
+	create_profile_repo_fixture "$fixture_home" "$fixture_repo" "$fixture_remote"
+
+	local result
+	result=$(
+		set -- help
+		# shellcheck source=../profile-readme-helper.sh
+		source "$SOURCE_HELPER" >/dev/null
+		printf '%s\n' harmless >"${fixture_repo}/.DS_Store"
+		if ! _profile_assert_canonical_clean "$fixture_repo"; then
+			printf '%s\n' untracked-rejected
+			return 0
+		fi
+		printf '%s\n' mutation >>"${fixture_repo}/README.md"
+		if _profile_assert_canonical_clean "$fixture_repo" 2>/dev/null; then
+			printf '%s\n' tracked-accepted
+			return 0
+		fi
+		printf '%s\n' ok
+	)
+	if [[ "$result" != "ok" ]]; then
+		print_result "$test_name" 1 "unexpected cleanliness result: ${result}"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
 test_update_migrates_generated_readme_with_commit_history_chart() {
 	local test_name="profile update adds commit-history chart to older generated README"
 
@@ -466,7 +500,17 @@ test_update_migrates_generated_readme_with_commit_history_chart() {
 	install_helper_with_libs "${helper_dir}"
 	write_stub_dependencies "${helper_dir}"
 	create_profile_repo_fixture "${fixture_home}" "${fixture_repo}" "${fixture_remote}"
-	printf '\n> Stats auto-updated by [aidevops](https://aidevops.sh).\n' >>"${fixture_repo}/README.md"
+	cat >>"${fixture_repo}/README.md" <<'EOF'
+
+> Stats auto-updated by [aidevops](https://aidevops.sh).
+
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://commit-history.com/embed/profile-repo?theme=dark" />
+    <img alt="profile-repo's commit history" src="https://commit-history.com/embed/profile-repo" />
+  </picture>
+</div>
+EOF
 	git -C "${fixture_repo}" add README.md
 	git -C "${fixture_repo}" commit -m "test: mark fixture as generated" >/dev/null
 	git -C "${fixture_repo}" push >/dev/null
@@ -488,8 +532,8 @@ test_update_migrates_generated_readme_with_commit_history_chart() {
 		print_result "${test_name}" 1 "migration did not add one username-specific chart"
 		return 0
 	fi
-	if grep -Fq '<a href="https://commit-history.com/' "$readme"; then
-		print_result "${test_name}" 1 "migrated chart contains an unnecessary provider backlink"
+	if [[ "$(grep -c '<a href="https://commit-history.com/profile-repo">' "$readme")" -ne 1 ]]; then
+		print_result "${test_name}" 1 "migrated chart is not linked to the username activity profile"
 		return 0
 	fi
 
@@ -766,14 +810,14 @@ EOF
 		return 0
 	fi
 
-	# Verify the final generated block is theme-aware and has no provider backlink.
+	# Verify the final generated block is theme-aware and links to the activity profile.
 	if ! grep -Fq 'srcset="https://commit-history.com/embed/profile-repo?theme=dark"' "$readme" ||
 		! grep -Fq 'src="https://commit-history.com/embed/profile-repo"' "$readme"; then
 		print_result "${test_name}" 1 "commit-history light/dark image URLs missing"
 		return 0
 	fi
-	if grep -Fq '<a href="https://commit-history.com/' "$readme"; then
-		print_result "${test_name}" 1 "commit-history chart contains an unnecessary provider backlink"
+	if ! grep -Fq '<a href="https://commit-history.com/profile-repo">' "$readme"; then
+		print_result "${test_name}" 1 "commit-history chart does not link to the username activity profile"
 		return 0
 	fi
 	if [[ "$(tail -n 1 "$readme")" != "</div>" ]]; then
@@ -1019,6 +1063,69 @@ test_work_with_ai_unavailable_is_not_zero() {
 	fi
 	if grep -qF 'unavailableh' "$output_file"; then
 		print_result "$test_name" 1 "unavailable status was formatted as a numeric hour value"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+test_model_usage_renders_activity_metrics_without_costs() {
+	local test_name="model usage renders cache and session activity without cost or savings claims"
+	TEST_DIR=$(mktemp -d)
+	# shellcheck source=../profile-readme-data-lib.sh
+	source "$SOURCE_DATA_LIB"
+	# shellcheck source=../profile-readme-render-lib.sh
+	source "$SOURCE_RENDER_LIB"
+	local model_json token_totals output_file
+	model_json='[{"model":"model-a","requests":2,"input_tokens":100,"output_tokens":100,"cache_read_tokens":800,"cache_write_tokens":0,"session_count":2,"total_session_count":2,"session_hours":1.5,"cost_total":0}]'
+	token_totals='{"total_all":1000,"cache_hit_pct":80.0}'
+	output_file="${TEST_DIR}/model-usage.md"
+	_render_model_usage_table "AI Model Usage" "$model_json" "$token_totals" >"$output_file"
+
+	if ! grep -Fq '| Model | Requests | Input | Output | Cache read | Cache Hit-Rate % | Session Count | Session Hours |' "$output_file" ||
+		! grep -Fq '| model-a | 2 | 100 | 100 | 800 | 80.0% | 2 | 1.5h |' "$output_file" ||
+		! grep -Fq '| **Total** | **2** | **100** | **100** | **800** | **80.0%** | **2** | **1.5h** |' "$output_file"; then
+		print_result "$test_name" 1 "activity metric columns or values are missing"
+		return 0
+	fi
+	if grep -Eq 'API Cost|Cache savings|Model savings|total saved|all-Opus' "$output_file"; then
+		print_result "$test_name" 1 "obsolete cost or savings output remains"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+test_observability_model_usage_calculates_sessions_and_hours() {
+	local test_name="observability model usage calculates distinct sessions and generation hours"
+	TEST_DIR=$(mktemp -d)
+	# shellcheck source=../profile-readme-data-lib.sh
+	source "$SOURCE_DATA_LIB"
+	OBS_DB_FILE="${TEST_DIR}/llm-requests.db"
+	sqlite3 "$OBS_DB_FILE" '
+		CREATE TABLE llm_requests (
+			timestamp TEXT, session_id TEXT, model_id TEXT, duration_ms INTEGER,
+			tokens_input INTEGER, tokens_output INTEGER, tokens_cache_read INTEGER,
+			tokens_cache_write INTEGER, cost REAL
+		);
+		INSERT INTO llm_requests VALUES
+			("2026-09-01T00:00:00Z", "session-1", "model-a", 3600000, 10, 1, 100, 0, 1.0),
+			("2026-09-01T01:00:00Z", "session-1", "model-a", 1800000, 20, 2, 200, 0, 1.0),
+			("2026-09-01T02:00:00Z", "session-2", "model-a", 1800000, 30, 3, 300, 0, 1.0),
+			("2026-09-01T03:00:00Z", "session-2", "model-b", 3600000, 40, 4, 400, 0, 1.0);'
+
+	local result
+	result=$(_get_model_usage_from_obs_db "")
+	if ! printf '%s' "$result" | jq -e '
+		(INDEX(.model)) as $models
+		| ($models["model-a"].requests == 3)
+		and ($models["model-a"].session_count == 2)
+		and ($models["model-a"].total_session_count == 2)
+		and ($models["model-a"].session_hours == 2)
+		and ($models["model-b"].session_count == 1)
+		and ($models["model-b"].session_hours == 1)
+	' >/dev/null; then
+		print_result "$test_name" 1 "unexpected observability aggregation: ${result}"
 		return 0
 	fi
 	print_result "$test_name" 0
@@ -1375,6 +1482,8 @@ main() {
 		teardown
 		test_internal_override_rejects_canonical_checkout
 		teardown
+		test_canonical_cleanliness_ignores_untracked_files
+		teardown
 		test_update_migrates_generated_readme_with_commit_history_chart
 		teardown
 		test_inject_markers_into_existing_readme
@@ -1391,6 +1500,10 @@ main() {
 	test_work_with_ai_worker_counts_above_thousand
 	teardown
 	test_work_with_ai_unavailable_is_not_zero
+	teardown
+	test_model_usage_renders_activity_metrics_without_costs
+	teardown
+	test_observability_model_usage_calculates_sessions_and_hours
 	teardown
 	test_screen_json_paths_are_optional_and_fail_visibly
 	teardown

--- a/.agents/tools/auto-reason.md
+++ b/.agents/tools/auto-reason.md
@@ -72,7 +72,7 @@ identifiers used for an intentional comparison:
 simple
 standard
 thinking
-openai/gpt-5.5
+openai/gpt-5.6-terra
 anthropic/claude-sonnet-4-6
 google/gemini-pro
 openrouter/deepseek-r1
@@ -170,10 +170,10 @@ auto-reason-{slug}/
 Prefer at least two independent model families in the judge panel when available. Example:
 
 ```text
-author: openai/gpt-5.5
+author: openai/gpt-5.6-terra
 critic: anthropic/claude-haiku-4-5
-synthesizer: openai/gpt-5.5
-judges: anthropic/claude-haiku-4-5,google/gemini-pro,openai/gpt-5.5
+synthesizer: openai/gpt-5.6-terra
+judges: anthropic/claude-haiku-4-5,google/gemini-pro,openai/gpt-5.6-terra
 ```
 
 If only one provider is configured, proceed with same-provider fresh contexts and state the limitation in `summary.md`.

--- a/TODO.md
+++ b/TODO.md
@@ -1326,6 +1326,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18400 Prefer standalone Brave for Playwright automation ref:GH#31168 pr:#31169 completed:2026-09-04
 
+- [ ] t18401 Restore profile activity reporting #bug #framework #interactive ref:GH#31199 -> [todo/tasks/t18401-brief.md]
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/todo/tasks/t18401-brief.md
+++ b/todo/tasks/t18401-brief.md
@@ -1,0 +1,100 @@
+---
+mode: subagent
+---
+
+<!-- aidevops:brief-schema=v2 -->
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t18401: Restore profile activity reporting
+
+## Pre-flight
+
+- [x] Memory recall: `GitHub profile README screen-time publication commit-history model usage metrics GPT-5.5` → 0 hits — no relevant lessons.
+- [x] Discovery pass: 2 recent commits / 0 merged related PRs / 0 open related PRs touched the target area.
+- [x] File refs verified: 6 target refs checked and present at HEAD.
+- [x] Tier: `standard` — the SQL aggregation and publication boundary are resolved but span multiple shell components.
+- [x] Seeded draft PR decision recorded: skipped — implementation and focused verification were already complete before task allocation.
+
+## Origin
+
+- **Created:** 2026-09-05
+- **Session:** OpenCode interactive session
+- **Created by:** AI DevOps (ai-interactive)
+- **Conversation context:** Restore a stale public profile update path, replace speculative cost/savings presentation with measurable activity, and remove GPT-5.5 from active auto-reason examples.
+
+## What
+
+Publish profile README updates even when the read-only canonical checkout contains harmless untracked files, link the commit-history chart to the user's activity profile, and render per-model cache hit rate, distinct session count, and generation hours instead of API cost and savings estimates.
+
+## Why
+
+The screen-time collector was healthy, but publication stopped because `.DS_Store` made the canonical checkout fail a strict cleanliness check. The profile also exposed cost assumptions that do not represent subscription usage and omitted the measurable session activity available in local observability data.
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** The behavior and target paths are known, but the work coordinates SQL fallback sources, Markdown rendering, isolated Git publication, and backward-compatible chart migration.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/profile-readme-data-lib.sh` — aggregate distinct sessions and request duration from observability, OpenCode, and JSONL fallback data.
+- `EDIT: .agents/scripts/profile-readme-render-lib.sh` — replace cost/savings columns and prose with cache and session activity.
+- `EDIT: .agents/scripts/profile-readme-helper.sh` — link and migrate commit-history charts; ignore untracked canonical files while retaining tracked-change and unpushed-commit guards.
+- `EDIT: .agents/scripts/tests/test-profile-readme-boundary.sh` — cover aggregation, rendering, chart migration, and cleanliness boundaries.
+- `EDIT: .agents/scripts/commands/auto-reason.md` — use workload tiers in defaults and examples.
+- `EDIT: .agents/tools/auto-reason.md` — remove GPT-5.5 from concrete comparison examples.
+
+### Complete Write Surface
+
+- **Callers/readers:** `profile-readme-helper.sh generate` calls `_get_profile_model_usage_bundle` and `_render_model_usage_table`; `update` calls `_ensure_commit_history_chart` inside an isolated publication worktree.
+- **Writers/mutation paths:** profile updates write only `README.md` in the temporary publication worktree and push its default branch; the configured canonical checkout remains unchanged.
+- **Existing verification/tests:** `.agents/scripts/tests/test-profile-readme-boundary.sh`, ShellCheck, and `.agents/scripts/linters-local.sh` cover the affected shell surfaces.
+- **Schemas/config:** `llm_requests.session_id`, `duration_ms`, token columns, and OpenCode `message.session_id` plus assistant JSON timestamps supply the metrics; no schema migration is required.
+- **Generated/deployed mirrors:** `~/.aidevops/agents/` and OpenCode command files are refreshed through `setup.sh` after merge; the public profile README refreshes through `profile-readme-helper.sh update`.
+- **Migrations/backfills:** existing unlinked commit-history picture blocks are wrapped during the next update; historical model rows remain reportable.
+- **Cleanup/rollback paths:** publication worktrees retain guarded cleanup; reverting the source commit restores the prior table and cleanliness policy without data migration.
+
+### Implementation Steps
+
+1. Add session fields to every model-data source and preserve exact all-period distinct-session totals.
+2. Render only rows with requests, calculate cache hit rate from token totals, and show unavailable duration as an em dash rather than a false zero.
+3. Wrap new and legacy commit-history pictures in the documented user-profile link.
+4. Change canonical preflight to ignore untracked files while preserving tracked-change, unpushed-commit, and before/after mutation checks.
+5. Replace GPT-5.5 auto-reason defaults/examples with workload tiers or the current intentional comparison model.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** the existing isolated publication worktree and before/after canonical state comparison remain unchanged.
+- **Migration/rollback:** legacy chart migration is idempotent and adds at most one profile anchor; rollback needs no data change.
+- **Mixed-version/backward compatibility:** JSONL rows without duration render `—`; older data without global session totals falls back to the sum of available per-model counts.
+- **Idempotency/retry:** repeated profile updates detect the existing exact link and do not nest anchors or duplicate charts.
+- **Partial failure/recovery:** a failed chart migration removes its temporary file and aborts before replacing or committing the generated README.
+
+### Verification Before Dispatch
+
+```bash
+.agents/scripts/tests/test-profile-readme-boundary.sh
+.agents/scripts/profile-readme-helper.sh generate
+shellcheck .agents/scripts/profile-readme-data-lib.sh .agents/scripts/profile-readme-render-lib.sh .agents/scripts/profile-readme-helper.sh .agents/scripts/tests/test-profile-readme-boundary.sh
+.agents/scripts/linters-local.sh
+```
+
+- **Surface mapping:** the boundary test covers SQL aggregation, Markdown output, migration idempotency, and canonical Git safety; `generate` exercises current local data; ShellCheck and local linters cover shell and repository policy.
+- **Broad verification trigger:** not required; no shared dependency, root config, or release infrastructure changed.
+
+### Recoverability Checkpoint
+
+- [x] Focused functional verification passes: `.agents/scripts/tests/test-profile-readme-boundary.sh` — 24/24 passed.
+- [x] WIP commit created before broad gates: `c603e83f5 fix: restore profile activity reporting`.
+
+## Acceptance Criteria
+
+- [x] A canonical profile checkout containing only untracked files can publish through an isolated worktree, while tracked changes and unpushed commits remain blocked.
+- [x] New and legacy commit-history charts link exactly once to `https://commit-history.com/<user>` and retain light/dark embeds.
+- [x] Model tables show `Cache Hit-Rate %`, `Session Count`, and `Session Hours` and contain no API-cost or savings columns/prose.
+- [x] Current observability data produces exact distinct-session totals and summed generation duration; unavailable fallback duration is not represented as measured zero.
+- [x] Active auto-reason guidance no longer selects GPT-5.5 by default or example.

--- a/todo/tasks/t18401-brief.md
+++ b/todo/tasks/t18401-brief.md
@@ -88,7 +88,7 @@ shellcheck .agents/scripts/profile-readme-data-lib.sh .agents/scripts/profile-re
 
 ### Recoverability Checkpoint
 
-- [x] Focused functional verification passes: `.agents/scripts/tests/test-profile-readme-boundary.sh` — 25/25 passed.
+- [x] Focused functional verification passes: `.agents/scripts/tests/test-profile-readme-boundary.sh` — 26/26 passed.
 - [x] WIP commit created before broad gates: `c603e83f5 fix: restore profile activity reporting`.
 
 ## Acceptance Criteria

--- a/todo/tasks/t18401-brief.md
+++ b/todo/tasks/t18401-brief.md
@@ -88,7 +88,7 @@ shellcheck .agents/scripts/profile-readme-data-lib.sh .agents/scripts/profile-re
 
 ### Recoverability Checkpoint
 
-- [x] Focused functional verification passes: `.agents/scripts/tests/test-profile-readme-boundary.sh` — 24/24 passed.
+- [x] Focused functional verification passes: `.agents/scripts/tests/test-profile-readme-boundary.sh` — 25/25 passed.
 - [x] WIP commit created before broad gates: `c603e83f5 fix: restore profile activity reporting`.
 
 ## Acceptance Criteria


### PR DESCRIPTION
## Summary

Restore isolated profile publication with harmless untracked canonical files, link commit-history charts, replace cost and savings output with cache/session activity, and remove GPT-5.5 from auto-reason examples.

## Files Changed

- `.agents/scripts/profile-readme-data-lib.sh`
- `.agents/scripts/profile-readme-render-lib.sh`
- `.agents/scripts/profile-readme-helper.sh`
- `.agents/scripts/tests/test-profile-readme-boundary.sh`
- `.agents/scripts/commands/auto-reason.md`
- `.agents/tools/auto-reason.md`
- `TODO.md`
- `todo/tasks/t18401-brief.md`

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — the profile boundary suite exercised isolated publication and passed 26/26; the production profile generate command succeeded against current screen-time, OpenCode, and observability data; ShellCheck and `linters-local.sh` passed.

## Decisions

- Keep historical GPT-5.5 usage visible while removing it from active auto-reason examples.
- Count distinct sessions exactly across each reporting period and publish generation hours only when every contributing duration is valid.
- Use the established prompt-cache formula: cache reads divided by cache reads plus uncached input.
- Retain tracked-change, unpushed-commit, isolated-worktree, and before/after canonical-state guards while ignoring harmless untracked files.

Resolves #31199

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 plugin for [OpenCode](https://opencode.ai) v1.18.28 with gpt-5.6-sol spent 1h 33m and 800,941 tokens on this with the user in an interactive session.