### PR TITLE
GH#31201: Install native Codex CLI workflows during setup and update

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -8,7 +8,7 @@ mode: subagent
 
 New to aidevops? Type `/onboarding`.
 
-**Supported runtimes:** Claude Code and OpenCode. For headless dispatch, use `headless-runtime-helper.sh run` — not bare runtime CLIs.
+**Runtimes:** Claude Code, OpenCode, [Codex CLI](tools/ai-assistants/codex-cli.md). Headless: `headless-runtime-helper.sh run`.
 
 **Identity:** describe yourself as AI DevOps (framework) and name the host app only from version-check output. MCP tools are auxiliary, not identity/persona.
 

--- a/.agents/aidevops/architecture.md
+++ b/.agents/aidevops/architecture.md
@@ -31,7 +31,7 @@ tools:
 
 ## Supported Runtime Integrations
 
-Claude Code and OpenCode are supported runtimes. Canonical agents, workflows, and
+Claude Code, OpenCode and [Codex CLI](../tools/ai-assistants/codex-cli.md) support interactive workflows. Canonical agents, workflows, and
 workload tiers remain provider-agnostic; generated adapters and runtime
 configuration supply runtime-specific commands, tools, and concrete model mappings.
 

--- a/.agents/hooks/codex_lifecycle.py
+++ b/.agents/hooks/codex_lifecycle.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Adapt documented Codex lifecycle events to aidevops's shared policies."""
+
+import json
+import os
+from pathlib import Path
+import sys
+
+import git_safety_guard as guard
+
+
+def handle(event):
+    """Return Codex hook output; policy decisions remain in shared helpers."""
+    name = event.get("hook_event_name")
+    if name == "SessionStart":
+        agents = Path(__file__).resolve().parent.parent
+        context = (f"Read {agents / 'AGENTS.md'} and {agents / 'build-plus.md'}. "
+                   f"Codex runtime guidance: {agents / 'tools/ai-assistants/codex-cli.md'}. "
+                   "Resume the current task after compaction; preserve its worktree and lifecycle stage.")
+        return {"hookSpecificOutput": {"hookEventName": name, "additionalContext": context}}
+    if name != "PreToolUse":
+        return None
+    tool = event.get("tool_name")
+    if tool not in ("Bash", "apply_patch"):
+        return None
+    command = event.get("tool_input", {}).get("command")
+    if not isinstance(command, str) or not command:
+        return guard._direct_write_deny("Codex hook command payload is missing or invalid")
+    if tool == "apply_patch":
+        return guard._check_canonical_write("", command)
+    return guard._check_command_policy(command)
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+        if event.get("cwd"):
+            os.chdir(event["cwd"])
+        result = handle(event)
+    except (OSError, ValueError, TypeError, AttributeError):
+        result = guard._direct_write_deny("Codex lifecycle payload could not be validated")
+    if result:
+        print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/hooks/codex_lifecycle.py
+++ b/.agents/hooks/codex_lifecycle.py
@@ -11,17 +11,17 @@ import sys
 import git_safety_guard as guard
 
 
-def handle(event):
-    """Return Codex hook output; policy decisions remain in shared helpers."""
-    name = event.get("hook_event_name")
-    if name == "SessionStart":
-        agents = Path(__file__).resolve().parent.parent
-        context = (f"Read {agents / 'AGENTS.md'} and {agents / 'build-plus.md'}. "
-                   f"Codex runtime guidance: {agents / 'tools/ai-assistants/codex-cli.md'}. "
-                   "Resume the current task after compaction; preserve its worktree and lifecycle stage.")
-        return {"hookSpecificOutput": {"hookEventName": name, "additionalContext": context}}
-    if name != "PreToolUse":
-        return None
+def session_context():
+    """Restore bounded framework pointers at session boundaries."""
+    agents = Path(__file__).resolve().parent.parent
+    context = (f"Read {agents / 'AGENTS.md'} and {agents / 'build-plus.md'}. "
+               f"Codex runtime guidance: {agents / 'tools/ai-assistants/codex-cli.md'}. "
+               "Resume the current task after compaction; preserve its worktree and lifecycle stage.")
+    return {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": context}}
+
+
+def check_tool(event):
+    """Translate Codex's command field to the shared shell or patch policy."""
     tool = event.get("tool_name")
     if tool not in ("Bash", "apply_patch"):
         return None
@@ -31,6 +31,16 @@ def handle(event):
     if tool == "apply_patch":
         return guard._check_canonical_write("", command)
     return guard._check_command_policy(command)
+
+
+def handle(event):
+    """Return Codex hook output; policy decisions remain in shared helpers."""
+    name = event.get("hook_event_name")
+    if name == "SessionStart":
+        return session_context()
+    if name == "PreToolUse":
+        return check_tool(event)
+    return None
 
 
 def main():

--- a/.agents/scripts/codex-mcp-config.py
+++ b/.agents/scripts/codex-mcp-config.py
@@ -103,7 +103,7 @@ def reconcile(data):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--config", type=Path, default=Path.home() / ".codex/config.toml")
+    parser.add_argument("--config", type=Path, default=Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex") / "config.toml")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
     config = args.config.expanduser().resolve()

--- a/.agents/scripts/codex-setup.py
+++ b/.agents/scripts/codex-setup.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Install native Codex guidance, workflow skills and compatible lifecycle hooks."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import tempfile
+
+START = "<!-- aidevops:codex:start -->"
+END = "<!-- aidevops:codex:end -->"
+
+
+def write_changed(path, text):
+    """Atomically update an owned file, preserving mode and detecting races."""
+    original = path.read_bytes() if path.exists() else None
+    if original == text.encode():
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=".aidevops-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as output:
+            output.write(text)
+            os.fchmod(output.fileno(), path.stat().st_mode & 0o777 if path.exists() else 0o600)
+        if (path.read_bytes() if path.exists() else None) != original:
+            raise ValueError("destination changed concurrently; retry setup")
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def guidance(home, agents):
+    """Maintain a small marked block without replacing personal instructions."""
+    path = home / "AGENTS.md"
+    text = path.read_text() if path.exists() else ""
+    block = (f"{START}\nRead {agents / 'AGENTS.md'} for aidevops framework rules.\n"
+             f"Use {agents / 'build-plus.md'} as the default coding workflow.\n"
+             f"Read {agents / 'tools/ai-assistants/codex-cli.md'} for Codex controls, "
+             f"skills, hooks and runtime differences.\n{END}")
+    if START in text or END in text:
+        if text.count(START) != 1 or text.count(END) != 1 or text.index(END) < text.index(START):
+            raise ValueError("invalid aidevops guidance markers")
+        text = text[:text.index(START)] + block + text[text.index(END) + len(END):]
+    else:
+        text = block + "\n\n" + text
+    write_changed(path, text)
+    override = home / "AGENTS.override.md"
+    if override.exists() and override.read_text().strip():
+        print("Codex: AGENTS.override.md takes precedence; include the aidevops AGENTS.md reference there if wanted")
+
+
+def skills(home, agents):
+    """Generate bounded pointer skills from the same command sources as OpenCode."""
+    sources = {}
+    for directory in (agents / "commands", agents / "scripts/commands"):
+        for source in sorted(directory.glob("*.md")):
+            if source.is_file() and source.stem != "SKILL":
+                name = source.stem
+                if not name.startswith("aidevops-"):
+                    name = "aidevops-" + name
+                sources[name] = source
+    # Main-agent links may not exist on a minimal install yet.
+    sources.setdefault("aidevops-build-plus", agents / "build-plus.md")
+    for name, source in sources.items():
+        if not source.is_file() or not re.fullmatch(r"[a-z0-9-]+", name):
+            continue
+        directory = home / name
+        target = directory / "SKILL.md"
+        if target.exists() and START not in target.read_text():
+            print(f"Codex: preserved personal skill {name}")
+            continue
+        description = f"Run the aidevops {name.removeprefix('aidevops-')} workflow when explicitly requested."
+        text = (f"---\nname: {name}\ndescription: {json.dumps(description)}\n---\n\n{START}\n"
+                f"Read {source} and follow that workflow for the user's request.\n"
+                f"Read {agents / 'AGENTS.md'} first if it is not already loaded.\n"
+                "Treat $ARGUMENTS in the source as the user's accompanying request, not a shell variable.\n"
+                "Use the current runtime's tools; OpenCode agent names and tool permissions are routing guidance.\n"
+                f"{END}\n")
+        write_changed(target, text)
+        # Workflow commands, especially release/deploy, require explicit selection.
+        metadata = directory / "agents/openai.yaml"
+        if not metadata.exists():
+            write_changed(metadata, "policy:\n  allow_implicit_invocation: false\n")
+    print(f"Codex: reconciled workflow skills in {home}")
+
+
+def hooks(home, agents):
+    """Append owned hooks while preserving custom entries and trust choices."""
+    path = home / "hooks.json"
+    data = json.loads(path.read_text()) if path.exists() else {}
+    events = data.setdefault("hooks", {})
+    command = "python3 " + shlex.quote(str(agents / "hooks/codex_lifecycle.py"))
+    for event, matcher in (("SessionStart", "startup|resume|clear|compact"),
+                           ("PreToolUse", "^(Bash|apply_patch)$")):
+        groups = events.setdefault(event, [])
+        handler = {"type": "command", "command": command, "timeout": 15,
+                   "statusMessage": "aidevops " + event}
+        # Stable command identity avoids duplicate registration and preserves disabled hooks.
+        if not any(h.get("command") == command for group in groups for h in group.get("hooks", [])):
+            groups.append({"matcher": matcher, "hooks": [handler]})
+    write_changed(path, json.dumps(data, indent=2) + "\n")
+    print("Codex: lifecycle hooks installed; review/trust new hooks with /hooks")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("guidance", "skills", "hooks", "all"))
+    parser.add_argument("--agents", type=Path, default=Path.home() / ".aidevops/agents")
+    parser.add_argument("--codex-home", type=Path,
+                        default=Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex"))
+    parser.add_argument("--skills-home", type=Path, default=Path.home() / ".agents/skills")
+    args = parser.parse_args()
+    if args.mode in ("guidance", "all"):
+        guidance(args.codex_home, args.agents)
+    if args.mode in ("skills", "all") and os.environ.get("AIDEVOPS_FEATURE_COMMANDS_CODEX", "yes") == "yes":
+        skills(args.skills_home, args.agents)
+    if args.mode in ("hooks", "all"):
+        hooks(args.codex_home, args.agents)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError, TypeError, AttributeError) as error:
+        raise SystemExit(f"Codex setup failed ({type(error).__name__}); inspect destination format and retry") from None

--- a/.agents/scripts/codex-setup.py
+++ b/.agents/scripts/codex-setup.py
@@ -54,8 +54,8 @@ def guidance(home, agents):
         print("Codex: AGENTS.override.md takes precedence; include the aidevops AGENTS.md reference there if wanted")
 
 
-def skills(home, agents):
-    """Generate bounded pointer skills from the same command sources as OpenCode."""
+def command_sources(agents):
+    """Collect canonical command paths, collapsing prefixed aliases."""
     sources = {}
     for directory in (agents / "commands", agents / "scripts/commands"):
         for source in sorted(directory.glob("*.md")):
@@ -64,9 +64,24 @@ def skills(home, agents):
                 if not name.startswith("aidevops-"):
                     name = "aidevops-" + name
                 sources[name] = source
-    # Main-agent links may not exist on a minimal install yet.
     sources.setdefault("aidevops-build-plus", agents / "build-plus.md")
-    for name, source in sources.items():
+    return sources
+
+
+def skill_text(name, source, agents):
+    """Render a native skill without copying runtime-specific prompt bodies."""
+    description = f"Run the aidevops {name.removeprefix('aidevops-')} workflow when explicitly requested."
+    return (f"---\nname: {name}\ndescription: {json.dumps(description)}\n---\n\n{START}\n"
+            f"Read {source} and follow that workflow for the user's request.\n"
+            f"Read {agents / 'AGENTS.md'} first if it is not already loaded.\n"
+            "Treat $ARGUMENTS in the source as the user's accompanying request, not a shell variable.\n"
+            "Use the current runtime's tools; OpenCode agent names and tool permissions are routing guidance.\n"
+            f"{END}\n")
+
+
+def skills(home, agents):
+    """Generate bounded pointer skills from the same command sources as OpenCode."""
+    for name, source in command_sources(agents).items():
         if not source.is_file() or not re.fullmatch(r"[a-z0-9-]+", name):
             continue
         directory = home / name
@@ -74,14 +89,7 @@ def skills(home, agents):
         if target.exists() and START not in target.read_text():
             print(f"Codex: preserved personal skill {name}")
             continue
-        description = f"Run the aidevops {name.removeprefix('aidevops-')} workflow when explicitly requested."
-        text = (f"---\nname: {name}\ndescription: {json.dumps(description)}\n---\n\n{START}\n"
-                f"Read {source} and follow that workflow for the user's request.\n"
-                f"Read {agents / 'AGENTS.md'} first if it is not already loaded.\n"
-                "Treat $ARGUMENTS in the source as the user's accompanying request, not a shell variable.\n"
-                "Use the current runtime's tools; OpenCode agent names and tool permissions are routing guidance.\n"
-                f"{END}\n")
-        write_changed(target, text)
+        write_changed(target, skill_text(name, source, agents))
         # Workflow commands, especially release/deploy, require explicit selection.
         metadata = directory / "agents/openai.yaml"
         if not metadata.exists():

--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -413,6 +413,8 @@ runtime_config_changes_detected() {
 			.agents/scripts/generate-opencode-*.sh | \
 			.agents/scripts/generate-claude-*.sh | \
 			.agents/scripts/runtime-registry.sh | \
+			.agents/scripts/codex-setup.py | \
+			.agents/scripts/codex-mcp-config.py | \
 			.agents/scripts/mcp-config-adapter.sh | \
 			.agents/scripts/prompt-injection-adapter.sh | \
 			.agents/scripts/lib/agent_config.py) return 0 ;;

--- a/.agents/scripts/generate-runtime-config-commands.sh
+++ b/.agents/scripts/generate-runtime-config-commands.sh
@@ -455,6 +455,9 @@ _generate_commands_for_runtime() {
 	if [[ "$skipped_count" -gt 0 ]]; then
 		print_warning "$display_name: skipped $skipped_count command file(s) that disappeared during generation"
 	fi
+	if [[ "$runtime_id" == "codex" ]]; then
+		python3 "${SCRIPT_DIR}/codex-setup.py" skills || return 1
+	fi
 	print_success "$display_name: $command_count commands in $cmd_dir"
 	return 0
 }

--- a/.agents/scripts/generate-runtime-config-mcp.sh
+++ b/.agents/scripts/generate-runtime-config-mcp.sh
@@ -49,6 +49,12 @@ _generate_mcp_for_runtime() {
 		fi
 	fi
 
+	# Codex has a preserving TOML reconciler; keep generic generation on it.
+	if [[ "$runtime_id" == "codex" ]]; then
+		python3 "${SCRIPT_DIR}/codex-mcp-config.py" || return 1
+		return 0
+	fi
+
 	local mcp_count=0
 
 	# Shared MCP definitions -- defined once, registered for each runtime

--- a/.agents/scripts/mcp-config-adapter.sh
+++ b/.agents/scripts/mcp-config-adapter.sh
@@ -242,7 +242,7 @@ else
 			echo "claude-code"
 		fi
 		# Codex
-		if [[ -d "$HOME/.codex" ]] || command -v codex >/dev/null 2>&1; then
+		if [[ -d "${CODEX_HOME:-$HOME/.codex}" ]] || command -v codex >/dev/null 2>&1; then
 			echo "codex"
 		fi
 		# Cursor
@@ -453,9 +453,9 @@ _register_mcp_claude() {
 _register_mcp_codex() {
 	local mcp_name="$1"
 	local mcp_json="$2"
-	local codex_config="$HOME/.codex/config.toml"
+	local codex_config="${CODEX_HOME:-$HOME/.codex}/config.toml"
 
-	mkdir -p "$HOME/.codex"
+	mkdir -p "${CODEX_HOME:-$HOME/.codex}"
 
 	if ! command -v jq >/dev/null 2>&1; then
 		print_warning "jq not found — cannot configure Codex"

--- a/.agents/scripts/prompt-injection-adapter.sh
+++ b/.agents/scripts/prompt-injection-adapter.sh
@@ -21,7 +21,7 @@
 # Supported runtimes and their prompt mechanisms:
 #   opencode   — json-instructions     (opencode.json "instructions" field)
 #   claude     — agents-md-autodiscovery (~/.config/Claude/AGENTS.md, ~/.claude/AGENTS.md)
-#   codex      — codex-instructions-md  (~/.codex/instructions.md)
+#   codex      — codex-agents-md  (~/.codex/AGENTS.md)
 #   cursor     — cursorrules-plus-agents (~/.cursor/rules/ + AGENTS.md)
 #   droid      — factory-skills         (~/.factory/skills/)
 #   gemini     — gemini-agents-md       (~/.gemini/AGENTS.md)
@@ -90,7 +90,7 @@ if declare -f rt_detect_installed >/dev/null 2>&1; then
 		}
 		case "$runtime_id" in
 		opencode) echo "json-instructions" ;;
-		codex) echo "codex-instructions-md" ;;
+		codex) echo "codex-agents-md" ;;
 		cursor) echo "cursorrules-plus-agents" ;;
 		droid) echo "factory-skills" ;;
 		gemini-cli) echo "gemini-agents-md" ;;
@@ -147,7 +147,7 @@ else
 	_PIA_PROMPT_MECHANISMS=(
 		"json-instructions"
 		"agents-md-autodiscovery"
-		"codex-instructions-md"
+		"codex-agents-md"
 		"cursorrules-plus-agents"
 		"factory-skills"
 		"gemini-agents-md"
@@ -485,18 +485,13 @@ _deploy_prompt_agents_md() {
 	return 0
 }
 
-# Codex: create ~/.codex/instructions.md with framework pointer
+# Codex: use the native global AGENTS.md discovery contract.
 _deploy_prompt_codex_instructions() {
-	local instructions_file="${HOME}/.codex/instructions.md"
-	local ref_line='Read ~/.aidevops/agents/AGENTS.md for AI DevOps framework capabilities and rules.'
-
-	# Only deploy if codex is installed or ~/.codex exists
-	if ! command -v codex &>/dev/null && [[ ! -d "${HOME}/.codex" ]]; then
-		_pia_log "info" "Codex not installed — skipping"
+	local codex_dir="${CODEX_HOME:-$HOME/.codex}"
+	if ! command -v codex &>/dev/null && [[ ! -d "$codex_dir" ]]; then
 		return 0
 	fi
-
-	_pia_ensure_reference_in_file "$instructions_file" "$ref_line" "aidevops"
+	python3 "${_PIA_DIR}/codex-setup.py" guidance || return 1
 	return 0
 }
 
@@ -713,7 +708,7 @@ deploy_prompts_for_runtime() {
 	agents-md-autodiscovery)
 		_deploy_prompt_agents_md "$runtime_id"
 		;;
-	codex-instructions-md)
+	codex-agents-md)
 		_deploy_prompt_codex_instructions
 		;;
 	cursorrules-plus-agents)
@@ -814,8 +809,8 @@ show_prompt_deployment_status() {
 				;;
 			esac
 			;;
-		codex-instructions-md)
-			if grep -q "aidevops" "${HOME}/.codex/instructions.md" 2>/dev/null; then
+		codex-agents-md)
+			if grep -q "aidevops" "${CODEX_HOME:-$HOME/.codex}/AGENTS.md" 2>/dev/null; then
 				deployed="yes"
 			fi
 			;;

--- a/.agents/scripts/runtime-registry.sh
+++ b/.agents/scripts/runtime-registry.sh
@@ -132,7 +132,7 @@ _RT_DISPLAY_NAME=(
 _RT_CONFIG_PATH=(
 	"\$HOME/.config/opencode/opencode.json"            # opencode
 	"\$HOME/.config/Claude/claude_desktop_config.json" # claude-code
-	"\$HOME/.codex/config.json"                        # codex
+	"\$CODEX_HOME/config.toml"                         # codex
 	"\$HOME/.cursor/mcp.json"                          # cursor
 	"\$HOME/.config/droid/mcp.json"                    # droid
 	"\$HOME/.gemini/settings.json"                     # gemini-cli
@@ -150,7 +150,7 @@ _RT_CONFIG_PATH=(
 _RT_CONFIG_FORMAT=(
 	"json" # opencode
 	"json" # claude-code
-	"json" # codex
+	"toml" # codex
 	"json" # cursor
 	"json" # droid
 	"json" # gemini-cli
@@ -166,20 +166,20 @@ _RT_CONFIG_FORMAT=(
 
 # --- MCP root key (the JSON key under which MCP servers are defined) ---
 _RT_MCP_ROOT_KEY=(
-	"mcp"        # opencode — inside opencode.json
-	"mcpServers" # claude-code
-	"mcpServers" # codex
-	"mcpServers" # cursor
-	"mcpServers" # droid
-	"mcpServers" # gemini-cli
-	"mcpServers" # windsurf
-	"mcpServers" # continue
-	"mcpServers" # kilo
-	"mcpServers" # kiro
-	""           # aider
-	"mcpServers" # amp
-	"mcpServers" # kimi
-	"mcpServers" # qwen
+	"mcp"         # opencode — inside opencode.json
+	"mcpServers"  # claude-code
+	"mcp_servers" # codex
+	"mcpServers"  # cursor
+	"mcpServers"  # droid
+	"mcpServers"  # gemini-cli
+	"mcpServers"  # windsurf
+	"mcpServers"  # continue
+	"mcpServers"  # kilo
+	"mcpServers"  # kiro
+	""            # aider
+	"mcpServers"  # amp
+	"mcpServers"  # kimi
+	"mcpServers"  # qwen
 )
 
 # --- Slash command / prompt / skill directories ---
@@ -189,7 +189,7 @@ _RT_MCP_ROOT_KEY=(
 _RT_COMMAND_DIR=(
 	"\$HOME/.config/opencode/command" # opencode
 	"\$HOME/.claude/commands"         # claude-code
-	"\$HOME/.codex/prompts"           # codex (invoked as /prompts:name)
+	"\$CODEX_HOME/prompts"            # codex (invoked as /prompts:name)
 	"\$HOME/.cursor/commands"         # cursor (Cursor 1.6+)
 	"\$HOME/.factory/commands"        # droid (Factory CLI)
 	"\$HOME/.gemini/commands"         # gemini-cli (TOML format)
@@ -209,7 +209,7 @@ _RT_COMMAND_DIR=(
 _RT_PROMPT_MECHANISM=(
 	"AGENTS.md"     # opencode
 	"AGENTS.md"     # claude-code
-	"system-prompt" # codex
+	"AGENTS.md"     # codex
 	"config"        # cursor (.cursorrules)
 	"AGENTS.md"     # droid
 	"system-prompt" # gemini-cli
@@ -229,7 +229,7 @@ _RT_PROMPT_MECHANISM=(
 _RT_SESSION_DB=(
 	"\$HOME/.local/share/opencode/opencode.db"                                            # opencode (SQLite)
 	"\$HOME/.claude/projects"                                                             # claude-code (JSONL dir)
-	"\$HOME/.codex/sessions"                                                              # codex (JSONL, date-partitioned)
+	"\$CODEX_HOME/sessions"                                                               # codex (JSONL, date-partitioned)
 	"\$HOME/Library/Application Support/Cursor/User/workspaceStorage"                     # cursor (SQLite state.vscdb per workspace)
 	"\$HOME/.factory/sessions"                                                            # droid (JSONL per session)
 	"\$HOME/.gemini/tmp"                                                                  # gemini-cli (JSON per session, per project hash)
@@ -274,8 +274,8 @@ _RT_VAULT_MODE_UNMANAGED="unmanaged"
 #   external    runtime stores history outside local aidevops control.
 #   none        no known local history path.
 _RT_VAULT_SESSION_HISTORY_MODE=(
-	"managed"   # opencode (SQLite path can be relocated to Vault-managed root)
-	"managed"   # claude-code (JSONL project dir can be relocated to Vault-managed root)
+	"managed"                   # opencode (SQLite path can be relocated to Vault-managed root)
+	"managed"                   # claude-code (JSONL project dir can be relocated to Vault-managed root)
 	"$_RT_VAULT_MODE_UNMANAGED" # codex
 	"$_RT_VAULT_MODE_UNMANAGED" # cursor
 	"$_RT_VAULT_MODE_UNMANAGED" # droid
@@ -284,8 +284,8 @@ _RT_VAULT_SESSION_HISTORY_MODE=(
 	"$_RT_VAULT_MODE_UNMANAGED" # continue
 	"$_RT_VAULT_MODE_UNMANAGED" # kilo
 	"$_RT_VAULT_MODE_UNMANAGED" # kiro
-	"none"      # per-repo markdown, not centrally managed
-	"external"  # amp (server-side)
+	"none"                      # per-repo markdown, not centrally managed
+	"external"                  # amp (server-side)
 	"$_RT_VAULT_MODE_UNMANAGED" # kimi
 	"$_RT_VAULT_MODE_UNMANAGED" # qwen
 )
@@ -372,7 +372,7 @@ _RT_HEADLESS_SUPPORT=(
 _RT_HEADLESS_CMDLINE_PATTERN=(
 	"\\.opencode run "         # opencode — headless via "run" subcommand
 	"claude (-p|--print|run) " # claude-code — headless via -p, --print, or run
-	"codex "                   # codex — all CLI invocations are headless
+	"codex exec "              # codex — only exec is headless
 	""                         # cursor — no headless mode
 	"droid run "               # droid — headless via "run" subcommand
 	"gemini "                  # gemini-cli — all CLI invocations are headless
@@ -547,6 +547,8 @@ _rt_index() {
 # Handles the "\$HOME" literal stored in arrays (to avoid premature expansion).
 _rt_expand_path() {
 	local path="$1"
+	local codex_home="${CODEX_HOME:-$HOME/.codex}"
+	path="${path//\$CODEX_HOME/$codex_home}"
 	# Replace literal $HOME or \$HOME with actual HOME value
 	path="${path//\\\$HOME/$HOME}"
 	path="${path//\$HOME/$HOME}"

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -1584,7 +1584,7 @@ _inject_agents_reference_legacy() {
 		fi
 	fi
 
-	# Deploy Codex instructions.md (Codex reads ~/.codex/instructions.md as system prompt)
+	# Deploy Codex global AGENTS.md guidance
 	_deploy_codex_instructions
 
 	# Deploy Cursor AGENTS.md (Cursor reads ~/.cursor/rules/*.md as context)
@@ -1596,39 +1596,15 @@ _inject_agents_reference_legacy() {
 	return 0
 }
 
-# Deploy instructions.md to Codex config directory.
-# Codex reads ~/.codex/instructions.md as its system-level instructions.
+# Share Codex's native guidance installer with setup/update and the adapter.
 _deploy_codex_instructions() {
-	local codex_dir="$HOME/.codex"
-	local instructions_file="$codex_dir/instructions.md"
-
-	# Only deploy if Codex is installed or config dir exists
+	local codex_dir="${CODEX_HOME:-$HOME/.codex}"
 	if [[ ! -d "$codex_dir" ]] && ! command -v codex >/dev/null 2>&1; then
 		return 0
 	fi
-
-	mkdir -p "$codex_dir"
-
-	local reference_content="$_AIDEVOPS_REFERENCE_LINE"
-
-	if [[ -f "$instructions_file" ]]; then
-		# shellcheck disable=SC2088  # Tilde is a literal grep pattern, not a path
-		if grep -q '~/.aidevops/agents/AGENTS.md' "$instructions_file" 2>/dev/null; then
-			print_info "Codex instructions.md already has aidevops reference"
-			return 0
-		fi
-		# Prepend reference to existing instructions
-		local temp_file
-		temp_file=$(mktemp)
-		echo "$reference_content" >"$temp_file"
-		echo "" >>"$temp_file"
-		cat "$instructions_file" >>"$temp_file"
-		mv "$temp_file" "$instructions_file"
-		print_success "Added aidevops reference to $instructions_file"
-	else
-		echo "$reference_content" >"$instructions_file"
-		print_success "Created $instructions_file with aidevops reference"
-	fi
+	local helper_dir
+	helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)" || return 1
+	python3 "$helper_dir/codex-setup.py" guidance || return 1
 	return 0
 }
 

--- a/.agents/scripts/setup/modules/config.sh
+++ b/.agents/scripts/setup/modules/config.sh
@@ -204,6 +204,7 @@ update_runtime_configs() {
 		print_info "Unified generator not found — falling back to per-runtime updates"
 		update_opencode_config
 		update_claude_config
+		update_codex_config || return $?
 		return 0
 	fi
 
@@ -232,12 +233,16 @@ update_runtime_configs() {
 			all --runtime "$runtime" || return $?
 	done
 
+	# The incremental ai-session update uses this path too.
+	update_codex_config || return $?
 	return 0
 }
 
 update_codex_config() {
+	local helper_dir
+	helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)" || return 1
 	# Only run if Codex is installed or config dir exists
-	if [[ ! -d "$HOME/.codex" ]] && ! command -v codex >/dev/null 2>&1; then
+	if [[ ! -d "${CODEX_HOME:-$HOME/.codex}" ]] && ! command -v codex >/dev/null 2>&1; then
 		return 0
 	fi
 
@@ -250,6 +255,7 @@ update_codex_config() {
 
 	# Deploy aidevops MCP servers to Codex config.toml
 	_deploy_codex_mcps || return 1
+	python3 "$helper_dir/codex-setup.py" all || return 1
 
 	print_success "Codex configuration updated"
 	return 0

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -2677,7 +2677,7 @@ setup_codex_cli() {
 # Docker Desktop 4.40+ with MCP Toolkit extension is required for `docker mcp`.
 # OrbStack, Colima, Rancher Desktop do not support it.
 _fix_codex_docker_mcp() {
-	local config="$HOME/.codex/config.toml"
+	local config="${CODEX_HOME:-$HOME/.codex}/config.toml"
 	[[ -f "$config" ]] || return 0
 
 	# Check if MCP_DOCKER section exists

--- a/.agents/scripts/tests/test-codex-setup.py
+++ b/.agents/scripts/tests/test-codex-setup.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Native Codex installation and lifecycle contract regression tests."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS.parent / "hooks"))
+import codex_lifecycle as lifecycle
+
+spec = importlib.util.spec_from_file_location("codex_setup", SCRIPTS / "codex-setup.py")
+setup = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(setup)
+
+
+class CodexSetupTests(unittest.TestCase):
+    def test_guidance_preserves_personal_and_override(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "AGENTS.md").write_text("Personal instructions\n")
+            (root / "AGENTS.override.md").write_text("Override\n")
+            setup.guidance(root, root / "agents")
+            first = (root / "AGENTS.md").read_text()
+            setup.guidance(root, root / "agents")
+            self.assertEqual(first, (root / "AGENTS.md").read_text())
+            self.assertIn("Personal instructions\n", first)
+            self.assertIn("build-plus.md", first)
+            self.assertEqual((root / "AGENTS.override.md").read_text(), "Override\n")
+
+    def test_malformed_markers_unchanged(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "AGENTS.md").write_text(setup.START)
+            with self.assertRaises(ValueError):
+                setup.guidance(root, root)
+            self.assertEqual((root / "AGENTS.md").read_text(), setup.START)
+
+    def test_skills_update_and_personal_collision(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            agents = root / "agents"
+            commands = agents / "scripts/commands"
+            commands.mkdir(parents=True)
+            (commands / "full-loop.md").write_text("First version")
+            (agents / "build-plus.md").write_text("Build")
+            skills = root / "skills"
+            personal = skills / "aidevops-build-plus/SKILL.md"
+            personal.parent.mkdir(parents=True)
+            personal.write_text("Personal skill")
+            setup.skills(skills, agents)
+            target = skills / "aidevops-full-loop/SKILL.md"
+            self.assertIn(str(commands / "full-loop.md"), target.read_text())
+            self.assertNotIn("First version", target.read_text())
+            self.assertIn("allow_implicit_invocation: false", (target.parent / "agents/openai.yaml").read_text())
+            self.assertEqual(personal.read_text(), "Personal skill")
+            first = target.read_bytes()
+            setup.skills(skills, agents)
+            self.assertEqual(first, target.read_bytes())
+
+    def test_hooks_merge_idempotent(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            custom = {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "custom"}]}]}}
+            path = root / "hooks.json"
+            path.write_text(json.dumps(custom))
+            setup.hooks(root, root / "agents")
+            first = path.read_bytes()
+            setup.hooks(root, root / "agents")
+            self.assertEqual(first, path.read_bytes())
+            data = json.loads(first)
+            self.assertEqual(data["hooks"]["Stop"], custom["hooks"]["Stop"])
+            self.assertEqual(len(data["hooks"]["PreToolUse"]), 1)
+
+    def test_custom_home_and_feature_flag(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with patch.dict(os.environ, {"CODEX_HOME": str(root / "codex"), "AIDEVOPS_FEATURE_COMMANDS_CODEX": "no"}):
+                with patch("sys.argv", ["codex-setup", "all", "--agents", str(root / "agents"), "--skills-home", str(root / "skills")]):
+                    setup.main()
+            self.assertTrue((root / "codex/AGENTS.md").exists())
+            self.assertFalse((root / "skills").exists())
+            result = subprocess.run(  # nosec B603 -- fixed shell and repository registry
+                ["/bin/bash", "-c", 'source "$1"; rt_config_path codex; rt_config_format codex; rt_command_dir codex', "test", str(SCRIPTS / "runtime-registry.sh")],
+                env={**os.environ, "CODEX_HOME": str(root / "codex")}, capture_output=True, text=True, check=True)
+            self.assertEqual(result.stdout.splitlines(), [str(root / "codex/config.toml"), "toml", str(root / "codex/prompts")])
+
+    def test_real_setup_update_twice(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            agents = root / ".aidevops/agents"
+            agents.parent.mkdir(parents=True)
+            agents.symlink_to(SCRIPTS.parent, target_is_directory=True)
+            codex = root / "custom-codex"
+            codex.mkdir()
+            command = 'source "$1"; print_info() { :; }; print_success() { :; }; update_codex_config; update_codex_config'
+            subprocess.run(  # nosec B603 -- real setup module with isolated HOME
+                ["/bin/bash", "-c", command, "test", str(SCRIPTS / "setup/modules/config.sh")],
+                env={**os.environ, "HOME": str(root), "CODEX_HOME": str(codex),
+                     "AIDEVOPS_FEATURE_COMMANDS_CODEX": "yes"},
+                capture_output=True, text=True, check=True)
+            self.assertTrue((codex / "AGENTS.md").is_file())
+            self.assertTrue((codex / "config.toml").is_file())
+            data = json.loads((codex / "hooks.json").read_text())
+            self.assertEqual(len(data["hooks"]["PreToolUse"]), 1)
+            self.assertTrue((root / ".agents/skills/aidevops-full-loop/SKILL.md").is_file())
+
+    def test_codex_patch_and_command_contract(self):
+        event = {"hook_event_name": "PreToolUse", "tool_name": "apply_patch", "tool_input": {"command": "*** Begin Patch\n*** End Patch"}}
+        with patch.object(lifecycle.guard, "_check_canonical_write", return_value={"denied": True}) as check:
+            self.assertEqual(lifecycle.handle(event), {"denied": True})
+            check.assert_called_once_with("", event["tool_input"]["command"])
+        event["tool_name"] = "Bash"
+        with patch.object(lifecycle.guard, "_check_command_policy", return_value=None) as check:
+            self.assertIsNone(lifecycle.handle(event))
+            check.assert_called_once_with(event["tool_input"]["command"])
+        event["tool_input"] = {}
+        self.assertEqual(lifecycle.handle(event)["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    def test_resume_context(self):
+        output = lifecycle.handle({"hook_event_name": "SessionStart", "source": "compact"})
+        self.assertIn("Resume the current task", output["hookSpecificOutput"]["additionalContext"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/tools/ai-assistants/codex-cli.md
+++ b/.agents/tools/ai-assistants/codex-cli.md
@@ -1,0 +1,86 @@
+---
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Codex CLI integration
+
+`setup.sh --non-interactive` and `aidevops update` reconcile the Codex integration
+when the CLI is installed or its configuration directory exists. Restart Codex
+for changed global guidance and configuration to load.
+
+## Start working
+
+Launch in your repository or linked worktree:
+
+```bash
+codex -C /path/to/repo --sandbox danger-full-access --ask-for-approval never
+```
+
+This is the explicit full-access launch: no shell sandbox or approval prompts.
+Setup preserves your permission and model settings. Plain `codex` uses those
+existing defaults. `--dangerously-bypass-approvals-and-sandbox` is the equivalent
+combined flag. Neither form automatically trusts new lifecycle hooks.
+
+Global `AGENTS.md` loads the framework and Build+ workflow automatically. Select
+an explicit workflow with `$aidevops-build-plus`, `$aidevops-full-loop`, or another
+`$aidevops-…` skill. Use `/skills` to discover installed skills. Supply the task
+in the same message. Read the named canonical workflow before executing it.
+
+## Installed surfaces
+
+| Capability | Codex integration |
+|---|---|
+| Framework instructions and default Build+ | Small managed block in `$CODEX_HOME/AGENTS.md` (default `~/.codex`) |
+| Main agents and workflow commands | Pointer skills in `~/.agents/skills/aidevops-*/SKILL.md`, generated from shared command sources |
+| Legacy slash commands | `~/.codex/prompts/aidevops-*.md`, invoked as `/prompts:aidevops-…`; retained for compatibility |
+| Startup, resume and compaction | `SessionStart` hook restores framework pointers and continuation guidance |
+| Shell and patch safety | `PreToolUse` adapter calls the same command and canonical-write policies as Claude Code |
+| MCP | `config.toml` migrations preserve custom servers; new shared defaults are disabled until explicitly enabled |
+| Memory and task lifecycle | Shared CLI helpers, including `memory-helper.sh` and `full-loop-helper.sh`; Vault access still requires an unlocked Vault |
+| Session mining | Existing Codex runtime miner; session location follows `CODEX_HOME` |
+
+Native skills require explicit invocation so commands such as release cannot
+activate merely from a matching description. `AIDEVOPS_FEATURE_COMMANDS_CODEX=no`
+skips both legacy command and native skill installation; it does not remove
+previously installed skills. Personal unmarked skills are preserved on collision.
+
+## Hooks and overrides
+
+Open `/hooks` once to review and trust the newly installed hooks. Codex binds trust
+to hook definitions; changed definitions may need another review. Setup preserves
+existing hooks, disabled entries, and `features.hooks` settings. If hooks are
+untrusted or disabled, follow the framework's pre-edit and safety checks explicitly.
+
+A nonempty `$CODEX_HOME/AGENTS.override.md` takes precedence over `AGENTS.md`.
+Setup reports this and leaves the override untouched. Include the framework
+reference there if you want aidevops active under that override. Legacy
+`instructions.md` is preserved, but is not assumed to load automatically.
+
+## Runtime differences
+
+OpenCode's agent picker, per-agent model/tool profiles, native TypeScript tools,
+MCP connect/disconnect tool, and database session controls are not installed into
+Codex. Skills supply workflow guidance; they do not create equivalent isolated
+agent permissions. Use the shared shell helpers and Codex's native tools. Keep
+full-loop ownership in the primary session unless the user requests delegation.
+
+Hooks cover documented local tool paths, not hosted tools or arbitrary external
+processes. The adapter does not claim complete containment. Codex's native
+compaction is retained; the startup hook restores pointers rather than replacing
+its compaction algorithm. Headless dispatch remains supported through the
+framework's existing Claude Code/OpenCode runners, not a newly invented Codex runner.
+
+## Verification and sources
+
+Inspect `/skills`, `/hooks`, and `/mcp` in a new Codex session. Ask it to list the
+instruction files it loaded and confirm both global and repository guidance.
+For a focused reconciliation run `python3 ~/.aidevops/agents/scripts/codex-setup.py all`.
+
+Contracts checked against the installed CLI and official documentation:
+[AGENTS.md](https://learn.chatgpt.com/docs/agent-configuration/agents-md.md),
+[skills](https://learn.chatgpt.com/docs/build-skills.md),
+[hooks and tool payloads](https://learn.chatgpt.com/docs/hooks.md), and
+[deprecated custom prompts](https://learn.chatgpt.com/docs/custom-prompts.md).

--- a/README.md
+++ b/README.md
@@ -2073,6 +2073,12 @@ Primary agents live at `.agents/<name>.md`. Each is a domain expert with its own
 
 The `aidevops-` prefix differentiates framework commands from each client's native slash commands and groups them alphabetically in the command picker. It applies to **every** aidevops slash command — not just main agents — so `/aidevops-preflight`, `/aidevops-release`, `/aidevops-commit` etc. all sort together in your `/` menu.
 
+Codex setup/update also installs global `AGENTS.md` guidance, native workflow
+skills and compatible lifecycle hooks. Build+ loads by default; use `/skills`
+for workflows and `/hooks` to review/trust new hooks. Existing personal settings
+are preserved. For full-access launch flags and runtime differences, see
+[Codex CLI integration](.agents/tools/ai-assistants/codex-cli.md).
+
 #### Supported AI clients (14)
 
 The framework installs itself across these clients. Slash commands, agent definitions, and (optionally) session-memory mining are wired up per-client by `setup.sh`, gated on per-client feature flags in `.agents/scripts/runtime-registry.sh`.
@@ -2081,7 +2087,7 @@ The framework installs itself across these clients. Slash commands, agent defini
 |---|---|---|---|---|
 | OpenCode | ✅ `~/.config/opencode/command/` | config-based | ✅ default | Native tab-through primary agents |
 | Claude Code | ✅ `~/.claude/commands/` | ✅ `~/.claude/agents/` | ✅ default | Full feature parity |
-| Codex CLI | ✅ `~/.codex/prompts/` | — | ✅ default | Invoked as `/prompts:aidevops-<name>` |
+| Codex CLI | ✅ native skills + legacy `~/.codex/prompts/` | Workflow skills | ✅ default | `$aidevops-<name>`; legacy `/prompts:aidevops-<name>` |
 | Cursor | ✅ `~/.cursor/commands/` (≥1.6) | ✅ `~/.cursor/agents/` | ✅ default | Frontmatter stripped (not supported) |
 | Droid (Factory) | ✅ `~/.factory/commands/` | — | opt-in | — |
 | Gemini CLI | ✅ `~/.gemini/commands/` | — | opt-in | Converted to TOML (`prompt = """..."""`) |


### PR DESCRIPTION
## Summary

Install automatic AGENTS.md and Build+ guidance, native workflow skills, compatible lifecycle hooks, and CODEX_HOME-aware configuration; preserve personal settings and legacy prompts. Cover full and incremental setup and retain the existing MCP reconciler.

## Files Changed

.agents/AGENTS.md, .agents/aidevops/architecture.md, .agents/hooks/codex_lifecycle.py, .agents/scripts/codex-mcp-config.py, .agents/scripts/codex-setup.py, .agents/scripts/deploy-agents-on-merge.sh, .agents/scripts/generate-runtime-config-commands.sh, .agents/scripts/generate-runtime-config-mcp.sh, .agents/scripts/mcp-config-adapter.sh, .agents/scripts/prompt-injection-adapter.sh, .agents/scripts/runtime-registry.sh, .agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/setup/modules/config.sh, .agents/scripts/setup/modules/tool-install.sh, .agents/scripts/tests/test-codex-setup.py, .agents/tools/ai-assistants/codex-cli.md, README.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Real update_codex_config runs twice in an isolated HOME under macOS Bash 3.2 and installs 118 skills. Real Codex hook executions allow shell/patch operations in a linked worktree and deny canonical patches. Codex 0.153.2 doctor reports config.load ok. Its app-server, launched with --strict-config, discovers all 118 aidevops skills (including Build+ and full-loop) and both lifecycle hooks with zero discovery errors; new hooks correctly remain untrusted until reviewed in /hooks. Passed: 8 native setup/hook regressions, 8 MCP regressions, 14 shared safety tests, incremental deployment and command reconciliation fixtures, ShellCheck and changed-file local quality gates.

Local closeout review: inspected branch evidence bundle `2627c488b9cca4b5a7faca561478e0f2fd325dcddf2369a43dc3b11492d0df6b`; no unresolved blocking findings. The always-loaded AGENTS.md change reduces its size and adds a pointer; no baseline increase.

Resolves #31201


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 automated scan.