### PR TITLE
docs: aggregate authorized Astra thinking release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default thinking to GPT-6 Astra low, with bounded headless reasoning escalation to medium and high (#31222).
+
+### Fixed
+
+- Allow bounded parent-directory verification without widening filesystem access (#31220).
+- Recover squash-integrated release deployment (#31216).
+- Preserve TODO-sync trash recovery (#31217).
+- Fix worktree fixture leaks and PR archive attribution (#31212).
+
 ## [3.32.310] - 2026-09-05
 
 ### Changed


### PR DESCRIPTION
## Summary

Aggregate the authorized Astra thinking release after main advanced during its pre-publication preflight. Only `CHANGELOG.md` changes: document already-merged work using the existing Unreleased sections.

## Immutable release sources

- PR #31222 at `5a7d5133169d55f5817881f78e0cf7f886344d88` (original authorized release source)
- PR #31220 at `73031ffcd813969ff0e588dbb8f3ac75a6621472` (intervening reviewed merge)

The squash merge must carry `Aidevops-Release-Aggregator-PR` and these exact `Aidevops-Release-Aggregates: PR@MERGE_SHA` trailers. Retry the existing source #31222 using the guarded tagless recovery path; do not manually recreate a tag or clear the release lane.

## Runtime Testing

Risk: low; self-assessed documentation-only aggregation. `.agents/scripts/linters-local.sh` passed. Direct diff review confirms only release notes change and no code or release guard changes. Underlying source PRs are already reviewed and merged.

## Authorization

The user explicitly requested full-loop through release, including already-merged default-branch work. Publication previously stopped before remote tag mutation when main advanced; this PR supplies reviewed exact-tip provenance.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.310 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 43m and 211,185 tokens on this with the user in an interactive session.