### PR TITLE
GH#31207: add interactive runtime launch commands and main-agent selection

### DIFF
--- a/.agents/scripts/runtime-launcher-helper.sh
+++ b/.agents/scripts/runtime-launcher-helper.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Resolve relative to this deployed bundle, including when invoked from a checkout.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/runtime-launcher.py" "$@"

--- a/.agents/scripts/runtime-launcher.py
+++ b/.agents/scripts/runtime-launcher.py
@@ -136,8 +136,8 @@ def execute(command, prompt_input=None):
                 shutil.copyfileobj(sys.stdin.buffer, stream)
             stream.seek(0)
             os.dup2(stream.fileno(), 0)
-            os.execvp(command[0], command)
-    os.execvp(command[0], command)
+            os.execvp(command[0], command)  # nosec B606 -- fixed adapter executable, user-authorized argv, no shell.
+    os.execvp(command[0], command)  # nosec B606 -- fixed adapter executable, user-authorized argv, no shell.
 
 
 def native_launch(runtime, args):

--- a/.agents/scripts/runtime-launcher.py
+++ b/.agents/scripts/runtime-launcher.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Launch interactive clients with framework guidance and explicit permissions."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parent.parent
+ALIASES = {"oc": "opencode", "claude": "claude-code", "gemini": "gemini-cli",
+           "cn": "continue", "cursor-agent": "cursor", "kiro-cli": "kiro"}
+# Interactive adapters; GUI binaries must never be substituted for terminal agents.
+RUNTIMES = {
+    "codex": ("codex", ["--sandbox", "danger-full-access", "--ask-for-approval", "never"]),
+    "claude-code": ("claude", ["--dangerously-skip-permissions"]),
+    "opencode": ("opencode", ["--auto"]),
+    "cursor": ("cursor-agent", ["--yolo"]),
+    "droid": ("droid", []),
+    "gemini-cli": ("gemini", ["--yolo"]),
+    "continue": ("cn", ["--auto"]),
+    "kilo": ("kilo", ["--auto"]),
+    "kiro": ("kiro-cli", ["chat", "--trust-all-tools"]),
+    "aider": ("aider", ["--yes-always"]),
+    "amp": ("amp", ["--dangerously-allow-all"]),
+    "kimi": ("kimi", ["--yolo"]),
+    "qwen": ("qwen", ["--yolo"]),
+    "windsurf": (None, []),
+}
+OPENCODE_MODES = {"conversation", "remote-interactive", "desktop", "server", "attach"}
+
+
+def main_agents():
+    """Use the setup-owned main-agent links, not workflow commands or subagents."""
+    return {p.stem.removeprefix("aidevops-"): p.resolve()
+            for p in sorted((ROOT / "commands").glob("aidevops-*.md")) if p.is_file()}
+
+
+def usage():
+    print("Usage: aidevops <runtime> [main-agent] [launcher options] [-- native arguments]")
+    print("Default agent: build-plus. Launches interactively with full-access flags where supported.")
+    print("Launcher options: --dry-run, --list-agents, --native (no injected defaults), --help")
+    print("Runtimes: " + ", ".join(RUNTIMES))
+    print("Examples: aidevops codex; aidevops claude automate; aidevops codex seo -- -m MODEL")
+    print("Droid retains configured interactive autonomy; Windsurf has no terminal agent adapter.")
+
+
+def parse_args(args, agents):
+    """Only consume wrapper options before --; preserve native arguments verbatim."""
+    agent = "build-plus"
+    if args and not args[0].startswith("-"):
+        agent = args.pop(0).lower().removeprefix("aidevops-")
+        agent = {"build+": "build-plus", "ai-devops": "framework"}.get(agent, agent)
+    if agent not in agents:
+        raise ValueError(f"Unknown main agent: {agent}. Use --list-agents; pass native subcommands with --native.")
+    dry_run = False
+    native = []
+    for index, arg in enumerate(args):
+        if arg == "--":
+            native.extend(args[index + 1:])
+            break
+        if arg == "--dry-run":
+            dry_run = True
+        else:
+            native.extend(args[index:])
+            break
+    return agent, dry_run, native
+
+
+def guidance(agent, source):
+    return (f"For this session, use aidevops main agent {agent}. Read {ROOT / 'AGENTS.md'} "
+            f"and {source} and follow their workflow using this runtime's native tools. "
+            "This explicit main-agent selection replaces the default Build+ workflow. "
+            "Treat OpenCode-specific tool and permission metadata as runtime-specific. "
+            "Selecting an agent is not a task: wait for the user's request before doing work.")
+
+
+def cached_file(name, content):
+    """Keep immutable, content-addressed session guidance for clients requiring files."""
+    digest = hashlib.sha256(content.encode()).hexdigest()
+    directory = Path.home() / ".aidevops/cache/runtime-launchers" / digest
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    target = directory / name
+    if not target.exists():
+        fd, temporary = tempfile.mkstemp(dir=directory)
+        with os.fdopen(fd, "w") as output:
+            output.write(content)
+        os.replace(temporary, target)
+    return str(target)
+
+
+def kimi_args(prompt, dry_run):
+    # Kimi YAML agents inherit native tools, and preserve project/skill context.
+    content = prompt + "\n${KIMI_AGENTS_MD}\n${KIMI_SKILLS}\n"
+    path = "<generated-session-guidance.md>" if dry_run else cached_file("guidance.md", content)
+    config = "version: 1\nagent:\n  extend: default\n  system_prompt_path: " + json.dumps(path) + "\n"
+    config_path = "<generated-kimi-agent.yaml>" if dry_run else cached_file("agent.yaml", config)
+    return ["--agent-file", config_path]
+
+
+def agent_args(runtime, agent, source, prompt, dry_run):
+    adapters = {
+        "codex": ["-c", "developer_instructions=" + json.dumps(prompt)],
+        "claude-code": ["--append-system-prompt", prompt],
+        "opencode": ["--agent", "Build+" if agent == "build-plus" else
+                     "AI-DevOps" if agent == "framework" else "SEO" if agent == "seo" else agent.title()],
+        "cursor": [prompt], "droid": [prompt], "kiro": [prompt],
+        "gemini-cli": ["--prompt-interactive", prompt],
+        "qwen": ["--prompt-interactive", prompt],
+        "continue": ["--rule", prompt],
+        "kilo": ["--prompt", prompt],
+        "aider": ["--read", str(ROOT / "AGENTS.md"), "--read", str(source)],
+        "amp": [],
+    }
+    if runtime == "kimi":
+        return kimi_args(prompt, dry_run)
+    if runtime == "aider":
+        path = "<generated-session-guidance.md>" if dry_run else cached_file("guidance.md", prompt)
+        return adapters[runtime] + ["--read", path]
+    return adapters[runtime]
+
+
+def execute(command, prompt_input=None):
+    """Replace the launcher, preserving exit status, terminal output and signals."""
+    if prompt_input is not None:
+        # Amp documents piped initial input with interactive terminal output.
+        # Retain piped user input after the bootstrap instead of discarding it.
+        with tempfile.TemporaryFile() as stream:
+            stream.write((prompt_input + "\n").encode())
+            if not sys.stdin.isatty():
+                shutil.copyfileobj(sys.stdin.buffer, stream)
+            stream.seek(0)
+            os.dup2(stream.fileno(), 0)
+            os.execvp(command[0], command)
+    os.execvp(command[0], command)
+
+
+def native_launch(runtime, args):
+    binary = RUNTIMES[runtime][0]
+    if binary is None:
+        raise ValueError("Windsurf is an editor integration; launch its editor and use the installed aidevops workflows.")
+    execute([binary, *args])
+
+
+def launch(runtime, args):
+    if args and args[0] == "--native":
+        native_launch(runtime, args[1:])
+    if runtime == "opencode" and args and args[0] in OPENCODE_MODES:
+        execute(["bash", str(ROOT / "scripts/opencode-launcher-helper.sh"), *args])
+    agents = main_agents()
+    if args and args[0] == "--list-agents":
+        print("\n".join(agents))
+        return
+    agent, dry_run, native = parse_args(args, agents)
+    binary, flags = RUNTIMES[runtime]
+    if binary is None:
+        raise ValueError("Windsurf has no supported terminal agent. Use the editor's aidevops workflows.")
+    if not dry_run and not shutil.which(binary):
+        raise ValueError(f"{binary} is not installed or not on PATH. Install this runtime, then run aidevops update.")
+    prompt = guidance(agent, agents[agent])
+    selected = agent_args(runtime, agent, agents[agent], prompt, dry_run)
+    command = [binary, *flags, *selected, *native]
+    if runtime == "opencode":
+        command = ["bash", str(ROOT / "scripts/opencode-launcher-helper.sh"), *flags, *selected, *native]
+    if runtime == "droid":
+        print("aidevops: Droid interactive mode uses your configured autonomy (/settings).", file=sys.stderr)
+    if dry_run:
+        print(shlex.join(command))
+        if runtime == "amp":
+            print("Initial stdin: " + prompt)
+        return
+    execute(command, prompt if runtime == "amp" else None)
+
+
+def main(args):
+    if not args or args[0] in {"-h", "--help", "help"}:
+        usage()
+        return
+    runtime = ALIASES.get(args[0], args[0])
+    if runtime not in RUNTIMES:
+        raise ValueError(f"Unknown runtime: {runtime}")
+    if len(args) > 1 and args[1] in {"-h", "--help", "help"}:
+        usage()
+        return
+    launch(runtime, args[1:])
+
+
+if __name__ == "__main__":
+    try:
+        main(sys.argv[1:])
+    except (OSError, ValueError) as error:
+        print(f"aidevops: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.agents/scripts/tests/test-runtime-launcher.py
+++ b/.agents/scripts/tests/test-runtime-launcher.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exercise real launcher processes with recording CLIs, without model inference."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("launcher", SCRIPTS / "runtime-launcher.py")
+LAUNCHER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(LAUNCHER)
+
+
+class RuntimeLauncherTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="aidevops launcher ")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.env = dict(os.environ, HOME=str(self.root), PATH=str(self.bin) + os.pathsep + os.environ["PATH"])
+        self.output = self.root / "result.json"
+        self.env["RECORD_OUTPUT"] = str(self.output)
+        for name, _ in LAUNCHER.RUNTIMES.values():
+            if name:
+                script = self.bin / name
+                script.write_text(f"#!{sys.executable}\nimport json,os,sys\nfrom pathlib import Path\n"
+                                  "data={'argv':sys.argv[1:],'cwd':os.getcwd()}\n"
+                                  "if Path(sys.argv[0]).name == 'amp':data['stdin']=sys.stdin.read()\n"
+                                  "Path(os.environ['RECORD_OUTPUT']).write_text(json.dumps(data))\n"
+                                  "sys.exit(int(os.environ.get('RECORD_EXIT','0')))\n")
+                script.chmod(0o755)
+
+    def run_launcher(self, *args, input_text=""):
+        return subprocess.run(["/bin/bash", str(SCRIPTS / "runtime-launcher-helper.sh"), *args],
+                              env=self.env, cwd=self.root, input=input_text, text=True,
+                              capture_output=True, timeout=20)
+
+    def record(self, *args):
+        result = self.run_launcher(*args)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(self.output.read_text())
+
+    def test_codex_defaults_and_literal_passthrough(self):
+        literal = "spaces $HOME `echo nope` $(false)"
+        data = self.record("codex", "--", "-m", literal)
+        self.assertEqual(data["argv"][:4], ["--sandbox", "danger-full-access", "--ask-for-approval", "never"])
+        self.assertIn("main agent build-plus", data["argv"][5])
+        self.assertEqual(data["argv"][-2:], ["-m", literal])
+        self.assertEqual(Path(data["cwd"]).resolve(), self.root.resolve())
+
+    def test_claude_selection_and_aliases(self):
+        for alias in ("claude", "claude-code"):
+            data = self.record(alias, "automate")
+            self.assertEqual(data["argv"][:2], ["--dangerously-skip-permissions", "--append-system-prompt"])
+            self.assertIn("main agent automate", data["argv"][2])
+            self.assertIn("wait for the user's request", data["argv"][2])
+
+    def test_all_terminal_adapters_remain_interactive(self):
+        for runtime in LAUNCHER.RUNTIMES:
+            if runtime in {"windsurf", "opencode"}:
+                continue
+            with self.subTest(runtime=runtime):
+                data = self.record(runtime, "seo")
+                self.assertNotIn("--execute", data["argv"])
+                self.assertNotIn("--print", data["argv"])
+                self.assertNotIn("--no-interactive", data["argv"])
+                self.assertNotIn("exec", data["argv"])
+
+    def test_amp_retains_user_stdin(self):
+        result = self.run_launcher("amp", "automate", input_text="User's actual task\n")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        text = json.loads(self.output.read_text())["stdin"]
+        self.assertIn("main agent automate", text)
+        self.assertTrue(text.endswith("User's actual task\n"))
+
+    def test_kimi_files_and_dry_run(self):
+        result = self.run_launcher("kimi", "automate", "--dry-run")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse((self.root / ".aidevops").exists())
+        data = self.record("kimi", "automate")
+        config = Path(data["argv"][-1]).read_text()
+        self.assertIn("extend: default", config)
+        prompt_path = json.loads(config.split("system_prompt_path: ")[1])
+        self.assertIn("main agent automate", Path(prompt_path).read_text())
+
+    def test_errors_and_exit_status(self):
+        for args in (("codex", "../automate"), ("codex", "does-not-exist"), ("windsurf",)):
+            self.assertNotEqual(self.run_launcher(*args).returncode, 0)
+        self.env["RECORD_EXIT"] = "37"
+        self.assertEqual(self.run_launcher("codex").returncode, 37)
+
+    def test_help_list_and_native_do_not_inject_defaults(self):
+        for option in ("--help", "--list-agents"):
+            result = self.run_launcher("codex", option)
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("build-plus", result.stdout)
+            self.assertFalse(self.output.exists())
+        self.assertEqual(self.record("codex", "--native", "login", "--help")["argv"], ["login", "--help"])
+
+    def test_opencode_protected_modes_are_unchanged(self):
+        for mode in LAUNCHER.OPENCODE_MODES:
+            with patch.object(LAUNCHER, "execute", side_effect=SystemExit) as execute:
+                with self.assertRaises(SystemExit):
+                    LAUNCHER.launch("opencode", [mode, "--dry-run"])
+                self.assertEqual(execute.call_args.args[0][-2:], [mode, "--dry-run"])
+                self.assertNotIn("--auto", execute.call_args.args[0])
+        data = self.record("opencode", "seo", "--shared-db")
+        self.assertEqual(data["argv"], ["--auto", "--agent", "SEO"])
+
+    def test_registry_coverage(self):
+        script = 'source "$1"; printf "%s\\n" "${_RT_IDS[@]}"'
+        result = subprocess.run(["/bin/bash", "-c", script, "bash", str(SCRIPTS / "runtime-registry.sh")],
+                                capture_output=True, text=True, check=True)
+        self.assertEqual(set(result.stdout.splitlines()), set(LAUNCHER.RUNTIMES))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/tests/test-runtime-launcher.py
+++ b/.agents/scripts/tests/test-runtime-launcher.py
@@ -39,7 +39,8 @@ class RuntimeLauncherTest(unittest.TestCase):
                 script.chmod(0o755)
 
     def run_launcher(self, *args, input_text=""):
-        return subprocess.run(["/bin/bash", str(SCRIPTS / "runtime-launcher-helper.sh"), *args],
+        return subprocess.run(  # nosec B603 -- fixed local launcher, test-owned argv and environment.
+            ["/bin/bash", str(SCRIPTS / "runtime-launcher-helper.sh"), *args],
                               env=self.env, cwd=self.root, input=input_text, text=True,
                               capture_output=True, timeout=20)
 
@@ -117,7 +118,8 @@ class RuntimeLauncherTest(unittest.TestCase):
 
     def test_registry_coverage(self):
         script = 'source "$1"; printf "%s\\n" "${_RT_IDS[@]}"'
-        result = subprocess.run(["/bin/bash", "-c", script, "bash", str(SCRIPTS / "runtime-registry.sh")],
+        result = subprocess.run(  # nosec B603 -- constant shell program, repository-owned registry.
+            ["/bin/bash", "-c", script, "bash", str(SCRIPTS / "runtime-registry.sh")],
                                 capture_output=True, text=True, check=True)
         self.assertEqual(set(result.stdout.splitlines()), set(LAUNCHER.RUNTIMES))
 

--- a/.agents/tools/ai-assistants/runtime-launchers.md
+++ b/.agents/tools/ai-assistants/runtime-launchers.md
@@ -1,0 +1,96 @@
+---
+description: Interactive aidevops runtime shortcuts and main-agent selection
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Interactive runtime launchers
+
+`aidevops <runtime> [main-agent]` starts an interactive session in the current
+working directory. The default main agent is `build-plus`. Setup and update deploy
+the shared launcher with the CLI and framework bundle; no shell aliases or global
+permission settings are needed.
+
+```bash
+aidevops codex
+aidevops codex automate
+aidevops claude seo
+aidevops opencode research
+aidevops codex --list-agents
+aidevops claude automate --dry-run
+aidevops codex automate -- -m MODEL
+aidevops codex --native resume --last
+```
+
+Main-agent names come from the framework's `commands/aidevops-*.md` links, including
+`build-plus`, `automate`, `business`, `content`, `framework`, `health`, `legal`,
+`marketing-sales`, `product`, `research`, and `seo`. Names are case-insensitive;
+`Build+` and the `aidevops-` prefix also work. Workflow commands such as `full-loop`
+are tasks to invoke inside a session, not main-agent selectors.
+
+Put launcher options (`--dry-run`) before native options; use `--` to end launcher
+option handling. Native arguments retain their original boundaries and quoting.
+Use `--native` immediately after the runtime to run its native subcommands or to
+launch without injected permissions or agent guidance. For example,
+`aidevops codex --native login` and `aidevops claude --native --help`.
+
+## Runtime behavior
+
+The launchers request the following permissions for this invocation. Runtime and
+organization policies, explicit deny rules, framework safeguards and hook trust
+still apply. Codex hook trust remains separate from sandbox/approval flags.
+
+| Command | Executable / permissions | Main-agent guidance |
+| --- | --- | --- |
+| `codex` | `codex --sandbox danger-full-access --ask-for-approval never` | Session `developer_instructions` |
+| `claude`, `claude-code` | `claude --dangerously-skip-permissions` | Appended system instructions |
+| `opencode`, `oc` | Existing isolated launcher, `--auto` | Native `--agent` |
+| `cursor`, `cursor-agent` | `cursor-agent --yolo` | Initial interactive context |
+| `droid` | `droid`, configured interactive autonomy | Initial interactive context |
+| `gemini`, `gemini-cli` | `gemini --yolo` | `--prompt-interactive` |
+| `continue`, `cn` | `cn --auto` | Session `--rule` |
+| `kilo` | `kilo --auto` | TUI `--prompt` |
+| `kiro`, `kiro-cli` | `kiro-cli chat --trust-all-tools` | Initial interactive context |
+| `aider` | `aider --yes-always` | Framework, selected agent and session guidance as read-only context |
+| `amp` | `amp --dangerously-allow-all` | Initial stdin, preserving any piped user input |
+| `kimi` | `kimi --yolo` | YAML agent extending native `default` tools |
+| `qwen` | `qwen --yolo` | `--prompt-interactive` |
+| `windsurf` | Editor only | Use the editor's installed aidevops workflows |
+
+Codex and Claude session instructions select the workflow without submitting a
+task. Initial-context adapters may perform a bootstrap turn to read the framework;
+the context explicitly tells them to wait for the user's task. Enter the task in
+the terminal after launch. Aider loads the selected Markdown and explicit session guidance as read-only context;
+its available tools remain those of Aider. Amp uses its documented piped-input TUI
+mode, so terminal output must remain attached for interactive use.
+
+Kimi's YAML adapter targets the `kimi-cli` interface documented below. Its generated
+agent and prompt live in content-addressed `~/.aidevops/cache/runtime-launchers/`
+files. It inherits native tools and includes project/skill context; its system
+prompt uses the selected aidevops workflow. Dry runs do not write these files.
+
+Droid's interactive interface does not expose the Exec-only permission bypass
+flag. Select the desired autonomy in `/settings`; the launcher reports this
+limitation. It never switches to one-shot `droid exec` to obtain broader access.
+Windsurf's editor integration has no supported terminal agent adapter and returns
+an explanatory error. Cursor, Continue and Kiro use their terminal executables,
+not the similarly named editor binaries. Missing CLIs produce an actionable error;
+launching never installs software or modifies personal runtime settings.
+
+OpenCode keeps its existing `--dir`, `--shared-db`, `--session-id` and Tabby options.
+Its `conversation`, `remote-interactive`, `desktop`, `server` and `attach` modes
+are forwarded unchanged to the existing launcher, without injecting main-agent or
+permission flags. `opencode-desktop` and `opencode-sandbox` remain available.
+
+## Adapter references
+
+Verified against installed CLI help where available and upstream references:
+[Codex options](https://learn.chatgpt.com/docs/developer-commands.md?surface=cli),
+[Continue CLI](https://docs.continue.dev/cli/quickstart),
+[Droid interactive autonomy](https://docs.factory.ai/autonomy-and-safety/auto-run),
+[Kilo CLI options](https://kilo.ai/docs/code-with-ai/platforms/cli-reference),
+[Kiro CLI options](https://kiro.dev/docs/cli/reference/cli-commands/),
+[Kimi YAML agents](https://moonshotai.github.io/kimi-cli/en/customization/agents.html),
+[Aider options](https://aider.chat/docs/config/options.html).

--- a/README.md
+++ b/README.md
@@ -1984,6 +1984,23 @@ Primary agents live at `.agents/<name>.md`. Each is a domain expert with its own
 
 #### How to invoke a main agent
 
+Launch terminal clients directly with Build+ selected by default, or name a main agent:
+
+```bash
+aidevops codex
+aidevops codex automate
+aidevops claude seo
+aidevops opencode research
+```
+
+These shortcuts apply each CLI's supported full-access options for the session.
+They also support Cursor Agent, Gemini, Continue, Kilo, Kiro CLI, Aider, Amp, Kimi,
+Qwen and Droid (which retains its configured interactive autonomy). Use
+`aidevops codex --list-agents` to list main agents, `--dry-run` to preview a launch,
+and `--native` for native subcommands without injected defaults. See
+[interactive runtime launchers](.agents/tools/ai-assistants/runtime-launchers.md)
+for aliases, argument forwarding and runtime limitations.
+
 | Client | Invocation |
 |---|---|
 | **OpenCode** | Tab through the agent picker in the UI — Build+ is the default. Main agents are registered as top-level agents in OpenCode's config. |

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1123,7 +1123,10 @@ _help_commands() {
 	echo "  gpt56-context <cmd> Manage the 300K GPT-5.6 OpenCode context cap (enable/disable/status)"
 	echo "  client-format      Client request format alignment (extract/check/canary/monitor)"
 	echo "  opencode-db <cmd>  OpenCode SQLite maintenance/session lookup (check/report/sessions/maintain/window/status/install)"
-	echo "  opencode [args]    Launch OpenCode with aidevops per-session DB isolation"
+	echo "  opencode [agent] [args]    Launch OpenCode with Build+ and per-session DB isolation"
+	echo "  codex|claude [agent] [args]  Launch with full permissions (default agent: build-plus)"
+	echo "  <runtime> [agent] [args]     Also cursor, droid, gemini, continue, kilo, kiro, aider, amp, kimi, qwen"
+	echo "                              Use <runtime> --help or --list-agents for launch options"
 	echo "  opencode-desktop   Launch/install OpenCode Desktop with aidevops DB isolation"
 	echo "  opencode-sandbox   Test OpenCode versions in isolation (install/run/check/clean)"
 	echo "  approve <cmd>      Cryptographic issue/PR approval (setup/issue/pr/verify/status)"
@@ -1975,7 +1978,8 @@ main() {
 	client-format) _cmd_client_format "$@" ;;
 	github-app-auth | github-app | gh-auth) _dispatch_helper "github-app-auth-helper.sh" "github-app-auth-helper.sh" "$@" ;;
 	opencode-db | oc-db) _dispatch_helper "opencode-db-maintenance-helper.sh" "opencode-db-maintenance-helper.sh" "$@" ;;
-	opencode | oc) _dispatch_helper "opencode-launcher-helper.sh" "opencode-launcher-helper.sh" "$@" ;;
+	opencode | oc | codex | claude | claude-code | cursor | cursor-agent | droid | gemini | gemini-cli | continue | cn | kilo | kiro | kiro-cli | aider | amp | kimi | qwen | windsurf)
+		_dispatch_helper "runtime-launcher-helper.sh" "runtime-launcher-helper.sh" "$command" "$@" ;;
 	opencode-desktop | oc-desktop) _dispatch_helper "opencode-launcher-helper.sh" "opencode-launcher-helper.sh" desktop "$@" ;;
 	opencode-sandbox | oc-sandbox) _dispatch_helper "opencode-sandbox-helper.sh" "opencode-sandbox-helper.sh" "$@" ;;
 	review-gate | review_gate) _dispatch_helper "review-gate-config-helper.sh" "review-gate-config-helper.sh" "$@" ;;


### PR DESCRIPTION
## Summary

Add aidevops <runtime> [main-agent] shortcuts with Build+ defaults, runtime-supported full-access options and native argument passthrough. Preserve OpenCode isolated sessions and restricted modes; document Droid and editor-only limitations.

## Files Changed

.agents/scripts/runtime-launcher-helper.sh, .agents/scripts/runtime-launcher.py, .agents/scripts/tests/test-runtime-launcher.py, .agents/tools/ai-assistants/runtime-launchers.md, README.md, aidevops.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Nine launcher process tests covering all 14 registry entries; 32 existing OpenCode launcher tests; native parser checks for Codex, Claude, Cursor Agent, Qwen and Droid; real Codex TUI startup confirmed YOLO mode without submitting a task; ShellCheck, changed-file linters and Qlty smells passed.

Resolves #31207


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.309 plugin for [OpenCode](https://opencode.ai) v1.18.28