### PR TITLE
GH#31212: Fix worktree fixture leaks and PR archive attribution

### DIFF
--- a/.agents/scripts/pulse-cleanup-fixture-orphans.sh
+++ b/.agents/scripts/pulse-cleanup-fixture-orphans.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Sourced by pulse-cleanup.sh; legacy test fixtures go to recoverable trash only.
+
+# Require the exact pre-edit fixture shape and a missing temporary canonical repo.
+# Never infer disposability from a tmp.* name or an unreadable Git pointer alone.
+_pc_central_fixture_bytes() {
+	local candidate="$1"
+	local base="$2"
+	local now_epoch="$3"
+	local grace_secs="${ORPHAN_WORKTREE_GRACE_SECS:-1800}"
+	python3 - "$candidate" "$base" "$now_epoch" "$grace_secs" <<'PY'
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+
+candidate, base = map(Path, sys.argv[1:3])
+now, grace = map(int, sys.argv[3:5])
+
+def require(condition):
+    if not condition:
+        raise ValueError('fixture safety check failed')
+
+try:
+    require(grace >= 1800)
+    require(candidate.parent == base and not candidate.is_symlink())
+    require(base.resolve() == base and candidate.is_dir())
+    match = re.fullmatch(r'(tmp\.[A-Za-z0-9]+)-feature-auto-[0-9]{8}-[0-9]{6}', candidate.name)
+    require(match and now - candidate.stat().st_mtime >= grace)
+    entries = list(candidate.iterdir())
+    require({p.name for p in entries} <= {'.git', '.metadata_never_index', 'README.md', 'TODO.md'})
+    for entry in entries:
+        info = entry.lstat()
+        require(stat.S_ISREG(info.st_mode) and info.st_size <= 4096)
+        require(now - info.st_mtime >= grace)
+    require((candidate / 'README.md').read_bytes() == b'test\n')
+    pointer = (candidate / '.git').read_text().strip()
+    suffix = '/.git/worktrees/' + candidate.name
+    require(pointer.startswith('gitdir: /') and pointer.endswith(suffix))
+    root = Path(pointer[len('gitdir: '):-len(suffix)])
+    require(root.name == match[1] and '..' not in root.parts)
+    require(re.fullmatch(r'/(?:private/)?(?:tmp|var/folders/[^/]+/[^/]+/T)/tmp\.[A-Za-z0-9]+', str(root)))
+    require(root.parent.is_dir() and os.access(root.parent, os.R_OK | os.X_OK))
+    try:
+        root.lstat()
+    except FileNotFoundError:
+        pass
+    else:
+        raise ValueError('fixture canonical root still exists')
+    print(sum(p.lstat().st_blocks * 512 for p in entries))
+except (OSError, ValueError, UnicodeError):
+    sys.exit(1)
+PY
+	return $?
+}
+
+_pc_fixture_process_clear() {
+	local candidate="$1"
+	local process_output="" process_rc=0
+	process_output=$(lsof -t +D "$candidate" 2>&1) || process_rc=$?
+	[[ "$process_rc" -eq 1 && -z "$process_output" ]] || return 1
+	return 0
+}
+
+# API-free and independent of repos.json: deleted fixture repos are unregistered.
+# Optional audit mode reports candidates without moving anything.
+_pc_cleanup_central_fixture_orphans() {
+	local now_epoch="$1"
+	local mode="${2:-apply}"
+	local base="" candidate="" bytes=0 moved=0 eligible=0 skipped=0 total_bytes=0
+	[[ "$mode" == "apply" || "$mode" == "audit" ]] || return 1
+	command -v python3 >/dev/null 2>&1 && command -v lsof >/dev/null 2>&1 || { printf '0\n'; return 0; }
+	declare -F is_worktree_owned_by_others >/dev/null 2>&1 || { printf '0\n'; return 0; }
+	declare -F is_registered_canonical >/dev/null 2>&1 || { printf '0\n'; return 0; }
+	base=$(aidevops_worktree_base_dir_configured) || { printf '0\n'; return 0; }
+	for candidate in "$base"/tmp.*-feature-auto-*; do
+		[[ -d "$candidate" ]] || continue
+		if ! bytes=$(_pc_central_fixture_bytes "$candidate" "$base" "$now_epoch"); then
+			skipped=$((skipped + 1))
+			continue
+		fi
+		if _worktree_owner_alive "$candidate" "" || is_registered_canonical "$candidate"; then
+			skipped=$((skipped + 1))
+			continue
+		fi
+		# Include cwd and open files; diagnostics or an unavailable process scan veto.
+		if ! _pc_fixture_process_clear "$candidate"; then
+			skipped=$((skipped + 1))
+			continue
+		fi
+		eligible=$((eligible + 1))
+		total_bytes=$((total_bytes + bytes))
+		if [[ "$mode" == "audit" ]]; then
+			printf '[pulse-cleanup] fixture-candidate path=%s bytes=%s\n' "$candidate" "$bytes" >>"$LOGFILE"
+			continue
+		fi
+		# Revalidate the filesystem after the ownership/process checks.
+		if _pc_central_fixture_bytes "$candidate" "$base" "$now_epoch" >/dev/null &&
+			! _worktree_owner_alive "$candidate" "" && _pc_fixture_process_clear "$candidate" &&
+			_pc_trash_orphan_dir "$candidate"; then
+			log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$candidate" "abandoned-central-test-fixture" "trash"
+			moved=$((moved + 1))
+		else
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$candidate" "fixture-recheck-or-trash-failed" "skipped"
+		fi
+	done
+	printf '[pulse-cleanup] central-fixtures mode=%s eligible=%s candidate_bytes=%s moved=%s skipped=%s\n' "$mode" "$eligible" "$total_bytes" "$moved" "$skipped" >>"$LOGFILE"
+	printf '%s\n' "$moved"
+	return 0
+}

--- a/.agents/scripts/pulse-cleanup-worktree-removal.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-removal.sh
@@ -210,12 +210,14 @@ _pc_archive_and_remove_worktree_preserving_branch() {
 	local target_type="${8:-$_PC_ARCHIVE_TARGET_ISSUE}"
 	local archive_dir=""
 	local policy_reason=""
+	local branch_issue=""
 	local archived_context=""
 	local removal_reason="archived-${archive_reason}"
 	[[ -n "$rp_age" && -n "$wt_path_age" ]] || return 1
 
+	branch_issue=$(_pc_issue_from_branch "$wt_branch_age" 2>/dev/null || true)
 	if ! policy_reason=$(_pc_compact_archive_policy_clear "$wt_path_age" "$target_number" \
-		"$repo_slug_age" "$target_type"); then
+		"$repo_slug_age" "$target_type" "$branch_issue"); then
 		[[ -n "$policy_reason" ]] || policy_reason="archive-policy-unverified"
 		echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age:-detached} — ${policy_reason}" >>"$LOGFILE"
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
@@ -484,8 +486,7 @@ _pc_handle_terminal_worktree_archive() {
 	local audit_context
 	local terminal_pr_state=""
 	local terminal_pr_number=""
-	local archive_target_number=""
-	local archive_target_type="$_PC_ARCHIVE_TARGET_ISSUE"
+	local terminal_pr_record=""
 	local terminal_recovery_path="branch-preserved-terminal-pr"
 	local guard_ok
 	guard_ok=$(printf 'cle%s' 'ar')
@@ -499,21 +500,15 @@ _pc_handle_terminal_worktree_archive() {
 		return $?
 	fi
 
-	if terminal_pr_state=$(_pc_terminal_pr_state_for_branch "$repo_slug_age" "$wt_branch_age"); then
-		terminal_pr_number=$(_pc_pr_from_branch "$wt_branch_age" 2>/dev/null || true)
-		archive_target_number="$orphan_issue_num"
-		archive_target_type="$_PC_ARCHIVE_TARGET_ISSUE"
-		if [[ ! "$archive_target_number" =~ ^[1-9][0-9]*$ ]]; then
-			archive_target_number="$terminal_pr_number"
-			archive_target_type="pr"
-		fi
+	if terminal_pr_record=$(_pc_terminal_pr_for_branch "$repo_slug_age" "$wt_branch_age"); then
+		IFS=$'\t' read -r terminal_pr_state terminal_pr_number <<<"$terminal_pr_record"
 		if [[ -n "$terminal_pr_number" ]]; then
 			terminal_recovery_path="branch-preserved-terminal-pr-${terminal_pr_number}"
 		fi
 		audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "pr-${terminal_pr_state}" "$guard_ok" "$guard_ok" "$guard_ok" "$terminal_recovery_path")
 		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): archiving ${wt_branch_age:-detached} — branch PR ${terminal_pr_number:+#${terminal_pr_number} }is ${terminal_pr_state}" >>"$LOGFILE"
 		_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" \
-			"$audit_context" "$archive_target_number" "$repo_slug_age" "$_PC_ARCHIVE_REASON_POST_PR" "$archive_target_type"
+			"$audit_context" "$terminal_pr_number" "$repo_slug_age" "$_PC_ARCHIVE_REASON_POST_PR" "pr"
 		return $?
 	fi
 	return 1
@@ -1220,11 +1215,7 @@ _pc_relocate_registered_worktrees() {
 #
 # See also: GH#18346 (silent-skip logging fix preserved in helpers above)
 #######################################
-cleanup_worktrees() {
-	CLEANUP_WORKTREES_SKIPPED=0
-	CLEANUP_WORKTREES_REMOVED_COUNT=0
-	CLEANUP_WORKTREES_ARCHIVED_COUNT=0
-	CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT=0
+_pc_cleanup_fixture_passes() {
 	local total_removed=0
 	# Fast, API-free pass for detached regression-helper fixtures. Run before
 	# the GraphQL gate and merged-PR scan so a stale long-running cleanup cannot
@@ -1235,6 +1226,24 @@ cleanup_worktrees() {
 		[[ "$temp_removed" =~ ^[0-9]+$ ]] || temp_removed=0
 		total_removed=$((total_removed + temp_removed))
 	fi
+	if declare -F _pc_cleanup_central_fixture_orphans >/dev/null 2>&1; then
+		local fixtures_moved=0
+		fixtures_moved=$(_pc_cleanup_central_fixture_orphans "$(date +%s)") || fixtures_moved=0
+		[[ "$fixtures_moved" =~ ^[0-9]+$ ]] || fixtures_moved=0
+		total_removed=$((total_removed + fixtures_moved))
+	fi
+	printf '%s\n' "$total_removed"
+	return 0
+}
+
+cleanup_worktrees() {
+	CLEANUP_WORKTREES_SKIPPED=0
+	CLEANUP_WORKTREES_REMOVED_COUNT=0
+	CLEANUP_WORKTREES_ARCHIVED_COUNT=0
+	CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT=0
+	local total_removed=0
+	total_removed=$(_pc_cleanup_fixture_passes)
+	CLEANUP_WORKTREES_REMOVED_COUNT="$total_removed"
 	# GH#18979: Skip cleanup when API rate limit is low — both passes call
 	# `gh pr list` per repo/worktree, and blocking rate-limit waits cause
 	# the cleanup stage to hang for 10+ minutes, stalling the entire pulse

--- a/.agents/scripts/pulse-cleanup-worktree-state.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-state.sh
@@ -181,35 +181,48 @@ _pc_branch_archive_pr_state_clear() {
 }
 
 #######################################
-# Return terminal PR state for a branch head, if GitHub verifies one.
+# Return terminal PR state and identity for a branch head, if GitHub verifies one.
 #
 # Args:
 #   $1 - repo slug (owner/repo)
 #   $2 - branch name
-# Outputs: terminal PR state (CLOSED|MERGED)
+# Outputs: tab-separated terminal PR state (CLOSED|MERGED) and PR number
 # Returns: 0 when terminal PR found, 1 otherwise
 #######################################
-_pc_terminal_pr_state_for_branch() {
+_pc_terminal_pr_for_branch() {
 	local repo_slug="$1"
 	local branch_name="$2"
 	local pr_state=""
+	local pr_number=""
+	local pr_record=""
+	local open_pr=""
 
 	[[ -n "$repo_slug" && -n "$branch_name" ]] || return 1
-	pr_state=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state all --limit 1 --json state --jq '.[0].state // empty' 2>/dev/null) || return 1
+	# A branch can have multiple historical PRs: no terminal result may hide a
+	# still-open handoff. Query that veto independently of terminal pagination.
+	open_pr=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state open --limit 1 \
+		--json number --jq '.[0].number // empty' 2>/dev/null) || return 1
+	[[ -z "$open_pr" ]] || return 1
+	pr_record=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state all --limit 1 --json state,number \
+		--jq '.[0] | select(. != null) | [.state, .number] | @tsv' 2>/dev/null) || return 1
+	IFS=$'\t' read -r pr_state pr_number <<<"$pr_record"
 	case "$pr_state" in
 	CLOSED | MERGED)
-		printf '%s\n' "$pr_state"
+		[[ "$pr_number" =~ ^[1-9][0-9]*$ ]] || return 1
+		printf '%s\t%s\n' "$pr_state" "$pr_number"
 		return 0
 		;;
 	esac
 	# A directly associated OPEN PR outranks any numeric token embedded in the
 	# branch name. Only fall back when the local-only branch has no head PR.
-	[[ -z "$pr_state" ]] || return 1
+	[[ -z "$pr_record" ]] || return 1
 
+	pr_number=$(_pc_pr_from_branch "$branch_name" 2>/dev/null) || return 1
+	[[ "$pr_number" =~ ^[1-9][0-9]*$ ]] || return 1
 	pr_state=$(_pc_pr_state_for_branch_reference "$repo_slug" "$branch_name" 2>/dev/null) || return 1
 	case "$pr_state" in
 	CLOSED | MERGED)
-		printf '%s\n' "$pr_state"
+		printf '%s\t%s\n' "$pr_state" "$pr_number"
 		return 0
 		;;
 	esac
@@ -430,6 +443,7 @@ _pc_recent_worker_metric_exists() {
 #   $2 - issue or PR number
 #   $3 - repository slug
 #   $4 - target type: issue or pr
+#   $5 - optional branch issue whose retention policy must also pass for a PR
 # Outputs: a short skip reason when blocked
 # Returns: 0 when archival may proceed, 1 otherwise
 #######################################
@@ -438,6 +452,7 @@ _pc_compact_archive_policy_clear() {
 	local target_number="$2"
 	local repo_slug="$3"
 	local target_type="$4"
+	local branch_issue="${5:-}"
 	local labels=""
 	local label=""
 	local normalized_label=""
@@ -486,6 +501,9 @@ _pc_compact_archive_policy_clear() {
 		return 1
 	fi
 
+	if [[ "$target_type" == "pr" && "$branch_issue" =~ ^[1-9][0-9]*$ ]]; then
+		_pc_compact_archive_policy_clear "$wt_path" "$branch_issue" "$repo_slug" "issue" || return 1
+	fi
 	return 0
 }
 

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -100,6 +100,10 @@ if [[ -n "$_PULSE_CLEANUP_SCRIPT_DIR" && -f "$_PULSE_CLEANUP_SCRIPT_DIR/pulse-cl
 	# shellcheck source=pulse-cleanup-worktree-removal.sh
 	source "$_PULSE_CLEANUP_SCRIPT_DIR/pulse-cleanup-worktree-removal.sh"
 fi
+if [[ -n "$_PULSE_CLEANUP_SCRIPT_DIR" && -f "$_PULSE_CLEANUP_SCRIPT_DIR/pulse-cleanup-fixture-orphans.sh" ]]; then
+	# shellcheck source=pulse-cleanup-fixture-orphans.sh
+	source "$_PULSE_CLEANUP_SCRIPT_DIR/pulse-cleanup-fixture-orphans.sh"
+fi
 
 #######################################
 # Clean up safe-to-drop stashes across ALL managed repos (t1417)

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -78,7 +78,8 @@ run_helper() {
 	shift
 	(
 		cd "$target_dir" || exit 1
-		WORKTREE_REGISTRY_DIR="$TEST_REGISTRY_DIR" \
+		AIDEVOPS_WORKTREE_BASE_DIR="$TEST_WORKTREE_BASE" \
+			WORKTREE_REGISTRY_DIR="$TEST_REGISTRY_DIR" \
 			WORKTREE_REGISTRY_DB="$TEST_REGISTRY_DB" \
 			"$HELPER" "$@"
 	)
@@ -395,6 +396,10 @@ test_headless_planning_path_requires_worktree() {
 	local exit_code=0
 	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --file "README.md" 2>&1) || exit_code=$?
 
+	if [[ "$output" == *"LOOP_DECISION=worktree_created"* && "$output" != *"WORKTREE_PATH=${TEST_WORKTREE_BASE}/"* ]]; then
+		print_result "headless planning worktree stays inside fixture base" 1 "$output"
+		return 0
+	fi
 	if [[ "$exit_code" -ne 0 || "$output" == *"LOOP_DECISION=worktree"* || "$output" == *"LOOP_DECISION=worktree_created"* ]]; then
 		print_result "headless planning path requires a linked worktree" 0
 		return 0

--- a/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
@@ -269,6 +269,94 @@ SH
 	return 0
 }
 
+test_abandoned_central_fixtures() {
+	local base="" candidate="" fixture_root="" now_epoch=0 moved=0 rc=0
+	base=$(cd "$TEST_ROOT/Git/_worktrees" && pwd -P)
+	export AIDEVOPS_WORKTREE_BASE_DIR="$base"
+	export ORPHAN_WORKTREE_GRACE_SECS=1800
+	fixture_root="${TEST_ROOT}gone"
+	candidate="$base/${fixture_root##*/}-feature-auto-20260731-013454"
+	mkdir -p "$candidate"
+	printf 'test\n' >"$candidate/README.md"
+	printf 'gitdir: %s/.git/worktrees/%s\n' "$fixture_root" "${candidate##*/}" >"$candidate/.git"
+	now_epoch=$(($(date +%s) + 3600))
+	_pc_central_fixture_bytes "$candidate" "$base" "$now_epoch" >/dev/null || rc=1
+	print_result "exact abandoned central fixture is classified" "$rc"
+
+	rc=0
+	if _pc_central_fixture_bytes "$candidate" "$base" "$(date +%s)" >/dev/null; then rc=1; fi
+	print_result "recent central fixture is preserved" "$rc"
+	mkdir -p "$fixture_root"
+	rc=0
+	if _pc_central_fixture_bytes "$candidate" "$base" "$now_epoch" >/dev/null; then rc=1; fi
+	rmdir "$fixture_root"
+	print_result "fixture with an existing canonical root is preserved" "$rc"
+
+	printf 'important work\n' >"$candidate/README.md"
+	rc=0
+	if PYTHONOPTIMIZE=1 _pc_central_fixture_bytes "$candidate" "$base" "$now_epoch" >/dev/null; then rc=1; fi
+	print_result "non-fixture content is protected even with optimized Python" "$rc"
+	printf 'test\n' >"$candidate/README.md"
+	ln -s "$TEST_ROOT" "$candidate/TODO.md"
+	rc=0
+	if _pc_central_fixture_bytes "$candidate" "$base" "$now_epoch" >/dev/null; then rc=1; fi
+	rm "$candidate/TODO.md"
+	print_result "symlink inside fixture is preserved" "$rc"
+	touch "$candidate/.aidevops-preserve-forensics"
+	rc=0
+	if _pc_central_fixture_bytes "$candidate" "$base" "$now_epoch" >/dev/null; then rc=1; fi
+	rm "$candidate/.aidevops-preserve-forensics"
+	print_result "forensics marker prevents fixture cleanup" "$rc"
+
+	# Mock only process/ownership evidence; classification and trash moves are real.
+	_worktree_owner_alive() { return 1; }
+	lsof() { return 1; }
+	moved=$(_pc_cleanup_central_fixture_orphans "$now_epoch" audit)
+	rc=0
+	[[ "$moved" == 0 && -d "$candidate" ]] || rc=1
+	print_result "fixture audit mode never moves candidates" "$rc"
+	_worktree_owner_alive() { return 0; }
+	moved=$(_pc_cleanup_central_fixture_orphans "$now_epoch")
+	rc=0
+	[[ "$moved" == 0 && -d "$candidate" ]] || rc=1
+	print_result "owned fixture is preserved" "$rc"
+	_worktree_owner_alive() { return 1; }
+	lsof() { printf '123\n'; return 0; }
+	moved=$(_pc_cleanup_central_fixture_orphans "$now_epoch")
+	rc=0
+	[[ "$moved" == 0 && -d "$candidate" ]] || rc=1
+	print_result "fixture with open files is preserved" "$rc"
+	lsof() { printf 'inspection failed\n' >&2; return 1; }
+	moved=$(_pc_cleanup_central_fixture_orphans "$now_epoch")
+	rc=0
+	[[ "$moved" == 0 && -d "$candidate" ]] || rc=1
+	print_result "process inspection failure preserves fixture" "$rc"
+	lsof() { return 1; }
+	moved=$(unset -f is_registered_canonical; _pc_cleanup_central_fixture_orphans "$now_epoch")
+	rc=0
+	[[ "$moved" == 0 && -d "$candidate" ]] || rc=1
+	print_result "missing canonical guard preserves fixture" "$rc"
+	lsof() {
+		if [[ -f "$TEST_ROOT/process-appeared" ]]; then printf '123\n'; return 0; fi
+		touch "$TEST_ROOT/process-appeared"
+		return 1
+	}
+	moved=$(_pc_cleanup_central_fixture_orphans "$now_epoch")
+	rc=0
+	[[ "$moved" == 0 && -d "$candidate" ]] || rc=1
+	print_result "process appearing during revalidation preserves fixture" "$rc"
+	lsof() { return 1; }
+	moved=$(_pc_cleanup_central_fixture_orphans "$now_epoch")
+	rc=0
+	[[ "$moved" == 1 && ! -e "$candidate" ]] || rc=1
+	local recovered=""
+	for recovered in "$AIDEVOPS_ORPHAN_TRASH_ROOT"/*/"${candidate##*/}"; do
+		[[ -f "$recovered/README.md" && -f "$recovered/.git" ]] || rc=1
+	done
+	print_result "abandoned fixture moves intact to recoverable trash" "$rc"
+	return 0
+}
+
 main() {
 	if ! command -v jq >/dev/null 2>&1; then
 		printf 'SKIP jq unavailable\n'
@@ -279,6 +367,7 @@ main() {
 	test_ci_repair_sibling_name_validation
 	test_orphan_sibling_dirs_move_to_trash_only
 	test_standalone_clean_check_requires_successful_status
+	test_abandoned_central_fixtures
 	printf '\n%d/%d tests passed\n' "$TESTS_PASSED" "$TESTS_RUN"
 	[[ "$TESTS_FAILED" -eq 0 ]] || return 1
 	return 0

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -266,7 +266,7 @@ test_open_head_pr_outranks_embedded_terminal_reference() {
 	}
 
 	local terminal_state=""
-	terminal_state=$(_pc_terminal_pr_state_for_branch "testowner/testrepo" "repair/pr-23085-followup" 2>/dev/null)
+	terminal_state=$(_pc_terminal_pr_for_branch "testowner/testrepo" "repair/pr-23085-followup" 2>/dev/null)
 	local lookup_rc=$?
 	local rc=0
 	[[ "$lookup_rc" -eq 1 ]] || rc=1
@@ -279,10 +279,16 @@ test_open_head_pr_outranks_embedded_terminal_reference() {
 test_merged_branch_pr_removes_before_age_threshold() {
 	local repo_dir="${TEST_ROOT}/repo-merged-branch-pr"
 	local wt_path="${TEST_ROOT}/worker-wt-merged-branch-pr"
-	local branch_name="feature/auto-20260507-190806-gh23080"
+	local branch_name="feature/auto-20260507-190806"
 	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" || return 1
 	source_pulse_cleanup_with_stubs || return 1
 	gh_pr_list() {
+		local args="$*"
+		[[ "$args" == *"--state open"* ]] && return 0
+		if [[ "$args" == *"--json state,number"* ]]; then
+			printf 'MERGED\t23080\n'
+			return 0
+		fi
 		printf '%s\n' 'MERGED'
 		return 0
 	}
@@ -986,6 +992,56 @@ test_branch_pr_lookup_treats_null_pr_number_as_no_pr() {
 	return 0
 }
 
+test_terminal_pr_identity_and_policy_guards() {
+	source_pulse_cleanup_with_stubs || return 1
+	gh_pr_list() {
+		local args="$*"
+		[[ "$args" == *"--state open"* ]] && return 0
+		printf 'MERGED\t23080\n'
+		return 0
+	}
+	local record="" reason="" rc=0
+	record=$(_pc_terminal_pr_for_branch "testowner/testrepo" "feature/auto-gh23081") || rc=1
+	[[ "$record" == $'MERGED\t23080' ]] || rc=1
+	print_result "head PR identity outranks embedded issue number" "$rc"
+	gh_pr_list() {
+		local args="$*"
+		[[ "$args" == *"--state open"* ]] && return 0
+		printf 'MERGED\tnull\n'
+		return 0
+	}
+	rc=0
+	if _pc_terminal_pr_for_branch "testowner/testrepo" "repair/pr-23085-followup" >/dev/null; then rc=1; fi
+	print_result "malformed head PR identity cannot fall back to branch token" "$rc"
+	gh_pr_list() {
+		local args="$*"
+		if [[ "$args" == *"--state open"* ]]; then printf '23090\n'; else printf 'MERGED\t23080\n'; fi
+		return 0
+	}
+	rc=0
+	if _pc_terminal_pr_for_branch "testowner/testrepo" "feature/auto-gh23081" >/dev/null; then rc=1; fi
+	print_result "open head PR vetoes another merged PR for the same branch" "$rc"
+	gh() {
+		local target_type="${1:-}"
+		if [[ "$target_type" == "pr" ]]; then printf 'security\n'; fi
+		return 0
+	}
+	rc=0
+	if reason=$(_pc_compact_archive_policy_clear "$TEST_ROOT" 23080 "testowner/testrepo" pr 23081); then rc=1; fi
+	[[ "$reason" == "protected-security" ]] || rc=1
+	print_result "PR security label protects issue-numbered branch" "$rc"
+	gh() {
+		local target_type="${1:-}"
+		if [[ "$target_type" == "issue" ]]; then printf 'preserve-forensics\n'; fi
+		return 0
+	}
+	rc=0
+	if reason=$(_pc_compact_archive_policy_clear "$TEST_ROOT" 23080 "testowner/testrepo" pr 23081); then rc=1; fi
+	[[ "$reason" == "protected-preserve-forensics" ]] || rc=1
+	print_result "branch issue retention also protects PR archive" "$rc"
+	return 0
+}
+
 TEST_ROOT=$(mktemp -d)
 trap teardown EXIT
 export HOME="${TEST_ROOT}/home"
@@ -1020,6 +1076,7 @@ test_no_newline_pr_output_blocks_local_commit_cleanup
 test_no_newline_open_pr_output_blocks_clean_fastpath
 test_branch_pr_lookup_uses_null_safe_jq_filter
 test_branch_pr_lookup_treats_null_pr_number_as_no_pr
+test_terminal_pr_identity_and_policy_guards
 
 echo ""
 echo "Results: $((TESTS_RUN - TESTS_FAILED))/${TESTS_RUN} passed, ${TESTS_FAILED} failed."

--- a/.agents/workflows/worktree-cleanup.md
+++ b/.agents/workflows/worktree-cleanup.md
@@ -50,6 +50,23 @@ metrics, security or forensics markers/labels, repeated zero-session failures,
 unclear repository/task attribution, remote policy lookup failures, and archive
 creation or verification failures.
 
+Terminal branch PR cleanup carries the PR number from the verified lookup;
+timestamp-only branch names do not need an embedded issue number. Any open PR
+for the same head vetoes terminal cleanup. PR retention labels and any parsed
+branch issue's retention labels must both permit archival.
+
+## Abandoned central test fixtures
+
+The API-free cleanup pass also recognises legacy `tmp.<random>-feature-auto-*`
+fixtures in the configured central worktree base, independently of `repos.json`.
+It requires the exact bounded fixture file shape, a missing OS-temporary
+canonical repo, a minimum 30-minute age, and clear ownership/process checks.
+Symlinks, extra files, forensics markers, live roots, and uncertain inspection
+preserve the directory. Eligible fixtures go to recoverable trash only, never a
+permanent-delete fallback. The `central-fixtures` log row reports eligible count,
+candidate bytes, moved count, and skipped count. Test producers must set their
+own `AIDEVOPS_WORKTREE_BASE_DIR` and remove it in teardown.
+
 ## Manual Cleanup (interactive sessions)
 
 ```bash


### PR DESCRIPTION
## Summary

Isolate pre-edit fixtures; add an API-free, guarded central fixture trash pass with audit counts; carry verified PR identity into compact archives while preserving open-PR and retention vetoes. Document the cleanup contract.

## Files Changed

.agents/scripts/pulse-cleanup-fixture-orphans.sh, .agents/scripts/pulse-cleanup-worktree-removal.sh, .agents/scripts/pulse-cleanup-worktree-state.sh, .agents/scripts/pulse-cleanup.sh, .agents/scripts/tests/test-pre-edit-check.sh, .agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh, .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh, .agents/workflows/worktree-cleanup.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: pre-edit 27/27, orphan-sibling 20/20, worker-owned/no-PR 33/33, async cleanup 17/17; local linters passed. Live audit and apply moved 58 exact abandoned fixtures to recoverable trash and verified compact archive/removal of two terminal-PR worktrees with branches preserved. Broader temp suite 12/14: the same two TODO-sync trash tests fail on unchanged baseline, tracked separately.

Resolves #31212


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.310 plugin for [OpenCode](https://opencode.ai) v1.18.28 with gpt-6-astra spent 1h 3m and 364,449 tokens on this with the user in an interactive session.