### PR TITLE
GH#31203: remove remaining Auggie MCP integrations

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
@@ -92,9 +92,6 @@ _status_recommended_tools() {
 _status_ai_tools() {
 	print_header "AI Tools & MCPs"
 	check_cmd opencode && print_success "OpenCode CLI" || print_warning "OpenCode CLI - not installed"
-	if check_cmd auggie; then
-		check_file "$HOME/.augment/session.json" && print_success "Augment Context Engine (authenticated)" || print_warning "Augment Context Engine (not authenticated)"
-	else print_warning "Augment Context Engine - not installed"; fi
 	check_cmd bd && print_success "Beads CLI (task graph)" || print_warning "Beads CLI (bd) - not installed"
 	echo ""
 	return 0

--- a/.agents/scripts/mcp-register-claude.sh
+++ b/.agents/scripts/mcp-register-claude.sh
@@ -22,7 +22,6 @@
 #   mcp-register-claude.sh                    # Register all templates
 #   mcp-register-claude.sh --dry-run          # Preview all commands
 #   mcp-register-claude.sh --list             # Show status
-#   mcp-register-claude.sh augment             # Register specific templates
 #   mcp-register-claude.sh --skip quickfile   # Skip templates with placeholders
 
 set -euo pipefail

--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -848,17 +848,101 @@ migrate_agent_to_agents_folder() {
 	return 0
 }
 
-# Remove deprecated MCP and tool entries from a config file.
+# Remove legacy Auggie MCP entries from an app config file.
+# Supports OpenCode's .mcp, mcpServers-based apps, and VS Code's .servers.
+# Args: $1 = path to tmp config file to modify in-place
+# Sets _cleanup_count to number of entries removed.
+_remove_legacy_auggie_mcp_entries() {
+	local tmp_config="$1"
+	local legacy_auggie_mcps=(
+		"auggie-mcp"
+		"augment-context-engine"
+		"Augment-Context-Engine"
+		"augmentcode"
+		"augment-code"
+	)
+	_cleanup_count=0
+
+	local mcp=""
+	for mcp in "${legacy_auggie_mcps[@]}"; do
+		if jq -e --arg mcp "$mcp" '
+			def object_has($name): ((objects | has($name)) // false);
+			((.mcp // {}) | object_has($mcp)) or
+			((.mcpServers // {}) | object_has($mcp) or (type == "array" and any(.[]?; .name == $mcp))) or
+			((.servers // {}) | object_has($mcp))' "$tmp_config" >/dev/null 2>&1; then
+			jq --arg mcp "$mcp" '
+				delpaths([["mcp", $mcp], ["servers", $mcp]]) |
+				if (.mcpServers | type) == "array" then .mcpServers |= map(select(.name != $mcp)) else del(.mcpServers[$mcp]) end' \
+				"$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
+			((++_cleanup_count))
+		fi
+	done
+
+	return 0
+}
+
+# Remove Auggie MCP sections generated for Codex's TOML config.
+_remove_legacy_auggie_codex_entries() {
+	local codex_config="$HOME/.codex/config.toml"
+	[[ -f "$codex_config" ]] || return 0
+	if ! grep -Eq '^\[mcp_servers\.(auggie-mcp|augment-context-engine|Augment-Context-Engine|augmentcode|augment-code)(\.|\])' "$codex_config"; then
+		return 0
+	fi
+
+	local tmp_config
+	tmp_config=$(mktemp)
+	if ! awk '
+		/^\[mcp_servers\.(auggie-mcp|augment-context-engine|Augment-Context-Engine|augmentcode|augment-code)(\.|\])/ { skip = 1; next }
+		/^\[/ { skip = 0 }
+		!skip { print }
+	' "$codex_config" >"$tmp_config"; then
+		rm -f "$tmp_config"
+		return 1
+	fi
+
+	create_backup_with_rotation "$codex_config" "codex-config"
+	mv "$tmp_config" "$codex_config"
+	print_info "Removed deprecated Auggie MCP entries from $codex_config"
+	return 0
+}
+
+# Remove Auggie MCP blocks generated for Aider's YAML config.
+_remove_legacy_auggie_aider_entries() {
+	local aider_config="$HOME/.aider.conf.yml"
+	[[ -f "$aider_config" ]] || return 0
+	if ! grep -Eq '^  (auggie-mcp|augment-context-engine|Augment-Context-Engine|augmentcode|augment-code):' "$aider_config"; then
+		return 0
+	fi
+
+	local tmp_config
+	tmp_config=$(mktemp)
+	if ! awk '
+		/^mcpServers:[[:space:]]*$/ { in_mcp_servers = 1; print; next }
+		in_mcp_servers && /^  (auggie-mcp|augment-context-engine|Augment-Context-Engine|augmentcode|augment-code):/ { skip = 1; next }
+		skip && (/^[^[:space:]]/ || /^  [^[:space:]#][^:]*:/) { skip = 0 }
+		in_mcp_servers && /^[^[:space:]#]/ { in_mcp_servers = 0 }
+		!skip { print }
+	' "$aider_config" >"$tmp_config"; then
+		rm -f "$tmp_config"
+		return 1
+	fi
+
+	create_backup_with_rotation "$aider_config" "aider-config"
+	mv "$tmp_config" "$aider_config"
+	print_info "Removed deprecated Auggie MCP entries from $aider_config"
+	return 0
+}
+
+# Remove deprecated MCP and tool entries from an OpenCode config file.
 # Args: $1 = path to tmp config file to modify in-place
 # Sets _cleanup_count to number of entries removed.
 _remove_deprecated_mcp_entries() {
 	local tmp_config="$1"
-	_cleanup_count=0
+	_remove_legacy_auggie_mcp_entries "$tmp_config"
+	local removed_count="$_cleanup_count"
 
 	# MCPs replaced by curl subagents in v2.79.0
 	local deprecated_mcps=(
-		"auggie-mcp"
-		"augment-context-engine"
 		"hetzner-webapp"
 		"hetzner-brandlight"
 		"hetzner-marcusquinn"
@@ -889,10 +973,11 @@ _remove_deprecated_mcp_entries() {
 		"$gh_grep_tool"
 	)
 
+	local mcp=""
 	for mcp in "${deprecated_mcps[@]}"; do
-		if jq -e --arg mcp "$mcp" '.mcp[$mcp]' "$tmp_config" >/dev/null 2>&1; then
+		if jq -e --arg mcp "$mcp" '(.mcp // {})[$mcp] != null' "$tmp_config" >/dev/null 2>&1; then
 			jq --arg mcp "$mcp" 'del(.mcp[$mcp])' "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-			((++_cleanup_count))
+			((++removed_count))
 		fi
 	done
 
@@ -900,7 +985,7 @@ _remove_deprecated_mcp_entries() {
 		if jq -e ".tools[\"$tool\"]" "$tmp_config" >/dev/null 2>&1; then
 			jq "del(.tools[\"$tool\"])" "$tmp_config" >"${tmp_config}.new" &&
 				mv "${tmp_config}.new" "$tmp_config" &&
-				((++_cleanup_count))
+				((++removed_count))
 		fi
 	done
 
@@ -911,7 +996,7 @@ _remove_deprecated_mcp_entries() {
 		jq --arg ahrefs_tool "$ahrefs_tool" 'del(.agent.SEO.tools["dataforseo_*"]) | del(.agent.SEO.tools["serper_*"]) | del(.agent.SEO.tools[$ahrefs_tool])' \
 			"$tmp_config" >"${tmp_config}.new" &&
 			mv "${tmp_config}.new" "$tmp_config" &&
-			((++_cleanup_count))
+			((++removed_count))
 	fi
 
 	if jq -e --arg auggie_tool "$auggie_tool" --arg augment_tool "$augment_tool" '(.agent // {}) | to_entries[]? | (.value.tools // {}) | keys[]? | select(. == $auggie_tool or . == $augment_tool)' \
@@ -919,9 +1004,10 @@ _remove_deprecated_mcp_entries() {
 		jq --arg auggie_tool "$auggie_tool" --arg augment_tool "$augment_tool" '(.agent // {}) as $agents | reduce ($agents | keys[]) as $name (. ; del(.agent[$name].tools[$auggie_tool]) | del(.agent[$name].tools[$augment_tool]))' \
 			"$tmp_config" >"${tmp_config}.new" &&
 			mv "${tmp_config}.new" "$tmp_config" &&
-			((++_cleanup_count))
+			((++removed_count))
 	fi
 
+	_cleanup_count="$removed_count"
 	return 0
 }
 
@@ -994,7 +1080,7 @@ _migrate_mcp_npx_to_binary() {
 	return 0
 }
 
-# Remove deprecated MCP entries from opencode.json
+# Remove deprecated MCP entries from supported app configs.
 # These MCPs have been replaced by curl-based subagents (zero context cost)
 #
 # The one-time cleanup (remove deprecated entries + migrate npx→binary) is
@@ -1003,43 +1089,75 @@ _migrate_mcp_npx_to_binary() {
 # The recurring update_mcp_paths_in_opencode call is NOT guarded — it resolves
 # stale binary paths on every run (paths can change after package upgrades).
 cleanup_deprecated_mcps() {
-	local opencode_config
-	opencode_config=$(find_opencode_config) || return 0
-
-	if [[ ! -f "$opencode_config" ]]; then
-		return 0
-	fi
-
 	if ! command -v jq &>/dev/null; then
 		return 0
 	fi
 
+	local opencode_config=""
+	opencode_config=$(find_opencode_config) || true
+
 	# One-time cleanup: remove deprecated MCPs and migrate npx→binary paths.
 	# Sentinel version must be bumped whenever new deprecated MCPs are added.
-	local _sentinel="${HOME}/.aidevops/.migrations/cleanup-deprecated-mcps-v2"
+	local _sentinel="${HOME}/.aidevops/.migrations/cleanup-deprecated-mcps-v4"
 	if [[ ! -f "$_sentinel" ]]; then
-		local cleaned=0
-		local tmp_config
-		tmp_config=$(mktemp)
-		trap 'rm -f "${tmp_config:-}"' RETURN
+		if [[ -n "$opencode_config" && -f "$opencode_config" ]]; then
+			local cleaned=0
+			local tmp_config
+			tmp_config=$(mktemp)
+			trap 'rm -f "${tmp_config:-}"' RETURN
 
-		cp "$opencode_config" "$tmp_config"
+			cp "$opencode_config" "$tmp_config"
 
-		# Remove deprecated MCP and tool entries
-		_remove_deprecated_mcp_entries "$tmp_config"
-		cleaned=$((cleaned + _cleanup_count))
+			# Remove deprecated MCP and tool entries
+			_remove_deprecated_mcp_entries "$tmp_config"
+			cleaned=$((cleaned + _cleanup_count))
 
-		# Migrate npx/pipx commands to full binary paths (faster startup, PATH-independent)
-		_migrate_mcp_npx_to_binary "$tmp_config"
-		cleaned=$((cleaned + _cleanup_count))
+			# Migrate npx/pipx commands to full binary paths (faster startup, PATH-independent)
+			_migrate_mcp_npx_to_binary "$tmp_config"
+			cleaned=$((cleaned + _cleanup_count))
 
-		if [[ $cleaned -gt 0 ]]; then
-			create_backup_with_rotation "$opencode_config" "opencode"
-			mv "$tmp_config" "$opencode_config"
-			print_info "Updated $cleaned MCP entry/entries in opencode.json (using full binary paths)"
-		else
-			rm -f "$tmp_config"
+			if [[ $cleaned -gt 0 ]]; then
+				create_backup_with_rotation "$opencode_config" "opencode"
+				mv "$tmp_config" "$opencode_config"
+				print_info "Updated $cleaned MCP entry/entries in opencode.json (using full binary paths)"
+			else
+				rm -f "$tmp_config"
+			fi
 		fi
+
+		local app_config=""
+		local app_config_entry=""
+		local app_tmp_config=""
+		local backup_name=""
+		local app_configs=(
+			"$HOME/.claude.json:claude-config"
+			"$HOME/.cursor/mcp.json:cursor-mcp"
+			"$HOME/.codeium/windsurf/mcp_config.json:windsurf-mcp"
+			"$HOME/.gemini/settings.json:gemini-config"
+			"$HOME/.kilo/mcp.json:kilo-mcp"
+			"$HOME/.kiro/settings/mcp.json:kiro-mcp"
+			"$HOME/.amp/settings.json:amp-config"
+			"$HOME/.continue/config.json:continue-config"
+		)
+		for app_config_entry in "${app_configs[@]}"; do
+			app_config="${app_config_entry%:*}"
+			backup_name="${app_config_entry##*:}"
+			[[ -f "$app_config" ]] || continue
+
+			app_tmp_config=$(mktemp)
+			cp "$app_config" "$app_tmp_config"
+			_remove_legacy_auggie_mcp_entries "$app_tmp_config"
+			if [[ $_cleanup_count -gt 0 ]]; then
+				create_backup_with_rotation "$app_config" "$backup_name"
+				mv "$app_tmp_config" "$app_config"
+				print_info "Removed $_cleanup_count deprecated MCP entry/entries from $app_config"
+			else
+				rm -f "$app_tmp_config"
+			fi
+		done
+
+		_remove_legacy_auggie_codex_entries
+		_remove_legacy_auggie_aider_entries
 
 		# Write sentinel
 		mkdir -p "$(dirname "$_sentinel")"
@@ -1047,7 +1165,9 @@ cleanup_deprecated_mcps() {
 	fi
 
 	# Always resolve bare binary names to full paths (fixes PATH-dependent startup)
-	update_mcp_paths_in_opencode
+	if [[ -n "$opencode_config" && -f "$opencode_config" ]]; then
+		update_mcp_paths_in_opencode
+	fi
 
 	return 0
 }

--- a/.agents/scripts/tests/test-remove-auggie-mcp.sh
+++ b/.agents/scripts/tests/test-remove-auggie-mcp.sh
@@ -98,7 +98,7 @@ test_migration_removes_stale_entries() {
 	local removed_mcp="${aug}${gie}-mcp"
 	local removed_context="${aug}ment-context-engine"
 
-	printf '{"mcp":{"%s":{},"%s":{},"context7":{}},"tools":{"%s_*":true,"%s_*":true,"context7_*":true},"agent":{"Build":{"tools":{"%s_*":true,"%s_*":true,"context7_*":true}}}}\n' \
+	printf '{"mcp":{"%s":{},"context7":{}},"mcpServers":[{"name":"%s"},{"name":"Augment-Context-Engine"},{"name":"sentry"}],"servers":{"augmentcode":{},"filesystem":{}},"tools":{"%s_*":true,"%s_*":true,"context7_*":true},"agent":{"Build":{"tools":{"%s_*":true,"%s_*":true,"context7_*":true}}}}\n' \
 		"$removed_mcp" "$removed_context" "$removed_mcp" "$removed_context" "$removed_mcp" "$removed_context" >"$tmp_config"
 
 	# shellcheck source=/dev/null
@@ -106,14 +106,14 @@ test_migration_removes_stale_entries() {
 	_remove_deprecated_mcp_entries "$tmp_config"
 
 	if jq -e --arg removed_mcp "$removed_mcp" --arg removed_context "$removed_context" \
-		'(.mcp[$removed_mcp] // .mcp[$removed_context] // .tools[$removed_mcp + "_*"] // .tools[$removed_context + "_*"] // .agent.Build.tools[$removed_mcp + "_*"] // .agent.Build.tools[$removed_context + "_*"])' \
+		'(.mcp[$removed_mcp] // (.mcpServers[]? | select(.name == $removed_context or .name == "Augment-Context-Engine")) // .servers.augmentcode // .tools[$removed_mcp + "_*"] // .tools[$removed_context + "_*"] // .agent.Build.tools[$removed_mcp + "_*"] // .agent.Build.tools[$removed_context + "_*"])' \
 		"$tmp_config" >/dev/null; then
 		print_result "migration removes stale Auggie/Augment config entries" 1 "stale entry remained"
 		rm -f "$tmp_config"
 		return 0
 	fi
 
-	if jq -e '.mcp.context7 and .tools["context7_*"] and .agent.Build.tools["context7_*"]' "$tmp_config" >/dev/null; then
+	if jq -e '.mcp.context7 and any(.mcpServers[]; .name == "sentry") and .servers.filesystem and .tools["context7_*"] and .agent.Build.tools["context7_*"]' "$tmp_config" >/dev/null; then
 		print_result "migration removes stale Auggie/Augment config entries" 0
 		rm -f "$tmp_config"
 		return 0
@@ -124,11 +124,58 @@ test_migration_removes_stale_entries() {
 	return 0
 }
 
+test_setup_cleanup_updates_supported_app_configs() {
+	local test_home
+	test_home="$(mktemp -d)"
+	mkdir -p "$test_home/.codex" "$test_home/.continue" "$test_home/.cursor" "$test_home/.gemini"
+
+	printf '{"mcpServers":{"auggie-mcp":{"command":"auggie"},"context7":{}}}\n' >"$test_home/.cursor/mcp.json"
+	printf '{"mcpServers":{"augment-context-engine":{"command":"auggie"},"sentry":{}}}\n' >"$test_home/.gemini/settings.json"
+	printf '{"mcpServers":[{"name":"auggie-mcp","transport":{"command":"auggie"}},{"name":"context7","transport":{}}]}\n' >"$test_home/.continue/config.json"
+	printf '[mcp_servers.auggie-mcp]\ncommand = "auggie"\n\n[mcp_servers.context7]\ncommand = "npx"\n' >"$test_home/.codex/config.toml"
+	printf 'mcpServers:\n  auggie-mcp:\n    command: "auggie"\n  context7:\n    command: "npx"\n' >"$test_home/.aider.conf.yml"
+
+	(
+		export HOME="$test_home"
+		find_opencode_config() { return 1; }
+		create_backup_with_rotation() { return 0; }
+		print_info() { return 0; }
+		# shellcheck source=/dev/null
+		source "$REPO_ROOT/.agents/scripts/setup/modules/migrations.sh"
+		cleanup_deprecated_mcps
+	)
+
+	if jq -e '.mcpServers["auggie-mcp"]' "$test_home/.cursor/mcp.json" >/dev/null ||
+		jq -e '.mcpServers["augment-context-engine"]' "$test_home/.gemini/settings.json" >/dev/null ||
+		jq -e '.mcpServers[]? | select(.name == "auggie-mcp")' "$test_home/.continue/config.json" >/dev/null ||
+		grep -Eq 'auggie-mcp|augment-context-engine' "$test_home/.codex/config.toml" "$test_home/.aider.conf.yml"; then
+		print_result "setup cleanup removes Auggie MCP from supported app configs" 1 "stale app entry remained"
+		rm -rf "$test_home"
+		return 0
+	fi
+
+	if jq -e '.mcpServers.context7' "$test_home/.cursor/mcp.json" >/dev/null &&
+		jq -e '.mcpServers.sentry' "$test_home/.gemini/settings.json" >/dev/null &&
+		jq -e 'any(.mcpServers[]; .name == "context7")' "$test_home/.continue/config.json" >/dev/null &&
+		grep -q '^\[mcp_servers.context7\]' "$test_home/.codex/config.toml" &&
+		grep -q '^  context7:' "$test_home/.aider.conf.yml" &&
+		[[ -f "$test_home/.aidevops/.migrations/cleanup-deprecated-mcps-v4" ]]; then
+		print_result "setup cleanup removes Auggie MCP from supported app configs" 0
+		rm -rf "$test_home"
+		return 0
+	fi
+
+	print_result "setup cleanup removes Auggie MCP from supported app configs" 1 "unrelated app config changed or sentinel missing"
+	rm -rf "$test_home"
+	return 0
+}
+
 main() {
 	test_runtime_generator_does_not_register_removed_mcp
 	test_removed_mcp_templates_are_deleted
 	test_opencode_registry_does_not_start_removed_binary
 	test_migration_removes_stale_entries
+	test_setup_cleanup_updates_supported_app_configs
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.opencode/server/mcp-dashboard.ts
+++ b/.opencode/server/mcp-dashboard.ts
@@ -38,7 +38,6 @@ const MCP_SERVERS: Array<{ name: string; command: string; port?: number; healthC
   { name: 'crawl4ai', command: 'npx crawl4ai-mcp-server@latest', port: 11235, healthCheck: 'http://localhost:11235/health' },
   { name: 'context7', command: 'npx @context7/mcp-server', port: 3007 },
   { name: 'repomix', command: 'npx repomix --mcp', port: 3008 },
-  { name: 'augment', command: 'augment-mcp-server', port: 3009 },
   { name: 'github', command: 'gh mcp-server', port: 3010 },
   { name: 'filesystem', command: 'npx @anthropic/mcp-server-filesystem', port: 3011 },
   { name: 'memory', command: 'npx @anthropic/mcp-server-memory', port: 3012 },

--- a/README.md
+++ b/README.md
@@ -1365,7 +1365,6 @@ The setup script offers to install these tools automatically.
 
 ### **AI Prompt Optimization**
 
-- **[Augment Context Engine](https://docs.augmentcode.com/context-services/mcp/overview)**: Semantic codebase retrieval with deep code understanding
 - **[Repomix](https://repomix.com/)**: Pack codebases into AI-friendly context (80% token reduction with compress mode)
 - **[DSPy](https://dspy.ai/)**: Framework for programming with language models
 - **[DSPyGround](https://dspyground.com/)**: Interactive playground for prompt optimization
@@ -1450,13 +1449,12 @@ See `.agents/tools/ocr/glm-ocr.md` for batch processing, PDF workflows, and Peek
 
 **Model Context Protocol servers for real-time AI assistant integration.** The framework configures these MCPs for **[OpenCode](https://opencode.ai/)** (TUI, Desktop, and Extension for Zed/VSCode).
 
-### **All Supported MCPs (20 available)**
+### **All Supported MCPs (19 available)**
 
 MCP integrations use reviewed local package runners or remote HTTPS endpoints. Security-sensitive local integrations use exact package pins where required; setup may globally cache selected tools for faster startup. Run `setup.sh` or `aidevops update-tools` to refresh managed tooling.
 
 | MCP | Purpose | Tier | API Key Required |
 |-----|---------|------|------------------|
-| [Augment Context Engine](https://docs.augmentcode.com/context-services/mcp/overview) | Semantic codebase retrieval | Global | Yes (Augment account) |
 | [Claude Code MCP](https://github.com/steipete/claude-code-mcp) | Claude as sub-agent | Global | No |
 | [Amazon Order History](https://github.com/marcusquinn/amazon-order-history-csv-download-mcp) | Order data extraction | Per-agent | No |
 | [Chrome DevTools](https://chromedevtools.github.io/devtools-protocol/) | Browser debugging & automation | Per-agent | No |
@@ -1503,7 +1501,6 @@ These use direct API calls via curl, avoiding MCP server startup entirely:
 
 **Context & Codebase:**
 
-- [Augment Context Engine](https://docs.augmentcode.com/context-services/mcp/overview) - Semantic codebase retrieval with deep code understanding
 - [llm-tldr](https://github.com/parcadei/llm-tldr) - Semantic code analysis with 95% token savings ([details below](#llm-tldr---semantic-code-analysis))
 - [Context7](https://context7.com/) - Real-time documentation access for thousands of libraries
 - [Repomix](https://github.com/yamadashy/repomix) - Pack codebases into AI-friendly context
@@ -1847,84 +1844,6 @@ Repomix runs as an MCP server for direct AI assistant integration:
 > Install globally first: `bun install -g repomix` (done automatically by `setup.sh`)
 
 See `.agents/tools/context/context-builder.md` for complete documentation.
-
-## **Augment Context Engine - Semantic Codebase Search**
-
-[Augment Context Engine](https://docs.augmentcode.com/context-services/mcp/overview) provides semantic codebase retrieval - understanding your code at a deeper level than simple text search. It's the recommended tool for real-time interactive coding sessions.
-
-### Why Augment Context Engine?
-
-| Feature | grep/glob | Augment Context Engine |
-|---------|-----------|------------------------|
-| Text matching | Exact patterns | Semantic understanding |
-| Cross-file context | Manual | Automatic |
-| Code relationships | None | Understands dependencies |
-| Natural language | No | Yes |
-
-Use it to:
-
-- Find related code across your entire codebase
-- Understand project architecture quickly
-- Discover patterns and implementations
-- Get context-aware code suggestions
-
-### Quick Setup
-
-```bash
-# 1. Install Auggie CLI (requires Node.js 22+)
-npm install -g @augmentcode/auggie@prerelease
-
-# 2. Authenticate (opens browser)
-auggie login
-
-# 3. Verify installation
-auggie token print
-```
-
-### MCP Integration
-
-Add to your AI assistant's MCP configuration:
-
-**OpenCode** (`~/.config/opencode/opencode.json`):
-
-```json
-{
-  "mcp": {
-    "augment-context-engine": {
-      "type": "local",
-      "command": ["auggie", "--mcp"],
-      "enabled": true
-    }
-  }
-}
-```
-
-**claude-code CLI**:
-
-```bash
-claude mcp add-json auggie-mcp --scope user '{"type":"stdio","command":"auggie","args":["--mcp"]}'
-```
-
-### Verification
-
-Test with this prompt:
-
-```text
-What is this project? Please use codebase retrieval tool to get the answer.
-```
-
-The AI should provide a semantic understanding of your project architecture.
-
-### Repomix vs Augment Context Engine
-
-| Use Case | Tool | When to Use |
-|----------|------|-------------|
-| **Interactive coding** | Augment Context Engine | Real-time semantic search during development |
-| **Share with external AI** | Repomix | Self-contained snapshot for ChatGPT, Claude web, etc. |
-| **Architecture review** | Repomix (compress) | 80% token reduction, structure only |
-| **CI/CD integration** | Repomix GitHub Action | Automated context in releases |
-
-See `.agents/tools/context/augment-context-engine.md` for complete documentation.
 
 ### llm-tldr - Semantic Code Analysis
 


### PR DESCRIPTION
## Summary

Remove stale Auggie/Augment references and clean legacy registrations across all file-backed runtime config formats supported by aidevops.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-status-lib.sh, .agents/scripts/mcp-register-claude.sh, .agents/scripts/setup/modules/migrations.sh, .agents/scripts/tests/test-remove-auggie-mcp.sh, .opencode/server/mcp-dashboard.ts, README.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime migration applied to existing app configs; 7 focused tests passed; full local linter suite passed; active config scans and process checks confirmed removal.

Resolves #31203


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 plugin for [OpenCode](https://opencode.ai) v1.18.28 with gpt-5.6-sol spent 40m and 395,723 tokens on this with the user in an interactive session.