### PR TITLE
GH#31240: Refill rejected parallel dispatch reservations

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -2181,9 +2181,19 @@ _dispatch_max_loop() {
 
 		local successes_so_far=0
 		successes_so_far=$(_dispatch_max_count_outcomes "$outcomes_file")
-		if _dispatch_max_should_stop "$processed_count" "$successes_so_far" "$effective_slots" "${#_pids[@]}"; then
+		if _dispatch_max_should_stop "$processed_count" "$successes_so_far" "$effective_slots"; then
 			break
 		fi
+		# Pending ceremonies reserve slots only until their outcomes are known.
+		# Wait and reconcile the current candidate rather than ending the round:
+		# a rejected ceremony frees its reservation for this unconsumed candidate.
+		while ((successes_so_far + ${#_pids[@]} >= effective_slots)); do
+			_dispatch_max_wait_for_reservation _pids
+			successes_so_far=$(_dispatch_max_count_outcomes "$outcomes_file")
+			if _dispatch_max_should_stop "$processed_count" "$successes_so_far" "$effective_slots"; then
+				break 2
+			fi
+		done
 
 		_dispatch_max_apply_inter_launch_delay "$successes_so_far" "${#_pids[@]}" "$processed_count" "$candidate_json" "$max_parallel"
 		_dispatch_max_spawn_candidate "$candidate_json" "$self_login" "$available_slots" "$outcomes_file" &
@@ -2198,6 +2208,23 @@ _dispatch_max_loop() {
 	local dispatched_count
 	dispatched_count=$(_dispatch_max_count_outcomes "$outcomes_file")
 	printf '%d %d\n' "$dispatched_count" "$processed_count"
+	return 0
+}
+
+#######################################
+# Wait for a pending admission reservation to finish, then remove completed
+# children so its terminal outcome can free capacity for the current candidate.
+#
+# Arguments:
+#   $1 - nameref-style array variable name
+#######################################
+_dispatch_max_wait_for_reservation() {
+	local target_array_name="$1"
+
+	if ! wait -n 2>/dev/null; then
+		echo "[pulse-wrapper] Dispatch_max: wait -n found no children while reconciling reservations" >>"$LOGFILE"
+	fi
+	_dispatch_max_refresh_pids "$target_array_name"
 	return 0
 }
 
@@ -2259,7 +2286,6 @@ _dispatch_max_wait_for_capacity() {
 #   $1 - processed count
 #   $2 - successes so far
 #   $3 - effective slot budget
-#   $4 - in-flight dispatch count
 # Returns:
 #   0 - stop the loop
 #   1 - continue dispatching
@@ -2268,10 +2294,9 @@ _dispatch_max_should_stop() {
 	local processed_count="$1"
 	local successes_so_far="$2"
 	local effective_slots="$3"
-	local in_flight_count="$4"
 
-	if ((successes_so_far + in_flight_count >= effective_slots)); then
-		echo "[pulse-wrapper] Dispatch_max: parallel iter=${processed_count} — stopping (successes=${successes_so_far} + in_flight=${in_flight_count} >= effective_slots=${effective_slots})" >>"$LOGFILE"
+	if ((successes_so_far >= effective_slots)); then
+		echo "[pulse-wrapper] Dispatch_max: parallel iter=${processed_count} — stopping (successes=${successes_so_far} >= effective_slots=${effective_slots})" >>"$LOGFILE"
 		return 0
 	fi
 	if [[ -f "${STOP_FLAG:-}" ]]; then

--- a/.agents/scripts/tests/test-dispatch-max-parallel.sh
+++ b/.agents/scripts/tests/test-dispatch-max-parallel.sh
@@ -416,10 +416,9 @@ test_parallel_loop_respects_budget() {
 	s=$(_dispatch_max_count_outcomes "$outcomes_file" "success")
 	rm -f "$candidate_file" "$outcomes_file"
 
-	# We expect dispatched_count=4 (at most). It might process 5-8 before stopping
-	# because the budget check happens BEFORE launching, but successes counter
-	# updates only AFTER subshell completes. The contract: dispatched_count <= effective_slots+max_parallel.
-	if (( s >= 4 )) && (( s <= 8 )); then
+	# Pending ceremonies reserve capacity, so a successful four-slot wave launches
+	# exactly four workers rather than overshooting while outcomes are in flight.
+	if [[ "$s" == "4" ]]; then
 		print_result "parallel_loop: respects effective_slots=4 budget (got s=${s})" 0
 	else
 		print_result "parallel_loop: respects effective_slots=4 budget" 1 "got s=${s}"
@@ -432,6 +431,81 @@ test_parallel_loop_respects_budget() {
 	else
 		print_result "parallel_loop: result.dispatched matches outcomes file" 1 \
 			"result=${result_dispatched} outcomes=${s}"
+	fi
+	return 0
+}
+
+test_parallel_loop_refills_rejected_reservation() {
+	# The first success and slow rejection consume both reservations. The final
+	# candidate must be retried after the rejection frees its slot.
+	# shellcheck disable=SC2317  # called via name resolution from loop
+	_dispatch_process_candidate() {
+		local candidate_json="$1" issue_num
+		issue_num=$(printf '%s' "$candidate_json" | jq -r '.number // 0' 2>/dev/null)
+		if [[ "$issue_num" == "801" ]]; then
+			sleep 0.15
+			_PULSE_LAST_LAUNCH_FAILURE="no_worker_process"
+			return 1
+		fi
+		sleep 0.02
+		return 0
+	}
+
+	local candidate_file outcomes_file result successes failures
+	candidate_file=$(mktemp)
+	outcomes_file=$(mktemp)
+	cat >"$candidate_file" <<'EOF'
+{"number":800,"repo_slug":"o/r","repo_path":"/t","url":"u","title":"t","labels":[]}
+{"number":801,"repo_slug":"o/r","repo_path":"/t","url":"u","title":"t","labels":[]}
+{"number":802,"repo_slug":"o/r","repo_path":"/t","url":"u","title":"t","labels":[]}
+EOF
+	: >"$outcomes_file"
+
+	rm -f "$STOP_FLAG"
+	result=$(_dispatch_max_loop "$candidate_file" 2 2 "test_user" 2 "$outcomes_file")
+	successes=$(_dispatch_max_count_outcomes "$outcomes_file" "success")
+	failures=$(_dispatch_max_count_outcomes "$outcomes_file" "fail")
+	rm -f "$candidate_file" "$outcomes_file"
+
+	if [[ "$result" == "2 3" && "$successes" == "2" && "$failures" == "1" ]]; then
+		print_result "parallel_loop: refills a rejected reservation in the same round" 0
+	else
+		print_result "parallel_loop: refills a rejected reservation in the same round" 1 \
+			"result=${result} successes=${successes} failures=${failures}"
+	fi
+	return 0
+}
+
+test_parallel_loop_all_rejections_finish() {
+	# Reconciliation must consume a finite queue of rejected ceremonies without
+	# spinning after each reservation is released.
+	# shellcheck disable=SC2317  # called via name resolution from loop
+	_dispatch_process_candidate() {
+		sleep 0.02
+		_PULSE_LAST_LAUNCH_FAILURE="no_worker_process"
+		return 1
+	}
+
+	local candidate_file outcomes_file result failures
+	candidate_file=$(mktemp)
+	outcomes_file=$(mktemp)
+	cat >"$candidate_file" <<'EOF'
+{"number":810,"repo_slug":"o/r","repo_path":"/t","url":"u","title":"t","labels":[]}
+{"number":811,"repo_slug":"o/r","repo_path":"/t","url":"u","title":"t","labels":[]}
+{"number":812,"repo_slug":"o/r","repo_path":"/t","url":"u","title":"t","labels":[]}
+EOF
+	: >"$outcomes_file"
+
+	rm -f "$STOP_FLAG"
+	result=$(_dispatch_max_loop "$candidate_file" 2 2 "test_user" 2 "$outcomes_file")
+	failures=$(_dispatch_max_count_outcomes "$outcomes_file" "fail")
+	rm -f "$candidate_file" "$outcomes_file"
+
+	if [[ "$result" == "0 3" && "$failures" == "3" ]]; then
+		print_result "parallel_loop: all rejected candidates finish without spinning" 0
+	else
+		print_result "parallel_loop: all rejected candidates finish without spinning" 1 \
+			"result=${result} failures=${failures}"
 	fi
 	return 0
 }
@@ -720,6 +794,8 @@ test_aggregate_outcomes_invalidates_canary_cache
 test_aggregate_outcomes_clears_throttle_on_success
 test_parallel_loop_end_to_end
 test_parallel_loop_respects_budget
+test_parallel_loop_refills_rejected_reservation
+test_parallel_loop_all_rejections_finish
 test_parallel_loop_stop_flag_aborts
 test_parallel_loop_graphql_budget_aborts
 test_parallel_loop_rest_budget_aborts


### PR DESCRIPTION
## Summary

Reconciled pending dispatch reservations before consuming later candidates, tightened the successful-wave budget contract, and added deterministic rejection refill and finite rejection regression coverage.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/tests/test-dispatch-max-parallel.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-dispatch-max-parallel.sh; shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/tests/test-dispatch-max-parallel.sh

Resolves #31240


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.313 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 4m and 85,810 tokens on this as a headless worker.