### PR TITLE
GH#31237: Count post-PR handoffs as non-failures

### DIFF
--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -9,6 +9,14 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
   autofile: $autofile
 };
 
+def non_failure_handoff_family:
+  (.results // {}) as $results
+  | ($results | keys_unsorted) as $result_names
+  | ($result_names | length) == 1
+  and $result_names[0] == "post_pr_handoff"
+  and ((.examples // []) | length) > 0
+  and all(.examples[]?; .result == "post_pr_handoff" and (.exit_code // 1) == 0);
+
 (if ($current.active_worker_processes // $current.pulse_health.workers_active // null) == null then null else ($current.active_worker_processes // $current.pulse_health.workers_active | number_or_zero) end) as $active_worker_processes |
 ($current.pulse_gauges.dispatch_capacity_final_max_workers // $current.pulse_health.workers_max // null) as $raw_max_workers |
 ($current.current_state_guardrails.available_slots_last // $current.pulse_gauges.pulse_dispatch_guardrail_available_slots // (if ($current.pulse_health.workers_max // null) == null or $active_worker_processes == null then null else ([($current.pulse_health.workers_max | number_or_zero) - $active_worker_processes, 0] | max) end)) as $raw_available_slots |
@@ -44,8 +52,8 @@ end) as $max_workers |
 ($summary.metrics.runtime_handoffs // $summary.metrics.succeeded // 0 | number_or_zero) as $hist_handoffs |
 ($summary.delivery_stages // {}) as $hist_delivery |
 (if $hist_delivery.delivered_successes == null then null else ($hist_delivery.delivered_successes | number_or_zero) end) as $hist_delivered |
-($summary.metrics.failure_families // []) as $failure_families |
-($recent_summary.metrics.failure_families // []) as $recent_failure_families |
+($summary.metrics.failure_families // [] | map(select(non_failure_handoff_family | not))) as $failure_families |
+($recent_summary.metrics.failure_families // [] | map(select(non_failure_handoff_family | not))) as $recent_failure_families |
 ($summary.progress_blockers // {}) as $progress_blockers |
 ($current.canonical_reconciliation.refusal_count // 0 | number_or_zero) as $canonical_reconciliation_refusal_count |
 ($current.canonical_reconciliation.classification // "none") as $canonical_reconciliation_classification |

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -140,6 +140,12 @@ if [[ "$cmd" == "providers" ]]; then
 JSON
   exit 0
 fi
+if [[ "${PULSE_CHECK_HANDOFF_FAILURE_FIXTURE:-}" == "yes" ]]; then
+  cat <<'JSON'
+{"window":{"since":"24h"},"metrics":{"total":20,"terminal_session_total":20,"runtime_handoffs":17,"succeeded":null,"result_counts":{"success":5,"post_pr_handoff":12,"blocked":3},"diagnostic_focus":{},"timing_ms":{"samples":20,"avg":1000,"max":2000},"recent_examples":[],"failure_groups":[],"failure_families":[{"fingerprint":"ff-v1:launch-failure","family":"launch-failure","count":12,"distinct_sessions":12,"first_ts":1,"last_ts":2,"confidence":"high","recovery_outcome":"recurring","results":{"post_pr_handoff":12},"examples":[{"result":"post_pr_handoff","exit_code":0}]}]},"pulse_stats":{},"delivery_stages":{"pr_opened":null,"pr_merged":null,"issue_solved":null,"delivered_successes":null,"check_state":"skipped"}}
+JSON
+  exit 0
+fi
 if [[ "${PULSE_CHECK_BLOCKER_FIXTURE:-}" == "retained" ]]; then
   cat <<'JSON'
 {"window":{"since":"7d"},"metrics":{"total":0,"terminal_session_total":0,"runtime_handoffs":0,"succeeded":null,"result_counts":{},"diagnostic_focus":{},"timing_ms":{"samples":0,"avg":0,"max":0},"recent_examples":[],"failure_groups":[],"failure_families":[]},"pulse_stats":{},"progress_blockers":{"scope":"global","event_total":13,"active_total":0,"retained_unverified_total":13,"retained_supervisor_permission_total":12,"active_blockers":[],"retained_unverified":[{"reason":"permission_required","source":"opencode-permission-broker","session_key":"supervisor-pulse","repo_slug":"private/repo-one","detail":"/private/path"},{"reason":"permission_required","source":"opencode-permission-broker","session_key":"supervisor-pulse-retry","repo_slug":"private/repo-two","detail":"private title"},{"reason":"permission_required","source":"opencode-permission-broker","session_key":"manual-cli","repo_slug":"private/repo-three"}]},"delivery_stages":{"pr_opened":null,"pr_merged":null,"issue_solved":null,"delivered_successes":null,"check_state":"skipped"}}
@@ -381,6 +387,11 @@ HANDOFF_RATE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.historical_runtime_hand
 assert_eq "json runtime handoff rate uses terminal session denominator" "90" "$HANDOFF_RATE"
 SUCCESS_RATE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.historical_success_rate')
 assert_eq "json delivered success rate is unknown without GitHub delivery check" "null" "$SUCCESS_RATE"
+HANDOFF_FAMILY_JSON=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_HANDOFF_FAILURE_FIXTURE=yes" "$HELPER" json 2>&1)
+assert_eq "post-PR handoff family is absent from remediation candidates" "0" \
+	"$(printf '%s' "$HANDOFF_FAMILY_JSON" | jq -r '.failure_family_remediation | length')"
+assert_eq "post-PR handoff family triggers no failure finding" "0" \
+	"$(printf '%s' "$HANDOFF_FAMILY_JSON" | jq -r '[.findings[] | select(.id == "worker-failure-family-launch-failure")] | length')"
 assert_eq "json reports canonical reconciliation refusal aggregate" "2" "$(printf '%s' "$JSON_OUT" | jq -r '.current_state.canonical_reconciliation.refusal_count')"
 assert_eq "json reports canonical reconciliation classification" "dirty_or_uncommitted" "$(printf '%s' "$JSON_OUT" | jq -r '.current_state.canonical_reconciliation.classification')"
 assert_eq "zero-worker active claim is actionable" "true" "$(printf '%s' "$JSON_OUT" | jq -r '.summary.zero_worker_active_claim_actionable')"

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -164,6 +164,8 @@ OWNER_PROCESS_START=$(_test_process_start_token "$$")
 #   issue-15         — false runtime_error_type sentinel; jq // treats false as
 #                      missing, but historical != null and != "" semantics
 #                      counted false as a non-empty runtime error marker.
+#   issue-19         — verified post-PR handoff; a non-failure runtime handoff
+#                      with delivery status intentionally still unknown.
 {
 	printf '{"ts":%d,"role":"worker","repo_slug":"example/repo-a","session_key":"issue-1","result":"success","exit_code":0,"duration_ms":1000,"load_1min":2.0,"load_per_cpu":0.25}\n' "$T_5MIN_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-2","result":"success","exit_code":0}\n' "$T_2H_AGO"
@@ -192,6 +194,7 @@ OWNER_PROCESS_START=$(_test_process_start_token "$$")
 	# remain distinct from a scoped event with the same session key.
 	printf '{"ts":%d,"role":"worker","session_key":"issue-18","issue_number":18,"model":"openai/gpt-5.5","result":"success","exit_code":0}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","repo_slug":"example/repo-c","session_key":"issue-18","result":"provider_error","exit_code":2}\n' "$((T_2H_AGO + 1))"
+	printf '{"ts":%d,"role":"worker","repo_slug":"example/repo-a","session_key":"issue-19","model":"openai/gpt-5.5","provider":"openai","result":"post_pr_handoff","exit_code":0}\n' "$T_5MIN_AGO"
 	# Non-worker runtime roles remain available in canonical metrics but must not
 	# affect worker activity, provider, or failure summaries.
 	printf '{"ts":%d,"role":"triage","session_key":"triage-1","model":"openai/gpt-5.5","provider":"openai","result":"provider_error","failure_reason":"local_error","exit_code":126}\n' "$T_5MIN_AGO"
@@ -332,13 +335,13 @@ fi
 # continuation-only sessions are reported separately and omitted from outcomes.
 # issue-8 (watchdog_stall_continue with exit_code=124) tests the t3215
 # regression case — must count as wc, not of, despite non-zero exit.
-assert_eq "2c: raw event total remains backward compatible" "18" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "2c: raw event total retains post-PR handoff evidence" "19" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
 assert_eq "2c1: reporting window is observation-only" "historical_observation_only" \
 	"$(printf '%s' "$JSON" | jq -r '.window.semantics')"
-assert_eq "2c2: terminal session outcomes = 13" "13" "$(printf '%s' "$JSON" | jq -r '.metrics.terminal_session_total')"
-assert_eq "2c2b: event_total aliases raw total" "18" "$(printf '%s' "$JSON" | jq -r '.metrics.event_total')"
+assert_eq "2c2: terminal session outcomes = 14" "14" "$(printf '%s' "$JSON" | jq -r '.metrics.terminal_session_total')"
+assert_eq "2c2b: event_total aliases raw total" "19" "$(printf '%s' "$JSON" | jq -r '.metrics.event_total')"
 assert_eq "2c3: continuation events = 4" "4" "$(printf '%s' "$JSON" | jq -r '.metrics.continuation_events')"
-assert_eq "2d: runtime handoffs = 5" "5" "$(printf '%s' "$JSON" | jq -r '.metrics.runtime_handoffs')"
+assert_eq "2d: runtime handoffs include post-PR handoffs" "6" "$(printf '%s' "$JSON" | jq -r '.metrics.runtime_handoffs')"
 assert_eq "2d2: delivered success is unknown when GitHub check is skipped" "null" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
 assert_eq "2e: watchdog_killed = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
@@ -351,9 +354,11 @@ assert_eq "2h: other_failure = 6 (heartbeat excluded, scoped failures counted)" 
 	"$(printf '%s' "$JSON" | jq -r '.metrics.other_failure')"
 assert_eq "2h2: terminal result_counts includes success bucket" "5" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.result_counts.success')"
+assert_eq "2h2a: terminal result_counts retain post-PR handoff evidence" "1" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.result_counts.post_pr_handoff')"
 assert_eq "2h2b: raw result counts retain continuation evidence" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.event_result_counts.signal_killed_continue')"
-assert_eq "2h3: timing summary includes terminal samples" "13" \
+assert_eq "2h3: timing summary includes terminal samples" "14" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.timing_ms.samples')"
 assert_eq "2h4: recent example carries load context" "2.0" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.session_key == "issue-1") | .load_1min')"
@@ -373,6 +378,10 @@ assert_eq "2h10b: failure groups expose classification pattern" "server_error|5x
 	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-6") | .classification_pattern')"
 assert_eq "2h11: continuation-only session omitted from terminal failure groups" "0" \
 	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.session_key == "issue-11")] | length')"
+assert_eq "2h11a: post-PR handoff omitted from terminal failure groups" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.session_key == "issue-19")] | length')"
+assert_eq "2h11b: post-PR handoff omitted from failure families" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_families[] | select(.results.post_pr_handoff != null)] | length')"
 assert_eq "2h12: diagnostic focus counts stall-killed sessions" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.diagnostic_focus.stall_hard_killed')"
 assert_eq "2h13: diagnostic focus counts terminal local runtime errors" "1" \
@@ -436,9 +445,9 @@ assert_eq "2x: legacy PID-only ownership remains unverified" "1" \
 JSON=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 24h --repo example/repo-a --no-pr-check --json 2>&1)
 assert_eq "2y: scoped metrics declare repository scope" "repository" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.scope')"
-assert_eq "2z: scoped raw total contains only repo-a events" "3" \
+assert_eq "2z: scoped raw total contains only repo-a events" "4" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.total')"
-assert_eq "2z1: scoped terminal total contains only repo-a outcomes" "3" \
+assert_eq "2z1: scoped terminal total contains only repo-a outcomes" "4" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.terminal_session_total')"
 assert_eq "2z2: scoped examples contain only repo-a" "0" \
 	"$(printf '%s' "$JSON" | jq -r '[.metrics.recent_examples[] | select(.repo_slug != "example/repo-a")] | length')"
@@ -468,9 +477,9 @@ echo "--- Section 3: 1h window ---"
 JSON=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 1h --no-pr-check --json 2>&1)
 # 1h window: issue-1 and resumed issue-16 are terminal successes; issue-4 is
 # continuation-only and therefore excluded from the outcome denominator.
-assert_eq "3a: 1h raw total = 4" "4" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
-assert_eq "3a2: 1h terminal total = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.terminal_session_total')"
-assert_eq "3b: 1h runtime handoffs = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.runtime_handoffs')"
+assert_eq "3a: 1h raw total = 5" "5" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "3a2: 1h terminal total = 3" "3" "$(printf '%s' "$JSON" | jq -r '.metrics.terminal_session_total')"
+assert_eq "3b: 1h runtime handoffs = 3" "3" "$(printf '%s' "$JSON" | jq -r '.metrics.runtime_handoffs')"
 assert_eq "3c: 1h watchdog_continued = 1" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
 assert_eq "3d: 1h watchdog_killed = 0" "0" \
@@ -535,7 +544,7 @@ OUT=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 24h --no-pr-check 2>&1)
 assert_contains "5a: human output names canonical jsonl source" \
 	"headless-runtime-metrics.jsonl" "$OUT"
 assert_contains "5b: human output names pulse-stats" "pulse-stats.json" "$OUT"
-assert_contains "5c: human output shows runtime handoff count" "Runtime handoffs:            5" "$OUT"
+assert_contains "5c: human output shows runtime handoff count" "Runtime handoffs:            6" "$OUT"
 assert_contains "5d: human output shows watchdog continued is heartbeat" \
 	"heartbeat" "$OUT"
 assert_contains "5d2: human output shows service interruption resumes" \
@@ -570,7 +579,7 @@ assert_eq "6c: openai capacity_slots uses redacted multiplier" "48" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .capacity_slots')"
 assert_eq "6c2: provider diagnostics retain raw duplicate/attempt evidence" "7" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.provider_model_usage[] | select(.provider == "openai" and .model == "openai/gpt-5.5") | .other_failure')"
-assert_eq "6c2b: provider diagnostics name runtime handoffs without calling them success" "0" \
+assert_eq "6c2b: provider diagnostics include post-PR runtime handoffs without calling them success" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.provider_model_usage[] | select(.provider == "openai" and .model == "openai/gpt-5.5") | .runtime_handoffs')"
 
 JSONC_DEFAULTS="$FIXTURE_DIR/aidevops.defaults.jsonc"
@@ -583,6 +592,7 @@ JSON=$(env \
 	"WAH_PULSE_STATS_FILE=$STATS" \
 	"WAH_PR_CACHE_FILE=$PR_CACHE" \
 	"WAH_OAUTH_POOL_FILE=$OAUTH_POOL" \
+	"WAH_OBJECTIVE_EVIDENCE_FILE=$OBJECTIVE_EVIDENCE" \
 	"JSONC_DEFAULTS=$JSONC_DEFAULTS" \
 	"JSONC_USER=$JSONC_USER" \
 	"$HELPER" providers --since 24h --json 2>&1)
@@ -661,13 +671,14 @@ echo "--- Section 8: objective outcome reconciliation ---"
 
 RECON_METRICS="$FIXTURE_DIR/reconciled-metrics.jsonl"
 cat >"$RECON_METRICS" <<EOF
-{"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-601","issue_number":601,"repo_slug":"owner/repo","attempt_id":"attempt-success","run_id":"run-a","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":$((T_5MIN_AGO + 1)),"role":"worker","session_key":"issue-601","issue_number":601,"repo_slug":"owner/repo","attempt_id":"attempt-success","run_id":"run-a","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
 {"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-602","issue_number":602,"repo_slug":"owner/repo","attempt_id":"attempt-failed","run_id":"run-b","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
 {"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-603","issue_number":603,"repo_slug":"owner/repo","attempt_id":"attempt-unknown","run_id":"run-c","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
 {"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-604","issue_number":604,"repo_slug":"owner/repo","attempt_id":"attempt-latest-failed","run_id":"run-d","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
 {"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-605","issue_number":605,"repo_slug":"owner/repo","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
 {"ts":$((T_5MIN_AGO - 20)),"role":"worker","session_key":"issue-606","issue_number":606,"repo_slug":"","attempt_id":"attempt-unscoped","run_id":"run-e","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
 {"ts":$((T_5MIN_AGO - 20)),"role":"worker","session_key":"issue-607","issue_number":607,"repo_slug":"owner/repo","attempt_id":"","run_id":"run-f","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-608","issue_number":608,"repo_slug":"owner/repo","result":"post_pr_handoff","exit_code":1}
 EOF
 cat >"$OBJECTIVE_EVIDENCE" <<EOF
 {"record_type":"attempt_outcome","repo":"owner/repo","issue_number":601,"attempt_id":"attempt-success","run_id":"run-a","effective_outcome":"success","evidence_timestamp":$T_5MIN_AGO}
@@ -685,7 +696,7 @@ assert_eq "8a: raw events remain queryable" "7" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.event_result_counts.premature_exit')"
 assert_eq "8b: reconciled success becomes an effective runtime handoff" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.runtime_handoffs')"
-assert_eq "8c: validated failures and raw fallbacks remain in failure totals" "5" \
+assert_eq "8c: validated failures and raw fallbacks remain in failure totals" "6" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.other_failure')"
 assert_eq "8d: successful attempt is absent from failure groups" "0" \
 	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 601)] | length')"
@@ -703,6 +714,8 @@ assert_eq "8j: empty repo slug remains an unscoped attempt match" "0" \
 	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 606)] | length')"
 assert_eq "8k: empty attempt identities never reconcile with each other" "1" \
 	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 607)] | length')"
+assert_eq "8l: nonzero post-PR handoff remains a failure" "1" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 608)] | length')"
 
 # ---------------------------------------------------------------------------
 # Summary.

--- a/.agents/scripts/worker-activity-failure-families.jq
+++ b/.agents/scripts/worker-activity-failure-families.jq
@@ -19,7 +19,8 @@ def _wah_failure_family:
     or ((.result // "") | test("launch")) then "launch-failure"
   else "other-failure" end;
 def _wah_failure_family_summary:
-  map(. + {failure_family: _wah_failure_family})
+  map(select(_wah_effective_failure))
+  | map(. + {failure_family: _wah_failure_family})
   | group_by(.failure_family)
   | map({
     fingerprint: ("ff-v1:" + .[0].failure_family),

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -86,10 +86,13 @@ WAH_SESSION_OUTCOME_JQ='
 			. + {raw_result:(.result // "unknown"), effective_outcome:$effective, outcome_source:"attempt_outcome"}
 			| if .effective_outcome == "success" then .result = "success" | .exit_code = 0 else . end
 		end;
+	def _wah_runtime_handoff:
+		(.result == "success" or .result == "post_pr_handoff")
+		and (.exit_code // 1) == 0;
 	def _wah_effective_failure:
 		(.effective_outcome // "") as $effective
 		| if ($effective | _wah_known_effective_outcome) then $effective == $outcome_failed
-		else ((.result // "") != "success" or (.exit_code // 1) != 0) end;
+		else (_wah_runtime_handoff | not) end;
 	def _wah_session_outcomes:
 		map(_wah_reconcile_outcome) as $all
 		| $all
@@ -181,7 +184,7 @@ WAH_METRIC_DETAILS_JQ=$WAH_SESSION_OUTCOME_JQ$WAH_FAILURE_FAMILY_JQ'
 				examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, session_id, work_dir, output_file, exit_code, duration_ms, provider_error_type, provider_status, runtime_error_type, classification_source, classification_pattern, launch_failure_cause, kill_reason, next_action}))
 			})
 			| sort_by(.count) | reverse | .[0:10]),
-		failure_families: ($failures | _wah_failure_family_summary)
+		failure_families: ($w | _wah_failure_family_summary)
 	}'
 
 #######################################
@@ -268,7 +271,7 @@ _wah_aggregate_metrics() {
 		| ($events | _wah_session_outcomes) as $w | {
 			total:  ($events | length),
 			terminal: ($w | length),
-			succ:   ([$w[] | select(.result == "success" and .exit_code == 0)] | length),
+			succ:   ([$w[] | select(_wah_runtime_handoff)] | length),
 			wk:     ([$w[] | select(.result == $watchdog_killed_result and _wah_effective_failure)] | length),
 			wc:     ([$events[] | select(.result == "watchdog_stall_continue")] | length),
 			sic:    ([$events[] | select(.result == $service_result)] | length),
@@ -443,7 +446,7 @@ _wah_provider_usage_json() {
 	((account_multiplier < 1)) && account_multiplier=1
 
 	if [[ -f "$pool" ]]; then
-		jq -rn --slurpfile pool "$pool" --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson account_multiplier "$account_multiplier" --arg rate_limit_result "$WAH_RESULT_RATE_LIMIT" --arg worker_role "$WAH_RUNTIME_ROLE" --arg status_empty '' --arg status_auth_error 'auth-error' --arg status_rate_limited 'rate-limited' --arg status_active 'active' --arg status_idle 'idle' '
+		jq -rn --slurpfile pool "$pool" --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson objective_outcomes "$(_wah_objective_outcomes_json)" --arg outcome_failed "$WAH_DELIVERY_FAILED" --argjson account_multiplier "$account_multiplier" --arg rate_limit_result "$WAH_RESULT_RATE_LIMIT" --arg worker_role "$WAH_RUNTIME_ROLE" --arg status_empty '' --arg status_auth_error 'auth-error' --arg status_rate_limited 'rate-limited' --arg status_active 'active' --arg status_idle 'idle' "$WAH_SESSION_OUTCOME_JQ"'
 			def account_status: .status // $status_empty;
 			def available_account:
 				(account_status) as $status
@@ -453,7 +456,8 @@ _wah_provider_usage_json() {
 				(.status // $status_idle) as $status
 				| $status == $status_active or $status == $status_idle;
 			($pool[0] // {}) as $pool_data
-			| [inputs | select(.role == $worker_role and (.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
+			| [inputs | select(.role == $worker_role and (.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $raw
+			| ($raw | map(_wah_reconcile_outcome)) as $w
 			| {
 				provider_model_usage: (
 					$w
@@ -462,9 +466,9 @@ _wah_provider_usage_json() {
 						provider: (.[0].provider // "unknown"),
 						model: (.[0].model // "unknown"),
 						count: length,
-						runtime_handoffs: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length),
-						rate_limited: (map(select(.result == $rate_limit_result or .provider_error_type == $rate_limit_result or .provider_status == "429")) | length),
-						other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and .result != $rate_limit_result and .provider_error_type != $rate_limit_result and .provider_status != "429")) | length),
+						runtime_handoffs: (map(select(_wah_runtime_handoff)) | length),
+						rate_limited: (map(select(_wah_effective_failure and (.result == $rate_limit_result or .provider_error_type == $rate_limit_result or .provider_status == "429"))) | length),
+						other_failure: (map(select(_wah_effective_failure and .result != $rate_limit_result and .provider_error_type != $rate_limit_result and .provider_status != "429")) | length),
 						latest_ts: (map(.ts // 0) | max)
 					})
 					| sort_by(.count, .latest_ts) | reverse | .[0:12]
@@ -491,10 +495,11 @@ _wah_provider_usage_json() {
 				)
 			}' <"$input_file" 2>/dev/null || printf '{"provider_model_usage":[],"recent_events":[],"account_pool":[]}'
 	else
-		jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg rate_limit_result "$WAH_RESULT_RATE_LIMIT" --arg worker_role "$WAH_RUNTIME_ROLE" '
-			[inputs | select(.role == $worker_role and (.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
+		jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson objective_outcomes "$(_wah_objective_outcomes_json)" --arg outcome_failed "$WAH_DELIVERY_FAILED" --arg rate_limit_result "$WAH_RESULT_RATE_LIMIT" --arg worker_role "$WAH_RUNTIME_ROLE" "$WAH_SESSION_OUTCOME_JQ"'
+			[inputs | select(.role == $worker_role and (.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $raw
+			| ($raw | map(_wah_reconcile_outcome)) as $w
 			| {
-				provider_model_usage: ($w | group_by([.provider // "unknown", .model // "unknown"]) | map({provider: (.[0].provider // "unknown"), model: (.[0].model // "unknown"), count: length, runtime_handoffs: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length), rate_limited: (map(select(.result == $rate_limit_result or .provider_error_type == $rate_limit_result or .provider_status == "429")) | length), other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and .result != $rate_limit_result and .provider_error_type != $rate_limit_result and .provider_status != "429")) | length), latest_ts: (map(.ts // 0) | max)}) | sort_by(.count, .latest_ts) | reverse | .[0:12]),
+				provider_model_usage: ($w | group_by([.provider // "unknown", .model // "unknown"]) | map({provider: (.[0].provider // "unknown"), model: (.[0].model // "unknown"), count: length, runtime_handoffs: (map(select(_wah_runtime_handoff)) | length), rate_limited: (map(select(_wah_effective_failure and (.result == $rate_limit_result or .provider_error_type == $rate_limit_result or .provider_status == "429"))) | length), other_failure: (map(select(_wah_effective_failure and .result != $rate_limit_result and .provider_error_type != $rate_limit_result and .provider_status != "429")) | length), latest_ts: (map(.ts // 0) | max)}) | sort_by(.count, .latest_ts) | reverse | .[0:12]),
 				recent_events: ($w | sort_by(.ts // 0) | reverse | .[0:10] | map({ts, provider, model, result, exit_code, issue_number, session_key})),
 				account_pool: []
 			}' <"$input_file" 2>/dev/null || printf '{"provider_model_usage":[],"recent_events":[],"account_pool":[]}'


### PR DESCRIPTION
## Summary

Classified exit-zero post-PR handoffs as runtime handoffs across summary, provider, and failure-family diagnostics while retaining raw outcome evidence.

## Files Changed

.agents/scripts/pulse-check-report.jq, .agents/scripts/tests/test-pulse-check-helper.sh, .agents/scripts/tests/test-worker-activity-helper.sh, .agents/scripts/worker-activity-failure-families.jq, .agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified through fixture-driven CLI execution: bash .agents/scripts/tests/test-worker-activity-helper.sh; bash .agents/scripts/tests/test-pulse-check-helper.sh; ShellCheck on changed shell files

Resolves #31237


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.313 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 12m and 203,699 tokens on this as a headless worker.