### PR TITLE
feat: default thinking to Astra low with reasoning escalation

### DIFF
--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -14,8 +14,9 @@
       "reasoning": { "openai/gpt-5.6-terra": "high" }
     },
     "thinking": {
-      "models": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"],
-      "reasoning": { "openai/gpt-5.6-sol": "medium" }
+      "models": ["openai/gpt-6-astra", "anthropic/claude-opus-4-6"],
+      "reasoning": { "openai/gpt-6-astra": "low" },
+      "reasoning_escalation": { "openai/gpt-6-astra": ["low", "medium", "high"] }
     }
   },
 

--- a/.agents/scripts/headless-runtime-run.sh
+++ b/.agents/scripts/headless-runtime-run.sh
@@ -311,13 +311,19 @@ _handle_cmd_run_terminal_attempt() {
 		fi
 		if [[ "$capability_blocked" -eq 1 && -z "$model_override" ]] &&
 			_resolve_capability_escalation "$role" "$tier_override" "$selected_model" "$variant_override"; then
+			# Same-tier reasoning consumes the existing route budget: availability
+			# fallback may revisit a model at its default effort, never reset retries.
+			if [[ "$tier_override" == "$_capability_escalation_tier" ]]; then
+				attempt=$((attempt + 1))
+			else
+				attempt=1
+				max_attempts=$(_headless_route_attempt_budget "$_capability_escalation_tier")
+			fi
 			tier_override="$_capability_escalation_tier"
 			selected_model="$_capability_escalation_model"
 			variant_override="$_capability_escalation_variant"
 			routing_reason="capability_escalation"
 			routing_escalated=1
-			attempt=1
-			max_attempts=$(_headless_route_attempt_budget "$tier_override")
 			prompt="The previous attempt reported a model capability limit after working on the task. Resume the existing session and worktree at the next authorized capability tier or reasoning level (${tier_override}: ${selected_model}${variant_override:+ ${variant_override}}), challenge the blocker using the accumulated evidence, and continue autonomously through implementation and verification. Do not request broader permissions or bypass policy, authentication, trust, or secret-handling boundaries. If model capability remains the only blocker, emit the exact marker BLOCKED: capability limit - <evidence> so runtime routing can evaluate the next configured tier or reasoning level. Use generic BLOCKED only for concrete terminal non-capability blockers. Stop at FULL_LOOP_COMPLETE or a supported BLOCKED outcome."
 			print_warning "$_capability_escalation_label"
 			_cmd_run_disposition="$_CMD_RUN_DISPOSITION_CONTINUE"

--- a/.agents/scripts/headless-runtime-run.sh
+++ b/.agents/scripts/headless-runtime-run.sh
@@ -231,11 +231,20 @@ _prepare_cmd_run_dispatch() {
 _resolve_capability_escalation() {
 	local role="$1"
 	local current_tier="$2"
+	local current_model="${3:-}"
+	local current_variant="${4:-}"
 	_capability_escalation_model=""
 	_capability_escalation_variant=""
 	_capability_escalation_label=""
 	_capability_escalation_tier=""
 	[[ "$role" == "worker" ]] || return 1
+	if [[ -n "$current_model" && -n "$current_variant" ]] &&
+		_capability_escalation_variant=$(model_tier_next_variant "$current_tier" "$current_model" "$current_variant"); then
+		_capability_escalation_tier="$current_tier"
+		_capability_escalation_model="$current_model"
+		_capability_escalation_label="${current_tier} capability limit — increasing ${current_model} reasoning from ${current_variant} to ${_capability_escalation_variant}"
+		return 0
+	fi
 	_capability_escalation_tier=$(model_tier_next "$current_tier" 2>/dev/null) || return 1
 	_capability_escalation_model=$(choose_model "$role" "" "$_capability_escalation_tier" "exact-tier") || return 1
 	_capability_escalation_variant=$(resolve_headless_variant "$role" "$_capability_escalation_tier" "$_capability_escalation_model")
@@ -301,7 +310,7 @@ _handle_cmd_run_terminal_attempt() {
 			capability_blocked=1
 		fi
 		if [[ "$capability_blocked" -eq 1 && -z "$model_override" ]] &&
-			_resolve_capability_escalation "$role" "$tier_override"; then
+			_resolve_capability_escalation "$role" "$tier_override" "$selected_model" "$variant_override"; then
 			tier_override="$_capability_escalation_tier"
 			selected_model="$_capability_escalation_model"
 			variant_override="$_capability_escalation_variant"
@@ -309,7 +318,7 @@ _handle_cmd_run_terminal_attempt() {
 			routing_escalated=1
 			attempt=1
 			max_attempts=$(_headless_route_attempt_budget "$tier_override")
-			prompt="The previous attempt reported a model capability limit after working on the task. Resume the existing session and worktree at the next authorized capability tier (${tier_override}: ${selected_model}${variant_override:+ ${variant_override}}), challenge the blocker using the accumulated evidence, and continue autonomously through implementation and verification. Do not request broader permissions or bypass policy, authentication, trust, or secret-handling boundaries. If model capability remains the only blocker, emit the exact marker BLOCKED: capability limit - <evidence> so runtime routing can evaluate the next configured tier. Use generic BLOCKED only for concrete terminal non-capability blockers. Stop at FULL_LOOP_COMPLETE or a supported BLOCKED outcome."
+			prompt="The previous attempt reported a model capability limit after working on the task. Resume the existing session and worktree at the next authorized capability tier or reasoning level (${tier_override}: ${selected_model}${variant_override:+ ${variant_override}}), challenge the blocker using the accumulated evidence, and continue autonomously through implementation and verification. Do not request broader permissions or bypass policy, authentication, trust, or secret-handling boundaries. If model capability remains the only blocker, emit the exact marker BLOCKED: capability limit - <evidence> so runtime routing can evaluate the next configured tier or reasoning level. Use generic BLOCKED only for concrete terminal non-capability blockers. Stop at FULL_LOOP_COMPLETE or a supported BLOCKED outcome."
 			print_warning "$_capability_escalation_label"
 			_cmd_run_disposition="$_CMD_RUN_DISPOSITION_CONTINUE"
 		else

--- a/.agents/scripts/model-registry-helper.sh
+++ b/.agents/scripts/model-registry-helper.sh
@@ -1315,7 +1315,7 @@ _route_lookup_models() {
 		fallback_model="${fallback_model:-anthropic/claude-sonnet-4-6}"
 		;;
 	thinking)
-		primary_model="${primary_model:-openai/gpt-5.6-sol}"
+		primary_model="${primary_model:-openai/gpt-6-astra}"
 		fallback_model="${fallback_model:-anthropic/claude-opus-4-6}"
 		;;
 	esac

--- a/.agents/scripts/shared-model-tier.sh
+++ b/.agents/scripts/shared-model-tier.sh
@@ -204,7 +204,7 @@ model_tier_candidates() {
 	case "$tier" in
 	simple) printf '%s\n' "openai/gpt-5.6-luna" "anthropic/claude-haiku-4-5" ;;
 	standard) printf '%s\n' "openai/gpt-5.6-terra" "zai-coding-plan/glm-5.2" "anthropic/claude-sonnet-4-6" ;;
-	thinking) printf '%s\n' "openai/gpt-5.6-sol" "anthropic/claude-opus-4-6" ;;
+	thinking) printf '%s\n' "openai/gpt-6-astra" "anthropic/claude-opus-4-6" ;;
 	*) return 1 ;;
 	esac
 	return 0
@@ -286,6 +286,39 @@ model_tier_variant() {
 		if [[ "$variant_result" == "found"$'\t'* ]]; then
 			variant="${variant_result#*$'\t'}"
 			[[ -z "$variant" ]] || printf '%s\n' "$variant"
+			return 0
+		fi
+	done
+	return 1
+}
+
+#######################################
+# Print the next explicitly configured reasoning level for this exact model.
+# Invalid, duplicate, descending, exhausted or unknown ladders fail closed.
+#######################################
+model_tier_next_variant() {
+	local requested_tier="$1"
+	local model="$2"
+	local current="$3"
+	local tier="" table="" routing_table="" framework_table="" previous_table=""
+	tier=$(normalize_model_tier_name "$requested_tier")
+	routing_table=$(model_routing_table_path 2>/dev/null) || routing_table=""
+	framework_table=$(model_routing_framework_table_path 2>/dev/null) || framework_table=""
+	command -v jq >/dev/null 2>&1 || return 1
+	for table in "$routing_table" "$framework_table"; do
+		[[ -n "$table" && -r "$table" && "$table" != "$previous_table" ]] || continue
+		previous_table="$table"
+		if jq -e --arg tier "$tier" --arg model "$model" \
+			'.tiers[$tier].reasoning_escalation | type == "object" and has($model)' "$table" >/dev/null 2>&1; then
+			jq -er --arg tier "$tier" --arg model "$model" --arg current "$current" '
+				["low", "medium", "high"] as $levels
+				| .tiers[$tier].reasoning_escalation[$model] as $ladder
+				| select(($ladder | type) == "array")
+				| [$ladder[] | . as $level | $levels | index($level)] as $ranks
+				| select(($ranks | all(. != null)) and ($ranks == ($ranks | sort | unique)))
+				| ($ladder | index($current)) as $index
+				| select($index != null) | $ladder[$index + 1] // empty
+			' "$table" 2>/dev/null || return 1
 			return 0
 		fi
 	done

--- a/.agents/scripts/tests/test-headless-openai-routing.sh
+++ b/.agents/scripts/tests/test-headless-openai-routing.sh
@@ -87,11 +87,11 @@ test_openai_allowlist_selects_simple_tier_model() {
 test_openai_allowlist_selects_thinking_tier_model() {
 	local selected=""
 	selected=$(select_model thinking)
-	if [[ "$selected" == "openai/gpt-5.6-sol" ]]; then
+	if [[ "$selected" == "openai/gpt-6-astra" ]]; then
 		print_result "OpenAI allowlist selects thinking tier from routing table" 0
 		return 0
 	fi
-	print_result "OpenAI allowlist selects thinking tier from routing table" 1 "Expected openai/gpt-5.6-sol, got ${selected:-<empty>}"
+	print_result "OpenAI allowlist selects thinking tier from routing table" 1 "Expected openai/gpt-6-astra, got ${selected:-<empty>}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-headless-routing-retry.sh
+++ b/.agents/scripts/tests/test-headless-routing-retry.sh
@@ -202,6 +202,44 @@ trap 'rm -rf "$fixture_dir"' EXIT
 	[[ "$(model_tier_candidate_index "$_capability_escalation_tier" "$_capability_escalation_model")" == "0" ]]
 )
 
+# Exercise the real result handler, preserving the session and model while
+# increasing reasoning only on the structured capability signal.
+(
+	role="worker"
+	model_override=""
+	tier_override="thinking"
+	selected_model="openai/gpt-6-astra"
+	variant_override="low"
+	session_key="reasoning-escalation"
+	work_dir="/work"
+	completion_state="blocked"
+	_HRW_STATUS_FAIL="fail"
+	attempt_exit=83
+	_run_result_label="blocked"
+	_run_classification_source="model_blocked_signal"
+	_run_classification_pattern="capability_limit"
+	_cmd_run_finish() { return 0; }
+	_handle_cmd_run_terminal_attempt
+	[[ "$_cmd_run_disposition" == "continue" && "$variant_override" == "medium" ]]
+	[[ "$selected_model" == "openai/gpt-6-astra" && "$tier_override" == "thinking" ]]
+	_handle_cmd_run_terminal_attempt
+	[[ "$_cmd_run_disposition" == "continue" && "$variant_override" == "high" ]]
+	_handle_cmd_run_terminal_attempt
+	[[ "$_cmd_run_disposition" == "return" && "$variant_override" == "high" ]]
+	variant_override="low"
+	_run_classification_pattern="permission_required"
+	_handle_cmd_run_terminal_attempt
+	[[ "$_cmd_run_disposition" == "return" && "$variant_override" == "low" ]]
+	_run_classification_pattern="capability_limit"
+	model_override="$selected_model"
+	_handle_cmd_run_terminal_attempt
+	[[ "$_cmd_run_disposition" == "return" && "$variant_override" == "low" ]]
+	if model_tier_next_variant thinking openai/gpt-6-astra xhigh ||
+		model_tier_next_variant thinking anthropic/claude-opus-4-6 low; then
+		exit 1
+	fi
+)
+
 routing_capture="${fixture_dir}/adaptive-routing.txt"
 (
 	role="worker"

--- a/.agents/scripts/tests/test-headless-routing-retry.sh
+++ b/.agents/scripts/tests/test-headless-routing-retry.sh
@@ -215,15 +215,19 @@ trap 'rm -rf "$fixture_dir"' EXIT
 	completion_state="blocked"
 	_HRW_STATUS_FAIL="fail"
 	attempt_exit=83
+	attempt=1
+	max_attempts=4
 	_run_result_label="blocked"
 	_run_classification_source="model_blocked_signal"
 	_run_classification_pattern="capability_limit"
 	_cmd_run_finish() { return 0; }
 	_handle_cmd_run_terminal_attempt
 	[[ "$_cmd_run_disposition" == "continue" && "$variant_override" == "medium" ]]
+	[[ "$attempt" -eq 2 && "$max_attempts" -eq 4 ]]
 	[[ "$selected_model" == "openai/gpt-6-astra" && "$tier_override" == "thinking" ]]
 	_handle_cmd_run_terminal_attempt
 	[[ "$_cmd_run_disposition" == "continue" && "$variant_override" == "high" ]]
+	[[ "$attempt" -eq 3 && "$max_attempts" -eq 4 ]]
 	_handle_cmd_run_terminal_attempt
 	[[ "$_cmd_run_disposition" == "return" && "$variant_override" == "high" ]]
 	variant_override="low"
@@ -234,6 +238,11 @@ trap 'rm -rf "$fixture_dir"' EXIT
 	model_override="$selected_model"
 	_handle_cmd_run_terminal_attempt
 	[[ "$_cmd_run_disposition" == "return" && "$variant_override" == "low" ]]
+	# Revisited default effort after availability fallback cannot renew budget.
+	model_override=""
+	attempt=4
+	_handle_cmd_run_terminal_attempt
+	[[ "$attempt" -eq 5 && "$max_attempts" -eq 4 ]]
 	if model_tier_next_variant thinking openai/gpt-6-astra xhigh ||
 		model_tier_next_variant thinking anthropic/claude-opus-4-6 low; then
 		exit 1

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -33,7 +33,7 @@ model: simple
 |------|-------|----------|
 | `simple` | openai/gpt-5.6-luna → anthropic/claude-haiku-4-5 | Complete low-consequence execution contracts |
 | `standard` | openai/gpt-5.6-terra → zai-coding-plan/glm-5.2 → anthropic/claude-sonnet-4-6 | Established-pattern implementation with normal judgment and recovery |
-| `thinking` | openai/gpt-5.6-sol → anthropic/claude-opus-4-6 | Consequential unresolved decisions, novel design, and synthesis-heavy work |
+| `thinking` | openai/gpt-6-astra → anthropic/claude-opus-4-6 | Consequential unresolved decisions, novel design, and synthesis-heavy work |
 
 **Model IDs**: Always fully-qualified (`claude-sonnet-4-6`, not `claude-sonnet-4`). Short-form → `ProviderModelNotFoundError`. CLI prefix: `anthropic/`, `google/`, `openai/`.
 
@@ -85,10 +85,10 @@ is always denied because secrets must flow through secret tooling, not prompts.
 - **Pulse**: Resolves `standard` through `model-availability-helper.sh resolve standard`, so it follows routing-table order, health checks, local routing-table overrides, and `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST`.
 - **Workers**: Follow configured candidate order within canonical `simple`, `standard`, or `thinking` routes after allowlist filtering and auth checks.
 - **Local switch**: Set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` to force both pulse and workers onto the default OpenAI fallbacks. If you want OpenAI primary but Anthropic fallback, reorder `custom/configs/model-routing-table.json` and omit the allowlist.
-- **Current default mapping**: The active routing table maps `simple` to OpenAI Luna then Anthropic Haiku, `standard` to OpenAI Terra then Z.AI GLM then Anthropic Sonnet, and `thinking` to OpenAI Sol then Anthropic Opus. Availability and provider policy decide the exact model at execution time.
-- **Reasoning mapping**: The routing table maps OpenAI `simple`, `standard`, and `thinking` to Luna `medium`, Terra `high`, and Sol `medium`. Other providers use their provider/runtime defaults unless configured explicitly.
-- **Capability escalation**: The exact structured marker `BLOCKED: capability limit - <evidence>` advances through `escalation_order` and resolves that tier's current first healthy candidate without pattern-driven downgrade. Headless dispatch starts another bounded route attempt. Interactive OpenCode re-prompts the same child session only when the child identity is known and it has attempted no side effects. Generic `BLOCKED` outcomes and the terminal configured tier remain terminal. Permission, authentication, provider, rate-limit, secret, policy, trust-boundary, locality, and billing failures retain dedicated fail-closed handling and never escalate capability to bypass controls.
-- **OpenAI tier rationale**: The automatic ladder prioritizes verified completion and measured cost: Luna handles bounded work, Terra handles general implementation, and Sol handles synthesis-heavy work. Routing telemetry supports evidence-based reordering without hardcoding provider assumptions.
+- **Current default mapping**: The active routing table maps `simple` to OpenAI Luna then Anthropic Haiku, `standard` to OpenAI Terra then Z.AI GLM then Anthropic Sonnet, and `thinking` to OpenAI Astra then Anthropic Opus. Availability and provider policy decide the exact model at execution time.
+- **Reasoning mapping**: The routing table maps OpenAI `simple`, `standard`, and `thinking` to Luna `medium`, Terra `high`, and Astra `low`. Other providers use their provider/runtime defaults unless configured explicitly.
+- **Capability escalation**: The exact structured marker `BLOCKED: capability limit - <evidence>` advances headless workers through the exact model's configured `reasoning_escalation` ladder before `escalation_order`. Astra uses `low → medium → high`, preserving the session and worktree; high is terminal in thinking. Unknown variants and models never receive guessed reasoning settings. Explicit model pins remain pinned. Interactive OpenCode escalates tiers only when the child identity is known and it has attempted no side effects; it does not automatically increase reasoning within thinking. Generic `BLOCKED` remains terminal. Permission, authentication, provider, rate-limit, secret, policy, trust-boundary, locality, and billing failures retain dedicated fail-closed handling and never escalate capability to bypass controls.
+- **OpenAI tier rationale**: The automatic ladder prioritizes verified completion and measured cost: Luna handles bounded work, Terra handles general implementation, and Astra handles synthesis-heavy work. Routing telemetry supports evidence-based reordering without hardcoding provider assumptions.
 - **OpenAI pro caveat**: `openai/gpt-5.6-sol-pro` passed a live OpenCode ChatGPT OAuth smoke test on 2026-07-10, but OpenAI publishes neither an API price nor comparative Sol Pro benchmarks. It remains excluded from automatic workers pending repository-specific completion-rate evidence. Historical `gpt-5.5-pro` and older `*-pro`/`o3-pro` IDs remain excluded.
 - **GLM-5.2 option**: Standard routing may use `zai-coding-plan/glm-5.2` when that OpenCode provider is authenticated. Direct `zai/glm-5.2` is intentionally excluded.
 - **Tier-aware effort**: `AIDEVOPS_HEADLESS_VARIANT_SIMPLE`, `AIDEVOPS_HEADLESS_VARIANT_STANDARD`, and `AIDEVOPS_HEADLESS_VARIANT_THINKING` can temporarily override routing-table reasoning.
@@ -99,17 +99,18 @@ is always denied because secrets must flow through secret tooling, not prompts.
 
 The September 2026 defaults are an educated, reversible operating choice, not a
 benchmark superiority claim: Luna medium avoids blanket maximum reasoning for
-bounded work; Terra high retains headroom for normal judgment and recovery; Sol
-medium keeps synthesis cheaper than routinely duplicating a flagship parent.
+bounded work; Terra high retains headroom for normal judgment and recovery; Astra
+low trials observed token efficiency for thinking work without blanket high effort.
 Use ordinary completion, verification, retries and parent repair to improve these
 choices, following `reference/agent-routing.md` "Improve efficiency during ordinary
 work". Historical replay remains opt-in for material unresolved comparisons, not
 a prerequisite for building with the framework.
 
-GPT-6 Astra medium is a reasonable explicitly selected interactive daily driver
-when its judgment saves human intervention. It does not replace the shared worker
-ladder or change other models' reasoning. Reserve Astra or higher effort for a
-specific difficult decision rather than routine second opinions. Same-model
+Increase reasoning when verification exposes an unresolved reasoning error or
+bounded approaches stop producing new evidence, not after every failed command.
+For high-risk decisions, explicitly select higher effort upfront when justified.
+Compare total tokens and time per verified outcome, including retries and repair;
+fewer tokens per response alone do not establish lower cost. Same-model
 OpenCode children cannot exceed their parent's known reasoning setting; use an
 explicit parent effort change when genuinely needed, not a bypass of that cap.
 
@@ -137,7 +138,7 @@ Example custom override for OpenAI-capable headless routing:
 {
   "tiers": {
     "standard": { "models": ["openai/gpt-5.6-terra", "anthropic/claude-sonnet-4-6"] },
-    "thinking": { "models": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"] }
+    "thinking": { "models": ["openai/gpt-6-astra", "anthropic/claude-opus-4-6"] }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Most AI tools still leave you doing the hard coordination yourself: finding the right context, choosing a model, protecting secrets, managing branches, watching CI, spotting stuck work, and remembering what went wrong last time. aidevops puts structure around that work so agents can share context, work safely in parallel, spend model budget where it matters, and leave the system better than they found it.
 
-> **Recommended setup:** [OpenCode](https://opencode.ai/) + OpenAI GPT-5.6 models. aidevops routes Luna to bounded work, Terra to general implementation, and Sol to consequential reasoning and synthesis. Claude models (Anthropic) remain fully supported fallbacks, and other model providers are evaluated as their quality, latency, and cost profiles change.
+> **Recommended setup:** [OpenCode](https://opencode.ai/) + OpenAI GPT-5.6 Luna / Terra and GPT-6 Astra. aidevops routes Luna to bounded work, Terra to general implementation, and Astra at low reasoning to consequential reasoning and synthesis. Claude models (Anthropic) remain fully supported fallbacks, and other model providers are evaluated as their quality, latency, and cost profiles change.
 
 *"Scope a mission to redesign the landing pages — break it into milestones, dispatch workers in parallel, validate each milestone, and track budget across the whole project."*
 
@@ -92,7 +92,7 @@ the required notices and preferred credit text.
 
 - **Purpose**: AI-assisted DevOps automation framework
 - **Install**: `npm install -g aidevops && aidevops update`
-- **Recommended runtime/models**: OpenCode + OpenAI GPT-5.6 Luna / Terra / Sol
+- **Recommended runtime/models**: OpenCode + OpenAI GPT-5.6 Luna / Terra / GPT-6 Astra
 - **Entry**: `aidevops` CLI, `~/.aidevops/agents/AGENTS.md`
 - **Stack**: Bash scripts, TypeScript (Bun), MCP servers
 - **Recent focus**: evidence-based model routing, indexed worker worktrees, audited deployment copies, release provenance, and OpenCode control-plane safety
@@ -287,7 +287,7 @@ git clone https://github.com/marcusquinn/aidevops.git ~/Git/aidevops
 - Ensure all PATH and alias changes work in both bash, zsh, and fish
 - When Claude Code is installed, add a `claude` alias that runs `claude --dangerously-skip-permissions` (skips per-tool permission prompts). Re-running setup updates the alias automatically. To grant permissions per-session instead, press **Shift-Tab** inside Claude Code to cycle through permission modes (default → skip permissions → auto-approve).
 
-**New users: Start [OpenCode](https://opencode.ai/) and type `/onboarding`** to configure your services interactively. OpenCode is the recommended tool for aidevops; the default routing uses OpenAI GPT-5.6 Luna, Terra, and Sol across the simple, standard, and thinking tiers. The onboarding wizard will:
+**New users: Start [OpenCode](https://opencode.ai/) and type `/onboarding`** to configure your services interactively. OpenCode is the recommended tool for aidevops; the default routing uses OpenAI GPT-5.6 Luna, Terra, and GPT-6 Astra across the simple, standard, and thinking tiers. The onboarding wizard will:
 - Explain what **[aidevops](https://aidevops.sh)** can do
 - Ask about your work to give personalized recommendations
 - Show which services are configured vs need setup
@@ -446,7 +446,7 @@ See `.agents/tools/task-management/beads.md` for complete documentation and inst
 
 ### OpenAI Models in OpenCode (Recommended)
 
-OpenCode with OpenAI is the current recommended aidevops setup. Delegation defaults are GPT-5.6 Luna **medium** for bounded low-consequence work, Terra **high** for established-pattern implementation, and Sol **medium** for consequential decisions, architecture, and synthesis-heavy work. GPT-6 Astra **medium** is an optional interactive daily driver; selecting it does not replace the cheaper child tiers.
+OpenCode with OpenAI is the current recommended aidevops setup. Delegation defaults are GPT-5.6 Luna **medium** for bounded low-consequence work, Terra **high** for established-pattern implementation, and GPT-6 Astra **low** for consequential decisions, architecture, and synthesis-heavy work. Headless thinking workers escalate Astra reasoning **low → medium → high** only on an evidence-bearing capability-limit signal; operational failures never trigger that escalation. Interactive children retain their parent's reasoning ceiling. See [model routing](.agents/tools/context/model-routing.md) for overrides and escalation boundaries.
 
 Optimise through ordinary verified work, retries and parent repair rather than a prerequisite benchmark project. API prices are directional resource-cost estimates, not ChatGPT subscription allowance percentages. See [practical model and effort selection](.agents/tools/context/model-routing.md#practical-model-and-effort-selection) for the strategy, estimate scope and safe escalation rules.
 
@@ -460,7 +460,7 @@ aidevops model-accounts-pool add openai
 **Why this is the default:**
 
 - **Pragmatic defaults** — reversible choices improved through actual completion and repair evidence, not a claim of benchmark superiority
-- **Tiered cost/latency split** — Luna for bounded work, Terra for general implementation, and Sol where deeper judgement is worth the extra budget
+- **Tiered cost/latency split** — Luna for bounded work, Terra for general implementation, and Astra where deeper judgement is worth the extra budget
 - **Provider isolation** — OpenAI accounts rotate independently from Anthropic, Google, Cursor, and local providers
 - **Fallback-friendly** — Claude, Gemini, Cursor, and local models remain available when a task or rate-limit profile calls for them
 
@@ -578,7 +578,7 @@ The secure workflow is included at `.github/workflows/opencode-agent.yml`.
 
 See `.agents/tools/git/opencode-github-security.md` for the full security documentation.
 
-**Supported AI tool:** [OpenCode](https://opencode.ai/) is the recommended and tested AI coding tool for aidevops. All features, agents, and workflows are designed and tested for OpenCode first. The default OpenAI routing maps GPT-5.6 Luna, Terra, and Sol to the simple, standard, and thinking tiers. [Claude](https://claude.ai/) models (Anthropic) remain fully supported fallbacks, and other providers are tested as their capabilities change.
+**Supported AI tool:** [OpenCode](https://opencode.ai/) is the recommended and tested AI coding tool for aidevops. All features, agents, and workflows are designed and tested for OpenCode first. The default OpenAI routing maps GPT-5.6 Luna, Terra, and GPT-6 Astra to the simple, standard, and thinking tiers. [Claude](https://claude.ai/) models (Anthropic) remain fully supported fallbacks, and other providers are tested as their capabilities change.
 
 The native `ai_research` tool uses OpenCode's configured providers and canonical `simple`, `standard`, and `thinking` workload tiers; it does not require a specific provider credential.
 
@@ -586,7 +586,7 @@ The native `ai_research` tool uses OpenCode's configured providers and canonical
 
 - **[OpenCode](https://opencode.ai/)** - The recommended AI coding agent. Powerful agentic TUI/CLI with native MCP support, Tab-based agent switching, LSP integration, plugin ecosystem, and excellent DX. All aidevops features are designed and tested for OpenCode first.
 - **[OpenCode Zen](https://opencode.ai/)** - Free tier of OpenCode with included models. Start working with AI straight away at no cost -- no API keys or subscriptions required.
-- **OpenAI GPT-5.6 Luna / Terra / Sol** - Recommended tier family for aidevops today: Luna for bounded work, Terra for routine implementation, and Sol for consequential reasoning and high-impact decisions.
+- **OpenAI GPT-5.6 Luna / Terra / GPT-6 Astra** - Recommended tier mapping for aidevops today: Luna for bounded work, Terra for routine implementation, and Astra for consequential reasoning and high-impact decisions.
 - **[Claude](https://claude.ai/)** (Anthropic) - Fully supported alternative provider. Claude models remain useful for fallback, cross-provider verification, and users with Claude Pro/Max OAuth access.
 - **[Tabby](https://tabby.sh/)** - Recommended terminal. Colour-coded Profiles per project/repo, **auto-syncs tab titles with git/session context and marks OpenCode turns from the first submitted message as ⚪, 🔴, 🟡, or 🟢.**
 - **[Zed](https://zed.dev/)** - Recommended editor. High-performance with AI integration (use with the OpenCode Agent Extension).
@@ -873,7 +873,7 @@ Supervisor (pulse loop)
 │   ├── task_assignment → worker inbox
 │   ├── status_report → coordinator outbox
 │   └── broadcast → all agents
-└── Model Routing (tier-based: GPT-5.6 Luna / Terra / Sol / provider fallbacks)
+└── Model Routing (tier-based: GPT-5.6 Luna / Terra / GPT-6 Astra / provider fallbacks)
 ```
 
 **Key components:**


### PR DESCRIPTION
## Summary

- Default the thinking workload tier to GPT-6 Astra at low reasoning; retain Opus availability fallback and unchanged simple/standard tiers.
- Add exact-model, strictly increasing low → medium → high headless capability escalation through the existing structured capability-limit handler. Preserve model pins and dedicated operational/security failure paths.
- Refresh static thinking fallbacks, README and routing guidance. Interactive children retain parent effort ceilings and existing tier-only escalation.

## Implementation context

Files: `.agents/configs/model-routing-table.json`, `.agents/scripts/shared-model-tier.sh`, `.agents/scripts/headless-runtime-run.sh`, `.agents/scripts/model-registry-helper.sh`, existing routing tests, `.agents/tools/context/model-routing.md`, and `README.md`.

Reference pattern: `model_tier_variant` layered table resolution and `_resolve_capability_escalation` structured result handling. Reasoning overrides set starting effort, not a hard maximum; explicit model pins suppress automatic capability escalation.

## Runtime Testing

Risk: high (bounded runtime retry state-machine change). Testing: runtime-verified via the real result handler in the existing retry suite, proving low → medium → high → terminal, unchanged model/tier, permission-blocker non-escalation, explicit model pin preservation and unknown variant/model rejection. Installed OpenCode model metadata confirms Astra supports low, medium and high. No comparative performance claim or new benchmark infrastructure.

Passed:
- `.agents/scripts/linters-local.sh` (all required local checks; pre-existing shfmt and historical-size advisories only)
- `bash .agents/scripts/tests/test-headless-routing-retry.sh`
- `bash .agents/scripts/tests/test-headless-openai-routing.sh` (6 tests)
- `bash .agents/scripts/tests/test-model-routing-overlay.sh`
- `bash .agents/scripts/tests/test-canonical-model-tiers.sh`
- `node --test .agents/plugins/opencode-aidevops/tests/test-model-routing.mjs` (7 tests)

## Review

Direct exact-diff inspection and independent bounded runtime review: no concrete P1/P2 introduced defect found in the final changes. Same-tier escalation consumes the existing route budget, preventing availability fallback from renewing reasoning retries; regression verified. Final evidence bundle SHA-256: `9fe951ee8fc8223c4372842e7fbc33ccccc23d99624c75d1f5fa570956072f7d` (prompt-injection scan clean).

## Release intent

User explicitly authorized full-loop through release. Evaluate total tokens/time per verified outcome including retries; this is a reversible operating default based on observed token efficiency, not benchmark superiority.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.310 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 24m and 190,994 tokens on this with the user in an interactive session.