### PR TITLE
GH#31199: finalize profile and command deployment

### DIFF
--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -40,6 +40,7 @@ echo -e "${BLUE}Generating OpenCode commands...${NC}"
 mkdir -p "$OPENCODE_COMMAND_DIR"
 
 command_count=0
+manual_command_names=" "
 
 # Agent name constants (single source of truth for agent renames)
 readonly AGENT_BUILD="Build+"
@@ -88,6 +89,7 @@ create_command() {
 		cat <<<"$body"
 	} >"${OPENCODE_COMMAND_DIR}/${name}.md"
 
+	manual_command_names+="${name} "
 	((++command_count))
 	echo -e "  ${GREEN}✓${NC} Created /${name} command"
 	return 0
@@ -168,8 +170,11 @@ discover_commands() {
 		# Skip SKILL.md (not a command)
 		[[ "$cmd_name" == "SKILL" ]] && continue
 
-		# Skip if already manually defined (avoid duplicates)
-		[[ -f "$OPENCODE_COMMAND_DIR/$cmd_name.md" ]] && continue
+		# Preserve commands defined explicitly during this run, but refresh
+		# previously auto-discovered files so stale routing metadata cannot survive.
+		case "$manual_command_names" in
+		*" $cmd_name "*) continue ;;
+		esac
 
 		# Preserve OpenCode frontmatter while removing provider-neutral tiers.
 		if copy_discovered_command "$cmd_file" "$OPENCODE_COMMAND_DIR/$cmd_name.md"; then

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -857,7 +857,10 @@ _ensure_commit_history_chart() {
 				rm -f "$migrate_tmp"
 				return 1
 			fi
-			mv "$migrate_tmp" "$readme_path"
+			mv "$migrate_tmp" "$readme_path" || {
+				rm -f "$migrate_tmp"
+				return 1
+			}
 			return 0
 		fi
 		if ! awk -v href="${chart_href}" '

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -842,7 +842,7 @@ _ensure_commit_history_chart() {
 			return 0
 		fi
 		local migrate_tmp
-		migrate_tmp=$(mktemp)
+		migrate_tmp=$(mktemp "${readme_path}.commit-history.XXXXXX") || return 1
 		local legacy_href="https://commit-history.com/${gh_user}"
 		if grep -Fq "<a href=\"${legacy_href}\">" "$readme_path" 2>/dev/null; then
 			if ! awk -v old="href=\"${legacy_href}\"" -v new="href=\"${chart_href}\"" '
@@ -893,7 +893,10 @@ _ensure_commit_history_chart() {
 			rm -f "$migrate_tmp"
 			return 1
 		fi
-		mv "$migrate_tmp" "$readme_path" || return 1
+		mv "$migrate_tmp" "$readme_path" || {
+			rm -f "$migrate_tmp"
+			return 1
+		}
 		return 0
 	fi
 

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -813,10 +813,11 @@ _build_commit_history_chart() {
 	if [[ -z "$gh_user" ]]; then
 		return 0
 	fi
+	local chart_href="https://commit-history.com/${gh_user}?metric=total"
 
 	cat <<EOF
 <div align="center">
-  <a href="https://commit-history.com/${gh_user}">
+  <a href="${chart_href}">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://commit-history.com/embed/${gh_user}?theme=dark" />
       <img alt="${gh_user}'s commit history" src="https://commit-history.com/embed/${gh_user}" />
@@ -835,13 +836,31 @@ _ensure_commit_history_chart() {
 	if ! grep -Fq '> Stats auto-updated by [aidevops]' "$readme_path" 2>/dev/null; then
 		return 0
 	fi
+	local chart_href="https://commit-history.com/${gh_user}?metric=total"
 	if grep -Fq 'https://commit-history.com/embed/' "$readme_path" 2>/dev/null; then
-		if grep -Fq "<a href=\"https://commit-history.com/${gh_user}\">" "$readme_path" 2>/dev/null; then
+		if grep -Fq "<a href=\"${chart_href}\">" "$readme_path" 2>/dev/null; then
 			return 0
 		fi
 		local migrate_tmp
 		migrate_tmp=$(mktemp)
-		if ! awk -v href="https://commit-history.com/${gh_user}" '
+		local legacy_href="https://commit-history.com/${gh_user}"
+		if grep -Fq "<a href=\"${legacy_href}\">" "$readme_path" 2>/dev/null; then
+			if ! awk -v old="href=\"${legacy_href}\"" -v new="href=\"${chart_href}\"" '
+				{
+					start = index($0, old)
+					if (start > 0) {
+						$0 = substr($0, 1, start - 1) new substr($0, start + length(old))
+					}
+					print
+				}
+			' "$readme_path" >"$migrate_tmp"; then
+				rm -f "$migrate_tmp"
+				return 1
+			fi
+			mv "$migrate_tmp" "$readme_path"
+			return 0
+		fi
+		if ! awk -v href="${chart_href}" '
 			function emit_picture() {
 				if (picture_block ~ /commit-history[.]com\/embed\//) {
 					print "  <a href=\"" href "\">"

--- a/.agents/scripts/tests/test-opencode-command-model-tiers.sh
+++ b/.agents/scripts/tests/test-opencode-command-model-tiers.sh
@@ -53,6 +53,13 @@ grep -Fq 'mode: subagent' "$COMMAND_DIR/concrete.md"
 
 mkdir -p "$TEST_ROOT/agents/scripts/commands" "$TEST_ROOT/home"
 cp "$TEST_ROOT/tier.md" "$TEST_ROOT/agents/scripts/commands/tier.md"
+cat >"$TEST_ROOT/agents/scripts/commands/agent-review.md" <<'EOF_COLLISION'
+---
+description: Conflicting source command
+---
+
+Conflicting source body
+EOF_COLLISION
 mkdir -p "$TEST_ROOT/home/.config/opencode/command"
 cat >"$TEST_ROOT/home/.config/opencode/command/tier.md" <<'EOF_STALE'
 ---
@@ -74,6 +81,10 @@ if grep -q 'openai/gpt-5.5\|Stale body' "$legacy_command"; then
 	exit 1
 fi
 grep -Fq 'Keep this body example: model: standard' "$legacy_command"
+if grep -q 'Conflicting source body' "$TEST_ROOT/home/.config/opencode/command/agent-review.md"; then
+	printf '%s\n' 'FAIL: auto-discovery overwrote a manually defined command' >&2
+	exit 1
+fi
 
 printf '%s\n' 'PASS: OpenCode commands inherit tier-routed models and preserve concrete IDs'
 exit 0

--- a/.agents/scripts/tests/test-opencode-command-model-tiers.sh
+++ b/.agents/scripts/tests/test-opencode-command-model-tiers.sh
@@ -53,11 +53,24 @@ grep -Fq 'mode: subagent' "$COMMAND_DIR/concrete.md"
 
 mkdir -p "$TEST_ROOT/agents/scripts/commands" "$TEST_ROOT/home"
 cp "$TEST_ROOT/tier.md" "$TEST_ROOT/agents/scripts/commands/tier.md"
+mkdir -p "$TEST_ROOT/home/.config/opencode/command"
+cat >"$TEST_ROOT/home/.config/opencode/command/tier.md" <<'EOF_STALE'
+---
+description: Stale generated command
+model: openai/gpt-5.5
+---
+
+Stale body
+EOF_STALE
 HOME="$TEST_ROOT/home" AIDEVOPS_DIR="$TEST_ROOT" \
 	bash "$REPO_ROOT/.agents/scripts/generate-opencode-commands.sh" >/dev/null
 legacy_command="$TEST_ROOT/home/.config/opencode/command/tier.md"
 if grep -q '^model: standard$' "$legacy_command"; then
 	printf '%s\n' 'FAIL: workload tier leaked through legacy OpenCode command generator' >&2
+	exit 1
+fi
+if grep -q 'openai/gpt-5.5\|Stale body' "$legacy_command"; then
+	printf '%s\n' 'FAIL: legacy OpenCode command generator preserved stale output' >&2
 	exit 1
 fi
 grep -Fq 'Keep this body example: model: standard' "$legacy_command"

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -519,6 +519,14 @@ EOF
 		print_helper_failure "${test_name}" "first helper update command failed" "$update_output"
 		return 0
 	fi
+	git -C "${fixture_repo}" fetch origin >/dev/null
+	git -C "${fixture_repo}" reset --hard origin/main >/dev/null
+	local legacy_link_tmp="${TEST_DIR}/legacy-link-readme"
+	awk '{ sub(/\?metric=total/, ""); print }' "${fixture_repo}/README.md" >"$legacy_link_tmp"
+	mv "$legacy_link_tmp" "${fixture_repo}/README.md"
+	git -C "${fixture_repo}" add README.md
+	git -C "${fixture_repo}" commit -m "test: restore legacy chart link" >/dev/null
+	git -C "${fixture_repo}" push >/dev/null
 	if ! HOME="${fixture_home}" bash "${helper_path}" update >"$update_output" 2>&1; then
 		print_helper_failure "${test_name}" "second helper update command failed" "$update_output"
 		return 0
@@ -532,7 +540,8 @@ EOF
 		print_result "${test_name}" 1 "migration did not add one username-specific chart"
 		return 0
 	fi
-	if [[ "$(grep -c '<a href="https://commit-history.com/profile-repo">' "$readme")" -ne 1 ]]; then
+	if [[ "$(grep -c '<a href="https://commit-history.com/profile-repo?metric=total">' "$readme")" -ne 1 ]] ||
+		grep -Fq '<a href="https://commit-history.com/profile-repo">' "$readme"; then
 		print_result "${test_name}" 1 "migrated chart is not linked to the username activity profile"
 		return 0
 	fi
@@ -816,7 +825,7 @@ EOF
 		print_result "${test_name}" 1 "commit-history light/dark image URLs missing"
 		return 0
 	fi
-	if ! grep -Fq '<a href="https://commit-history.com/profile-repo">' "$readme"; then
+	if ! grep -Fq '<a href="https://commit-history.com/profile-repo?metric=total">' "$readme"; then
 		print_result "${test_name}" 1 "commit-history chart does not link to the username activity profile"
 		return 0
 	fi


### PR DESCRIPTION
## Summary

- refresh existing auto-discovered OpenCode command files instead of preserving stale generated output
- preserve commands defined explicitly during the same generator run
- link generated commit-history charts to the requested total-activity view and migrate the previous generated link safely
- cover stale GPT-5.5 output replacement, explicit-command collisions, and chart-link migration

## Verification

- `bash .agents/scripts/tests/test-opencode-command-model-tiers.sh`
- `bash .agents/scripts/tests/test-profile-readme-boundary.sh` — 26/26 passed
- `shellcheck .agents/scripts/generate-opencode-commands.sh .agents/scripts/profile-readme-helper.sh .agents/scripts/tests/test-opencode-command-model-tiers.sh .agents/scripts/tests/test-profile-readme-boundary.sh`
- `.agents/scripts/linters-local.sh`
- `git diff --check origin/main...HEAD`

Ref #31199
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.310 plugin for [OpenCode](https://opencode.ai) v1.18.28 with gpt-5.6-sol spent 2h 36m and 1,209,507 tokens on this with the user in an interactive session.