### PR TITLE
GH#31205: Optimise delegation effort and refresh Astra pricing

### DIFF
--- a/.agents/configs/model-pricing.json
+++ b/.agents/configs/model-pricing.json
@@ -1,13 +1,16 @@
 {
   "_comment": "Single source of truth for LLM model pricing (per 1M tokens). Consumed by observability.mjs and shared-constants.sh get_model_pricing(). Update this file when model pricing changes.",
   "_format": "Each key is a substring matched against model IDs. Values: input, output, cache_read, cache_write (all per 1M tokens in USD).",
-  "version": "2026-08-21.1",
+  "_openai_source": "https://developers.openai.com/api/docs/pricing?latest-pricing=standard — GPT-6 Astra and GPT-5.6 Sol/Terra/Luna verified 2026-09-05. Sol promotional pricing is available at least through 2026-11-21. Other entries were not revalidated in this refresh.",
+  "_estimate_scope": "The refreshed OpenAI rates are Standard short-context API-equivalent estimates, not invoices or ChatGPT subscription allowance percentages. Long-context rates, Fast mode, regional uplifts and subscription capacity are not modelled by this flat table.",
+  "version": "2026-09-05.1",
   "models": {
     "opus-4":          { "input": 15.0,  "output": 75.0,  "cache_read": 1.50,   "cache_write": 18.75 },
     "sonnet-4":        { "input": 3.0,   "output": 15.0,  "cache_read": 0.30,   "cache_write": 3.75  },
     "haiku-4":         { "input": 0.80,  "output": 4.0,   "cache_read": 0.08,   "cache_write": 1.0   },
     "haiku-3":         { "input": 0.80,  "output": 4.0,   "cache_read": 0.08,   "cache_write": 1.0   },
-    "gpt-5.6-sol":     { "input": 5.0,   "output": 30.0,  "cache_read": 0.50,   "cache_write": 6.25  },
+    "gpt-6-astra":     { "input": 10.0,  "output": 50.0,  "cache_read": 1.0,    "cache_write": 12.50 },
+    "gpt-5.6-sol":     { "input": 4.0,   "output": 20.0,  "cache_read": 0.40,   "cache_write": 5.0   },
     "gpt-5.6-terra":   { "input": 2.0,   "output": 12.0,  "cache_read": 0.20,   "cache_write": 2.50  },
     "gpt-5.6-luna":    { "input": 0.20,  "output": 1.20,  "cache_read": 0.02,   "cache_write": 0.25  },
     "gpt-5.3-codex":   { "input": 3.50,  "output": 28.0,  "cache_read": 0.35,   "cache_write": 3.50  },

--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -7,7 +7,7 @@
   "tiers": {
     "simple": {
       "models": ["openai/gpt-5.6-luna", "anthropic/claude-haiku-4-5"],
-      "reasoning": { "openai/gpt-5.6-luna": "max" }
+      "reasoning": { "openai/gpt-5.6-luna": "medium" }
     },
     "standard": {
       "models": ["openai/gpt-5.6-terra", "zai-coding-plan/glm-5.2", "anthropic/claude-sonnet-4-6"],

--- a/.agents/plugins/opencode-aidevops/observability-pricing.mjs
+++ b/.agents/plugins/opencode-aidevops/observability-pricing.mjs
@@ -16,7 +16,7 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const HOME = homedir();
-const FALLBACK_PRICING_VERSION = "2026-08-21.1";
+const FALLBACK_PRICING_VERSION = "2026-09-05.1";
 
 /** Hardcoded fallback — used only when model-pricing.json is unreadable */
 const FALLBACK_PRICING = {
@@ -24,7 +24,8 @@ const FALLBACK_PRICING = {
   "sonnet-4":  { input: 3.0,   output: 15.0,  cacheRead: 0.30,   cacheWrite: 3.75  },
   "haiku-4":   { input: 0.80,  output: 4.0,   cacheRead: 0.08,   cacheWrite: 1.0   },
   "haiku-3":   { input: 0.80,  output: 4.0,   cacheRead: 0.08,   cacheWrite: 1.0   },
-  "gpt-5.6-sol":   { input: 5.0,  output: 30.0, cacheRead: 0.50, cacheWrite: 6.25  },
+  "gpt-6-astra":   { input: 10.0, output: 50.0, cacheRead: 1.0, cacheWrite: 12.50 },
+  "gpt-5.6-sol":   { input: 4.0,  output: 20.0, cacheRead: 0.40, cacheWrite: 5.0   },
   "gpt-5.6-terra": { input: 2.0,  output: 12.0, cacheRead: 0.20, cacheWrite: 2.50  },
   "gpt-5.6-luna":  { input: 0.20, output: 1.20, cacheRead: 0.02, cacheWrite: 0.25  },
 };

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-cost-backfill.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-cost-backfill.mjs
@@ -38,9 +38,9 @@ SELECT session_id || '|' || printf('%.8f', cost) || '|' || COALESCE(pricing_vers
 FROM llm_requests ORDER BY session_id;
     `);
     assert.equal(first, [
-      "luna-old|0.46700000|2026-08-21.1",
-      "sol-zero|5.00000000|2026-08-21.1",
-      "terra-old|4.67000000|2026-08-21.1",
+      "luna-old|0.46700000|2026-09-05.1",
+      "sol-zero|4.00000000|2026-09-05.1",
+      "terra-old|4.67000000|2026-09-05.1",
       "terra-unverified|1.25000000|legacy-unverified",
     ].join("\n"));
     assert.match(readFileSync(markerPath, "utf8"), /^\d{4}-\d{2}-\d{2}T/);

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-pricing.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-pricing.mjs
@@ -7,9 +7,12 @@ import { test } from "node:test";
 import { getPricing } from "../observability.mjs";
 import { PRICING_VERSION } from "../observability-pricing.mjs";
 
-test("GPT-5.6 pricing uses published API rates", () => {
+test("GPT-6 Astra and GPT-5.6 pricing use published Standard short-context API rates", () => {
+  assert.deepEqual(getPricing("openai/gpt-6-astra"), {
+    input: 10.0, output: 50.0, cacheRead: 1.0, cacheWrite: 12.50,
+  });
   assert.deepEqual(getPricing("gpt-5.6-sol"), {
-    input: 5.0, output: 30.0, cacheRead: 0.50, cacheWrite: 6.25,
+    input: 4.0, output: 20.0, cacheRead: 0.40, cacheWrite: 5.0,
   });
   assert.deepEqual(getPricing("gpt-5.6-terra"), {
     input: 2.0, output: 12.0, cacheRead: 0.20, cacheWrite: 2.50,
@@ -17,7 +20,7 @@ test("GPT-5.6 pricing uses published API rates", () => {
   assert.deepEqual(getPricing("gpt-5.6-luna"), {
     input: 0.20, output: 1.20, cacheRead: 0.02, cacheWrite: 0.25,
   });
-  assert.equal(PRICING_VERSION, "2026-08-21.1");
+  assert.equal(PRICING_VERSION, "2026-09-05.1");
 });
 
 test("Sol Pro does not inherit unpublished standard Sol pricing", () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-routing-join.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-routing-join.mjs
@@ -92,7 +92,7 @@ test("completed child responses join queued routing decisions to parent feedback
     assert.equal(summary.tokensTotal, 17);
     assert.equal(summary.models[0], "openai/gpt-5.6-luna");
     assert.deepEqual(summary.aidevopsVersions, ["3.32.240"]);
-    assert.deepEqual(summary.pricingVersions, ["2026-08-21.1"]);
+    assert.deepEqual(summary.pricingVersions, ["2026-09-05.1"]);
     assert.deepEqual(summary.populationsUsed, ["interactive_child"]);
 
     observability.recordSubagentOutcome({
@@ -118,7 +118,7 @@ test("completed child responses join queued routing decisions to parent feedback
 SELECT routing_population || '|' || aidevops_version || '|' || pricing_version
 FROM llm_requests WHERE message_id = 'message-1';
     `);
-    assert.equal(persisted, "interactive_child|3.32.240|2026-08-21.1");
+    assert.equal(persisted, "interactive_child|3.32.240|2026-09-05.1");
 
     const outcomePayload = JSON.parse(sqlite.sqliteExecSync(`
 SELECT payload_json FROM runtime_events WHERE event_type = 'subagent.host.outcome' LIMIT 1;

--- a/.agents/reference/agent-routing.md
+++ b/.agents/reference/agent-routing.md
@@ -32,12 +32,26 @@ The selected agent changes the system prompt and domain knowledge loaded for the
 - A thinking-tier parent does not require thinking-tier children. When reliable, offload bounded, independent, output-heavy discovery, analysis, and tool work to simple or standard children; keep small low-output calls direct when delegation overhead outweighs context savings.
 - Batch independent children in one parallel call. Require final-only summaries with the decision, evidence (paths/lines or commands), uncertainty, and next action; raw logs stay in child context and the parent owns synthesis.
 - Keep the parent progressing on non-overlapping work. Do not finalize with children pending; use their returned evidence or complete the work locally and disregard late results.
-- Subagents must not dispatch further subagents. OpenCode maps the requested effort to the provider and clamps it so child reasoning never exceeds the parent session.
+- Subagents must not dispatch further subagents. OpenCode clamps configured child reasoning to the parent's known effort only for the exact same model. Different models retain their tier's reasoning: effort names are not comparable compute budgets across models. A medium parent does not globally cap children at medium.
 - In interactive OpenCode sessions, an eligible child can end with the exact marker `BLOCKED: capability limit - <evidence>`. The plugin re-prompts that same child session at the next configured tier so prior evidence is retained. Generic blockers, headless dispatch, terminal tiers, and children that attempted side effects never take this automatic path.
 - For full-loop work, persist stable unit IDs, dependencies, explicit file/question ownership, effort tier, and a reuse key before dispatch. Parallel-ready units must have disjoint file ownership; overlap is serialized even when capacity is available.
 - Effective concurrency is the minimum of the plan cap, mode cap, and available global slots. Interactive batches remain capped at two; headless uses its configured per-task cap.
 - Persist completed-unit evidence and reuse it after retries or runtime interruption. The primary repeats delegated exploration only when its evidence is absent, stale, or contradictory.
 - Consolidate adversarial review into bounded correctness/concurrency, security/trust, compatibility/quality, and test-adequacy units, followed by one synthesis and one repair pass.
+
+### Improve efficiency during ordinary work
+
+Optimise verified completion per allowance window and human attention, not minimum
+tokens per call. Choose pragmatic, reversible routes using the task, current
+pricing and available outcomes; a separate benchmark project is not a prerequisite.
+Keep workload tier, concrete model and reasoning effort distinct; current defaults
+and estimate limitations live in `tools/context/model-routing.md`.
+
+- Delegate when a child can discard substantial irrelevant material or investigate an independent question. Use tools directly for deterministic answers or small results already needed by the parent; do not buy a second opinion merely for reassurance.
+- Supply the question, narrow source scope, acceptance evidence and stop condition rather than the whole parent transcript. Request a few hundred words when sufficient; summary length and advisory output limits do not cap hidden reasoning or total work.
+- Count child context, tools, reasoning, parent integration and repair in the outcome. Validate the evidence without repeating the investigation. Missing context calls for better context; repeated capability failure calls for a stronger route, not a tour through every effort level.
+- Reuse existing routing feedback, checks and concrete repair evidence. Distinguish host completion from verified acceptance. Repeated repair justifies raising that task class's route; repeated easy verified success supports a lower-effort choice. Record reusable lessons through the existing self-improvement workflow, not a new dashboard or per-task ceremony.
+- Preserve permission, trust, locality, billing and side-effect boundaries. Safe task-level choices remain autonomous; persistent shared defaults use the normal reviewed change/release path. Interrupt the user only for authority or a consequential trade-off, and keep delivery moving.
 
 ## Primary agents
 

--- a/.agents/scripts/shared-model-tier.sh
+++ b/.agents/scripts/shared-model-tier.sh
@@ -550,7 +550,8 @@ get_model_pricing() {
 	ms="${ms%%-202*}"
 	case "$ms" in
 	*gpt-5.6-sol-pro*) echo "$fallback_default_pricing" ;;
-	*gpt-5.6-sol*) echo "5.0|30.0|0.50|6.25" ;;
+	*gpt-6-astra*) echo "10.0|50.0|1.0|12.50" ;;
+	*gpt-5.6-sol*) echo "4.0|20.0|0.40|5.0" ;;
 	*gpt-5.6-terra*) echo "2.0|12.0|0.20|2.50" ;;
 	*gpt-5.6-luna*) echo "0.20|1.20|0.02|0.25" ;;
 	*opus-4* | *claude-opus*) echo "15.0|75.0|1.50|18.75" ;;

--- a/.agents/scripts/tests/test-headless-routing-retry.sh
+++ b/.agents/scripts/tests/test-headless-routing-retry.sh
@@ -290,7 +290,7 @@ routing_capture="${fixture_dir}/adaptive-routing.txt"
 	variant_override=$(resolve_headless_variant "$role" "$tier_override" "$selected_model")
 	_cmd_run_attempt_loop
 )
-[[ "$(<"$routing_capture")" == "simple|0|max|openai/gpt-5.6-luna|max" ]]
+[[ "$(<"$routing_capture")" == "simple|0|medium|openai/gpt-5.6-luna|medium" ]]
 
 (
 	attempt_exit=81

--- a/.agents/scripts/tests/test-headless-runtime-variant.sh
+++ b/.agents/scripts/tests/test-headless-runtime-variant.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AGENTS_SCRIPTS="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# Load the same routing dependency as the production headless entrypoint.
+# shellcheck source=/dev/null
+source "${AGENTS_SCRIPTS}/shared-constants.sh"
 # shellcheck source=/dev/null
 source "${AGENTS_SCRIPTS}/headless-runtime-model.sh"
 
@@ -57,19 +60,19 @@ assert_equals "high" "$actual" "pulse standard routing keeps configured variant"
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "simple" "openai/gpt-5.6-luna")
-assert_equals "max" "$actual" "GPT-5.6 Luna simple worker uses max routed effort" || true
+assert_equals "medium" "$actual" "GPT-5.6 Luna simple worker uses medium routed effort" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "thinking" "openai/gpt-5.6-sol")
-assert_equals "max" "$actual" "GPT-5.6 Sol thinking worker uses max routed effort" || true
+assert_equals "medium" "$actual" "GPT-5.6 Sol thinking worker uses medium routed effort" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "thinking" "openai/gpt-5.6-sol-fast")
-assert_equals "max" "$actual" "GPT-5.6 Sol Fast thinking worker uses max provider mapping" || true
+assert_equals "" "$actual" "unmapped Sol Fast ID does not inherit another model's reasoning" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "standard" "openai/gpt-5.6-sol")
-assert_equals "high" "$actual" "GPT-5.6 Sol standard worker uses high routed effort" || true
+assert_equals "" "$actual" "Sol outside its configured tier does not inherit Terra reasoning" || true
 
 with_clean_variant_env
 AIDEVOPS_HEADLESS_VARIANT_THINKING="high"
@@ -88,7 +91,7 @@ assert_equals "xhigh" "$actual" "explicit GPT-5.6 Sol xhigh opt-in remains avail
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "pulse" "thinking" "openai/gpt-5.6-sol")
-assert_equals "max" "$actual" "pulse thinking tier uses the same max runtime mapping" || true
+assert_equals "medium" "$actual" "pulse thinking tier uses the same medium runtime mapping" || true
 
 with_clean_variant_env
 

--- a/.agents/scripts/tests/test-model-pricing-gpt56.sh
+++ b/.agents/scripts/tests/test-model-pricing-gpt56.sh
@@ -20,7 +20,8 @@ assert_equals() {
 	return 0
 }
 
-assert_equals "5.0|30.0|0.50|6.25" "$(get_model_pricing openai/gpt-5.6-sol)" "Sol JSON pricing"
+assert_equals "10.0|50.0|1.0|12.50" "$(get_model_pricing openai/gpt-6-astra)" "Astra JSON pricing"
+assert_equals "4.0|20.0|0.40|5.0" "$(get_model_pricing openai/gpt-5.6-sol)" "Sol JSON pricing"
 assert_equals "2.0|12.0|0.20|2.50" "$(get_model_pricing openai/gpt-5.6-terra)" "Terra JSON pricing"
 assert_equals "0.20|1.20|0.02|0.25" "$(get_model_pricing openai/gpt-5.6-luna)" "Luna JSON pricing"
 assert_equals "3.0|15.0|0.30|3.75" "$(get_model_pricing openai/gpt-5.6-sol-pro)" "Sol Pro uses unknown-model default"
@@ -28,7 +29,8 @@ assert_equals "3.0|15.0|0.30|3.75" "$(get_model_pricing openai/gpt-5.6-sol-pro)"
 _MODEL_PRICING_JSON_LOADED=1
 _MODEL_PRICING_JSON=""
 
-assert_equals "5.0|30.0|0.50|6.25" "$(get_model_pricing openai/gpt-5.6-sol)" "Sol hardcoded fallback pricing"
+assert_equals "10.0|50.0|1.0|12.50" "$(get_model_pricing openai/gpt-6-astra)" "Astra hardcoded fallback pricing"
+assert_equals "4.0|20.0|0.40|5.0" "$(get_model_pricing openai/gpt-5.6-sol)" "Sol hardcoded fallback pricing"
 assert_equals "2.0|12.0|0.20|2.50" "$(get_model_pricing openai/gpt-5.6-terra)" "Terra hardcoded fallback pricing"
 assert_equals "0.20|1.20|0.02|0.25" "$(get_model_pricing openai/gpt-5.6-luna)" "Luna hardcoded fallback pricing"
 assert_equals "3.0|15.0|0.30|3.75" "$(get_model_pricing openai/gpt-5.6-sol-pro)" "Sol Pro hardcoded unknown-model default"

--- a/.agents/scripts/tests/test-model-routing-overlay.sh
+++ b/.agents/scripts/tests/test-model-routing-overlay.sh
@@ -27,7 +27,7 @@ source "${SCRIPTS_DIR}/shared-constants.sh"
 
 [[ "$(model_tier_candidates standard)" == "custom/standard" ]]
 [[ "$(model_tier_candidates simple | sed -n '1p')" == "openai/gpt-5.6-luna" ]]
-[[ "$(model_tier_variant simple openai/gpt-5.6-luna)" == "max" ]]
+[[ "$(model_tier_variant simple openai/gpt-5.6-luna)" == "medium" ]]
 [[ "$(model_tier_next simple)" == "standard" ]]
 
 cat >"$custom_table" <<'JSON'

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -86,7 +86,7 @@ is always denied because secrets must flow through secret tooling, not prompts.
 - **Workers**: Follow configured candidate order within canonical `simple`, `standard`, or `thinking` routes after allowlist filtering and auth checks.
 - **Local switch**: Set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` to force both pulse and workers onto the default OpenAI fallbacks. If you want OpenAI primary but Anthropic fallback, reorder `custom/configs/model-routing-table.json` and omit the allowlist.
 - **Current default mapping**: The active routing table maps `simple` to OpenAI Luna then Anthropic Haiku, `standard` to OpenAI Terra then Z.AI GLM then Anthropic Sonnet, and `thinking` to OpenAI Sol then Anthropic Opus. Availability and provider policy decide the exact model at execution time.
-- **Reasoning mapping**: The routing table maps OpenAI `simple`, `standard`, and `thinking` to Luna `max`, Terra `high`, and Sol `medium`. Other providers use their provider/runtime defaults unless configured explicitly.
+- **Reasoning mapping**: The routing table maps OpenAI `simple`, `standard`, and `thinking` to Luna `medium`, Terra `high`, and Sol `medium`. Other providers use their provider/runtime defaults unless configured explicitly.
 - **Capability escalation**: The exact structured marker `BLOCKED: capability limit - <evidence>` advances through `escalation_order` and resolves that tier's current first healthy candidate without pattern-driven downgrade. Headless dispatch starts another bounded route attempt. Interactive OpenCode re-prompts the same child session only when the child identity is known and it has attempted no side effects. Generic `BLOCKED` outcomes and the terminal configured tier remain terminal. Permission, authentication, provider, rate-limit, secret, policy, trust-boundary, locality, and billing failures retain dedicated fail-closed handling and never escalate capability to bypass controls.
 - **OpenAI tier rationale**: The automatic ladder prioritizes verified completion and measured cost: Luna handles bounded work, Terra handles general implementation, and Sol handles synthesis-heavy work. Routing telemetry supports evidence-based reordering without hardcoding provider assumptions.
 - **OpenAI pro caveat**: `openai/gpt-5.6-sol-pro` passed a live OpenCode ChatGPT OAuth smoke test on 2026-07-10, but OpenAI publishes neither an API price nor comparative Sol Pro benchmarks. It remains excluded from automatic workers pending repository-specific completion-rate evidence. Historical `gpt-5.5-pro` and older `*-pro`/`o3-pro` IDs remain excluded.
@@ -94,6 +94,34 @@ is always denied because secrets must flow through secret tooling, not prompts.
 - **Tier-aware effort**: `AIDEVOPS_HEADLESS_VARIANT_SIMPLE`, `AIDEVOPS_HEADLESS_VARIANT_STANDARD`, and `AIDEVOPS_HEADLESS_VARIANT_THINKING` can temporarily override routing-table reasoning.
 - **Fallback**: If routed resolution fails entirely, the framework uses the active table's ordered candidates and then its shipped deterministic table. An explicit provider allowlist fails closed when no listed candidate is usable.
 - **Deprecated**: `PULSE_MODEL` and `AIDEVOPS_HEADLESS_MODELS` env vars are respected as overrides for one release cycle with deprecation warnings. Remove from `credentials.sh`.
+
+### Practical model and effort selection
+
+The September 2026 defaults are an educated, reversible operating choice, not a
+benchmark superiority claim: Luna medium avoids blanket maximum reasoning for
+bounded work; Terra high retains headroom for normal judgment and recovery; Sol
+medium keeps synthesis cheaper than routinely duplicating a flagship parent.
+Use ordinary completion, verification, retries and parent repair to improve these
+choices, following `reference/agent-routing.md` "Improve efficiency during ordinary
+work". Historical replay remains opt-in for material unresolved comparisons, not
+a prerequisite for building with the framework.
+
+GPT-6 Astra medium is a reasonable explicitly selected interactive daily driver
+when its judgment saves human intervention. It does not replace the shared worker
+ladder or change other models' reasoning. Reserve Astra or higher effort for a
+specific difficult decision rather than routine second opinions. Same-model
+OpenCode children cannot exceed their parent's known reasoning setting; use an
+explicit parent effort change when genuinely needed, not a bypass of that cap.
+
+Pricing source: [OpenAI Standard pricing](https://developers.openai.com/api/docs/pricing?latest-pricing=standard),
+checked 2026-09-05. Per million short-context input/cached-input/output tokens:
+Luna $0.20/$0.02/$1.20; Terra $2/$0.20/$12; Sol $4/$0.40/$20; Astra $10/$1/$50.
+Sol's promotional rates are available at least through 2026-11-21. The shared flat
+pricing table provides API-equivalent estimates: it does not model long-context
+rates, Fast mode or regional uplifts. With ChatGPT OAuth, use API prices only as
+directional resource-cost signals, never an exact subscription allowance percentage
+or cash charge. Preserve recorded pricing versions when comparing outcomes; this
+refresh does not reprice already-versioned historical requests.
 
 ### Per-user override that survives auto-update
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ the required notices and preferred credit text.
 - `/auto-browse` - Learn, optimize, and graduate repeatable browser operations and web data-mining workflows
 - `/report-render` - Render report-ready Markdown or JSON to HTML with sticky TOC, print CSS, evidence badges, and source cards for PDF export
 - `/report-token-use` - Generate a local per-session token, model, compaction, and MCP-use report
-- `/optimize-tiers` - Compare production routing telemetry with sealed historical model replay before changing model defaults
+- `/optimize-tiers` - Optionally investigate unresolved model comparisons with production telemetry and sealed historical replay
 - `/pulse` - Run the autonomous supervisor loop for dispatch, merge, diagnostics, and stuck-work recovery
 - `/serve-sim` / `serve-sim-helper.sh` - Exercise mobile web flows in simulator-backed local previews
 
@@ -446,7 +446,9 @@ See `.agents/tools/task-management/beads.md` for complete documentation and inst
 
 ### OpenAI Models in OpenCode (Recommended)
 
-OpenCode with OpenAI is the current recommended aidevops setup. The default routing uses GPT-5.6 Luna for bounded low-consequence work, Terra for established-pattern implementation, and Sol for consequential decisions, architecture, and synthesis-heavy work.
+OpenCode with OpenAI is the current recommended aidevops setup. Delegation defaults are GPT-5.6 Luna **medium** for bounded low-consequence work, Terra **high** for established-pattern implementation, and Sol **medium** for consequential decisions, architecture, and synthesis-heavy work. GPT-6 Astra **medium** is an optional interactive daily driver; selecting it does not replace the cheaper child tiers.
+
+Optimise through ordinary verified work, retries and parent repair rather than a prerequisite benchmark project. API prices are directional resource-cost estimates, not ChatGPT subscription allowance percentages. See [practical model and effort selection](.agents/tools/context/model-routing.md#practical-model-and-effort-selection) for the strategy, estimate scope and safe escalation rules.
 
 **Authenticate via the pool:**
 
@@ -457,7 +459,7 @@ aidevops model-accounts-pool add openai
 
 **Why this is the default:**
 
-- **Best current cross-tier results** — strongest observed balance across interactive Build+, workers, review, and dispatch tiers
+- **Pragmatic defaults** — reversible choices improved through actual completion and repair evidence, not a claim of benchmark superiority
 - **Tiered cost/latency split** — Luna for bounded work, Terra for general implementation, and Sol where deeper judgement is worth the extra budget
 - **Provider isolation** — OpenAI accounts rotate independently from Anthropic, Google, Cursor, and local providers
 - **Fallback-friendly** — Claude, Gemini, Cursor, and local models remain available when a task or rate-limit profile calls for them


### PR DESCRIPTION
## Summary

Set simple delegation to Luna medium in .agents/configs/model-routing-table.json; retain Terra high, Sol medium and existing provider/security boundaries. Add current Astra and promotional Sol Standard short-context estimates to model-pricing.json and JS/shell fallbacks. Update agent-routing.md, model-routing.md and README to prioritise pragmatic production feedback over prerequisite benchmarking, clarify exact-model effort clamping, and distinguish API estimates from subscription allowance percentages. Update existing coupled routing/pricing tests and repair the variant test dependency setup.

## Files Changed

.agents/configs/model-pricing.json, .agents/configs/model-routing-table.json, .agents/plugins/opencode-aidevops/observability-pricing.mjs, .agents/plugins/opencode-aidevops/tests/test-observability-cost-backfill.mjs, .agents/plugins/opencode-aidevops/tests/test-observability-pricing.mjs, .agents/plugins/opencode-aidevops/tests/test-observability-routing-join.mjs, .agents/reference/agent-routing.md, .agents/scripts/shared-model-tier.sh, .agents/scripts/tests/test-headless-routing-retry.sh, .agents/scripts/tests/test-headless-runtime-variant.sh, .agents/scripts/tests/test-model-pricing-gpt56.sh, .agents/scripts/tests/test-model-routing-overlay.sh, .agents/tools/context/model-routing.md, README.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified local routing resolution, override and retry paths; 36 Node routing/effort/pricing/SQLite feedback tests pass. Existing shell pricing, routing overlay, headless variant/retry, canonical tier and reasoning migration suites pass. linters-local.sh passes including ShellCheck, Secretlint, Markdown and required complexity/portability gates. Direct closeout review clean; evidence digest 6109bf82aef473026f5199cdfaf46389b1c2f5120fc1b5f217dfd6a4d8a2cee4.

Resolves #31205


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 plugin for [OpenCode](https://opencode.ai) v1.18.28 with gpt-6-astra spent 32m and 298,594 tokens on this with the user in an interactive session.