### PR TITLE
GH#31189: Allow bounded parent-directory verification

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -31,6 +31,7 @@ import { execSync } from "child_process";
 
 // Extracted modules
 import { createConfigHook } from "./config-hook.mjs";
+import { adaptToolDefinition } from "./tool-definition.mjs";
 import { createMcpSessionRuntime, getOnDemandMcpAgents } from "./mcp-registry.mjs";
 import { enforceManagedMcpArtifactPath } from "./mcp-activation-tool.mjs";
 import { createQualityHooks } from "./quality-hooks.mjs";
@@ -231,6 +232,7 @@ function createConversationHooks({client, conversation, directory}) {
   ]);
   return {
     config: configHook,
+    "tool.definition": adaptToolDefinition,
     "chat.message": async () => 0,
     "chat.params": async (input, output) => applyConversationRootVariant(
       input,
@@ -588,6 +590,7 @@ export async function AidevopsPlugin({ directory, client }) {
 
     // Custom tools + pool management
     tool: baseTools,
+    "tool.definition": adaptToolDefinition,
 
     // Record routed request identity and select parent-safe child effort.
     "chat.message": subagentEffortHooks.chatMessage,

--- a/.agents/plugins/opencode-aidevops/tests/test-team-interface-conversation-profile.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-team-interface-conversation-profile.mjs
@@ -703,6 +703,7 @@ test("conversation plugin exposes only the minimal restricted hook surface", () 
       "chat.params",
       "config",
       "experimental.chat.system.transform",
+      "tool.definition",
       "tool.execute.before",
     ]);
     assert.deepEqual(evidence.config.plugin, [pluginUrl]);

--- a/.agents/plugins/opencode-aidevops/tests/test-tool-definition.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-tool-definition.mjs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Marcus Quinn
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { adaptToolDefinition, LEGACY_PARENT_GUIDANCE, BOUNDED_PARENT_GUIDANCE } from "../tool-definition.mjs";
+
+test("only the known Bash directory paragraph changes, preserving parameters and safety text", async () => {
+  const suffix = '\n\n2. Command Execution:\n   - Always quote file paths that contain spaces with double quotes';
+  const parameters = { command: { type: "string" } };
+  const output = { description: `Preamble\n${LEGACY_PARENT_GUIDANCE}${suffix}`, parameters };
+  await adaptToolDefinition({ toolID: "bash" }, output);
+  assert.equal(output.description, `Preamble\n${BOUNDED_PARENT_GUIDANCE}${suffix}`);
+  assert.equal(output.parameters, parameters);
+  await adaptToolDefinition({ toolID: "bash" }, output);
+  assert.equal(output.description, `Preamble\n${BOUNDED_PARENT_GUIDANCE}${suffix}`);
+  assert.match(output.description, /child names are materially needed/);
+  assert.match(output.description, /pre-edit Git checks/);
+});
+
+test("other tools and unknown upstream descriptions remain untouched", async () => {
+  for (const [toolID, description] of [["read", LEGACY_PARENT_GUIDANCE], ["bash", "New upstream guidance"]]) {
+    const output = { description };
+    await adaptToolDefinition({ toolID }, output);
+    assert.equal(output.description, description);
+  }
+});
+
+test("both plugin modes register the definition adapter", () => {
+  const entry = readFileSync(new URL("../index.mjs", import.meta.url), "utf8");
+  assert.equal(entry.split('"tool.definition": adaptToolDefinition').length - 1, 2);
+});
+
+test("bounded check accepts a high-cardinality parent with spaces without output, and rejects non-directories", () => {
+  const root = mkdtempSync(join(tmpdir(), "parent-verification-"));
+  try {
+    const parent = join(root, "parent with spaces");
+    mkdirSync(parent);
+    for (let i = 0; i < 3000; i++) writeFileSync(join(parent, `child-${i}`), "");
+    for (const [path, status] of [[parent, 0], [join(root, "missing"), 1], [join(parent, "child-0"), 1]]) {
+      const result = spawnSync("test", ["-d", path], { encoding: "utf8" });
+      assert.equal(result.status, status);
+      assert.equal(result.stdout, "");
+      assert.equal(result.stderr, "");
+    }
+    const helper = fileURLToPath(new URL("../../../scripts/command-policy-helper.py", import.meta.url));
+    const result = spawnSync("python3", [helper, "check-command", "--command", `test -d "${parent}"`], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).decision, "allow");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/.agents/plugins/opencode-aidevops/tool-definition.mjs
+++ b/.agents/plugins/opencode-aidevops/tool-definition.mjs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+// OpenCode owns packages/opencode/src/tool/bash.txt. Adapt only its known
+// listing-only paragraph through the public tool.definition hook; do not
+// replace the tool, its parameters, or any runtime permission enforcement.
+export const LEGACY_PARENT_GUIDANCE = `1. Directory Verification:
+   - If the command will create new directories or files, first use \`ls\` to verify the parent directory exists and is the correct location
+   - For example, before running "mkdir foo/bar", first use \`ls foo\` to check that "foo" exists and is the intended parent directory`;
+
+export const BOUNDED_PARENT_GUIDANCE = `1. Directory Verification:
+   - Before creating files or directories, verify the exact intended parent path relative to the command's workdir (or use an absolute path).
+   - When only existence and directory type are needed, use a bounded check such as \`test -d "foo"\` before \`mkdir "foo/bar"\`. Exit 0 confirms a directory; failure must stop creation. This does not enumerate children.
+   - A successful check does not establish that an arbitrary existing directory is the correct parent: confirm the intended location from task context first. Quote paths, including paths with spaces.
+   - When child names are materially needed, use an appropriately scoped directory listing or dedicated Read operation instead.
+   - These checks do not grant filesystem access or replace pre-edit Git checks, destructive-operation confirmation, or other permission controls.`;
+
+export async function adaptToolDefinition(input, output) {
+  if (input.toolID !== "bash" || typeof output.description !== "string") return;
+  // Exact matching leaves future upstream revisions and other plugins' text
+  // untouched rather than broadly deleting an unknown safety paragraph.
+  output.description = output.description.replace(LEGACY_PARENT_GUIDANCE, BOUNDED_PARENT_GUIDANCE);
+}


### PR DESCRIPTION
## Summary

Adapt the known OpenCode Bash directory-verification paragraph through tool.definition in both plugin modes. Permit quoted test -d checks without enumerating children while retaining scoped discovery, intended-parent validation, Git checks, and filesystem permissions. Files: .agents/plugins/opencode-aidevops/index.mjs, tool-definition.mjs, tests/test-tool-definition.mjs.

## Files Changed

.agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/tests/test-tool-definition.mjs, .agents/plugins/opencode-aidevops/tool-definition.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --test .agents/plugins/opencode-aidevops/tests/test-tool-definition.mjs: 4 passed, including a 3000-child parent with spaces and zero output, missing/file rejection, and command-policy acceptance. Node syntax checks, git diff --check, and linters-local.sh passed. Runtime testing: self-assessed low-risk instruction adapter; direct hook and filesystem-check execution passed. Closeout bundle 2368adf1c3be8f4eb07fc01a6842e084ad9714ceebcd3e51c389eee30d53bd4e reviewed with no blocking findings.

Resolves #31189


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.310 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 11m and 69,347 tokens on this with the user in an interactive session.