### PR TITLE
GH#31218: Generate daily total contribution profile charts

### DIFF
--- a/.agents/scripts/profile-contribution-chart.md
+++ b/.agents/scripts/profile-contribution-chart.md
@@ -1,0 +1,52 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Profile Total Contributions chart
+
+`profile-readme-helper.sh update` generates `assets/contributions/total-light.svg`,
+`total-dark.svg`, and `total.json` in its isolated profile publication worktree.
+The README and these three explicit asset paths are published in one commit.
+The existing hourly profile scheduler attempts a refresh once per UTC day; a
+successful current-date asset set avoids further API calls that day. No new timer
+or third-party image service is required.
+
+## Data definition
+
+The chart uses GitHub's canonical `contributionCalendar.totalContributions`,
+covering all contribution types rather than reconstructing a total from
+viewer-dependent public/restricted buckets. Windows are disjoint calendar months from account creation through
+the prior UTC day's final second. The current month is partial; today is excluded.
+Only month totals and their running cumulative sum are published. No repository
+identities, event details, credentials, or separate private contribution buckets
+are written to assets.
+
+Queries use the authenticated `gh` CLI, with at most 12 monthly aliases per
+request and a bounded 400-month history. A typical 13-year history needs about
+14 requests per daily refresh, including identity lookup. Missing months, null
+counts, API errors, and unavailable credentials retain the last successful chart.
+Rendering and README migration finish before writing. Local I/O errors abort the
+publisher so a partial asset set is not pushed. Commit/push failures do not mark
+the remote profile as refreshed; the next isolated run starts from remote state.
+
+## Verification link and freshness
+
+The chart and visible verification link open the user's `commit-history.com`
+Total view. That independent service may have a different refresh cutoff, so the
+README explains why totals can differ. Compatible HTML renderers receive
+`target="_blank" rel="noopener noreferrer"`; GitHub's Markdown API strips these
+attributes. GitHub users can Ctrl/Cmd-click the link to open a new tab.
+
+Each SVG includes an updated date and data-through date. GitHub's image cache can
+delay the display after a new commit. If the scheduler host is asleep/offline,
+the next successful scheduled invocation catches up; this is not a hosted uptime
+guarantee.
+
+## Verification commands
+
+```bash
+python3 .agents/scripts/tests/test-profile-contribution-chart.py
+bash .agents/scripts/tests/test-profile-readme-boundary.sh
+bash .agents/scripts/tests/test-profile-readme-contributions-fail-closed.sh
+shellcheck .agents/scripts/profile-readme-helper.sh
+bash .agents/scripts/profile-readme-helper.sh update --dry-run
+```

--- a/.agents/scripts/profile-contribution-chart.py
+++ b/.agents/scripts/profile-contribution-chart.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Publish aggregate-only GitHub contribution charts with the profile README.
+
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+
+import argparse
+import datetime as dt
+import html
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+ASSET_DIR = Path("assets/contributions")
+FILES = ("total-light.svg", "total-dark.svg", "total.json")
+START = "<!-- TOTAL-CONTRIBUTIONS-START -->"
+END = "<!-- TOTAL-CONTRIBUTIONS-END -->"
+UTC = dt.timezone.utc
+
+
+class FetchError(Exception):
+    """Unverified or unavailable remote data; retain the published chart."""
+
+
+def graphql(query, login):
+    """Use gh's credential handling; never expose raw API errors or credentials."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", "graphql", "--input", "-"],
+            input=json.dumps({"query": query, "variables": {"login": login}}),
+            capture_output=True, text=True, timeout=60, check=True,
+        )
+        payload = json.loads(result.stdout)
+        if not isinstance(payload, dict) or payload.get("errors"):
+            raise FetchError("GitHub returned incomplete contribution data")
+        user = payload["data"]["user"]
+        if not isinstance(user, dict) or user.get("login", "").casefold() != login.casefold():
+            raise FetchError("GitHub profile identity could not be verified")
+        return user
+    except (OSError, subprocess.SubprocessError, ValueError, KeyError, TypeError) as exc:
+        raise FetchError("GitHub contribution lookup unavailable") from exc
+
+
+def monthly_windows(created, today):
+    """Disjoint UTC months, ending at yesterday's final second (never future days)."""
+    current = dt.date(created.year, created.month, 1)
+    while current < today:
+        following = dt.date(current.year + (current.month == 12), current.month % 12 + 1, 1)
+        end = dt.datetime.combine(min(following, today), dt.time(), UTC) - dt.timedelta(seconds=1)
+        yield current.strftime("%Y-%m"), current.isoformat() + "T00:00:00Z", end.strftime("%Y-%m-%dT%H:%M:%SZ")
+        current = following
+
+
+def fetch_history(login, today, client=graphql):
+    identity = client("query($login:String!){user(login:$login){login createdAt}}", login)
+    try:
+        created = dt.date.fromisoformat(identity["createdAt"][:10])
+        if not dt.date(2007, 1, 1) <= created <= today:
+            raise ValueError("invalid account creation date")
+    except (KeyError, ValueError, TypeError) as exc:
+        raise FetchError("GitHub account creation date unavailable") from exc
+    windows = list(monthly_windows(created, today))
+    if len(windows) > 400:
+        raise FetchError("Contribution history exceeds the bounded query window")
+    points, cumulative = [], 0
+    for offset in range(0, len(windows), 12):
+        batch = windows[offset:offset + 12]
+        aliases = [
+            f'm{i}:contributionsCollection(from:"{begin}",to:"{end}")'
+            + "{contributionCalendar{totalContributions}}"
+            for i, (_, begin, end) in enumerate(batch)
+        ]
+        response = client("query($login:String!){user(login:$login){login " + " ".join(aliases) + "}}", login)
+        for i, (month, _, _) in enumerate(batch):
+            collection = response.get(f"m{i}")
+            if not isinstance(collection, dict):
+                raise FetchError("Missing contribution month")
+            calendar = collection.get("contributionCalendar")
+            total = calendar.get("totalContributions") if isinstance(calendar, dict) else None
+            if type(total) is not int or total < 0:
+                raise FetchError("Incomplete contribution totals")
+            cumulative += total
+            # Only public aggregate counts: never publish individual private buckets.
+            points.append({"month": month, "total": total, "cumulative": cumulative})
+    return {
+        "schema": "aidevops.total-contributions/v1", "user": login,
+        "updated": today.isoformat(), "through": (today - dt.timedelta(days=1)).isoformat(),
+        "metric": "GitHub contributionCalendar.totalContributions",
+        "total": cumulative, "months": points,
+    }
+
+
+def compact(value):
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f}M"
+    if value >= 1000:
+        return f"{value / 1000:.0f}K"
+    return str(round(value))
+
+
+def render_svg(data, dark=False):
+    bg, fg, muted, grid = ("#0d1117", "#e6edf3", "#8b949e", "#30363d") if dark else ("#ffffff", "#24292f", "#57606a", "#d0d7de")
+    user = html.escape(data["user"], quote=True)
+    points = data["months"]
+    values = [point["cumulative"] for point in points] or [0]
+    maximum = max(max(values), 1)
+    left, top, width, height = 76, 100, 848, 250
+    coords = [(left + i * width / max(len(values) - 1, 1), top + height * (1 - value / maximum)) for i, value in enumerate(values)]
+    line = " ".join(f'{"M" if i == 0 else "L"}{x:.1f},{y:.1f}' for i, (x, y) in enumerate(coords))
+    area = line + f" L{coords[-1][0]:.1f},{top + height} L{left},{top + height} Z"
+    parts = [
+        '<svg xmlns="http://www.w3.org/2000/svg" width="960" height="420" viewBox="0 0 960 420" role="img" aria-labelledby="title desc">',
+        f'<title id="title">{user}: Total Contributions</title>',
+        f'<desc id="desc">{data["total"]:,} cumulative GitHub contributions through {data["through"]}. Updated {data["updated"]} UTC.</desc>',
+        '<defs><linearGradient id="area" x2="0" y2="1"><stop stop-color="#16a34a" stop-opacity=".2"/><stop offset="1" stop-color="#16a34a" stop-opacity=".02"/></linearGradient></defs>',
+        f'<rect width="960" height="420" fill="{bg}"/>',
+        f'<g font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" fill="{fg}">',
+        '<text x="32" y="39" font-size="26" font-weight="600">Total Contributions</text>',
+        f'<text x="924" y="39" text-anchor="end" font-size="26" font-weight="600">{data["total"]:,}</text>',
+        f'<text x="32" y="66" font-size="14" fill="{muted}">@{user} · Cumulative monthly totals · Through {data["through"]} UTC</text>',
+    ]
+    for index in range(5):
+        y = top + height * index / 4
+        parts.extend([
+            f'<path d="M{left},{y} H924" stroke="{grid}" stroke-width="1"/>',
+            f'<text x="64" y="{y + 5}" text-anchor="end" font-size="13" fill="{muted}">{compact(maximum * (1 - index / 4))}</text>',
+        ])
+    for index in sorted({round(i * (len(points) - 1) / 5) for i in range(6)}) if points else []:
+        x = coords[index][0]
+        parts.append(f'<text x="{x:.1f}" y="377" text-anchor="middle" font-size="13" fill="{muted}">{points[index]["month"]}</text>')
+    parts.extend([
+        f'<path d="{area}" fill="url(#area)"/>',
+        f'<path d="{line}" fill="none" stroke="#16a34a" stroke-width="3" stroke-linejoin="round"/>',
+        f'<circle cx="{coords[-1][0]:.1f}" cy="{coords[-1][1]:.1f}" r="4" fill="#16a34a"/>',
+        f'<text x="32" y="406" font-size="12" fill="{muted}">Source: GitHub · Includes all six contribution types · Updated {data["updated"]} UTC</text>',
+        '</g></svg>',
+    ])
+    return "\n".join(parts) + "\n"
+
+
+def chart_block(login):
+    return f'''{START}
+<div align="center">
+  <a href="https://commit-history.com/{login}?metric=total" target="_blank" rel="noopener noreferrer">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="assets/contributions/total-dark.svg" />
+      <img alt="{login}'s cumulative total GitHub contributions" src="assets/contributions/total-light.svg" width="960" />
+    </picture>
+  </a>
+</div>
+
+[Verify on commit-history.com](https://commit-history.com/{login}?metric=total) · [Chart data](assets/contributions/total.json)
+
+Includes commits, issues, pull requests, reviews, repositories, and restricted contributions. Refreshed daily through the prior UTC day; commit-history.com may use a different refresh cutoff. GitHub controls link navigation—Ctrl/Cmd-click opens verification in a new tab.
+{END}'''
+
+
+def migrate_readme(text, login):
+    block = chart_block(login)
+    if START in text or END in text:
+        if text.count(START) != 1 or text.count(END) != 1 or text.index(END) < text.index(START):
+            raise ValueError("Ambiguous contribution chart markers")
+        return text[:text.index(START)] + block + text[text.index(END) + len(END):]
+    # Only replace the known generated chart container, not arbitrary pictures.
+    pattern = r'<div align="center">(?:(?!</div>).)*https://commit-history\.com/embed/' + re.escape(login) + r'(?=[?"\s])(?:(?!</div>).)*</div>'
+    matches = list(re.finditer(pattern, text, re.DOTALL))
+    if len(matches) > 1:
+        raise ValueError("Multiple legacy contribution charts")
+    if matches:
+        match = matches[0]
+        return text[:match.start()] + block + text[match.end():]
+    return text.rstrip() + "\n\n" + block + "\n"
+
+
+def safe_paths(repo, readme):
+    """Fail closed on symlinked artifacts, including ancestor directories."""
+    for path in [repo / "assets", repo / ASSET_DIR, readme] + [repo / ASSET_DIR / name for name in FILES]:
+        if path.is_symlink() or (path.exists() and not (path.is_file() or path.is_dir())):
+            raise ValueError("Unsafe contribution chart artifact path")
+    if not readme.is_file():
+        raise ValueError("Profile README is not a regular file")
+
+
+def valid_history(data, login, today):
+    """Do not trust repository-cached strings as SVG markup or freshness proof."""
+    try:
+        if data["schema"] != "aidevops.total-contributions/v1" or data["user"] != login:
+            return False
+        updated = dt.date.fromisoformat(data["updated"])
+        through = dt.date.fromisoformat(data["through"])
+        if updated > today or through != updated - dt.timedelta(days=1):
+            return False
+        if not isinstance(data["months"], list) or len(data["months"]) > 400:
+            return False
+        cumulative, previous = 0, ""
+        for point in data["months"]:
+            month = point["month"]
+            if not re.fullmatch(r"[0-9]{4}-(0[1-9]|1[0-2])", month) or not previous < month <= through.strftime("%Y-%m"):
+                return False
+            if type(point["total"]) is not int or point["total"] < 0:
+                return False
+            cumulative += point["total"]
+            if type(point["cumulative"]) is not int or point["cumulative"] != cumulative:
+                return False
+            previous = month
+        return type(data["total"]) is int and data["total"] == cumulative
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
+def refresh(repo, readme, login, dry_run=False, today=None, client=graphql):
+    today = today or dt.datetime.now(UTC).date()
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9-]{0,38}", login):
+        raise ValueError("Invalid GitHub username")
+    safe_paths(repo, readme)
+    destination = repo / ASSET_DIR
+    cached = None
+    try:
+        cached = json.loads((destination / "total.json").read_text())
+    except (OSError, ValueError):
+        pass
+    fresh = valid_history(cached, login, today) and cached["updated"] == today.isoformat()
+    if fresh and all((destination / name).is_file() for name in FILES):
+        data = cached
+    else:
+        try:
+            data = fetch_history(login, today, client)
+        except FetchError:
+            print("Warning: GitHub chart refresh unavailable; retaining the last successful chart", file=sys.stderr)
+            return False
+    updated_readme = migrate_readme(readme.read_text(), login)
+    payloads = {
+        destination / "total-light.svg": render_svg(data),
+        destination / "total-dark.svg": render_svg(data, dark=True),
+        destination / "total.json": json.dumps(data, indent=2) + "\n",
+        readme: updated_readme,
+    }
+    changed = {path: text for path, text in payloads.items() if not path.exists() or path.read_text() != text}
+    if dry_run:
+        print(f"Contribution chart preview: total={data['total']} through={data['through']} changed_files={len(changed)}")
+        return bool(changed)
+    # Fetch, validate, render and migrate everything before any artifact changes.
+    # An I/O failure aborts the publisher, so no partial set reaches the remote.
+    destination.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".contribution-chart-", dir=repo) as staging:
+        for index, (path, text) in enumerate(changed.items()):
+            staged = Path(staging) / str(index)
+            staged.write_text(text)
+        for index, path in enumerate(changed):
+            os.replace(Path(staging) / str(index), path)
+    print(f"Contribution chart: total={data['total']} through={data['through']} changed_files={len(changed)}")
+    return bool(changed)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, type=Path)
+    parser.add_argument("--readme", required=True, type=Path)
+    parser.add_argument("--user", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    try:
+        gitdir = subprocess.check_output(["git", "-C", str(args.repo), "rev-parse", "--absolute-git-dir"], text=True).strip()
+        common = subprocess.check_output(["git", "-C", str(args.repo), "rev-parse", "--path-format=absolute", "--git-common-dir"], text=True).strip()
+        if Path(gitdir).resolve() == Path(common).resolve():
+            raise ValueError("Contribution chart updates require a linked publication worktree")
+        if args.readme.resolve().parent != args.repo.resolve():
+            raise ValueError("The chart README must be inside the publication worktree")
+        refresh(args.repo.resolve(), args.readme, args.user, args.dry_run)
+    except (OSError, ValueError, KeyError, TypeError, subprocess.SubprocessError) as exc:
+        print(f"Contribution chart update aborted: {type(exc).__name__}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -833,6 +833,9 @@ EOF
 _ensure_commit_history_chart() {
 	local readme_path="$1"
 	local gh_user="$2"
+	if grep -Fq '<!-- TOTAL-CONTRIBUTIONS-START -->' "$readme_path"; then
+		return 0
+	fi
 	if ! grep -Fq '> Stats auto-updated by [aidevops]' "$readme_path" 2>/dev/null; then
 		return 0
 	fi
@@ -1318,8 +1321,14 @@ _update_push_with_recovery() {
 	local commit_msg="$2"
 
 	git -C "$profile_repo" add README.md || return 1
-	if ! git -C "$profile_repo" commit -m "$commit_msg" --no-verify 2>/dev/null; then
-		if git -C "$profile_repo" diff --cached --quiet -- README.md; then
+	local chart_file=""
+	for chart_file in total-light.svg total-dark.svg total.json; do
+		if [[ -f "$profile_repo/assets/contributions/$chart_file" ]]; then
+			git -C "$profile_repo" add -- "assets/contributions/$chart_file" || return 1
+		fi
+	done
+	if ! git -C "$profile_repo" commit -m "$commit_msg" 2>/dev/null; then
+		if git -C "$profile_repo" diff --cached --quiet; then
 			echo "No changes to commit after profile README update"
 			return 0
 		fi
@@ -1394,7 +1403,7 @@ _cmd_update_in_repo() {
 
 	# Replace content between markers
 	local tmp_file
-	tmp_file=$(mktemp)
+	tmp_file=$(mktemp "${profile_repo}/.profile-readme.XXXXXX") || return 1
 	NEW_STATS="$new_stats" awk '
 		/<!-- STATS-START -->/ {
 			print "<!-- STATS-START -->"
@@ -1411,6 +1420,12 @@ _cmd_update_in_repo() {
 	' "$readme_path" >"$tmp_file"
 	local gh_user
 	gh_user=$(_resolve_profile_user "$profile_repo")
+	local chart_args=(--repo "$profile_repo" --readme "$tmp_file" --user "$gh_user")
+	[[ "$dry_run" != true ]] || chart_args+=(--dry-run)
+	if ! python3 "${SCRIPT_DIR}/profile-contribution-chart.py" "${chart_args[@]}"; then
+		rm -f "$tmp_file"
+		return 1
+	fi
 	if ! _ensure_commit_history_chart "$tmp_file" "$gh_user"; then
 		rm -f "$tmp_file"
 		return 1
@@ -1421,7 +1436,12 @@ _cmd_update_in_repo() {
 	old_normalized=$(_normalize_readme_for_compare "$readme_path")
 	new_normalized=$(_normalize_readme_for_compare "$tmp_file")
 	local readme_dirty=false
-	if ! git -C "$profile_repo" diff --quiet -- README.md; then
+	local publication_status=""
+	if ! publication_status=$(git -C "$profile_repo" status --porcelain --untracked-files=all -- README.md assets/contributions/total-light.svg assets/contributions/total-dark.svg assets/contributions/total.json); then
+		rm -f "$tmp_file"
+		return 1
+	fi
+	if [[ -n "$publication_status" ]]; then
 		readme_dirty=true
 	fi
 	if [[ "$old_normalized" == "$new_normalized" && "$readme_dirty" == false ]]; then

--- a/.agents/scripts/tests/test-profile-contribution-chart.py
+++ b/.agents/scripts/tests/test-profile-contribution-chart.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Focused standard-library checks for the contribution chart boundary.
+
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+
+import datetime as dt
+import importlib.util
+import json
+from pathlib import Path
+import re
+import tempfile
+import unittest
+from unittest.mock import patch
+import xml.etree.ElementTree as ET
+
+SPEC = importlib.util.spec_from_file_location("chart", Path(__file__).parents[1] / "profile-contribution-chart.py")
+chart = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(chart)
+TODAY = dt.date(2026, 9, 5)
+
+
+def client(query, login):
+    if "createdAt" in query:
+        return {"login": login, "createdAt": "2026-07-17T00:00:00Z"}
+    return {"login": login, **{
+        alias: {"contributionCalendar": {"totalContributions": 21}, "totalCommitContributions": 999}
+        for alias in re.findall(r"(m\d+):contributionsCollection", query)
+    }}
+
+
+class ChartTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.repo = Path(self.temp.name)
+        self.readme = self.repo / "README.md"
+        self.readme.write_text("# Profile\n\nManual content.\n")
+
+    def refresh(self, **kwargs):
+        return chart.refresh(self.repo, self.readme, "fixture", today=TODAY, client=client, **kwargs)
+
+    def snapshot(self):
+        return {str(path.relative_to(self.repo)): path.read_bytes() for path in self.repo.rglob("*") if path.is_file()}
+
+    def test_disjoint_month_boundaries_and_current_day_exclusion(self):
+        windows = list(chart.monthly_windows(dt.date(2024, 2, 20), dt.date(2024, 3, 2)))
+        self.assertEqual(windows, [
+            ("2024-02", "2024-02-01T00:00:00Z", "2024-02-29T23:59:59Z"),
+            ("2024-03", "2024-03-01T00:00:00Z", "2024-03-01T23:59:59Z"),
+        ])
+        self.assertEqual(len(list(chart.monthly_windows(dt.date(2024, 2, 20), dt.date(2024, 3, 1)))), 1)
+
+    def test_canonical_total_is_used_without_summing_private_buckets(self):
+        data = chart.fetch_history("fixture", TODAY, client)
+        self.assertEqual(data["total"], 63)
+        self.assertEqual([row["cumulative"] for row in data["months"]], [21, 42, 63])
+        self.assertEqual(data["through"], "2026-09-04")
+        self.assertEqual(set(data["months"][0]), {"month", "total", "cumulative"})
+
+    def test_history_is_batched_into_at_most_twelve_months(self):
+        calls = []
+
+        def long_history(query, login):
+            if "createdAt" in query:
+                return {"login": login, "createdAt": "2024-01-17T00:00:00Z"}
+            calls.append(query)
+            return client(query, login)
+
+        data = chart.fetch_history("fixture", TODAY, long_history)
+        self.assertEqual(len(data["months"]), 33)
+        self.assertEqual(len(calls), 3)
+        self.assertTrue(all(query.count("contributionsCollection") <= 12 for query in calls))
+
+    def test_daily_refresh_is_idempotent_and_skips_remote_calls(self):
+        self.assertTrue(self.refresh())
+        before = self.snapshot()
+        with patch.object(chart, "fetch_history", side_effect=AssertionError("unexpected remote fetch")):
+            self.assertFalse(self.refresh())
+        self.assertEqual(before, self.snapshot())
+
+    def test_next_day_api_failure_preserves_all_existing_files(self):
+        self.refresh()
+        before = self.snapshot()
+        with patch.object(chart, "fetch_history", side_effect=chart.FetchError("failure")):
+            self.assertFalse(chart.refresh(self.repo, self.readme, "fixture", today=TODAY + dt.timedelta(days=1)))
+        self.assertEqual(before, self.snapshot())
+
+    def test_incomplete_or_invalid_months_never_replace_last_good(self):
+        self.refresh()
+        before = self.snapshot()
+        for bad in (None, {}, {"contributionCalendar": {"totalContributions": True}}, {"contributionCalendar": {"totalContributions": -1}}):
+            def invalid(query, login):
+                value = client(query, login)
+                if "m0:" in query:
+                    value["m0"] = bad
+                return value
+
+            chart.refresh(self.repo, self.readme, "fixture", today=TODAY + dt.timedelta(days=1), client=invalid)
+            self.assertEqual(before, self.snapshot())
+
+    def test_dry_run_leaves_readme_and_assets_unchanged(self):
+        before = self.snapshot()
+        self.assertTrue(self.refresh(dry_run=True))
+        self.assertEqual(before, self.snapshot())
+
+    def test_svg_themes_are_well_formed_and_script_free(self):
+        data = chart.fetch_history("fixture", TODAY, client)
+        for dark in (False, True):
+            svg = chart.render_svg(data, dark)
+            root = ET.fromstring(svg)
+            self.assertEqual(root.attrib["viewBox"], "0 0 960 420")
+            self.assertIn("63 cumulative", svg)
+            self.assertIn("#0d1117" if dark else "#ffffff", svg)
+            self.assertNotIn("<script", svg)
+            self.assertNotIn("<image", svg)
+
+    def test_legacy_linked_chart_is_migrated_once(self):
+        old = '# Heading\n<div align="center">\n<a href="https://commit-history.com/fixture?metric=total">\n<picture><img src="https://commit-history.com/embed/fixture" /></picture>\n</a>\n</div>\nManual suffix\n'
+        migrated = chart.migrate_readme(old, "fixture")
+        self.assertEqual(migrated, chart.migrate_readme(migrated, "fixture"))
+        self.assertEqual(migrated.count(chart.START), 1)
+        self.assertIn('target="_blank" rel="noopener noreferrer"', migrated)
+        self.assertIn('https://commit-history.com/fixture?metric=total', migrated)
+        self.assertIn("Manual suffix", migrated)
+        self.assertNotIn("commit-history.com/embed/", migrated)
+
+    def test_bad_markers_abort_before_asset_writes(self):
+        self.readme.write_text(chart.START + "\n" + chart.START)
+        before = self.snapshot()
+        with self.assertRaises(ValueError):
+            self.refresh()
+        self.assertEqual(before, self.snapshot())
+
+    def test_symlinked_asset_destination_is_rejected(self):
+        (self.repo / "outside").mkdir()
+        (self.repo / "assets").symlink_to(self.repo / "outside", target_is_directory=True)
+        with self.assertRaises(ValueError):
+            self.refresh()
+
+    def test_cached_markup_is_not_trusted(self):
+        self.refresh()
+        path = self.repo / chart.ASSET_DIR / "total.json"
+        data = json.loads(path.read_text())
+        data["months"][0]["month"] = '</text><script>alert(1)</script>'
+        self.assertFalse(chart.valid_history(data, "fixture", TODAY))
+        path.write_text(json.dumps(data))
+        self.refresh()
+        self.assertNotIn("<script", (path.parent / "total-light.svg").read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -81,6 +81,7 @@ install_helper_with_libs() {
 	chmod +x "${helper_path}"
 	cp "${SOURCE_DATA_LIB}" "${helper_dir}/profile-readme-data-lib.sh"
 	cp "${SOURCE_RENDER_LIB}" "${helper_dir}/profile-readme-render-lib.sh"
+	cp "${SOURCE_HELPER%/*}/profile-contribution-chart.py" "${helper_dir}/profile-contribution-chart.py"
 	_test_copy_shared_deps "${SOURCE_HELPER%/*}" "${helper_dir}" || return 1
 	cp "${SOURCE_HELPER%/*}/audit-worktree-removal-helper.sh" \
 		"${SOURCE_HELPER%/*}/shared-sqlite-backup.sh" \
@@ -222,6 +223,69 @@ strip_dynamic_sections() {
 		/<!-- UPDATED-END -->/ { skip_updated = 0; print; next }
 		!skip_stats && !skip_updated { print }
 	' "$file_path"
+	return 0
+}
+
+test_chart_assets_publish_and_chart_only_changes_are_not_skipped() {
+	local test_name="daily chart assets publish together and chart-only repairs commit without refetch"
+	TEST_DIR=$(mktemp -d)
+	local fixture_home="$TEST_DIR/home" fixture_repo="$TEST_DIR/profile-repo"
+	local fixture_remote="$TEST_DIR/profile-remote.git" helper_dir="$TEST_DIR/helper"
+	local stub_bin="$TEST_DIR/bin" output="$TEST_DIR/output" calls="$TEST_DIR/graphql-calls"
+	mkdir -p "$helper_dir" "$fixture_home" "$stub_bin"
+	install_helper_with_libs "$helper_dir"
+	write_stub_dependencies "$helper_dir"
+	create_profile_repo_fixture "$fixture_home" "$fixture_repo" "$fixture_remote"
+	cat >"$stub_bin/gh" <<'PY'
+#!/usr/bin/env python3
+import json, os, re, sys
+if sys.argv[1:3] != ["api", "graphql"]:
+    sys.exit(1)
+request = json.load(sys.stdin)
+with open(os.environ["PROFILE_TEST_GRAPHQL_CALLS"], "a") as out:
+    out.write("query\n")
+user = {"login": request["variables"]["login"]}
+if "createdAt" in request["query"]:
+    user["createdAt"] = "2020-01-17T00:00:00Z"
+else:
+    user.update({key: {"contributionCalendar": {"totalContributions": 21}}
+                 for key in re.findall(r"(m\d+):contributionsCollection", request["query"])})
+print(json.dumps({"data": {"user": user}}))
+PY
+	chmod +x "$stub_bin/gh"
+	local phase="" first_calls=0 before_head=""
+	for phase in initial chart-only; do
+		if [[ "$phase" == chart-only ]]; then
+			git -C "$fixture_repo" fetch origin >/dev/null 2>&1
+			git -C "$fixture_repo" reset --hard origin/main >/dev/null
+			printf 'outdated chart\n' >"$fixture_repo/assets/contributions/total-light.svg"
+			git -C "$fixture_repo" add assets/contributions/total-light.svg
+			git -C "$fixture_repo" commit -m 'test: simulate stale image' >/dev/null
+			git -C "$fixture_repo" push origin main >/dev/null 2>&1
+		fi
+		before_head=$(git --git-dir="$fixture_remote" rev-parse main)
+		if ! HOME="$fixture_home" PATH="$stub_bin:${SOURCE_HELPER%/*}:$PATH" \
+			PROFILE_TEST_GRAPHQL_CALLS="$calls" \
+			AIDEVOPS_REPOS_FILE="$fixture_home/.config/aidevops/repos.json" \
+			AIDEVOPS_WORKTREE_BASE_DIR="$TEST_DIR/worktrees" \
+			bash "$helper_dir/profile-readme-helper.sh" update >"$output" 2>&1; then
+			print_helper_failure "$test_name" "$phase update failed" "$output"
+			return 0
+		fi
+		if [[ "$(git --git-dir="$fixture_remote" rev-list --count "$before_head..main")" != 1 ]] ||
+			! git --git-dir="$fixture_remote" show main:assets/contributions/total-light.svg | grep -q '<svg' ||
+			! git --git-dir="$fixture_remote" show main:README.md | grep -q 'TOTAL-CONTRIBUTIONS-START'; then
+			print_result "$test_name" 1 "$phase publication missing chart or commit"
+			return 0
+		fi
+		if [[ "$phase" == initial ]]; then
+			first_calls=$(wc -l <"$calls" | tr -d ' ')
+		elif [[ "$(wc -l <"$calls" | tr -d ' ')" != "$first_calls" ]]; then
+			print_result "$test_name" 1 "same-day asset repair unexpectedly queried GitHub"
+			return 0
+		fi
+	done
+	print_result "$test_name" 0
 	return 0
 }
 
@@ -1537,6 +1601,8 @@ main() {
 	fi
 
 	if [[ "$mode" != "--unit-only" ]]; then
+		test_chart_assets_publish_and_chart_only_changes_are_not_skipped
+		teardown
 		test_update_preserves_manual_sections
 		teardown
 		test_update_recovers_dirty_profile_publication_worktree

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -316,6 +316,15 @@ Don't:
 - Introduce decorative gradients, glassmorphism, or heavy shadows into operational tooling.
 - Use skeleton placeholder brand values in UI or generated guidelines.
 
+## Profile contribution chart
+
+- Use repository-hosted, first-party SVGs for cumulative **Total Contributions**, not a third-party embed with a narrower metric.
+- Match GitHub's light and dark README surfaces. Use a green cumulative line, a subtle area fill, system typography, and an accessible title/description; no external fonts or executable SVG content.
+- Show the exact total, source, UTC data cutoff, and last successful update date. Publish aggregate monthly counts only, never private repository names or events.
+- Keep the chart linked to the user's `commit-history.com` Total view, with a visible verification link and raw aggregate chart data alongside it.
+- Request a new tab with `target="_blank" rel="noopener noreferrer"` on compatible renderers. GitHub strips those attributes: disclose Ctrl/Cmd-click rather than claim a forced new tab.
+- Refresh once per UTC day through the existing profile updater. Retain the last successful chart on data failure and publish light/dark assets and README together.
+
 ## Responsive Behaviour
 
 - Dashboard grids should use auto-fit/auto-fill patterns and collapse to one column below the card minimum width.


### PR DESCRIPTION
## Summary

Generate aggregate-only light/dark SVGs and chart data from GitHub's canonical contribution calendar. Refresh daily through the existing profile publisher, atomically publish explicit chart assets with README, preserve last-good data on API failure, migrate legacy images idempotently, and retain Total verification links. DESIGN.md records visual and navigation preferences.

## Files Changed

.agents/scripts/profile-contribution-chart.md, .agents/scripts/profile-contribution-chart.py, .agents/scripts/profile-readme-helper.sh, .agents/scripts/tests/test-profile-contribution-chart.py, .agents/scripts/tests/test-profile-readme-boundary.sh, DESIGN.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 12 focused Python tests; 27 profile boundary tests including real local-remote chart-only publication and daily no-refetch; contributions fail-closed suite exit 0; local lint and ShellCheck passed. Live GitHub query verified 60,038 contributions across 153 months through 2026-09-04. GitHub Markdown API confirmed target=_blank is stripped; README documents Ctrl/Cmd-click.

Resolves #31218


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.310 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 2h 12m and 505,840 tokens on this with the user in an interactive session.