### PR TITLE
GH#31238: validate generated brief Files Scope

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -17,6 +17,7 @@
 #   0  — dispatch proceeds (premise holds, or no validator registered)
 #   10 — premise falsified; caller closes the issue with a rationale comment
 #   20 — validator error; dispatch proceeds with a warning log
+#   30 — malformed implementation brief; dispatch is blocked for repair
 #
 # Usage:
 #   pre-dispatch-validator-helper.sh validate <issue-number> <slug>
@@ -146,6 +147,54 @@ _register_validators() {
 	_VALIDATOR_REGISTRY["upstream-watch"]="_validator_upstream_watch"
 	_VALIDATOR_REGISTRY["runtime-audit"]="_validator_runtime_audit"
 	return 0
+}
+
+# Generated implementation work with a cited repository file must declare a
+# non-empty canonical Files Scope before a worker/model attempt. The worker
+# scope guard remains authoritative at edit time; this check prevents a known
+# malformed brief from consuming a dispatch only to fail there. Explicit
+# planning-only briefs remain outside this implementation-only preflight.
+_brief_requires_files_scope() {
+	local issue_body="$1"
+
+	if printf '%s' "$issue_body" | grep -Eqi 'planning-only|pure planning|brief-only|no code changes'; then
+		return 1
+	fi
+
+	printf '%s' "$issue_body" | grep -qE '<!-- aidevops:generator=[a-z0-9_-]+[^>]* cited_file=[^ >]+'
+	return $?
+}
+
+_brief_files_scope_has_path() {
+	local issue_body="$1"
+	local scope_section=""
+
+	scope_section=$(printf '%s' "$issue_body" |
+		awk '
+			/^## Files Scope[[:space:]]*$/ { found=1; level=2; next }
+			/^### Files Scope[[:space:]]*$/ { found=1; level=3; next }
+			found && level == 2 && /^## / { found=0 }
+			found && level == 3 && (/^# / || /^## / || /^### /) { found=0 }
+			found { print }
+		')
+
+	[[ -n "$scope_section" ]] || return 1
+	# shellcheck disable=SC2016 # literal regular expression anchors
+	printf '%s\n' "$scope_section" |
+		grep -qE '^[[:space:]]*-[[:space:]]*(EDIT|NEW):[[:space:]]*`?[^`[:space:]][^`]*`?[[:space:]]*$'
+}
+
+_validate_implementation_brief_scope() {
+	local issue_number="$1"
+	local issue_body="$2"
+
+	_brief_requires_files_scope "$issue_body" || return 0
+	if _brief_files_scope_has_path "$issue_body"; then
+		return 0
+	fi
+
+	_log "ERROR" "brief-defect: #${issue_number} generated implementation brief lacks a non-empty canonical Files Scope; add '### Files Scope' with '- EDIT: \`repo-relative/path\`' before dispatch"
+	return 30
 }
 
 # ---------------------------------------------------------------------------
@@ -1882,6 +1931,12 @@ cmd_validate() {
 		_log "WARN" "Failed to fetch issue body for #${issue_number} — proceeding (validator error)"
 		return 20
 	}
+
+	local scope_rc=0
+	_validate_implementation_brief_scope "$issue_number" "$issue_body" || scope_rc=$?
+	if [[ "$scope_rc" -ne 0 ]]; then
+		return "$scope_rc"
+	fi
 
 	local pre_generator_rc=0
 	_run_pre_generator_validators "$issue_number" "$slug" "$issue_body" "$issue_api_path" || pre_generator_rc=$?

--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -197,6 +197,21 @@ _validate_implementation_brief_scope() {
 	return 30
 }
 
+_load_validated_issue_context() {
+	local issue_number="$1"
+	local slug="$2"
+
+	_PDV_ISSUE_API_PATH="repos/${slug}/issues/${issue_number}"
+	_PDV_ISSUE_BODY=$(gh api "$_PDV_ISSUE_API_PATH" --jq '.body // ""' 2>/dev/null) || {
+		_log "WARN" "Failed to fetch issue body for #${issue_number} — proceeding (validator error)"
+		return 20
+	}
+
+	local scope_rc=0
+	_validate_implementation_brief_scope "$issue_number" "$_PDV_ISSUE_BODY" || scope_rc=$?
+	return "$scope_rc"
+}
+
 # ---------------------------------------------------------------------------
 # Merge-stuck zero-progress meta-issue validator (GH#24729)
 # ---------------------------------------------------------------------------
@@ -1924,19 +1939,9 @@ cmd_validate() {
 		return 20
 	fi
 
-	# Fetch issue body
-	local issue_body
-	local issue_api_path="repos/${slug}/issues/${issue_number}"
-	issue_body=$(gh api "$issue_api_path" --jq '.body // ""' 2>/dev/null) || {
-		_log "WARN" "Failed to fetch issue body for #${issue_number} — proceeding (validator error)"
-		return 20
-	}
-
-	local scope_rc=0
-	_validate_implementation_brief_scope "$issue_number" "$issue_body" || scope_rc=$?
-	if [[ "$scope_rc" -ne 0 ]]; then
-		return "$scope_rc"
-	fi
+	_load_validated_issue_context "$issue_number" "$slug" || return $?
+	local issue_body="$_PDV_ISSUE_BODY"
+	local issue_api_path="$_PDV_ISSUE_API_PATH"
 
 	local pre_generator_rc=0
 	_run_pre_generator_validators "$issue_number" "$slug" "$issue_body" "$issue_api_path" || pre_generator_rc=$?

--- a/.agents/scripts/pulse-simplification-issues.sh
+++ b/.agents/scripts/pulse-simplification-issues.sh
@@ -206,6 +206,10 @@ _complexity_scan_build_md_issue_body() {
 **Detected topic:** ${topic_label:-Unknown}
 **Current size:** ${line_count} lines
 
+### Files Scope
+
+- EDIT: \`${file_path}\`
+
 ### Classify before acting
 
 **First, determine the file type** — the correct action depends on whether this is an instruction doc or a reference corpus:
@@ -535,6 +539,10 @@ _complexity_scan_sh_build_issue_body_with_sig() {
 
 **File:** \`${file_path}\`
 **Violations:** ${violation_count} functions exceed ${COMPLEXITY_FUNC_LINE_THRESHOLD} lines
+
+### Files Scope
+
+- EDIT: \`${file_path}\`
 
 ### Functions exceeding threshold
 

--- a/.agents/scripts/tests/test-large-file-gate-body.sh
+++ b/.agents/scripts/tests/test-large-file-gate-body.sh
@@ -236,6 +236,17 @@ assert_contains \
 	"$sh_body_section" \
 	"Complexity Bump Justification"
 
+# Test 3.6: generated shell brief has an editable canonical scope
+assert_contains \
+	"sh-complexity: canonical Files Scope heading" \
+	"$sh_body_section" \
+	"### Files Scope"
+# shellcheck disable=SC2016 # literal generator template expression
+assert_contains \
+	"sh-complexity: cited file is editable" \
+	"$sh_body_section" \
+	'- EDIT: \`${file_path}\`'
+
 ######################################################################
 # Part 4: MD agent doc body (pulse-simplification.sh)
 #
@@ -269,6 +280,17 @@ assert_contains \
 	"md-simplification: complexity-bump-ok label mention" \
 	"$md_body_section" \
 	"complexity-bump-ok"
+
+# Test 4.5: generated Markdown brief has an editable canonical scope
+assert_contains \
+	"md-simplification: canonical Files Scope heading" \
+	"$md_body_section" \
+	"### Files Scope"
+# shellcheck disable=SC2016 # literal generator template expression
+assert_contains \
+	"md-simplification: cited file is editable" \
+	"$md_body_section" \
+	'- EDIT: \`${file_path}\`'
 
 ######################################################################
 # Part 5: Requeue body (pulse-simplification-state.sh)

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -147,6 +147,28 @@ GHEOF
 	return 0
 }
 
+# Create a `gh` stub for generated implementation-brief scope preflight tests.
+create_gh_stub_generated_brief_body() {
+	local body="$1"
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	printf '%s\n' "$body" >"$body_file"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
+	cat "${body_file}"
+	exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "\$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
 create_gh_stub_zero_progress_body() {
 	local permission_value="${1:-write}"
 	local body_file="${TEST_ROOT}/issue_body.txt"
@@ -505,7 +527,8 @@ GHEOF
 create_gh_stub_function_complexity_duplicate() {
 	local body_file="${TEST_ROOT}/issue_body.txt"
 	local actions_file="${TEST_ROOT}/gh-actions.log"
-	printf '<!-- aidevops:generator=function-complexity-sweep cited_file=packages/gui-web/src/InventorySurfaces.tsx smell_count=3 -->\n## Qlty Maintainability\n' >"$body_file"
+	# shellcheck disable=SC2016 # literal generated issue body
+	printf '<!-- aidevops:generator=function-complexity-sweep cited_file=packages/gui-web/src/InventorySurfaces.tsx smell_count=3 -->\n## Qlty Maintainability\n\n### Files Scope\n\n- EDIT: `packages/gui-web/src/InventorySurfaces.tsx`\n' >"$body_file"
 	: >"$actions_file"
 
 	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
@@ -657,6 +680,67 @@ test_bypass_env_var() {
 		print_result "bypass_env_var exits 0" 0
 	else
 		print_result "bypass_env_var exits 0" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_generated_implementation_brief_without_scope_blocks_dispatch() {
+	setup_test_env
+	# shellcheck disable=SC2016 # literal generated issue body
+	create_gh_stub_generated_brief_body '<!-- aidevops:generator=example-gate cited_file=.agents/scripts/example.sh -->
+## What
+Implement the generated repair.'
+
+	local rc=0 output=""
+	output=$("$HELPER_SCRIPT" validate "31238" "marcusquinn/aidevops" 2>&1) || rc=$?
+
+	if [[ "$rc" -eq 30 ]] && [[ "$output" == *"brief-defect"* ]] && [[ "$output" == *"Files Scope"* ]]; then
+		print_result "generated implementation brief without scope blocks before dispatch" 0
+	else
+		print_result "generated implementation brief without scope blocks before dispatch" 1 "Expected typed exit 30, got ${rc}: ${output}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_generated_implementation_brief_with_scope_allows_dispatch() {
+	setup_test_env
+	# shellcheck disable=SC2016 # literal generated issue body
+	create_gh_stub_generated_brief_body '<!-- aidevops:generator=example-gate cited_file=.agents/scripts/example.sh -->
+### Files Scope
+
+- EDIT: `.agents/scripts/example.sh`'
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "31238" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "generated implementation brief with scope remains dispatchable" 0
+	else
+		print_result "generated implementation brief with scope remains dispatchable" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_planning_only_generated_brief_without_scope_allows_dispatch() {
+	setup_test_env
+	# shellcheck disable=SC2016 # literal generated issue body
+	create_gh_stub_generated_brief_body '<!-- aidevops:generator=example-gate cited_file=.agents/scripts/example.sh -->
+## Plan
+Planning-only: document options; no code changes.'
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "31238" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "planning-only generated brief is not treated as implementation" 0
+	else
+		print_result "planning-only generated brief is not treated as implementation" 1 "Expected exit 0, got ${rc}"
 	fi
 
 	teardown_test_env
@@ -1047,6 +1131,9 @@ main() {
 	test_unregistered_generator
 	test_validator_error
 	test_bypass_env_var
+	test_generated_implementation_brief_without_scope_blocks_dispatch
+	test_generated_implementation_brief_with_scope_allows_dispatch
+	test_planning_only_generated_brief_without_scope_allows_dispatch
 	test_zero_progress_meta_recovered_blocks_dispatch
 	test_zero_progress_meta_recovered_readonly_allows_dispatch_without_write
 	test_zero_progress_meta_active_allows_dispatch


### PR DESCRIPTION
## Summary

Generated shell and Markdown simplification briefs now declare their editable target, while pre-dispatch rejects malformed implementation scope before a worker launch.

## Files Changed

.agents/scripts/pre-dispatch-validator-helper.sh, .agents/scripts/pulse-simplification-issues.sh, .agents/scripts/tests/test-large-file-gate-body.sh, .agents/scripts/tests/test-pre-dispatch-validator.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck; test-large-file-gate-body.sh (35/35); test-pre-dispatch-validator.sh (32/32); test-pulse-wrapper-complexity-scan.sh (18/18).

Resolves #31238


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.313 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 10m and 173,431 tokens on this as a headless worker.