### PR TITLE
GH#31221: Reduce GitHub API waste with freshness-safe transport and scheduling

### DIFF
--- a/.agents/reference/github-api-efficiency.md
+++ b/.agents/reference/github-api-efficiency.md
@@ -71,38 +71,10 @@ aggregate: `pulse-wrapper-cycle-gates.sh` owns the exact completed cutoff.
 
 ### Native transport boundary
 
-The PATH shim applies the shared cooldown before native requests, including raw
-agent commands. A wrapper-admitted boot/recovery read is not charged twice, but
-cooldown is rechecked immediately before transport. Local-only commands remain
-usable without fabricated HTTP attempts. Execution failures, including those
-without a complete HTTP response, do not authorise an alternate transport.
-
-Supported non-interactive, single-request `gh api` REST shapes use
-`gh-transport-governor.py` and `gh_transport_budget.py`. They inspect included
-response headers without enabling `GH_DEBUG`, preserve native body bytes/status,
-and never cache a response body. Existing explicit pagination admits each page
-separately. Authenticated conditional `304` responses own zero primary cost;
-failed/unknown costs remain unknown. A changed native framing contract fails
-closed rather than returning injected headers as successful application data.
-
-The private local SQLite state reserves in-flight REST work atomically. Only
-resource-owned response headers establish remaining quota; `/rate_limit` JSON
-is not an admission balance. Missing/stale observations allow one serialized
-observation, not an assumed new allowance. Unknown spend remains debt; a later
-response from another credential cannot erase it. Out-of-order responses cannot
-increase remaining quota within a live reset window. PID birth identity guards
-recovery, and scope aliases prevent an existing credential acquiring a second
-budget when its owner configuration changes.
-
-`AIDEVOPS_GH_QUOTA_OWNER` may name a trusted user/installation quota owner;
-multiple PATs for that owner share an allowance. Unresolved callers deliberately
-share a conservative host scope. Cache visibility must still be credential-scoped.
-This is local coordination, **not** a claim of distributed fleet admission.
-Native opaque fan-out, GraphQL, interactive terminal and unsupported CLI shapes
-retain native semantics and the common cooldown; do not infer exact request
-costs or per-HTTP admission for those paths. Explicit quota capture is still
-needed for their benchmark evidence. `AIDEVOPS_GH_TRANSPORT_GOVERNOR_DISABLE=1`
-rolls back the REST adapter without disabling the shared cooldown.
+Read [GitHub API transport and freshness](github-api-transport.md) for the shared
+cooldown, bounded authenticated REST-read admission, native compatibility limits,
+query-shape optimisations, and generation-fenced event queue. These controls do
+not relax this benchmark's completeness or correctness requirements.
 
 ### Quota-cost attribution
 

--- a/.agents/reference/github-api-efficiency.md
+++ b/.agents/reference/github-api-efficiency.md
@@ -61,6 +61,49 @@ The benchmark validates:
 Any unknown quota cost or unclassified transport attempt prevents `PASS`.
 Never derive a benchmark by reading the raw JSONL/log source directly.
 
+### Live diagnostics versus completed-cycle proof
+
+`gh-api-instrument.sh report` now writes `gh-api-calls-by-stage-live.json` by
+default (override `AIDEVOPS_GH_API_LIVE_REPORT`). It does not replace the canonical
+completed-cycle report or its digest-bound evidence sidecar. Explicit output
+paths remain supported. Batch prefetch no longer publishes a partial-cycle
+aggregate: `pulse-wrapper-cycle-gates.sh` owns the exact completed cutoff.
+
+### Native transport boundary
+
+The PATH shim applies the shared cooldown before native requests, including raw
+agent commands. A wrapper-admitted boot/recovery read is not charged twice, but
+cooldown is rechecked immediately before transport. Local-only commands remain
+usable without fabricated HTTP attempts. Execution failures, including those
+without a complete HTTP response, do not authorise an alternate transport.
+
+Supported non-interactive, single-request `gh api` REST shapes use
+`gh-transport-governor.py` and `gh_transport_budget.py`. They inspect included
+response headers without enabling `GH_DEBUG`, preserve native body bytes/status,
+and never cache a response body. Existing explicit pagination admits each page
+separately. Authenticated conditional `304` responses own zero primary cost;
+failed/unknown costs remain unknown. A changed native framing contract fails
+closed rather than returning injected headers as successful application data.
+
+The private local SQLite state reserves in-flight REST work atomically. Only
+resource-owned response headers establish remaining quota; `/rate_limit` JSON
+is not an admission balance. Missing/stale observations allow one serialized
+observation, not an assumed new allowance. Unknown spend remains debt; a later
+response from another credential cannot erase it. Out-of-order responses cannot
+increase remaining quota within a live reset window. PID birth identity guards
+recovery, and scope aliases prevent an existing credential acquiring a second
+budget when its owner configuration changes.
+
+`AIDEVOPS_GH_QUOTA_OWNER` may name a trusted user/installation quota owner;
+multiple PATs for that owner share an allowance. Unresolved callers deliberately
+share a conservative host scope. Cache visibility must still be credential-scoped.
+This is local coordination, **not** a claim of distributed fleet admission.
+Native opaque fan-out, GraphQL, interactive terminal and unsupported CLI shapes
+retain native semantics and the common cooldown; do not infer exact request
+costs or per-HTTP admission for those paths. Explicit quota capture is still
+needed for their benchmark evidence. `AIDEVOPS_GH_TRANSPORT_GOVERNOR_DISABLE=1`
+rolls back the REST adapter without disabling the shared cooldown.
+
 ### Quota-cost attribution
 
 Quota cost is known only when the operation owns authoritative per-request

--- a/.agents/reference/github-api-transport.md
+++ b/.agents/reference/github-api-transport.md
@@ -1,0 +1,141 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2026 Marcus Quinn -->
+
+# GitHub API transport and freshness
+
+These controls reduce unnecessary work while preserving fresh action-boundary
+checks. They do not establish a production savings percentage; use the matched
+windows and completeness gates in [the efficiency benchmark](github-api-efficiency.md).
+
+## Correct queries before more caching
+
+- CLI `--state closed` means **closed but unmerged**. REST `/pulls?state=closed`
+  contains merged and unmerged PRs. The REST adapter filters before satisfying
+  `--limit`, so a closed-only request can scan a large merged history. Merged-PR
+  reconciliation requests `--state merged` and still validates `mergedAt`.
+- Healthy closed-only list reads prefer native server-side filtering rather
+  than unconditional REST-first. Explicit/low-GraphQL REST fallback retains
+  equivalent semantics. This is a query-shape decision, not an assumed quota
+  balance or a relaxation of JSON-field equivalence.
+- Peer monitoring reuses per-repository observations instead of three requests
+  per peer. Preserve the upstream dispatch-ownership, device-freshness and
+  unknown-observation contract: creation origin is not current ownership.
+  Invalid time configuration or failed collection cannot become a zero-work
+  observation or overwrite the previous state and dispatch overrides.
+- Dirty-worktree checks request comments updated within the active hold window,
+  with a boundary margin, and paginate all relevant pages. They do not inspect
+  only the first hundred old comments. Failed/malformed evidence is a hold, not
+  a clear result. A later resolution is determined by timestamps, not response
+  order; ambiguous timestamps do not grant resume or clearance.
+
+No additional persistent comment or historical-PR body cache is required by
+these changes. Existing TTLs are not lengthened, future-dated discovery cache
+entries miss, and discovery data never replaces final lock/trust/head/check
+verification.
+
+## Common native boundary
+
+The PATH shim applies the shared cooldown before ordinary native requests,
+including raw agent commands. Wrapper-admitted boot/recovery reads are not
+charged twice, but cooldown is rechecked immediately before dispatch. Local-only
+commands remain usable without fabricated HTTP attempts. `gh search` is a REST
+search operation, not a GraphQL query.
+
+Native execution errors without a usable HTTP response stop alternate
+transports. A successful HTTP response which cannot reproduce a requested local
+projection retains the existing semantically equivalent read fallback. Native
+exit `125` is not an unsupported-shape signal after execution: an explicit
+handled receipt prevents replaying the request.
+
+## Bounded authenticated REST reads
+
+`gh-transport-governor.py` and `gh_transport_budget.py` admit supported
+non-interactive authenticated `GET` shapes using private local SQLite state.
+They inspect included final-response headers without enabling `GH_DEBUG` and
+never cache a response body. Explicit REST pagination uses the same boundary
+per page. The credential fingerprint and native request use the same pinned
+child environment; credentials are never exported to a long-lived parent.
+
+- Resource-owned response headers establish remaining quota. `/rate_limit`
+  JSON is not treated as an admission balance.
+- In-flight reservations are atomic, with a bounded local concurrency ceiling
+  and protected reserve. Brief local contention waits without sending HTTP;
+  quota/reset stops do not spin or retry against another transport.
+- Missing/stale observations permit one serialized observation, not an assumed
+  new allowance. Unknown execution remains debt until a later response from
+  the same credential covers it. Out-of-order responses cannot restore spent
+  quota inside a live reset window.
+- PID birth identity protects recovery. A credential changing owner
+  configuration cannot obtain an independent second budget: live scope state
+  and reservations are merged conservatively.
+- `AIDEVOPS_GH_QUOTA_OWNER` may identify a trusted user/installation owner.
+  Multiple PATs for that owner share an allowance. Unresolved callers share a
+  conservative host scope. This is local coordination, **not distributed fleet
+  admission**. Permission-scoped cache identity remains a separate concern.
+
+Mutations, streamed inputs, inherited file descriptors, anonymous requests,
+GraphQL, interactive terminals and unsupported CLI shapes retain native
+execution plus common cooldown. The adapter must not break an unlinked signed
+body's inherited descriptor or turn injected headers into application data.
+
+Normal observations describe a native invocation and its final response; do not
+claim complete wire-level accounting for hidden native redirects/retries.
+Explicit `AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1` retains the existing multi-response
+recorder and serialization instead of this read adapter. Consequently, an
+exact-capture query-efficiency window is not alone proof of the new admission
+controller's normal-mode latency. Retain unknowns and require profile-appropriate
+evidence before tuning defaults or claiming an integrated benchmark pass.
+
+Rollback: `AIDEVOPS_GH_TRANSPORT_GOVERNOR_DISABLE=1` disables the read adapter,
+not shared cooldown. It does not authorize bypassing signatures or safety gates.
+
+## Durable PR wake hints
+
+`pulse-merge-dirty-queue.py` stores repo/PR identifiers, generation, wake and
+lease metadata under a private state directory. It stores no PR/check/review
+contents and grants no merge authority.
+
+- Signed receiver events invalidate first. A failed invalidation remains
+  latched for the whole delivery; a later successful invalidation cannot erase
+  that failure.
+- Repeated wakes coalesce, with a short debounce. Event and ordinary Pulse
+  processing share per-PR logical leases. No lock descriptor is inherited by
+  Git hooks. A live owner is not displaced merely because time elapsed.
+- Acknowledgement is generation-fenced. An event arriving during processing
+  survives the older completion. Unhandled hints remain available to polling.
+- Dirty poll candidates refresh initial PR metadata. The targeted event path
+  fetches once and lends its owned context to the existing pipeline; it does
+  not fetch the same initial object twice. All final safety gates still run.
+- Hints only break ties inside existing readiness categories. They do not move
+  a blocked PR ahead of merge-ready work, skip repositories, or replace polling.
+- Capacity is bounded at 4096 rows; unleased hints expire after seven days.
+  Expiry removes scheduling hints, not GitHub work. Queue failure disables the
+  event fast path while the authoritative polling path remains available.
+
+Runtime entrypoints enable `AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED` by default;
+explicit `0` is the rollback switch. Sourcing merge helpers alone does not opt
+in. Before the queue is present, ordinary polling creates no queue state.
+Dry-run processing does not claim or acknowledge hints. The private directory
+can be isolated with `AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_DIR`.
+
+**Do not slow the polling backstop without verified webhook coverage.** A
+configured listener is not proof that GitHub, the tunnel, all needed events and
+the receiver are working. Missing secret/configuration retains polling;
+configure secrets with `aidevops secret set GITHUB_WEBHOOK_SECRET`, never in chat.
+
+## Focused verification
+
+```bash
+python3 .agents/scripts/tests/test-gh-transport-budget.py
+bash .agents/scripts/tests/test-gh-shim.sh
+bash .agents/scripts/tests/test-gh-api-instrument.sh
+bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+bash .agents/scripts/tests/test-pulse-issue-reconcile.sh
+bash tests/test-peer-productivity-monitor.sh
+bash .agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh
+python3 .agents/scripts/tests/test-pulse-merge-dirty-queue.py
+python3 .agents/scripts/tests/test-pulse-merge-webhook-invalidation.py
+bash .agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
+bash .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
+bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+```

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -756,7 +756,6 @@ _approval_apply_issue_lifecycle_updates() {
 	local slug="$2"
 	local gh_user=""
 	local edit_err=""
-	local lock_err=""
 	local status_err=""
 	local restore_err=""
 	local _ah_labels_json=""
@@ -800,17 +799,10 @@ _approval_apply_issue_lifecycle_updates() {
 	_print_info "Lifecycle updated: status:available, removed needs-maintainer-review, added auto-dispatch"
 	_print_info "Assigned to $gh_user"
 
-	lock_err=$(_approval_lock_issue "$target_number" "$slug" 2>&1 >/dev/null) || {
-		_print_error "Approval advisory lock failure: issue #$target_number could not be locked after approval state updates"
-		[[ -n "$lock_err" ]] && _print_error "$lock_err"
-		restore_err=$(_approval_restore_nmr_hold issue "$target_number" "$slug" 2>&1 >/dev/null) || {
-			_print_error "Failed to restore needs-maintainer-review after lock uncertainty on issue #$target_number"
-			[[ -n "$restore_err" ]] && _print_error "$restore_err"
-		}
-		return 1
-	}
-	_print_info "Issue #$target_number locked (scope finalized, unlocks after worker completion)"
-
+	# The issue was locked before its signed snapshot was built. Do not mutate
+	# it a second time here: the fresh final-state read below must still verify
+	# locked=true. If another actor unlocked it, restore the hold rather than
+	# relocking and hiding a break in signed-snapshot continuity.
 	if ! _approval_verify_issue_state "$target_number" "$slug" "$gh_user"; then
 		restore_err=$(_approval_restore_nmr_hold issue "$target_number" "$slug" 2>&1 >/dev/null) || {
 			_print_error "Failed to restore needs-maintainer-review after final-state uncertainty on issue #$target_number"
@@ -818,6 +810,7 @@ _approval_apply_issue_lifecycle_updates() {
 		}
 		return 1
 	fi
+	_print_info "Issue #$target_number lock verified (scope finalized, unlocks after worker completion)"
 
 	# t2057: remove only the local claim stamp after the complete remote state is
 	# verified. Invoking `release` here would perform a second remote status write

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -102,6 +102,11 @@ source "${_SHIM_DIR}/managed-label-provisioning-lib.sh"
 # shellcheck disable=SC1091  # sibling library resolved at runtime via $_SHIM_DIR
 source "${_SHIM_DIR}/gh-write-policy-lib.sh"
 
+if [[ -f "${_SHIM_DIR}/gh-transport-controls.sh" ]]; then
+	# shellcheck source=./gh-transport-controls.sh
+	source "${_SHIM_DIR}/gh-transport-controls.sh"
+fi
+
 # Reject recursive entry rather than forwarding to another shim generation.
 # The resolver below prevents normal cross-generation selection; this sentinel
 # bounds any unexpected re-entry caused by a child process or stale shim.
@@ -321,7 +326,7 @@ gh() {
 	local path=""
 	local caller=""
 	path=$(_shim_classify_endpoint "${1:-}" "${2:-}")
-	caller=$(_shim_caller_label "${1:-}" "${2:-}")
+	caller=$(_shim_transport_caller_label "${1:-}" "${2:-}")
 	_shim_run_transport "$REAL_GH" "$path" "$caller" "${AIDEVOPS_GH_RETRY_INDEX:-0}" "$@"
 	return $?
 }
@@ -503,6 +508,10 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		exit 0
 	else
 		_rest_rc=$?
+		# A local admission/cooldown stop is not a failed JSON projection and
+		# must not be retried against a different API resource.
+		[[ "$_rest_rc" -ne 75 ]] || exit 75
+		[[ "$_rest_rc" -ne 125 ]] || exit 125
 		if [[ "$_SHIM_REST_REWRITE_ATTEMPTED" -eq 1 ]] && _shim_rest_rewrite_has_http_failure; then
 			exit "$_rest_rc"
 		fi

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -472,7 +472,11 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# Prefer REST in pulse/workflow REST-first mode; otherwise use the legacy
 		# low-GraphQL-budget fallback. This shares native GitHub quota pools instead
 		# of imposing a synthetic lower GraphQL budget.
-		_rest_read_first_enabled || _rest_should_fallback || return 1
+		if [[ "$_SHIM_READ_REWRITE" == pr:list ]] && _rest_pr_list_prefers_native_filter "${@:3}"; then
+			_rest_should_fallback || return 1
+		else
+			_rest_read_first_enabled || _rest_should_fallback || return 1
+		fi
 		[[ "$_GH_REQUEST_ATTEMPT_STATE_READY" -eq 1 ]] || return 1
 
 		# Extract repo and build stripped args.

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -483,12 +483,20 @@ gh_request_attempt_state_cleanup() {
 _gh_request_attempt_state_record() {
 	local logical_id="$1"
 	local http_status="$2"
+	local outcome="${3:-}"
 	local state_file="${AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_FILE:-}"
 	[[ -n "${_GH_API_REQUEST_LOGICAL_ID:-}" &&
 		"$logical_id" == "$_GH_API_REQUEST_LOGICAL_ID" ]] || return 0
 	[[ "${_GH_API_REQUEST_ATTEMPT_COUNT:-}" =~ ^[0-9]+$ ]] || _GH_API_REQUEST_ATTEMPT_COUNT=0
 	_GH_API_REQUEST_ATTEMPT_COUNT=$((_GH_API_REQUEST_ATTEMPT_COUNT + 1))
-	if [[ "$http_status" =~ ^[45][0-9][0-9]$ ]]; then
+	# Keep the private two-column wire compatible. Non-HTTP execution errors
+	# stop alternate transports too; public telemetry retains the actual status.
+	# A successful HTTP response can still fail gh's local --jq projection;
+	# preserve the existing equivalent-read fallback for that distinct case.
+	if [[ "$outcome" == error && ! "$http_status" =~ ^[1-5][0-9][0-9]$ ]]; then
+		http_status=transport-error
+	fi
+	if [[ "$http_status" =~ ^[45][0-9][0-9]$ || "$http_status" == transport-error ]]; then
 		_GH_API_REQUEST_HTTP_FAILURE=1
 	fi
 	if _gh_request_attempt_state_file_valid "$state_file"; then
@@ -526,7 +534,7 @@ gh_request_has_http_failure() {
 	if [[ "$logical_id" == "${AIDEVOPS_GH_REQUEST_ATTEMPT_STATE_LOGICAL_ID:-}" ]] &&
 		_gh_request_attempt_state_file_valid "$state_file"; then
 		while IFS=$'\t' read -r recorded_logical_id http_status; do
-			if [[ "$recorded_logical_id" == "$logical_id" && "$http_status" =~ ^[45][0-9][0-9]$ ]]; then
+			if [[ "$recorded_logical_id" == "$logical_id" && ( "$http_status" =~ ^[45][0-9][0-9]$ || "$http_status" == transport-error ) ]]; then
 				return 0
 			fi
 		done <"$state_file"
@@ -710,7 +718,9 @@ gh_record_attempt() {
 	[[ -n "$api_pool" ]] || api_pool=$(_gh_default_pool "$path")
 	[[ -n "$auth_mode" ]] || auth_mode="${AIDEVOPS_GH_AUTH_MODE:-$(_gh_default_auth "$api_pool")}"
 	[[ -n "$route_decision" ]] || route_decision="${AIDEVOPS_GH_ROUTE_DECISION:-${api_pool}-selected}"
-	_gh_request_attempt_state_record "$logical_id" "$http_status" || true
+	# Only the native boundary can attest a transport execution error. Legacy
+	# logical adapters may fail a local projection after a successful request.
+	_gh_request_attempt_state_record "$logical_id" "$http_status" "${AIDEVOPS_GH_NATIVE_EXECUTION_OUTCOME:-}" || true
 	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
 	_gh_append_v2 attempt "$caller" "$path" "$auth_mode" "$api_pool" "$route_decision" \
 		"$budget_remaining" "$logical_id" "$attempt_id" "$page" "$retry" "$outcome" \
@@ -782,7 +792,11 @@ gh_run_transport_attempt() {
 		fi
 	fi
 	start_ms=$(_gh_now_ms) || start_ms=""
-	if "$@"; then
+	local -a transport_command=("$@")
+	if declare -F _gh_transport_capture_errors >/dev/null 2>&1; then
+		transport_command=(_gh_transport_capture_errors "$@")
+	fi
+	if "${transport_command[@]}"; then
 		rc=0
 		if [[ -z "$quota_cost" && -n "$success_quota_cost" ]]; then
 			quota_cost="$success_quota_cost"
@@ -988,8 +1002,13 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		gh_record_efficiency_evidence "$@"
 		;;
 	report | aggregate)
+		# An ad-hoc report is not a completed-cycle publication. Keep it away
+		# from the canonical report/sidecar pair unless a target is explicit.
+		if [[ $# -eq 0 ]]; then
+			set -- "${AIDEVOPS_GH_API_LIVE_REPORT:-${GH_API_REPORT%.json}-live.json}"
+		fi
 		gh_aggregate_calls "$@"
-		printf 'Wrote %s\n' "${1:-$GH_API_REPORT}" >&2
+		printf 'Wrote %s\n' "$1" >&2
 		;;
 	trim)
 		gh_trim_log

--- a/.agents/scripts/gh-native-transport-lib.sh
+++ b/.agents/scripts/gh-native-transport-lib.sh
@@ -407,6 +407,18 @@ _shim_run_single_transport() {
 	local path="$1"; shift
 	local caller="$1"; shift
 	local retry="$1"; shift
+	if declare -F _ghqa_command_is_local_only >/dev/null 2>&1 && _ghqa_command_is_local_only "$executable" "$@"; then
+		"$executable" "$@"
+		return $?
+	fi
+	if declare -F _gh_transport_preflight >/dev/null 2>&1; then
+		_gh_transport_preflight "$@" || return $?
+	fi
+	if declare -F _gh_transport_run_rest >/dev/null 2>&1; then
+		local governed_rc=0
+		_gh_transport_run_rest "$executable" "$path" "$caller" "$retry" "$@" || governed_rc=$?
+		[[ "${_GHGT_HANDLED:-0}" -eq 0 && "$governed_rc" -eq 125 ]] || return "$governed_rc"
+	fi
 	local page=1
 	local decision="${AIDEVOPS_GH_ROUTE_DECISION:-}"
 	local exact_success_cost=""

--- a/.agents/scripts/gh-native-transport-lib.sh
+++ b/.agents/scripts/gh-native-transport-lib.sh
@@ -86,12 +86,12 @@ _find_real_gh() {
 
 # _shim_classify_endpoint <sub1> [<sub2>]
 # Classify a gh invocation for instrumentation. Returns one of:
-#   graphql | rest | search-graphql | other
+#   graphql | rest | search-rest | other
 _shim_classify_endpoint() {
 	local sub1="${1:-}" sub2="${2:-}"
 	case "$sub1" in
 	search)
-		printf 'search-graphql'
+		printf 'search-rest'
 		return 0
 		;;
 	api)

--- a/.agents/scripts/gh-quota-attribution-lib.sh
+++ b/.agents/scripts/gh-quota-attribution-lib.sh
@@ -616,6 +616,7 @@ _ghqa_command_is_local_only() {
 	shift
 	local subcommand="${1:-}"
 	: "$executable"
+	[[ "$subcommand" != auth || "${2:-}" != token ]] || return 0
 	case "$subcommand" in
 	--help | --version | help | version | completion | config | alias) return 0 ;;
 	esac

--- a/.agents/scripts/gh-transport-controls.sh
+++ b/.agents/scripts/gh-transport-controls.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# Shared transport boundary for the PATH shim, including raw agent commands.
+
+[[ -n "${_GH_TRANSPORT_CONTROLS_LOADED:-}" ]] && return 0
+_GH_TRANSPORT_CONTROLS_LOADED=1
+_GHGT_DIR="${BASH_SOURCE[0]%/*}"
+# shellcheck source=./shared-gh-secondary-cooldown.sh
+source "${_GHGT_DIR}/shared-gh-secondary-cooldown.sh"
+
+_gh_transport_preflight() {
+	local op_class="read"
+	local arg=""
+	case "${1:-}:${2:-}" in
+	*:create | *:edit | *:comment | *:close | *:reopen | *:lock | *:unlock | *:merge | *:review | *:delete | *:ready | *:rerun) op_class="write" ;;
+	esac
+	for arg in "$@"; do
+		case "$arg" in POST | PATCH | PUT | DELETE) op_class="write" ;; esac
+	done
+	# Wrappers may have charged the boot/recovery ramp already. Always recheck
+	# the actual cooldown at dispatch; skip only a duplicate ramp reservation.
+	local AIDEVOPS_GH_READ_RAMP_OVERRIDE="${AIDEVOPS_GH_READ_RAMP_OVERRIDE:-0}"
+	[[ "${AIDEVOPS_GH_WRAPPER_PREFLIGHT:-0}" != 1 ]] || AIDEVOPS_GH_READ_RAMP_OVERRIDE=1
+	_gh_secondary_cooldown_preflight "$op_class"
+	return $?
+}
+
+_gh_transport_record_error() {
+	local rc="$1"
+	local error_file="$2"
+	local response="${3:-}"
+	[[ "$rc" -ne 0 || -n "$response" ]] || return 0
+	# Native diagnostics are used only by the existing sanitizing classifier;
+	# never log command argv, credentials, endpoint values or response bodies.
+	response="${response}$(<"$error_file")"
+	AIDEVOPS_GH_COOLDOWN_NO_PROBE=1 \
+		_gh_secondary_cooldown_record_if_needed "$rc" "$response" \
+		"GH-CLI" "unknown" "" "transport" "gh" "${AIDEVOPS_PULSE_STAGE:-unknown}"
+	return 0
+}
+
+_gh_transport_capture_errors() {
+	local error_file=""
+	local rc=0
+	# Preserve native terminal/editor/progress behaviour in an attached TTY.
+	if [[ -t 2 ]]; then
+		"$@"
+		return $?
+	fi
+	mkdir -p "${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}" || return 75
+	error_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}/gh-transport-error.XXXXXX") || return 75
+	"$@" 2>"$error_file" || rc=$?
+	command cat "$error_file" >&2
+	_gh_transport_record_error "$rc" "$error_file"
+	rm -f -- "$error_file"
+	return "$rc"
+}
+
+# Return 125 only before transport for an unsupported shape. A supported REST
+# invocation records its response-owned metadata here, not a second attempt in
+# gh_run_transport_attempt. The Python adapter never caches response data.
+_gh_transport_run_rest() {
+	local executable="$1" path="$2" caller="$3" retry="$4"
+	shift 4
+	_GHGT_HANDLED=0
+	[[ "${1:-}" == api && "${AIDEVOPS_GH_TRANSPORT_GOVERNOR_DISABLE:-0}" != 1 ]] || return 125
+	command -v python3 >/dev/null 2>&1 || return 125
+	local temp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local metadata="" error_file="" start_ms="" end_ms="" elapsed="" rc=0
+	local status="" resource="" remaining="" reset="" retry_after="" cost="" attempted="" pool="" response="" outcome=success
+	mkdir -p "$temp_dir" || return 75
+	metadata=$(mktemp "${temp_dir}/gh-transport-meta.XXXXXX") || return 75
+	error_file=$(mktemp "${temp_dir}/gh-transport-error.XXXXXX") || { rm -f "$metadata"; return 75; }
+	start_ms=$(_gh_now_ms)
+	python3 "${_GHGT_DIR}/gh-transport-governor.py" "$metadata" "$executable" "$@" 2>"$error_file" || rc=$?
+	end_ms=$(_gh_now_ms)
+	command cat "$error_file" >&2
+	attempted=$(jq -r '.attempted // false' "$metadata" 2>/dev/null) || attempted=false
+	if [[ "$rc" -eq 125 && "$attempted" != true ]]; then
+		rm -f -- "$metadata" "$error_file"
+		return 125
+	fi
+	_GHGT_HANDLED=1
+	if [[ "$attempted" == true ]]; then
+		# Use explicit sentinels: IFS whitespace collapses empty TSV columns.
+		IFS='|' read -r status resource remaining reset retry_after cost < <(jq -r \
+			'[.status,.resource,.remaining,.reset,.retry_after,.cost] | map(if . == null then "x" else tostring end) | join("|")' "$metadata")
+		pool=$(_ghqa_pool_for_resource "$resource")
+		[[ "$resource" != code_search ]] || pool=rest-search
+		[[ "$pool" != unknown ]] || pool=rest-core
+		[[ "$rc" -eq 0 ]] || outcome=error
+		elapsed=$((end_ms - start_ms))
+		AIDEVOPS_GH_NATIVE_EXECUTION_OUTCOME="$outcome" \
+			gh_record_attempt "$path" "$caller" "$AIDEVOPS_GH_LOGICAL_ID" "" \
+			"$(_shim_transport_page "$@")" "$retry" "$outcome" "$status" "$elapsed" "$cost" \
+			"${AIDEVOPS_GH_AUTH_MODE:-}" "$pool" "${AIDEVOPS_GH_ROUTE_DECISION:-rest-response-owned}" "$remaining"
+		[[ "$status" == x ]] || response="HTTP/1.1 ${status}"$'\n'
+		[[ "$remaining" == x ]] || response="${response}x-ratelimit-remaining: ${remaining}"$'\n'
+		[[ "$reset" == x ]] || response="${response}x-ratelimit-reset: ${reset}"$'\n'
+		[[ "$retry_after" == x ]] || response="${response}retry-after: ${retry_after}"$'\n'
+	else
+		gh_record_call other "$caller" "" other transport-deferred 2>/dev/null || true
+	fi
+	_gh_transport_record_error "$rc" "$error_file" "$response"
+	rm -f -- "$metadata" "$error_file"
+	return "$rc"
+}
+
+return 0

--- a/.agents/scripts/gh-transport-controls.sh
+++ b/.agents/scripts/gh-transport-controls.sh
@@ -57,21 +57,25 @@ _gh_transport_capture_errors() {
 	return "$rc"
 }
 
-# Return 125 only before transport for an unsupported shape. A supported REST
-# invocation records its response-owned metadata here, not a second attempt in
-# gh_run_transport_attempt. The Python adapter never caches response data.
+# _GHGT_HANDLED distinguishes unsupported-before-execution from native exit125.
+# Supported REST records metadata here, not a second attempt in the ordinary
+# recorder. Exact capture retains its existing multi-response-frame owner.
 _gh_transport_run_rest() {
 	local executable="$1" path="$2" caller="$3" retry="$4"
 	shift 4
 	_GHGT_HANDLED=0
 	[[ "${1:-}" == api && "${AIDEVOPS_GH_TRANSPORT_GOVERNOR_DISABLE:-0}" != 1 ]] || return 125
+	[[ "${AIDEVOPS_GH_EXACT_QUOTA_CAPTURE:-0}" != 1 ]] || return 125
 	command -v python3 >/dev/null 2>&1 || return 125
 	local temp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
 	local metadata="" error_file="" start_ms="" end_ms="" elapsed="" rc=0
 	local status="" resource="" remaining="" reset="" retry_after="" cost="" attempted="" pool="" response="" outcome=success
 	mkdir -p "$temp_dir" || return 75
 	metadata=$(mktemp "${temp_dir}/gh-transport-meta.XXXXXX") || return 75
-	error_file=$(mktemp "${temp_dir}/gh-transport-error.XXXXXX") || { rm -f "$metadata"; return 75; }
+	error_file=$(mktemp "${temp_dir}/gh-transport-error.XXXXXX") || {
+		rm -f "$metadata"
+		return 75
+	}
 	start_ms=$(_gh_now_ms)
 	python3 "${_GHGT_DIR}/gh-transport-governor.py" "$metadata" "$executable" "$@" 2>"$error_file" || rc=$?
 	end_ms=$(_gh_now_ms)
@@ -102,7 +106,11 @@ _gh_transport_run_rest() {
 	else
 		gh_record_call other "$caller" "" other transport-deferred 2>/dev/null || true
 	fi
-	_gh_transport_record_error "$rc" "$error_file" "$response"
+	# Healthy responses do not need the multi-step error classifier. Local
+	# admission stops have no server response to classify at all.
+	if [[ "$attempted" == true && ("$rc" -ne 0 || "$remaining" == 0 || "$retry_after" != x || "$status" =~ ^[45]) ]]; then
+		_gh_transport_record_error "$rc" "$error_file" "$response"
+	fi
 	rm -f -- "$metadata" "$error_file"
 	return "$rc"
 }

--- a/.agents/scripts/gh-transport-governor.py
+++ b/.agents/scripts/gh-transport-governor.py
@@ -3,8 +3,9 @@
 # SPDX-FileCopyrightText: 2026 Marcus Quinn
 """Observe one supported native REST request without GH_DEBUG or payload logs.
 
-Return 125 only before execution, so callers may retain native handling for
-unsupported CLI shapes. Explicit pagination invokes this once per actual page.
+Return 125 with attempted=false for unsupported shapes; an executed native125
+is distinguished by attempted=true. Never decide fallback from exit code alone.
+Explicit pagination invokes this once per page.
 No response is cached, and no automatic transport retry is performed.
 """
 
@@ -34,11 +35,12 @@ BOOL_FLAGS = {"--include", "-i", "--silent"}
 
 
 def request_shape(args: list[str]) -> tuple[str, str, bool, bool] | None:
-    if not args or args[0] != "api":
+    if not args or args[0] != "api" or os.environ.get("GH_DEBUG"):
         return None
     endpoint = ""
     host = os.environ.get("GH_HOST", "github.com").lower()
     include = silent = False
+    method, explicit_method, fields = "GET", False, False
     index = 1
     while index < len(args):
         arg = args[index]
@@ -51,6 +53,14 @@ def request_shape(args: list[str]) -> tuple[str, str, bool, bool] | None:
                 value = args[index]
             if option == "--hostname":
                 host = value.lower()
+            if option in {"-X", "--method"}:
+                method, explicit_method = value.upper(), True
+            if option in {"-F", "--field", "-f", "--raw-field"}:
+                fields = True
+            # Do not change mutation, streamed-input or inherited descriptor
+            # semantics. Those requests retain native execution plus cooldown.
+            if option == "--input" or "/dev/fd/" in value or "/proc/self/fd/" in value:
+                return None
             # A caller-supplied Authorization header is a different identity.
             if option in {"-H", "--header"} and value.split(":", 1)[0].strip().lower() in {
                 "authorization", "x-gh-cache-ttl",
@@ -66,11 +76,14 @@ def request_shape(args: list[str]) -> tuple[str, str, bool, bool] | None:
         elif endpoint:
             return None
         else:
+            if arg.startswith("//"):
+                return None
             endpoint = arg.lstrip("/")
         index += 1
-    if host != "github.com" or not endpoint or ":" in endpoint or "#" in endpoint:
-        return None
     path = endpoint.split("?", 1)[0]
+    if (host != "github.com" or not path or ":" in path or "#" in endpoint
+            or method != "GET" or (fields and not explicit_method)):
+        return None
     if path in {"graphql", "rate_limit"}:
         return None
     resource = "code_search" if path == "search/code" else (
@@ -104,8 +117,8 @@ def included_headers(stream) -> tuple[int, dict[str, str], int]:
     return 0, {}, 0
 
 
-def execute(executable: str, args: list[str], output) -> int:
-    child = subprocess.Popen([executable, *args], stdout=output)
+def execute(executable: str, args: list[str], output, environment: dict[str, str]) -> int:
+    child = subprocess.Popen([executable, *args], stdout=output, env=environment)
     try:
         return child.wait(timeout=90)
     except subprocess.TimeoutExpired:
@@ -141,13 +154,26 @@ def run(metadata: Path, executable: str, args: list[str]) -> int:
     try:
         metadata.write_text('{"attempted":false}', encoding="utf-8")
         private_directory(temp_dir)
-        credential, authenticated = credential_identity(executable, host)
+        credential, authenticated, environment = credential_identity(executable, host)
+        if not authenticated:
+            # Do not mix anonymous-IP and authenticated-user allowances or
+            # trust an identity which could change before native execution.
+            return 125
         budget = Budget(directory, scope_key(host), credential)
-        reservation = budget.acquire(resource)
+        # Queue briefly for another local request, not for a GitHub reset.
+        # These retries never execute HTTP or retry a mutation.
+        for admission_try in range(21):
+            try:
+                reservation = budget.acquire(resource)
+                break
+            except Deferred as pause:
+                if not pause.retryable or admission_try == 20:
+                    raise
+                time.sleep(0.1)
         with tempfile.TemporaryFile(dir=temp_dir) as output:
             native_args = args if include else [*args, "--include"]
             metadata.write_text('{"attempted":true}', encoding="utf-8")
-            rc = execute(executable, native_args, output)
+            rc = execute(executable, native_args, output, environment)
             status, headers, body_offset = included_headers(output)
             if include:
                 output.seek(0)

--- a/.agents/scripts/gh-transport-governor.py
+++ b/.agents/scripts/gh-transport-governor.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Observe one supported native REST request without GH_DEBUG or payload logs.
+
+Return 125 only before execution, so callers may retain native handling for
+unsupported CLI shapes. Explicit pagination invokes this once per actual page.
+No response is cached, and no automatic transport retry is performed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import signal
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from gh_transport_budget import Budget, Deferred, credential_identity, private_directory, scope_key
+
+
+VALUE_FLAGS = {
+    "-X", "--method", "-H", "--header", "--hostname", "-F", "--field",
+    "-f", "--raw-field", "--input", "-q", "--jq", "-p", "--preview",
+    "-t", "--template",
+}
+BOOL_FLAGS = {"--include", "-i", "--silent"}
+
+
+def request_shape(args: list[str]) -> tuple[str, str, bool, bool] | None:
+    if not args or args[0] != "api":
+        return None
+    endpoint = ""
+    host = os.environ.get("GH_HOST", "github.com").lower()
+    include = silent = False
+    index = 1
+    while index < len(args):
+        arg = args[index]
+        option, _, value = arg.partition("=")
+        if option in VALUE_FLAGS:
+            if "=" not in arg:
+                index += 1
+                if index >= len(args):
+                    return None
+                value = args[index]
+            if option == "--hostname":
+                host = value.lower()
+            # A caller-supplied Authorization header is a different identity.
+            if option in {"-H", "--header"} and value.split(":", 1)[0].strip().lower() in {
+                "authorization", "x-gh-cache-ttl",
+            }:
+                return None
+        elif arg in BOOL_FLAGS:
+            include |= arg in {"--include", "-i"}
+            silent |= arg == "--silent"
+        elif arg.startswith("-"):
+            # Conservative: joined short options, cache, pagination, debug,
+            # GraphQL and future CLI options retain their native transport.
+            return None
+        elif endpoint:
+            return None
+        else:
+            endpoint = arg.lstrip("/")
+        index += 1
+    if host != "github.com" or not endpoint or ":" in endpoint or "#" in endpoint:
+        return None
+    path = endpoint.split("?", 1)[0]
+    if path in {"graphql", "rate_limit"}:
+        return None
+    resource = "code_search" if path == "search/code" else (
+        "search" if path.startswith("search/") else "core"
+    )
+    return host, resource, include, silent
+
+
+def included_headers(stream) -> tuple[int, dict[str, str], int]:
+    stream.seek(0)
+    first = stream.readline(8192)
+    match = re.fullmatch(rb"HTTP/[0-9.]+ ([0-9]{3})[^\r\n]*\r?\n", first)
+    if not match:
+        stream.seek(0)
+        return 0, {}, 0
+    headers: dict[str, str] = {}
+    while stream.tell() < 65536:
+        line = stream.readline(8192)
+        if line in {b"\n", b"\r\n"}:
+            return int(match[1]), headers, stream.tell()
+        if not line or b":" not in line:
+            break
+        name, value = line.decode("ascii", errors="replace").split(":", 1)
+        name = name.lower()
+        if name in {"x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-used",
+                    "x-ratelimit-reset", "x-ratelimit-resource", "retry-after"}:
+            # Duplicate rate headers are ambiguous, not additional authority.
+            if name in headers:
+                return 0, {}, 0
+            headers[name] = value.strip()
+    return 0, {}, 0
+
+
+def execute(executable: str, args: list[str], output) -> int:
+    child = subprocess.Popen([executable, *args], stdout=output)
+    try:
+        return child.wait(timeout=90)
+    except subprocess.TimeoutExpired:
+        print("[gh-transport] native REST request timed out", file=sys.stderr)
+        return 124
+    finally:
+        if child.poll() is None:
+            child.terminate()
+            try:
+                child.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                child.wait()
+
+
+def run(metadata: Path, executable: str, args: list[str]) -> int:
+    shape = request_shape(args)
+    if shape is None or sys.stdout.isatty():
+        return 125
+    host, resource, include, silent = shape
+    directory = Path(os.environ.get(
+        "AIDEVOPS_GH_TRANSPORT_STATE_DIR",
+        str(Path.home() / ".aidevops/state/gh-transport"),
+    ))
+    temp_dir = Path(os.environ.get(
+        "AIDEVOPS_TEMP_DIR", str(Path.home() / ".aidevops/.agent-workspace/tmp")
+    ))
+    budget = None
+    reservation = ""
+    started = time.time()
+    headers: dict[str, str] = {}
+    rc = None
+    try:
+        metadata.write_text('{"attempted":false}', encoding="utf-8")
+        private_directory(temp_dir)
+        credential, authenticated = credential_identity(executable, host)
+        budget = Budget(directory, scope_key(host), credential)
+        reservation = budget.acquire(resource)
+        with tempfile.TemporaryFile(dir=temp_dir) as output:
+            native_args = args if include else [*args, "--include"]
+            metadata.write_text('{"attempted":true}', encoding="utf-8")
+            rc = execute(executable, native_args, output)
+            status, headers, body_offset = included_headers(output)
+            if include:
+                output.seek(0)
+                shutil.copyfileobj(output, sys.stdout.buffer)
+            elif not status:
+                # A changed native framing contract must not turn injected
+                # headers into application data or silently report success.
+                print("[gh-transport] unrecognized native response framing", file=sys.stderr)
+                rc = rc or 1
+            elif not silent:
+                output.seek(body_offset)
+                shutil.copyfileobj(output, sys.stdout.buffer)
+            # Persist numeric metadata only, never endpoint, query, body or auth.
+            actual_resource = headers.get("x-ratelimit-resource", "")
+            known_resource = actual_resource in {"core", "search", "code_search"}
+            result = {
+                "attempted": True,
+                "status": status or None,
+                "resource": actual_resource if known_resource else None,
+                "remaining": int(headers["x-ratelimit-remaining"])
+                if headers.get("x-ratelimit-remaining", "").isdecimal() else None,
+                "reset": int(headers["x-ratelimit-reset"])
+                if headers.get("x-ratelimit-reset", "").isdecimal() else None,
+                "retry_after": int(headers["retry-after"])
+                if headers.get("retry-after", "").isdecimal() else None,
+                "cost": (0 if status == 304 else 1)
+                if known_resource and 200 <= status < 400
+                and (status != 304 or authenticated) else None,
+            }
+            metadata.write_text(json.dumps(result), encoding="utf-8")
+            return rc if rc >= 0 else 128 - rc
+    except Deferred as exc:
+        print(f"[gh-transport] deferred: {exc}", file=sys.stderr)
+        return 75
+    except (OSError, ValueError, sqlite3.Error):
+        # Metadata failure after execution is not permission to retry a
+        # successful mutation. Keep the observed native status when available.
+        print("[gh-transport] safe REST transport state unavailable", file=sys.stderr)
+        return (rc if rc >= 0 else 128 - rc) if rc is not None else 75
+    finally:
+        if budget is not None:
+            if reservation:
+                try:
+                    budget.finish(reservation, resource, headers, started=started)
+                except (OSError, ValueError, sqlite3.Error):
+                    print("[gh-transport] quota observation remains uncertain", file=sys.stderr)
+            budget.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 4:
+        raise SystemExit(2)
+    def interrupted(signum, _frame):
+        raise SystemExit(128 + signum)
+    for handled_signal in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+        signal.signal(handled_signal, interrupted)
+    raise SystemExit(run(Path(sys.argv[1]), sys.argv[2], sys.argv[3:]))

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Local atomic admission for observed GitHub REST resources, never a data cache.
+
+Only response headers establish quota. Unresolved identities deliberately share
+one conservative host scope, rather than granting each token a new allowance.
+This database coordinates local processes, not independently configured hosts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import subprocess
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+
+
+class Deferred(Exception):
+    """No safe admission is currently available."""
+
+
+def private_directory(path: Path) -> None:
+    if not path.is_absolute() or path.is_symlink():
+        raise ValueError("unsafe transport state directory")
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if path.stat().st_uid != os.getuid():
+        raise ValueError("transport state directory is not owned by this user")
+    path.chmod(0o700)
+
+
+def scope_key(host: str) -> str:
+    # Only trusted launch context may name a quota owner. A credential digest is
+    # not a quota owner: two PATs can spend the same user's allowance.
+    owner = os.environ.get("AIDEVOPS_GH_QUOTA_OWNER", "unresolved")
+    return hashlib.sha256(f"{host}\0{owner}".encode()).hexdigest()
+
+
+def credential_identity(executable: str, host: str) -> tuple[str, bool]:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        try:
+            token = subprocess.check_output(
+                [executable, "auth", "token", "--hostname", host],
+                stderr=subprocess.DEVNULL, timeout=5,
+            ).decode().strip()
+        except (OSError, ValueError, subprocess.SubprocessError):
+            token = "anonymous"
+    authenticated = bool(token and token != "anonymous")
+    return hashlib.sha256(f"{host}\0{token}".encode()).hexdigest(), authenticated
+
+
+def process_birth(pid: int) -> str:
+    try:
+        value = subprocess.check_output(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            stderr=subprocess.DEVNULL, timeout=2,
+        ).strip()
+        return hashlib.sha256(value).hexdigest() if value else ""
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+class Budget:
+    def __init__(self, directory: Path, scope: str, credential: str | None = None):
+        private_directory(directory)
+        self.path = directory / "admission.sqlite3"
+        if self.path.is_symlink():
+            raise ValueError("unsafe transport state file")
+        # O_NOFOLLOW closes the final-component creation race. SQLite then opens
+        # this user-owned file beneath a mode-700 directory.
+        fd = os.open(self.path, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+        os.close(fd)
+        if self.path.stat().st_uid != os.getuid():
+            raise ValueError("transport state file is not owned by this user")
+        self.path.chmod(0o600)
+        self.db = sqlite3.connect(self.path, timeout=2, isolation_level=None)
+        self.scope = scope
+        self.credential = credential or scope
+        self.birth = process_birth(os.getpid())
+        self.db.executescript("""
+            CREATE TABLE IF NOT EXISTS quota (
+                scope TEXT NOT NULL, resource TEXT NOT NULL,
+                remaining INTEGER NOT NULL, reset REAL NOT NULL,
+                observed REAL NOT NULL, blocked_until REAL NOT NULL DEFAULT 0,
+                quota_limit INTEGER NOT NULL,
+                PRIMARY KEY(scope, resource));
+            CREATE TABLE IF NOT EXISTS reservation (
+                id TEXT PRIMARY KEY, scope TEXT NOT NULL, resource TEXT NOT NULL,
+                started REAL NOT NULL, pid INTEGER NOT NULL,
+                birth TEXT NOT NULL, credential TEXT NOT NULL,
+                uncertain INTEGER NOT NULL DEFAULT 0);
+            CREATE TABLE IF NOT EXISTS binding (credential TEXT PRIMARY KEY, scope TEXT NOT NULL);
+            CREATE TABLE IF NOT EXISTS alias (scope TEXT PRIMARY KEY, target TEXT NOT NULL);
+        """)
+        with self.transaction():
+            self._bind_scope()
+
+    def _root(self, scope: str) -> str:
+        for _ in range(256):
+            row = self.db.execute("SELECT target FROM alias WHERE scope=?", (scope,)).fetchone()
+            if not row:
+                return scope
+            scope = row[0]
+        raise ValueError("quota scope alias cycle")
+
+    def _bind_scope(self) -> None:
+        self.scope = self._root(self.scope)
+        bound = self.db.execute(
+            "SELECT scope FROM binding WHERE credential=?", (self.credential,)
+        ).fetchone()
+        if bound and self._root(bound[0]) != self.scope:
+            previous = self._root(bound[0])
+            # A known credential cannot get a second allowance by changing from
+            # unresolved to configured owner. Merge, never split live evidence.
+            for row in self.db.execute(
+                "SELECT resource,remaining,reset,observed,blocked_until,quota_limit "
+                "FROM quota WHERE scope=?", (self.scope,)
+            ).fetchall():
+                old = self.db.execute(
+                    "SELECT remaining,reset,observed,blocked_until,quota_limit "
+                    "FROM quota WHERE scope=? AND resource=?", (previous, row[0])
+                ).fetchone()
+                values = row[1:] if not old else (
+                    min(row[1], old[0]), max(row[2], old[1]), min(row[3], old[2]),
+                    max(row[4], old[3]), min(row[5], old[4]),
+                )
+                self.db.execute("INSERT OR REPLACE INTO quota VALUES(?,?,?,?,?,?,?)",
+                                (previous, row[0], *values))
+            self.db.execute("DELETE FROM quota WHERE scope=?", (self.scope,))
+            self.db.execute("UPDATE reservation SET scope=? WHERE scope=?", (previous, self.scope))
+            self.db.execute("INSERT OR REPLACE INTO alias VALUES(?,?)", (self.scope, previous))
+            self.scope = previous
+        self.db.execute("INSERT OR REPLACE INTO binding VALUES(?,?)", (self.credential, self.scope))
+
+    @contextmanager
+    def transaction(self):
+        self.db.execute("BEGIN IMMEDIATE")
+        try:
+            self.scope = self._root(self.scope)
+            yield
+            self.db.execute("COMMIT")
+        except BaseException:
+            self.db.execute("ROLLBACK")
+            raise
+
+    def acquire(self, resource: str, *, now: float | None = None) -> str:
+        now = time.time() if now is None else now
+        with self.transaction():
+            # A dead executor is uncertain spend, not free quota. Converting it
+            # to debt permits a later serialized observation to recover safely.
+            for identity, pid, birth in self.db.execute(
+                "SELECT id,pid,birth FROM reservation WHERE scope=? AND uncertain=0",
+                (self.scope,),
+            ).fetchall():
+                try:
+                    os.kill(pid, 0)
+                    current_birth = self.birth if pid == os.getpid() else process_birth(pid)
+                    if birth and current_birth and birth != current_birth:
+                        raise ProcessLookupError
+                except ProcessLookupError:
+                    self.db.execute(
+                        "UPDATE reservation SET uncertain=1,started=? WHERE id=?",
+                        (now, identity),
+                    )
+            row = self.db.execute(
+                "SELECT remaining,reset,observed,blocked_until,quota_limit FROM quota "
+                "WHERE scope=? AND resource=?", (self.scope, resource)
+            ).fetchone()
+            total, active = self.db.execute(
+                "SELECT COUNT(*),COALESCE(SUM(uncertain=0),0) FROM reservation "
+                "WHERE scope=? AND resource=?",
+                (self.scope, resource),
+            ).fetchone()
+            if row and row[3] > now:
+                raise Deferred("resource cooldown is active")
+            floor = min(100, max(1, row[4] // 10)) if row and resource == "core" else 1
+            if row and row[1] > now and row[0] - total <= floor:
+                raise Deferred("REST resource reserve is protected")
+            # Expired/missing observations are not a new 5,000-point grant.
+            # Permit one serialized real request to obtain fresh headers.
+            fresh = row and 0 <= now - row[2] <= 20 and row[1] > now
+            if not fresh and active:
+                raise Deferred("waiting for an authoritative quota observation")
+            # A small local concurrency ceiling also applies with ample quota.
+            if active >= 4:
+                raise Deferred("local REST transport concurrency is occupied")
+            reservation = uuid.uuid4().hex
+            self.db.execute(
+                "INSERT INTO reservation(id,scope,resource,started,pid,birth,credential) VALUES(?,?,?,?,?,?,?)",
+                (reservation, self.scope, resource, now, os.getpid(), self.birth, self.credential),
+            )
+            return reservation
+
+    def finish(self, reservation: str, resource: str, headers: dict[str, str],
+               *, started: float, now: float | None = None) -> None:
+        now = time.time() if now is None else now
+        remaining = headers.get("x-ratelimit-remaining", "")
+        reset = headers.get("x-ratelimit-reset", "")
+        limit = headers.get("x-ratelimit-limit", "")
+        actual_resource = headers.get("x-ratelimit-resource", "")
+        valid = (actual_resource == resource and remaining.isdecimal() and limit.isdecimal()
+                 and 0 <= int(remaining) <= int(limit) <= 1000000
+                 and reset.isdecimal() and now < int(reset) <= now + 86400)
+        with self.transaction():
+            if valid:
+                row = self.db.execute(
+                    "SELECT remaining,reset,observed,blocked_until FROM quota "
+                    "WHERE scope=? AND resource=?", (self.scope, resource)
+                ).fetchone()
+                available, reset_at = int(remaining), int(reset)
+                blocked_until = 0.0
+                if row and row[1] > now:
+                    # Late responses and unresolved owners with different reset
+                    # epochs cannot restore quota observed to have been spent.
+                    available = min(available, row[0])
+                    reset_at = max(reset_at, row[1])
+                    blocked_until = row[3]
+                retry_after = headers.get("retry-after", "")
+                if retry_after.isdecimal():
+                    blocked_until = max(blocked_until, now + int(retry_after))
+                if available == 0:
+                    blocked_until = max(blocked_until, reset_at)
+                self.db.execute(
+                    "INSERT OR REPLACE INTO quota VALUES(?,?,?,?,?,?,?)",
+                    (self.scope, resource, available, reset_at, now, blocked_until, int(limit)),
+                )
+                # This response includes charges for completed unknown requests
+                # which ended before it started. Never clear concurrent work.
+                self.db.execute(
+                    "DELETE FROM reservation WHERE scope=? AND resource=? "
+                    "AND uncertain=1 AND credential=? AND started<?",
+                    (self.scope, resource, self.credential, started)
+                )
+                self.db.execute("DELETE FROM reservation WHERE id=?", (reservation,))
+            else:
+                # Uncertain execution may have spent a point. Keep its debt;
+                # it is covered only by a later authoritative observation.
+                self.db.execute(
+                    "UPDATE reservation SET uncertain=1,started=? WHERE id=?",
+                    (now, reservation),
+                )
+
+    def close(self) -> None:
+        self.db.close()

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -22,6 +22,10 @@ from pathlib import Path
 class Deferred(Exception):
     """No safe admission is currently available."""
 
+    def __init__(self, message: str, *, retryable: bool = False):
+        super().__init__(message)
+        self.retryable = retryable
+
 
 def private_directory(path: Path) -> None:
     if not path.is_absolute() or path.is_symlink():
@@ -39,7 +43,7 @@ def scope_key(host: str) -> str:
     return hashlib.sha256(f"{host}\0{owner}".encode()).hexdigest()
 
 
-def credential_identity(executable: str, host: str) -> tuple[str, bool]:
+def credential_identity(executable: str, host: str) -> tuple[str, bool, dict[str, str]]:
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
     if not token:
         try:
@@ -50,7 +54,12 @@ def credential_identity(executable: str, host: str) -> tuple[str, bool]:
         except (OSError, ValueError, subprocess.SubprocessError):
             token = "anonymous"
     authenticated = bool(token and token != "anonymous")
-    return hashlib.sha256(f"{host}\0{token}".encode()).hexdigest(), authenticated
+    environment = os.environ.copy()
+    if authenticated:
+        # Pin only the native child, not a long-lived wrapper or worker parent.
+        # The hashed identity and the request must use exactly the same token.
+        environment["GH_TOKEN"] = token
+    return hashlib.sha256(f"{host}\0{token}".encode()).hexdigest(), authenticated, environment
 
 
 def process_birth(pid: int) -> str:
@@ -184,10 +193,10 @@ class Budget:
             # Permit one serialized real request to obtain fresh headers.
             fresh = row and 0 <= now - row[2] <= 20 and row[1] > now
             if not fresh and active:
-                raise Deferred("waiting for an authoritative quota observation")
+                raise Deferred("waiting for an authoritative quota observation", retryable=True)
             # A small local concurrency ceiling also applies with ample quota.
             if active >= 4:
-                raise Deferred("local REST transport concurrency is occupied")
+                raise Deferred("local REST transport concurrency is occupied", retryable=True)
             reservation = uuid.uuid4().hex
             self.db.execute(
                 "INSERT INTO reservation(id,scope,resource,started,pid,birth,credential) VALUES(?,?,?,?,?,?,?)",

--- a/.agents/scripts/peer-productivity-monitor.sh
+++ b/.agents/scripts/peer-productivity-monitor.sh
@@ -78,6 +78,7 @@ MARKER_END="# END auto-managed by peer-productivity-monitor"
 WINDOW_HOURS="${AIDEVOPS_PEER_MONITOR_WINDOW_H:-24}"
 HYSTERESIS="${AIDEVOPS_PEER_MONITOR_HYSTERESIS:-3}"
 DRY_RUN="${AIDEVOPS_PEER_MONITOR_DRY_RUN:-0}"
+_PEER_JSON_ARRAY_TYPE="array"
 
 # Vote / action constants — keep in sync with _sanitize_action.
 readonly ACTION_HONOUR="honour"
@@ -356,7 +357,7 @@ discover_and_observe() {
 		local assigned_known=1
 		assigned_json=$(gh issue list --repo "$repo" --state open \
 			--limit 200 --json number,assignees,labels,updatedAt 2>/dev/null) || assigned_known=0
-		if ! printf '%s' "$assigned_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+		if ! printf '%s' "$assigned_json" | jq -e --arg array_type "$_PEER_JSON_ARRAY_TYPE" 'type == $array_type' >/dev/null 2>&1; then
 			assigned_known=0
 			assigned_json='[]'
 		fi
@@ -373,7 +374,7 @@ discover_and_observe() {
 		local pr_known=1
 		pr_json=$(gh pr list --repo "$repo" --state merged --limit 50 \
 			--json author,mergedAt,labels 2>/dev/null) || pr_known=0
-		if ! printf '%s' "$pr_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+		if ! printf '%s' "$pr_json" | jq -e --arg array_type "$_PEER_JSON_ARRAY_TYPE" 'type == $array_type' >/dev/null 2>&1; then
 			pr_known=0
 			pr_json='[]'
 		fi

--- a/.agents/scripts/peer-productivity-monitor.sh
+++ b/.agents/scripts/peer-productivity-monitor.sh
@@ -305,7 +305,7 @@ _aggregate_peer_observations() {
 					}
 				) | to_entries | sort_by(.key) | .[0:100] | from_entries)
 			}
-		)'
+		)' || return 1
 	return 0
 }
 
@@ -332,9 +332,9 @@ discover_and_observe() {
 		}
 	fi
 	# Compute since timestamp
+	[[ "$WINDOW_HOURS" =~ ^[1-9][0-9]*$ ]] || return 1
 	since_iso=$(date -u -v "-${WINDOW_HOURS}H" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
-		date -u -d "${WINDOW_HOURS} hours ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
-		echo "1970-01-01T00:00:00Z")
+		date -u -d "${WINDOW_HOURS} hours ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || return 1
 
 	log_msg INFO "discover_and_observe: self=$self_login window_since=$since_iso"
 
@@ -408,7 +408,7 @@ discover_and_observe() {
 		return 0
 	fi
 
-	printf '%s\n' "${observations[@]}" | _aggregate_peer_observations
+	printf '%s\n' "${observations[@]}" | _aggregate_peer_observations || return 1
 	return 0
 }
 
@@ -625,7 +625,10 @@ cmd_observe() {
 	}
 
 	local observations
-	observations=$(discover_and_observe "$self_login")
+	observations=$(discover_and_observe "$self_login") || {
+		log_msg WARN "peer observation incomplete — preserving peer state and override config"
+		return 0
+	}
 	local count
 	count=$(printf '%s' "$observations" | jq 'length' 2>/dev/null || echo 0)
 

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -1102,12 +1102,9 @@ _cmd_refresh() {
 
 	_log "refresh complete: search_calls=${_OWNER_SEARCH_CALLS} cache_writes=${_OWNER_CACHE_WRITES} errors=${_OWNER_ERRORS} tickle_fresh=${_PULSE_EVENTS_TICKLE_FRESH} tickle_stale=${_PULSE_EVENTS_TICKLE_STALE} conditional_304=${_OWNER_CONDITIONAL_304} conditional_refreshes=${_OWNER_CONDITIONAL_REFRESHES} conditional_misses=${_OWNER_CONDITIONAL_MISSES}"
 
-	# t2902: aggregate gh API call records to JSON report at the end of each
-	# refresh cycle. Fail-open: if gh-api-instrument.sh isn't sourced, the
-	# 2>/dev/null || true silences the unbound function and the host script
-	# keeps working. trim keeps the append-only log under MAX_LINES.
-	gh_aggregate_calls 2>/dev/null || true
-	gh_trim_log 2>/dev/null || true
+	# The completed Pulse cycle owns report/sidecar publication and retention.
+	# A partial prefetch must not overwrite its bounded coverage with a later
+	# cutoff. Standalone diagnostics use gh-api-instrument.sh report instead.
 
 	# Record tickle counters to pulse-stats.json (one timestamp entry per
 	# fresh/stale owner). Fail-open: pulse_stats_increment is sourced from

--- a/.agents/scripts/pulse-dirty-worktree-marker.py
+++ b/.agents/scripts/pulse-dirty-worktree-marker.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 """Evaluate dirty-worktree marker state from a GitHub comments JSON stream."""
 
 from __future__ import annotations
 
 import datetime
 import json
+import math
 import sys
 
 
@@ -21,29 +24,39 @@ def parse_timestamp(value: object) -> float | None:
     if not value:
         return None
     try:
-        return datetime.datetime.fromisoformat(
+        timestamp = datetime.datetime.fromisoformat(
             str(value).replace("Z", "+00:00")
-        ).timestamp()
+        )
+        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+            return None
+        return timestamp.timestamp()
     except ValueError:
         return None
 
 
 def load_comments() -> list[dict[str, object]]:
-    try:
-        value = json.load(sys.stdin)
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return []
-    return value if isinstance(value, list) else []
+    value = json.load(sys.stdin)
+    if not isinstance(value, list):
+        raise ValueError("comments must be an array")
+    # Native --paginate --slurp produces an array of pages. Legacy callers may
+    # still pass a flat page; both require complete, well-formed comment objects.
+    if value and all(isinstance(page, list) for page in value):
+        value = [comment for page in value for comment in page]
+    if not all(isinstance(comment, dict) and "body" in comment
+               and (comment["body"] is None or isinstance(comment["body"], str))
+               for comment in value):
+        raise ValueError("incomplete comments")
+    return value
 
 
 def resolve_now(now_override: str) -> float:
     if not now_override:
         return datetime.datetime.now(datetime.timezone.utc).timestamp()
 
-    try:
-        return float(now_override)
-    except ValueError:
-        return datetime.datetime.now(datetime.timezone.utc).timestamp()
+    value = float(now_override)
+    if not math.isfinite(value) or value < 0:
+        raise ValueError("invalid observation clock")
+    return value
 
 
 def latest_marker_state(
@@ -57,12 +70,17 @@ def latest_marker_state(
         body = str(comment.get("body") or "")
         created = parse_timestamp(comment.get("created_at") or comment.get("createdAt"))
         if created is None:
-            continue
+            raise ValueError("missing comment timestamp")
         if any(token in body for token in RESOLUTION_TOKENS):
-            latest_resolution_ts = created
+            if latest_resolution_ts is None or created > latest_resolution_ts:
+                latest_resolution_ts = created
         elif "WORKER_DIRTY_WORKTREE" in body:
-            latest_marker_ts = created
-            latest_marker_body = body
+            if latest_marker_ts is None or created > latest_marker_ts:
+                latest_marker_ts = created
+                latest_marker_body = body
+            elif created == latest_marker_ts and body != latest_marker_body:
+                # Ambiguous same-second ownership cannot grant runner resume.
+                latest_marker_body = ""
     return latest_marker_ts, latest_resolution_ts, latest_marker_body
 
 
@@ -74,16 +92,31 @@ def extract_runner_key(marker_body: str) -> str:
 
 
 def main() -> int:
-    hold_seconds = int(sys.argv[1])
-    now_override = sys.argv[2] if len(sys.argv) > 2 else ""
-    comments = load_comments()
-    now_epoch = resolve_now(now_override)
-    latest_marker_ts, latest_resolution_ts, latest_marker_body = latest_marker_state(
-        comments
-    )
+    try:
+        since_mode = len(sys.argv) > 1 and sys.argv[1] == "--since"
+        offset = 2 if since_mode else 1
+        hold_seconds = int(sys.argv[offset])
+        if hold_seconds < 0:
+            raise ValueError("negative hold")
+        now_override = sys.argv[offset + 1] if len(sys.argv) > offset + 1 else ""
+        now_epoch = resolve_now(now_override)
+        if since_mode:
+            # Include the integer-age boundary and GitHub's exclusive `since`.
+            cutoff = datetime.datetime.fromtimestamp(
+                now_epoch - hold_seconds - 1, datetime.timezone.utc
+            )
+            print(cutoff.strftime("%Y-%m-%dT%H:%M:%SZ"))
+            return 0
+        latest_marker_ts, latest_resolution_ts, latest_marker_body = latest_marker_state(
+            load_comments()
+        )
+    except (ValueError, TypeError, IndexError, OverflowError, UnicodeDecodeError):
+        print("unknown")
+        return 1
 
     if latest_marker_ts is None or (
-        latest_resolution_ts is not None and latest_resolution_ts >= latest_marker_ts
+        # Equal timestamps do not prove that resolution happened after failure.
+        latest_resolution_ts is not None and latest_resolution_ts > latest_marker_ts
     ):
         print(CLEAR_STATE)
         return 0

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -265,10 +265,12 @@ _verify_issue_conversation_lock() {
 	[[ "$retry_delay" -le 5 ]] || retry_delay=2
 
 	while [[ "$attempt" -le "$attempts" ]]; do
-		locked_state=$(gh api "repos/${slug}/issues/${issue_num}" --jq '.locked == true' 2>/dev/null) || locked_state=""
+		# Retry observed propagation lag, never an unknown transport outcome.
+		locked_state=$(gh api "repos/${slug}/issues/${issue_num}" --jq '.locked' 2>/dev/null) || return 1
 		if [[ "$locked_state" == "true" ]]; then
 			return 0
 		fi
+		[[ "$locked_state" == "false" ]] || return 1
 		if [[ "$attempt" -lt "$attempts" ]]; then
 			sleep "$retry_delay"
 		fi
@@ -291,6 +293,21 @@ lock_issue_for_worker() {
 	local reason="${3:-resolved}"
 
 	[[ -n "$issue_num" && -n "$slug" ]] || return 1
+
+	# Reconciliation frequently revisits an already-locked issue. Use a fresh
+	# REST read, not a marker or a cached discovery snapshot, to avoid repeated
+	# rejected mutations without weakening the launch-time trust boundary.
+	local locked_state=""
+	locked_state=$(gh api "repos/${slug}/issues/${issue_num}" --jq '.locked' 2>/dev/null) || return 1
+	case "$locked_state" in
+	true)
+		_record_auto_dispatch_lock "$issue_num" "$slug" || return 1
+		echo "[pulse-wrapper] Reused existing verified conversation lock for #${issue_num} in ${slug} (GH#30180)" >>"$LOGFILE"
+		return 0
+		;;
+	false) ;;
+	*) return 1 ;;
+	esac
 
 	# aidevops:trust-boundary — never launch a worker when the mutable public
 	# instruction surface could not be frozen and independently re-read.

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -240,6 +240,13 @@ check_dispatch_dedup() {
 	return 1
 }
 
+_read_issue_conversation_lock() {
+	local issue_num="$1"
+	local slug="$2"
+	gh api "repos/${slug}/issues/${issue_num}" --jq '.locked' 2>/dev/null || return 1
+	return 0
+}
+
 #######################################
 # Verify an issue conversation lock after GitHub accepts the lock mutation.
 # The issue REST read can briefly lag the mutation, so retry boundedly while
@@ -266,7 +273,7 @@ _verify_issue_conversation_lock() {
 
 	while [[ "$attempt" -le "$attempts" ]]; do
 		# Retry observed propagation lag, never an unknown transport outcome.
-		locked_state=$(gh api "repos/${slug}/issues/${issue_num}" --jq '.locked' 2>/dev/null) || return 1
+		locked_state=$(_read_issue_conversation_lock "$issue_num" "$slug") || return 1
 		if [[ "$locked_state" == "true" ]]; then
 			return 0
 		fi
@@ -298,7 +305,7 @@ lock_issue_for_worker() {
 	# REST read, not a marker or a cached discovery snapshot, to avoid repeated
 	# rejected mutations without weakening the launch-time trust boundary.
 	local locked_state=""
-	locked_state=$(gh api "repos/${slug}/issues/${issue_num}" --jq '.locked' 2>/dev/null) || return 1
+	locked_state=$(_read_issue_conversation_lock "$issue_num" "$slug") || return 1
 	case "$locked_state" in
 	true)
 		_record_auto_dispatch_lock "$issue_num" "$slug" || return 1

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -388,29 +388,37 @@ _dispatch_candidate_benign_block_reason() {
 #   $1 - issue number
 #   $2 - repo slug
 # Returns:
-#   0 - recent unresolved dirty-worktree marker exists
-#   1 - no active marker, expired marker, disabled, or API unavailable
+#   0 - recent unresolved marker, or evidence unavailable (conservative hold)
+#   1 - verified no active marker, expired marker, or disabled
 #######################################
 _dispatch_recent_dirty_worktree_marker_active() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local hold_seconds="${DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS:-900}"
-	_DISPATCH_DIRTY_MARKER_STATE="clear"
+	_DISPATCH_DIRTY_MARKER_STATE="unknown"
 
 	[[ "$hold_seconds" =~ ^[0-9]+$ ]] || hold_seconds="900"
-	[[ "$hold_seconds" -gt 0 ]] || return 1
+	if [[ "$hold_seconds" -eq 0 ]]; then
+		_DISPATCH_DIRTY_MARKER_STATE="clear"
+		return 1
+	fi
 
-	local comments_json=""
-	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" 2>/dev/null) || return 1
-	[[ -n "$comments_json" ]] || return 1
+	local comments_json="" since_iso="" now_epoch="${AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH:-}"
+	[[ -n "$now_epoch" ]] || now_epoch=$(date +%s) || return 0
+	since_iso=$(python3 "${_PULSE_DISPATCH_LIB_DIR}/pulse-dirty-worktree-marker.py" \
+		--since "$hold_seconds" "$now_epoch") || return 0
+	# Only comments updated within the hold window can contain an active marker
+	# or a later resolution. Still paginate: a busy thread can exceed one page.
+	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100&since=${since_iso}" \
+		--paginate --slurp 2>/dev/null) || return 0
 
 	local marker_state=""
 	marker_state=$(printf '%s' "$comments_json" | \
 		python3 "${_PULSE_DISPATCH_LIB_DIR}/pulse-dirty-worktree-marker.py" \
-			"$hold_seconds" "${AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH:-}") || marker_state=""
-	_DISPATCH_DIRTY_MARKER_STATE="${marker_state:-clear}"
+			"$hold_seconds" "$now_epoch") || return 0
+	_DISPATCH_DIRTY_MARKER_STATE="$marker_state"
 
-	[[ "$marker_state" == block:* ]] || return 1
+	case "$marker_state" in clear|expired:*) return 1 ;; esac
 	return 0
 }
 

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -127,7 +127,7 @@ _read_cache_issues_for_slug() {
 	fi
 	now_epoch=$(date +%s)
 	age_secs=$((now_epoch - last_epoch))
-	[[ "$age_secs" -lt 600 ]] || return 1  # Stale if > 10 minutes
+	[[ "$age_secs" -ge 0 && "$age_secs" -lt 600 ]] || return 1  # Future-dated or stale snapshots miss.
 
 	# Read issues array for this slug
 	local issues
@@ -187,11 +187,11 @@ _gh_pr_list_merged() {
 # This collapses what was previously two gh API calls per issue (search +
 # pr view --json body) into the single per-repo prefetch.
 #
-# Limit 200 most-recent closed PRs per repo, then filter to mergedAt locally.
-# GH#22802: REST fallback cannot represent gh's synthetic --state merged; it
-# can return closed-but-unmerged/open-adjacent data. Requiring mergedAt in the
-# jq filter fails closed and prevents the reconciler from closing issues while
-# their linked PR is still open or merely closed-unmerged.
+# Limit 200 merged PRs per repo. Both native gh and the current REST adapter
+# distinguish merged from closed-but-unmerged. Asking for closed here makes
+# the REST adapter scan until it finds 200 UNMERGED PRs, only to discard every
+# result below. Keep the mergedAt guard too: incomplete/malformed data must
+# never authorise closing an issue whose PR is open or closed-unmerged.
 #
 # Args:    $1 = slug (owner/repo)
 # Returns: prints lookup string on stdout (may be empty); exit 0 always.
@@ -204,7 +204,7 @@ _build_oimp_lookup_for_slug() {
 	# --json body costs more bytes per call but the trip count goes from
 	# ~200/cycle to 8/cycle — net ~30x reduction in API round-trips.
 	local merged_prs_json
-	merged_prs_json=$(_gh_pr_list_merged --repo "$slug" --state closed \
+	merged_prs_json=$(_gh_pr_list_merged --repo "$slug" --state merged \
 		--json number,body,mergedAt --limit 200 2>/dev/null) || merged_prs_json="[]"
 	[[ -n "$merged_prs_json" && "$merged_prs_json" != "null" ]] || return 0
 

--- a/.agents/scripts/pulse-merge-dirty-queue.py
+++ b/.agents/scripts/pulse-merge-dirty-queue.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Bounded local PR wake hints and leases; never a cache of merge authority."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+import uuid
+from pathlib import Path
+
+from gh_transport_budget import private_directory, process_birth
+
+
+MAX_HINTS = 4096
+RETENTION_SECONDS = 604800
+
+
+def target(repo: str, pr: str) -> tuple[str, int]:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9_.-]+", repo):
+        raise ValueError("invalid repository")
+    if repo.split("/")[1] in {".", ".."} or not pr.isdecimal() or not 0 < int(pr) <= 2147483647:
+        raise ValueError("invalid PR")
+    return repo.lower(), int(pr)
+
+
+def alive(pid: int, birth: str) -> bool:
+    if pid <= 0:
+        return True  # Corrupt ownership is not permission for a second actor.
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    current = process_birth(pid)
+    return not birth or not current or current == birth
+
+
+class Queue:
+    def __init__(self, directory: Path):
+        private_directory(directory)
+        path = directory / "work.sqlite3"
+        fd = os.open(path, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+        os.close(fd)
+        if path.stat().st_uid != os.getuid():
+            raise ValueError("foreign queue owner")
+        path.chmod(0o600)
+        self.db = sqlite3.connect(path, timeout=2, isolation_level=None)
+        self.db.row_factory = sqlite3.Row
+        self.db.execute("""CREATE TABLE IF NOT EXISTS work (
+            repo TEXT NOT NULL, pr INTEGER NOT NULL, generation TEXT NOT NULL,
+            updated REAL NOT NULL, wake_until REAL NOT NULL DEFAULT 0,
+            nonce TEXT NOT NULL DEFAULT '', pid INTEGER NOT NULL DEFAULT 0,
+            birth TEXT NOT NULL DEFAULT '', PRIMARY KEY(repo,pr))""")
+
+    def row(self, repo: str, pr: int):
+        row = self.db.execute("SELECT * FROM work WHERE repo=? AND pr=?", (repo, pr)).fetchone()
+        if row and row["nonce"] and not alive(row["pid"], row["birth"]):
+            self.db.execute("UPDATE work SET nonce='',pid=0,birth='',wake_until=0 WHERE repo=? AND pr=?", (repo, pr))
+            return self.db.execute("SELECT * FROM work WHERE repo=? AND pr=?", (repo, pr)).fetchone()
+        return row
+
+    def capacity(self, now: float) -> None:
+        # Expiry removes hints, not GitHub work. Polling remains authoritative.
+        self.db.execute("DELETE FROM work WHERE nonce='' AND updated<?", (now - RETENTION_SECONDS,))
+        if self.db.execute("SELECT count(*) FROM work").fetchone()[0] >= MAX_HINTS:
+            raise ValueError("queue capacity reached; polling recovery required")
+
+    def enqueue(self, repo: str, pr: int, now: float) -> str:
+        repo = repo.lower()
+        row = self.row(repo, pr)
+        if not row:
+            self.capacity(now)
+            self.db.execute("INSERT INTO work(repo,pr,generation,updated) VALUES(?,?,?,?)",
+                            (repo, pr, "", now))
+        wake = not row or (not row["nonce"] and row["wake_until"] <= now)
+        self.db.execute("UPDATE work SET generation=?,updated=?,wake_until=? WHERE repo=? AND pr=?",
+                        (uuid.uuid4().hex, now, now + 30 if wake else (row["wake_until"] if row else 0), repo, pr))
+        return "wake" if wake else "coalesced"
+
+    def claim(self, repo: str, pr: int, pid: int, now: float) -> dict | None:
+        repo = repo.lower()
+        row = self.row(repo, pr)
+        if row and row["nonce"]:
+            return None
+        birth = process_birth(pid)
+        if not birth or not alive(pid, birth):
+            raise ValueError("claim owner unavailable")
+        if not row:
+            self.capacity(now)
+            self.db.execute("INSERT INTO work(repo,pr,generation,updated) VALUES(?,?,?,?)",
+                            (repo, pr, "", now))
+        nonce = uuid.uuid4().hex
+        self.db.execute("UPDATE work SET nonce=?,pid=?,birth=?,wake_until=0 WHERE repo=? AND pr=?",
+                        (nonce, pid, birth, repo, pr))
+        return {"repo": repo, "pr": pr, "generation": row["generation"] if row else "",
+                "nonce": nonce, "pid": pid, "birth": birth}
+
+    def finish(self, receipt: dict, handled: bool) -> None:
+        repo, pr = target(receipt["repo"], str(receipt["pr"]))
+        row = self.row(repo, pr)
+        if not row or row["nonce"] != receipt["nonce"] or row["pid"] != receipt["pid"] or row["birth"] != receipt["birth"]:
+            raise ValueError("queue lease ownership changed")
+        same_generation = row["generation"] == receipt["generation"]
+        if same_generation and (handled or not row["generation"]):
+            self.db.execute("DELETE FROM work WHERE repo=? AND pr=?", (repo, pr))
+        else:
+            # New events during processing ALWAYS survive the old completion.
+            self.db.execute("UPDATE work SET nonce='',pid=0,birth='' WHERE repo=? AND pr=?", (repo, pr))
+
+    def priority(self, repo: str, now: float) -> str:
+        rows = self.db.execute("SELECT pr FROM work WHERE repo=? AND generation!='' AND updated>=? ORDER BY updated DESC LIMIT ?",
+                               (repo.lower(), now - RETENTION_SECONDS, MAX_HINTS)).fetchall()
+        return "|" + "|".join(str(row[0]) for row in rows) + "|" if rows else ""
+
+
+def main(args: list[str]) -> int:
+    directory = Path(os.environ.get("AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_DIR",
+                                    str(Path.home() / ".aidevops/state/pulse-merge-dirty")))
+    queue = None
+    try:
+        command = args[0]
+        if command == "priority" and not (directory / "work.sqlite3").exists():
+            print("")
+            return 0
+        queue = Queue(directory)
+        queue.db.execute("BEGIN IMMEDIATE")
+        now = time.time()
+        output = None
+        if command == "enqueue" and len(args) == 3:
+            output = queue.enqueue(*target(args[1], args[2]), now)
+        elif command == "claim" and len(args) == 4:
+            receipt = queue.claim(*target(args[1], args[2]), int(args[3]), now)
+            if receipt is None:
+                queue.db.execute("ROLLBACK")
+                return 75
+            output = json.dumps(receipt, separators=(",", ":"))
+        elif command == "finish" and len(args) == 3:
+            if args[2] not in {"0", "1"}:
+                raise ValueError("invalid handled flag")
+            queue.finish(json.loads(args[1]), args[2] == "1")
+        elif command == "priority" and len(args) == 2:
+            output = queue.priority(args[1], now)
+        else:
+            raise ValueError("invalid queue command")
+        queue.db.execute("COMMIT")
+        if output is not None:
+            print(output)
+        return 0
+    except (OSError, ValueError, TypeError, KeyError, IndexError, sqlite3.Error):
+        if queue is not None and queue.db.in_transaction:
+            queue.db.execute("ROLLBACK")
+        print("pulse merge queue unavailable; retain polling recovery", file=sys.stderr)
+        return 2
+    finally:
+        if queue is not None:
+            queue.db.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.agents/scripts/pulse-merge-dirty-queue.sh
+++ b/.agents/scripts/pulse-merge-dirty-queue.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# Local wake hints, not merge evidence. Polling and every action gate remain.
+
+[[ -n "${_PULSE_MERGE_DIRTY_QUEUE_LOADED:-}" ]] && return 0
+_PULSE_MERGE_DIRTY_QUEUE_LOADED=1
+_PULSE_MERGE_DIRTY_HELPER="${BASH_SOURCE[0]%/*}/pulse-merge-dirty-queue.py"
+
+_pulse_merge_queue_enabled() {
+	# Runtime entrypoints opt in; sourcing merge helpers alone stays side-effect
+	# free. Explicit zero is the rollback switch and is preserved by entrypoints.
+	[[ "${AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED:-0}" == 1 && "${DRY_RUN:-0}" != 1 ]] || return 1
+	[[ -f "$_PULSE_MERGE_DIRTY_HELPER" ]] && command -v python3 >/dev/null 2>&1 || return 1
+	return 0
+}
+
+_pulse_merge_queue_present() {
+	[[ -s "${AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_DIR:-${HOME}/.aidevops/state/pulse-merge-dirty}/work.sqlite3" ]] || return 1
+	return 0
+}
+
+_pulse_merge_queue_enqueue() {
+	local repo="$1" pr="$2"
+	if [[ "${AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED:-0}" != 1 || "${DRY_RUN:-0}" == 1 ]]; then
+		printf 'legacy\n'
+		return 0
+	fi
+	_pulse_merge_queue_enabled || return 1
+	python3 "$_PULSE_MERGE_DIRTY_HELPER" enqueue "$repo" "$pr"
+	return $?
+}
+
+# Outputs are caller-local dynamic-scope variables. Context is deliberately not
+# exported, and a borrowed claim must match the current Bash process and target.
+_pulse_merge_queue_begin() {
+	local repo="$1" pr="$2" mode="$3" borrowed="${4:-}"
+	_PULSE_MERGE_QUEUE_CONTEXT=""
+	_PULSE_MERGE_QUEUE_OWNED=0
+	_PULSE_MERGE_QUEUE_DIRTY=0
+	if [[ "${AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED:-0}" != 1 || "${DRY_RUN:-0}" == 1 ]]; then
+		return 0
+	fi
+	if ! _pulse_merge_queue_enabled; then
+		[[ "$mode" == poll ]] && return 0
+		return 4
+	fi
+	if [[ "$mode" == poll ]] && ! _pulse_merge_queue_present; then
+		return 0
+	fi
+	repo=$(printf '%s' "$repo" | LC_ALL=C tr '[:upper:]' '[:lower:]') || return 4
+	local owner_pid="${BASHPID:-}"
+	[[ -n "$owner_pid" ]] || owner_pid=$(exec sh -c 'printf "%s" "$PPID"') || return 4
+	if [[ -n "$borrowed" ]] && printf '%s' "$borrowed" | jq -e \
+		--arg repo "$repo" --argjson pr "$pr" --argjson pid "$owner_pid" \
+		'.repo == $repo and .pr == $pr and .pid == $pid and (.nonce | test("^[a-f0-9]{32}$"))' >/dev/null 2>&1; then
+		_PULSE_MERGE_QUEUE_CONTEXT="$borrowed"
+	else
+		local receipt="" rc=0
+		receipt=$(python3 "$_PULSE_MERGE_DIRTY_HELPER" claim "$repo" "$pr" "$owner_pid" 2>/dev/null) || rc=$?
+		[[ "$rc" -ne 75 ]] || return 4
+		if [[ "$rc" -ne 0 ]]; then
+			# A failed optimization cannot disable the authoritative polling path.
+			# Event fast paths, however, may not proceed without coordination.
+			[[ "$mode" == poll ]] && return 0
+			return 4
+		fi
+		if ! printf '%s' "$receipt" | jq -e --arg repo "$repo" --argjson pr "$pr" --argjson pid "$owner_pid" \
+			'.repo == $repo and .pr == $pr and .pid == $pid and (.nonce | test("^[a-f0-9]{32}$"))' >/dev/null 2>&1; then
+			return 4
+		fi
+		_PULSE_MERGE_QUEUE_CONTEXT="$receipt"
+		_PULSE_MERGE_QUEUE_OWNED=1
+	fi
+	if printf '%s' "$_PULSE_MERGE_QUEUE_CONTEXT" | jq -e '.generation | length > 0' >/dev/null 2>&1; then
+		_PULSE_MERGE_QUEUE_DIRTY=1
+	fi
+	return 0
+}
+
+_pulse_merge_queue_begin_object() {
+	local repo="$1" object="$2" borrowed="${3:-}"
+	_PULSE_MERGE_QUEUE_CONTEXT=""
+	_PULSE_MERGE_QUEUE_OWNED=0
+	_PULSE_MERGE_QUEUE_DIRTY=0
+	# Unconfigured receivers add no subprocesses to ordinary polling.
+	_pulse_merge_queue_enabled && _pulse_merge_queue_present || return 0
+	local pr=""
+	pr=$(printf '%s' "$object" | jq -r '.number // empty' 2>/dev/null) || return 4
+	[[ "$pr" =~ ^[1-9][0-9]*$ ]] || return 4
+	_pulse_merge_queue_begin "$repo" "$pr" poll "$borrowed"
+	return $?
+}
+
+_pulse_merge_queue_refresh_object() {
+	local repo="$1" output_var="$2"
+	[[ "$output_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	local pr="" refreshed=""
+	pr=$(printf '%s' "$_PULSE_MERGE_QUEUE_CONTEXT" | jq -r '.pr') || return 1
+	refreshed=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 AIDEVOPS_GH_REST_FIRST_READS=1 \
+		gh_pr_view "$pr" --repo "$repo" --json "$(_pulse_merge_ready_pr_json_fields)" 2>/dev/null) || return 1
+	printf '%s' "$refreshed" | jq -e --argjson pr "$pr" 'type == "object" and .number == $pr' >/dev/null || return 1
+	printf -v "$output_var" '%s' "$refreshed"
+	return 0
+}
+
+_pulse_merge_queue_finish() {
+	local result="$1" handled=0
+	[[ "${_PULSE_MERGE_QUEUE_OWNED:-0}" == 1 && -n "${_PULSE_MERGE_QUEUE_CONTEXT:-}" ]] || return 0
+	case "$result" in 0 | 2) handled=1 ;; esac
+	python3 "$_PULSE_MERGE_DIRTY_HELPER" finish "$_PULSE_MERGE_QUEUE_CONTEXT" "$handled" >/dev/null 2>&1 || true
+	_PULSE_MERGE_QUEUE_OWNED=0
+	return 0
+}
+
+_pulse_merge_queue_priority_keys() {
+	local repo="$1"
+	_pulse_merge_queue_enabled && _pulse_merge_queue_present || return 0
+	python3 "$_PULSE_MERGE_DIRTY_HELPER" priority "$repo" 2>/dev/null || true
+	return 0
+}
+
+return 0

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -343,17 +343,25 @@ _pmp_sort_prs_by_backlog_priority() {
 
 	local _tmp_lines=""
 	_tmp_lines=$(mktemp)
+	local dirty_keys=""
+	if declare -F _pulse_merge_queue_priority_keys >/dev/null 2>&1; then
+		dirty_keys=$(_pulse_merge_queue_priority_keys "$repo_slug")
+	fi
 	local i=0
 	while [[ "$i" -lt "$pr_count" ]]; do
-		local pr_obj="" category="" priority=""
+		local pr_obj="" category="" priority="" dirty_priority=1 pr_number=""
 		pr_obj=$(printf '%s' "$pr_json" | jq -c ".[$i]" 2>/dev/null)
 		category=$(_pmp_classify_pr_backlog_state "$pr_obj" "$repo_slug")
 		priority=$(_pmp_backlog_priority "$category")
-		printf '%03d\t%06d\t%s\n' "$priority" "$i" "$pr_obj" >>"$_tmp_lines"
+		if [[ -n "$dirty_keys" ]]; then
+			pr_number=$(printf '%s' "$pr_obj" | jq -r '.number // empty')
+			[[ "$pr_number" =~ ^[1-9][0-9]*$ && "$dirty_keys" == *"|${pr_number}|"* ]] && dirty_priority=0
+		fi
+		printf '%03d\t%d\t%06d\t%s\n' "$priority" "$dirty_priority" "$i" "$pr_obj" >>"$_tmp_lines"
 		i=$((i + 1))
 	done
 
-	LC_ALL=C sort "$_tmp_lines" | cut -f3- | jq -s '.'
+	LC_ALL=C sort "$_tmp_lines" | cut -f4- | jq -s '.'
 	rm -f "$_tmp_lines"
 	return 0
 }

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -41,6 +41,9 @@
 
 set -euo pipefail
 
+: "${AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED:=1}"
+export AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED
+
 # PATH normalisation for launchd/cron environments where PATH is minimal.
 _aidevops_path_prefix="/opt/homebrew/bin:/usr/local/bin:/bin:/usr/bin"
 if [[ "$(uname -s 2>/dev/null || true)" != "Darwin" && -d "/home/linuxbrew/.linuxbrew/bin" ]]; then

--- a/.agents/scripts/pulse-merge-webhook-receiver.sh
+++ b/.agents/scripts/pulse-merge-webhook-receiver.sh
@@ -56,6 +56,9 @@ fi
 AIDEVOPS_AGENTS_DIR="${SCRIPT_DIR%/scripts}"
 AGENTS_DIR="$AIDEVOPS_AGENTS_DIR"
 export AIDEVOPS_AGENTS_DIR AGENTS_DIR
+export PATH="${SCRIPT_DIR}:${PATH}"
+: "${AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED:=1}"
+export AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED
 
 # =============================================================================
 # Config + secret loading
@@ -237,6 +240,35 @@ _webhook_wait_for_dispatch_slot() {
 	return 0
 }
 
+_webhook_schedule_pr() {
+	local slug="$1" pr_number="$2" queue_action="legacy"
+	if declare -F _pulse_merge_queue_enqueue >/dev/null 2>&1; then
+		queue_action=$(_pulse_merge_queue_enqueue "$slug" "$pr_number" 2>>"$WEBHOOK_LOG_FILE") || {
+			_webhook_record_missed_recovery
+			_whlog WARN "Could not persist PR wake; retaining polling recovery"
+			return 0
+		}
+	fi
+	case "$queue_action" in
+	coalesced) return 0 ;;
+	wake|legacy) ;;
+	*)
+		_webhook_record_missed_recovery
+		_whlog WARN "Unrecognized queue receipt; retaining polling recovery"
+		return 0
+		;;
+	esac
+	_whlog INFO "Dispatching process_pr ${slug}#${pr_number}"
+	(
+		set +e
+		[[ "$queue_action" != wake ]] || sleep 2
+		process_pr "$slug" "$pr_number"
+		_whlog INFO "process_pr ${slug}#${pr_number} returned ${?}"
+	) &
+	_webhook_wait_for_dispatch_slot
+	return 0
+}
+
 _dispatch_webhook_action_line() {
 	local line="$1"
 	local verb="" version="" scope="" first="" second="" extra=""
@@ -266,7 +298,7 @@ _dispatch_webhook_action_line() {
 		return 0
 		;;
 	"INVALIDATE v1 collection")
-		_WEBHOOK_INVALIDATION_FAILED=0
+		# A later success must not erase an earlier failure in this delivery.
 		if [[ -n "$extra" ]]; then
 			_WEBHOOK_INVALIDATION_FAILED=1
 			_whlog ERROR "Rejected malformed collection invalidation record"
@@ -280,7 +312,7 @@ _dispatch_webhook_action_line() {
 		return 0
 		;;
 	"INVALIDATE v1 checks")
-		_WEBHOOK_INVALIDATION_FAILED=0
+		# Reset only at the accepted-delivery boundary, never between records.
 		if [[ -n "$extra" ]]; then
 			_WEBHOOK_INVALIDATION_FAILED=1
 			_whlog ERROR "Rejected malformed check invalidation record"
@@ -307,13 +339,7 @@ _dispatch_webhook_action_line() {
 			_whlog WARN "Skipped process_pr because canonical invalidation failed; polling remains active"
 			return 0
 		fi
-		_whlog INFO "Dispatching process_pr ${slug}#${pr_number}"
-		(
-			set +e
-			process_pr "$slug" "$pr_number"
-			_whlog INFO "process_pr ${slug}#${pr_number} returned ${?}"
-		) &
-		_webhook_wait_for_dispatch_slot
+		_webhook_schedule_pr "$slug" "$pr_number"
 		return 0
 	fi
 	if [[ "$verb" == "INVALIDATE" || "$verb" == "DELIVERY" ]]; then

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -94,6 +94,11 @@ PULSE_REVIEW_GATE_MODE_CI_REPAIR_ONLY="ci-repair-only"
 : "${PULSE_MERGE_BATCH_LIMIT:=50}"
 : "${PULSE_MERGE_CLOSE_CONFLICTING:=true}"
 
+if [[ -f "${BASH_SOURCE[0]%/*}/pulse-merge-dirty-queue.sh" ]]; then
+	# shellcheck source=./pulse-merge-dirty-queue.sh
+	source "${BASH_SOURCE[0]%/*}/pulse-merge-dirty-queue.sh"
+fi
+
 # Comma-delimited label pattern constant — avoids matching "origin:worker-takeover"
 # when checking for "origin:worker" in comma-joined label strings. (t2449)
 _OW_LABEL_PAT=",origin:worker,"
@@ -1740,6 +1745,14 @@ _pmp_stage_finalize_merge() {
 
 _process_single_ready_pr() {
 	local repo_slug="$1" pr_obj="$2" timing_prefix="${3:-}" stage_rc=0
+	local queue_parent_context="${_PULSE_MERGE_QUEUE_CONTEXT:-}"
+	local _PULSE_MERGE_QUEUE_CONTEXT="" _PULSE_MERGE_QUEUE_OWNED=0 _PULSE_MERGE_QUEUE_DIRTY=0
+	if declare -F _pulse_merge_queue_begin_object >/dev/null 2>&1; then
+		_pulse_merge_queue_begin_object "$repo_slug" "$pr_obj" "$queue_parent_context" || return 4
+		if [[ "$_PULSE_MERGE_QUEUE_DIRTY" -eq 1 && "${4:-0}" != 1 ]]; then
+			_pulse_merge_queue_refresh_object "$repo_slug" pr_obj || { _pulse_merge_queue_finish 1; return 1; }
+		fi
+	fi
 	local pr_number="" pr_state="" pr_mergeable="" pr_review="" pr_author="" pr_title="" pr_updated_at=""
 	local pr_head_ref_oid="" pr_head_ref_name="" pr_base_ref_name="" pr_labels="" pr_is_draft="false"
 	local _mergeability_start="" _branch_protection_start="" _ruleset_start=""
@@ -1753,10 +1766,15 @@ _process_single_ready_pr() {
 		_pmp_stage_admin_merge _pmp_stage_ruleset_fallback; do
 		stage_rc=0
 		"$stage" || stage_rc=$?
-		[[ "$stage_rc" -eq 10 ]] || return "$stage_rc"
+		if [[ "$stage_rc" -ne 10 ]]; then
+			declare -F _pulse_merge_queue_finish >/dev/null 2>&1 && _pulse_merge_queue_finish "$stage_rc"
+			return "$stage_rc"
+		fi
 	done
-	_pmp_stage_finalize_merge
-	return $?
+	stage_rc=0
+	_pmp_stage_finalize_merge || stage_rc=$?
+	declare -F _pulse_merge_queue_finish >/dev/null 2>&1 && _pulse_merge_queue_finish "$stage_rc"
+	return "$stage_rc"
 }
 
 #######################################
@@ -1794,16 +1812,23 @@ process_pr() {
 		return 1
 	fi
 
+	local queue_parent_context="${_PULSE_MERGE_QUEUE_CONTEXT:-}"
+	local _PULSE_MERGE_QUEUE_CONTEXT="" _PULSE_MERGE_QUEUE_OWNED=0 _PULSE_MERGE_QUEUE_DIRTY=0
+	if declare -F _pulse_merge_queue_begin >/dev/null 2>&1; then
+		_pulse_merge_queue_begin "$repo_slug" "$pr_number" event "$queue_parent_context" || return 4
+	fi
+
 	# Fetch the PR JSON in the same shape _merge_ready_prs_for_repo uses and
 	# synthesize a single-PR object. _process_single_ready_pr expects a compact
 	# JSON object with metadata used by draft, label, stale, and repair-routing
 	# gates.
 	local pr_obj
-	pr_obj=$(AIDEVOPS_GH_REST_FIRST_READS=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
+	pr_obj=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 AIDEVOPS_GH_REST_FIRST_READS=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json "$(_pulse_merge_ready_pr_json_fields)" 2>/dev/null) || pr_obj=""
 
 	if [[ -z "$pr_obj" || "$pr_obj" == "null" ]]; then
 		echo "[pulse-merge] process_pr: gh pr view failed for ${repo_slug}#${pr_number}" >>"$LOGFILE"
+		declare -F _pulse_merge_queue_finish >/dev/null 2>&1 && _pulse_merge_queue_finish 1
 		return 1
 	fi
 
@@ -1813,12 +1838,17 @@ process_pr() {
 	_pmp_normalize_pr_lifecycle_state_into pr_state "$pr_state"
 	if [[ "$pr_state" != "OPEN" ]]; then
 		echo "[pulse-merge] process_pr: PR ${repo_slug}#${pr_number} is not OPEN (state=${pr_state}) — skipping" >>"$LOGFILE"
+		local queue_result=1
+		case "$pr_state" in CLOSED|MERGED) queue_result=2 ;; esac
+		declare -F _pulse_merge_queue_finish >/dev/null 2>&1 && _pulse_merge_queue_finish "$queue_result"
 		return 1
 	fi
 
 	echo "[pulse-merge] process_pr: webhook-triggered merge attempt for ${repo_slug}#${pr_number} (t3038)" >>"$LOGFILE"
-	_process_single_ready_pr "$repo_slug" "$pr_obj"
-	return $?
+	local process_result=0
+	_process_single_ready_pr "$repo_slug" "$pr_obj" "" 1 || process_result=$?
+	declare -F _pulse_merge_queue_finish >/dev/null 2>&1 && _pulse_merge_queue_finish "$process_result"
+	return "$process_result"
 }
 
 #######################################

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -71,6 +71,9 @@ fi
 
 set -euo pipefail
 
+: "${AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED:=1}"
+export AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED
+
 _pulse_wrapper_deployed_scripts_dir() {
 	local agents_dir="${AIDEVOPS_AGENTS_DIR:-}"
 	local home_dir="${HOME:-}"

--- a/.agents/scripts/shared-gh-secondary-cooldown.sh
+++ b/.agents/scripts/shared-gh-secondary-cooldown.sh
@@ -804,6 +804,9 @@ _gh_secondary_cooldown_header_expires_at() {
 
 _gh_secondary_cooldown_rest_reset_at() {
 	local endpoint_arg="${1:-}"
+	# The native transport boundary already owns response headers. Do not
+	# recursively query a projection while recording a stopped transport.
+	[[ "${AIDEVOPS_GH_COOLDOWN_NO_PROBE:-0}" != 1 ]] || return 1
 	local endpoint_family=""
 	local resource_key="core"
 	local reset_at=""

--- a/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh
@@ -29,6 +29,29 @@ _rest_pr_list_requires_search() {
 	return 1
 }
 
+_rest_pr_list_prefers_native_filter() {
+	local state="open" arg=""
+	_rest_pr_list_requires_search "$@" && return 1
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		shift
+		case "$arg" in
+		--state|-s) [[ $# -gt 0 ]] || return 1; state="$1"; shift ;;
+		--state=*) state="${arg#--state=}" ;;
+		--repo|-R|--json|--jq|-q|--head|-H|--base|-B|--limit|-L)
+			[[ $# -gt 0 ]] || return 1
+			shift
+			;;
+		esac
+	done
+	# REST /pulls?state=closed includes merged PRs. Filtering them locally can
+	# walk the entire merged history just to establish there are no unmerged PRs.
+	# Native GraphQL applies CLOSED server-side. Keep REST as a quota fallback,
+	# not the preferred healthy-budget route for this low-selectivity query.
+	[[ "$state" == closed ]] || return 1
+	return 0
+}
+
 _rest_resolve_actor_filter() {
 	local actor="$1"
 	if [[ "$actor" == "@me" ]]; then

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -993,9 +993,11 @@ gh_issue_view() {
 #######################################
 gh_pr_list() {
 	local _rest_capable=0
+	local _prefer_native_filter=0
 	local _uses_search=0
 	local _pool="rest-core"
 	_rest_pr_list_can_preserve_args "$@" && _rest_capable=1
+	_rest_pr_list_prefers_native_filter "$@" && _prefer_native_filter=1
 	if _rest_pr_list_requires_search "$@"; then
 		_uses_search=1
 		_pool="rest-search"
@@ -1007,7 +1009,7 @@ gh_pr_list() {
 		return 0
 	fi
 	local _out="" _rc=0
-	if [[ $_rest_capable -eq 1 ]] && _rest_read_first_enabled; then
+	if [[ $_rest_capable -eq 1 && $_prefer_native_filter -eq 0 ]] && _rest_read_first_enabled; then
 		if [[ $_uses_search -eq 1 ]]; then
 			print_info "[INFO] gh-wrapper: REST-first read mode, routing search-filtered pr list to /search/issues"
 		else
@@ -1021,7 +1023,7 @@ gh_pr_list() {
 		fi
 		return $_rc
 	fi
-	if [[ $_rest_capable -eq 1 ]] && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest "$_pool" gh_pr_list; } || _rest_should_fallback; }; then
+	if [[ $_rest_capable -eq 1 ]] && { { [[ $_prefer_native_filter -eq 0 ]] && command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest "$_pool" gh_pr_list; } || _rest_should_fallback; }; then
 		if [[ $_uses_search -eq 1 ]]; then
 			print_info "[INFO] gh-wrapper: GraphQL budget low, routing search-filtered pr list to /search/issues"
 		else

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -476,6 +476,8 @@ _gh_with_timeout() {
 			return "$preflight_rc"
 		fi
 	fi
+	local AIDEVOPS_GH_WRAPPER_PREFLIGHT=1
+	export AIDEVOPS_GH_WRAPPER_PREFLIGHT
 	local secs
 	case "$op_class" in
 	read) secs="${AIDEVOPS_GH_READ_TIMEOUT:-15}" ;;

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -419,7 +419,7 @@ _gh_timeout_path_from_args() {
 	case "${command_name}:${subcommand}:${endpoint}" in
 	gh:api:graphql) printf 'graphql\n' ;;
 	gh:api:*) printf 'rest\n' ;;
-	gh:search:*) printf 'search-graphql\n' ;;
+	gh:search:*) printf 'search-rest\n' ;;
 	gh:*:*) printf 'graphql\n' ;;
 	*) printf 'other\n' ;;
 	esac
@@ -456,6 +456,18 @@ _gh_timeout_logical_id() {
 	return 0
 }
 
+_gh_timeout_cooldown_preflight() {
+	local op_class="$1" started="$2" caller="$3" path="$4"
+	local rc=0
+	if command -v _gh_secondary_cooldown_preflight >/dev/null 2>&1; then
+		_gh_secondary_cooldown_preflight "$op_class" || rc=$?
+	fi
+	if [[ "$rc" -ne 0 ]]; then
+		_gh_record_timeout_if_needed "$rc" "$started" "$caller" "$path" "$op_class"
+	fi
+	return "$rc"
+}
+
 _gh_with_timeout() {
 	local op_class="${1:-read}"
 	shift
@@ -468,14 +480,7 @@ _gh_with_timeout() {
 		timeout_start_ms=$(_gh_now_ms) || timeout_start_ms=""
 	fi
 	_gh_cooldown_context_from_args "$op_class" "$@"
-	if command -v _gh_secondary_cooldown_preflight >/dev/null 2>&1; then
-		local preflight_rc=0
-		_gh_secondary_cooldown_preflight "$op_class" || preflight_rc=$?
-		if [[ "$preflight_rc" -ne 0 ]]; then
-			_gh_record_timeout_if_needed "$preflight_rc" "$timeout_start_ms" "$timeout_caller" "$timeout_path" "$op_class"
-			return "$preflight_rc"
-		fi
-	fi
+	_gh_timeout_cooldown_preflight "$op_class" "$timeout_start_ms" "$timeout_caller" "$timeout_path" || return $?
 	local AIDEVOPS_GH_WRAPPER_PREFLIGHT=1
 	export AIDEVOPS_GH_WRAPPER_PREFLIGHT
 	local secs

--- a/.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh
+++ b/.agents/scripts/tests/test-auto-dispatch-conversation-lock.sh
@@ -80,9 +80,10 @@ export -f gh gh_pr_list
 source "${SCRIPTS_DIR}/pulse-dispatch-core.sh"
 
 reset_gh_calls
+GH_LOCKED=false,true
 if lock_issue_for_worker 41 owner/repo &&
 	grep -q -- 'issue lock 41 --repo owner/repo --reason resolved' "$GH_CALLS" &&
-	grep -q -- 'api repos/owner/repo/issues/41 --jq .locked == true' "$GH_CALLS" &&
+	[[ "$(grep -c -- 'api repos/owner/repo/issues/41 --jq .locked' "$GH_CALLS")" -eq 2 ]] &&
 	[[ -f "${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-41" ]]; then
 	pass "strict lock succeeds only after independent verification"
 else
@@ -90,9 +91,9 @@ else
 fi
 
 reset_gh_calls
-GH_LOCKED=false,false,false
+GH_LOCKED=false
 if ! lock_issue_for_worker 42 owner/repo &&
-	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 3 ]] &&
+	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 4 ]] &&
 	grep -q -- 'dispatch remains blocked' "$LOGFILE"; then
 	pass "unverified issue lock fails closed"
 else
@@ -100,9 +101,9 @@ else
 fi
 
 reset_gh_calls
-GH_LOCKED=false,true
+GH_LOCKED=false,false,true
 if lock_issue_for_worker 43 owner/repo &&
-	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 2 ]] &&
+	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 3 ]] &&
 	[[ -f "${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-43" ]]; then
 	pass "stale lock read retries and then succeeds"
 else
@@ -113,8 +114,8 @@ reset_gh_calls
 GH_LOCK_RC=1
 GH_LOCKED=true
 if lock_issue_for_worker 46 owner/repo &&
-	grep -q -- 'issue lock 46 --repo owner/repo --reason resolved' "$GH_CALLS" &&
-	grep -q -- 'api repos/owner/repo/issues/46 --jq .locked == true' "$GH_CALLS" &&
+	! grep -q -- '^issue lock ' "$GH_CALLS" &&
+	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 1 ]] &&
 	grep -q -- 'Reused existing verified conversation lock' "$LOGFILE" &&
 	[[ -f "${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-46" ]]; then
 	pass "already locked issue is accepted after independent verification"
@@ -127,19 +128,21 @@ reset_gh_calls
 GH_LOCKED=false
 GH_API_RC=1
 if ! lock_issue_for_worker 44 owner/repo &&
-	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 3 ]] &&
+	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 1 ]] &&
+	! grep -q -- '^issue lock ' "$GH_CALLS" &&
 	[[ ! -f "${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-44" ]]; then
-	pass "lock verification API errors exhaust retries and fail closed"
+	pass "unknown lock state stops without mutation or transport retries"
 else
-	fail "lock verification API errors exhaust retries and fail closed"
+	fail "unknown lock state stops without mutation or transport retries"
 fi
 
 reset_gh_calls
-GH_LOCKED=false,false,false
+GH_API_RC=0
+GH_LOCKED=false
 AIDEVOPS_CONVERSATION_LOCK_VERIFY_ATTEMPTS=999
 AIDEVOPS_CONVERSATION_LOCK_VERIFY_DELAY=999
 if ! lock_issue_for_worker 45 owner/repo &&
-	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 3 ]]; then
+	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 4 ]]; then
 	pass "oversized verification controls remain capped"
 else
 	fail "oversized verification controls remain capped"
@@ -160,8 +163,8 @@ mkdir -p "$AIDEVOPS_AUTO_DISPATCH_LOCK_DIR"
 : >"${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-53"
 : >"${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-55"
 if reconcile_auto_dispatch_issue_locks owner/repo "$snapshot" &&
-	grep -q -- 'issue lock 51 --repo owner/repo' "$GH_CALLS" &&
-	grep -q -- 'issue lock 52 --repo owner/repo' "$GH_CALLS" &&
+	! grep -q -- '^issue lock ' "$GH_CALLS" &&
+	[[ "$(grep -c -- '^api ' "$GH_CALLS")" -eq 2 ]] &&
 	grep -q -- 'issue unlock 53 --repo owner/repo' "$GH_CALLS" &&
 	[[ ! -f "${AIDEVOPS_AUTO_DISPATCH_LOCK_DIR}/owner--repo-53" ]] &&
 	! grep -q -- 'issue unlock 55 --repo owner/repo' "$GH_CALLS"; then

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -800,6 +800,22 @@ custom_report_message=$("${PARENT_DIR}/gh-api-instrument.sh" report "$custom_rep
 assert_file_exists "CLI custom report is created" "$custom_report"
 assert_eq "CLI reports the custom output path" "Wrote $custom_report" "$custom_report_message"
 
+# Ad-hoc diagnostics must not replace the completed-cycle proof pair.
+# This test owns a sentinel sidecar; sidecar validity has separate coverage.
+printf '{"fixture":"completed-cycle-sidecar"}\n' >"$AIDEVOPS_GH_API_EVIDENCE"
+cp "$AIDEVOPS_GH_API_REPORT" "$TMPDIR/completed-report.json"
+cp "$AIDEVOPS_GH_API_EVIDENCE" "$TMPDIR/completed-evidence.json"
+live_report="${AIDEVOPS_GH_API_REPORT%.json}-live.json"
+live_message=$("${PARENT_DIR}/gh-api-instrument.sh" report 2>&1 >/dev/null)
+assert_file_exists "CLI default creates a separate live report" "$live_report"
+assert_eq "CLI reports its live destination" "Wrote $live_report" "$live_message"
+preservation_status=0
+cmp -s "$TMPDIR/completed-report.json" "$AIDEVOPS_GH_API_REPORT" || preservation_status=1
+cmp -s "$TMPDIR/completed-evidence.json" "$AIDEVOPS_GH_API_EVIDENCE" || preservation_status=1
+assert_eq "live diagnostics preserve completed-cycle report and sidecar bytes" "0" "$preservation_status"
+assert_eq "batch prefetch does not publish partial-cycle proof" "0" \
+	"$(grep -c '^[[:space:]]*gh_aggregate_calls' "${PARENT_DIR}/pulse-batch-prefetch-helper.sh" || true)"
+
 # --- Test 13: time/line/byte retention is atomic and bounded -------------
 export AIDEVOPS_GH_API_LOG_MAX_LINES=3
 export AIDEVOPS_GH_API_LOG_MAX_BYTES=10000
@@ -1054,8 +1070,8 @@ assert_path_absent "all auth control commands bypass API telemetry" "$AIDEVOPS_G
 rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
 PATH="$NATIVE_FIXTURE:/usr/bin:/bin" \
 	"$SHIM_FIXTURE/gh" config get git_protocol >/dev/null
-assert_file_exists "non-auth command retains API telemetry" "$AIDEVOPS_GH_API_LOG"
-assert_eq "non-auth command retains one transport attempt" "1" \
+assert_file_exists "local config command retains logical telemetry" "$AIDEVOPS_GH_API_LOG"
+assert_eq "local config command makes no synthetic transport attempt" "0" \
 	"$(awk -F'\t' '$9 == "attempt" { count++ } END { print count + 0 }' "$AIDEVOPS_GH_API_LOG")"
 
 rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"

--- a/.agents/scripts/tests/test-gh-shim-routing-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-routing-cases.sh
@@ -58,6 +58,27 @@ else
 	_fail "REST-first GraphQL-only pr list preservation" "argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
 fi
 
+_reset_log
+AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_REST_FALLBACK_DISABLE_CACHE=1 \
+	STUB_RATE_LIMIT_REMAINING=5000 "$SHIM_RUN" pr list --repo owner/repo \
+	--state closed --json number >/dev/null 2>/dev/null || true
+argv=$(_read_argv)
+if [[ "$argv" == $'pr\nlist\n--repo\nowner/repo\n--state\nclosed\n--json\nnumber' ]]; then
+	_pass "healthy closed-unmerged reads use the server-side GraphQL filter despite REST-first mode"
+else
+	_fail "closed-unmerged query scanned merged REST history instead of using native filtering" "$argv"
+fi
+
+_reset_log
+AIDEVOPS_GH_REST_FIRST_READS=1 _GH_SHOULD_FALLBACK_OVERRIDE=1 \
+	"$SHIM_RUN" pr list --repo owner/repo --state closed --json number >/dev/null 2>/dev/null || true
+argv=$(_read_argv)
+if [[ "$argv" == *'/repos/owner/repo/pulls?state=closed'* ]]; then
+	_pass "closed-unmerged reads retain the semantically correct low-GraphQL REST fallback"
+else
+	_fail "closed-unmerged low-budget fallback was lost" "$argv"
+fi
+
 echo ""
 echo "Test 15g: native read attribution is caller-aware and privacy-safe"
 _reset_log

--- a/.agents/scripts/tests/test-gh-shim-transport-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-transport-cases.sh
@@ -92,4 +92,25 @@ else
 	_fail "authoritative exhaustion suppresses the next raw request locally"
 fi
 
+# Exact capture owns multi-frame native attempts. The normal final-response
+# adapter must never take that route away from an explicitly metered window.
+# shellcheck source=/dev/null
+source "${TMP}/scripts/gh-transport-controls.sh"
+_governor_rc=0
+AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 _gh_transport_run_rest \
+	"${TMP}/bin/gh" rest gh_api_rest 0 api user >/dev/null 2>/dev/null || _governor_rc=$?
+if [[ "$_governor_rc" -eq 125 && "$_GHGT_HANDLED" -eq 0 ]]; then
+	_pass "exact multi-response capture retains transport ownership"
+else
+	_fail "normal REST adapter intercepted exact transport capture"
+fi
+
+# shellcheck source=/dev/null
+source "${TMP}/scripts/gh-native-transport-lib.sh"
+if [[ "$(_shim_classify_endpoint search issues)" == search-rest && "$(_shim_classify_endpoint api graphql)" == graphql ]]; then
+	_pass "native search uses the REST search resource, not the GraphQL pool"
+else
+	_fail "native search quota family is misclassified"
+fi
+
 return 0

--- a/.agents/scripts/tests/test-gh-shim-transport-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-transport-cases.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# Sourced by the existing hermetic gh shim harness after legacy-path coverage.
+
+printf '\nTest 27: shared raw transport controls and response-owned quota\n'
+for library in gh-transport-controls.sh gh-transport-governor.py gh_transport_budget.py shared-gh-secondary-cooldown.sh; do
+	cp "${REPO_DIR}/.agents/scripts/${library}" "${TMP}/scripts/${library}"
+done
+mkdir -p "${TMP}/governor/tmp"
+export AIDEVOPS_GH_TRANSPORT_STATE_DIR="${TMP}/governor/state"
+export AIDEVOPS_TEMP_DIR="${TMP}/governor/tmp"
+export AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="${TMP}/governor/cooldown.json"
+export AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE="${TMP}/governor/events.jsonl"
+export AIDEVOPS_GH_API_LOG="${TMP}/governor/api.tsv"
+export AIDEVOPS_GH_READ_RAMP_ENABLED=0
+export AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1
+unset AIDEVOPS_GH_TRANSPORT_GOVERNOR_DISABLE AIDEVOPS_GH_EXACT_QUOTA_CAPTURE GH_DEBUG
+_governor_reset=$(($(date +%s) + 3600))
+printf '{"expires_at":%s}\n' "$_governor_reset" >"$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE"
+_reset_log
+_governor_rc=0
+"$SHIM_RUN" pr view 42 --repo owner/repo --json number >/dev/null 2>/dev/null || _governor_rc=$?
+if [[ "$_governor_rc" -eq 75 && ! -s "$STUB_GH_CALL_LOG" ]]; then
+	_pass "raw native reads stop during the shared cooldown without a request"
+else
+	_fail "raw native reads stop during the shared cooldown without a request"
+fi
+if "$SHIM_RUN" --version >/dev/null 2>/dev/null; then
+	_pass "local-only commands remain usable during cooldown"
+else
+	_fail "local-only commands remain usable during cooldown"
+fi
+rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE"
+
+export STUB_TRANSPORT_RESPONSE_FILE="${TMP}/governor/response"
+printf 'HTTP/2.0 200 OK\r\nX-Ratelimit-Resource: core\r\nX-Ratelimit-Limit: 5000\r\nX-Ratelimit-Remaining: 4999\r\nX-Ratelimit-Reset: %s\r\n\r\n{"fixture":true}\n' "$_governor_reset" >"$STUB_TRANSPORT_RESPONSE_FILE"
+_reset_log
+_governor_output=$("$SHIM_RUN" api user)
+if [[ "$_governor_output" == '{"fixture":true}' && "$(_read_attempt_quota "$AIDEVOPS_GH_API_LOG")" == 1 && "$(_read_last_attempt_field "$AIDEVOPS_GH_API_LOG" 15)" == 200 ]]; then
+	_pass "REST transport strips only injected headers and records actual response cost/status"
+else
+	_fail "REST transport strips only injected headers and records actual response cost/status"
+fi
+if [[ "$(wc -l <"$STUB_GH_CALL_LOG" | tr -d ' ')" -eq 1 ]]; then
+	_pass "quota observation does not probe rate_limit or repeat the REST request"
+else
+	_fail "quota observation does not probe rate_limit or repeat the REST request"
+fi
+"$SHIM_RUN" api user --include >"${TMP}/governor/included"
+if cmp -s "$STUB_TRANSPORT_RESPONSE_FILE" "${TMP}/governor/included"; then
+	_pass "explicit included-response output remains byte-for-byte native"
+else
+	_fail "explicit included-response output remains byte-for-byte native"
+fi
+
+_reset_log
+_governor_rc=0
+STUB_TRANSPORT_RC=125 "$SHIM_RUN" api user >/dev/null 2>/dev/null || _governor_rc=$?
+if [[ "$_governor_rc" -eq 125 && "$(wc -l <"$STUB_GH_CALL_LOG" | tr -d ' ')" -eq 1 ]]; then
+	_pass "native exit 125 is preserved without invoking fallback after execution"
+else
+	_fail "native exit 125 is preserved without invoking fallback after execution"
+fi
+
+printf 'HTTP/2.0 304 Not Modified\r\nX-Ratelimit-Resource: core\r\nX-Ratelimit-Limit: 5000\r\nX-Ratelimit-Remaining: 4999\r\nX-Ratelimit-Reset: %s\r\n\r\n' "$_governor_reset" >"$STUB_TRANSPORT_RESPONSE_FILE"
+_governor_rc=0
+STUB_TRANSPORT_RC=1 "$SHIM_RUN" api user -H 'If-None-Match: "fixture"' >/dev/null 2>/dev/null || _governor_rc=$?
+if [[ "$_governor_rc" -eq 1 && "$(_read_attempt_quota "$AIDEVOPS_GH_API_LOG")" == 0 ]]; then
+	_pass "response-owned conditional zero cost preserves native exit status"
+else
+	_fail "response-owned conditional zero cost preserves native exit status"
+fi
+
+printf 'not an included HTTP response\n' >"$STUB_TRANSPORT_RESPONSE_FILE"
+_governor_rc=0
+_governor_output=$("$SHIM_RUN" api user 2>/dev/null) || _governor_rc=$?
+if [[ "$_governor_rc" -ne 0 && -z "$_governor_output" ]]; then
+	_pass "unknown header framing cannot become successful application data"
+else
+	_fail "unknown header framing cannot become successful application data"
+fi
+
+printf 'HTTP/2.0 403 Forbidden\r\nX-Ratelimit-Resource: core\r\nX-Ratelimit-Limit: 5000\r\nX-Ratelimit-Remaining: 0\r\nX-Ratelimit-Reset: %s\r\n\r\n{}\n' "$_governor_reset" >"$STUB_TRANSPORT_RESPONSE_FILE"
+STUB_TRANSPORT_RC=1 "$SHIM_RUN" api user >/dev/null 2>/dev/null || true
+_reset_log
+_governor_rc=0
+"$SHIM_RUN" api user >/dev/null 2>/dev/null || _governor_rc=$?
+if [[ "$_governor_rc" -eq 75 && ! -s "$STUB_GH_CALL_LOG" ]]; then
+	_pass "authoritative exhaustion suppresses the next raw request locally"
+else
+	_fail "authoritative exhaustion suppresses the next raw request locally"
+fi
+
+return 0

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -71,6 +71,11 @@ mkdir -p "$TMP/bin"
 cat >"$TMP/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 # Stub gh that logs argv
+if [[ "${1:-}" == api && -n "${STUB_TRANSPORT_RESPONSE_FILE:-}" ]]; then
+	printf '%s\n' "$*" >>"$STUB_GH_CALL_LOG"
+	cat "$STUB_TRANSPORT_RESPONSE_FILE"
+	exit "${STUB_TRANSPORT_RC:-0}"
+fi
 if [[ "$1" == "api" && "$2" == "user" ]]; then
 	printf '%s\n' "${STUB_GH_USER:-managed}"
 	exit 0
@@ -408,6 +413,9 @@ source "${SCRIPT_DIR}/test-gh-shim-quota-cases.sh"
 # shellcheck source=./test-gh-shim-policy-cases.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/test-gh-shim-policy-cases.sh"
+
+# shellcheck source=./test-gh-shim-transport-cases.sh
+source "${SCRIPT_DIR}/test-gh-shim-transport-cases.sh"
 
 # =============================================================================
 # Summary

--- a/.agents/scripts/tests/test-gh-transport-budget.py
+++ b/.agents/scripts/tests/test-gh-transport-budget.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Focused admission invariants; no network or production state access."""
+
+import importlib.util
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+from gh_transport_budget import Budget, Deferred, scope_key  # noqa: E402
+
+SPEC = importlib.util.spec_from_file_location("governor", SCRIPTS / "gh-transport-governor.py")
+governor = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(governor)
+
+
+def headers(remaining=102, reset=2000, resource="core"):
+    return {"x-ratelimit-remaining": str(remaining), "x-ratelimit-reset": str(reset),
+            "x-ratelimit-resource": resource, "x-ratelimit-limit": "5000" if resource == "core" else "30"}
+
+
+class AdmissionTests(unittest.TestCase):
+    def setUp(self):
+        root = Path(os.environ.get("AIDEVOPS_TEMP_DIR", str(Path.home() / ".aidevops/.agent-workspace/tmp")))
+        root.mkdir(parents=True, exist_ok=True)
+        self.temp = tempfile.TemporaryDirectory(prefix="gh-budget-test-", dir=root)
+        self.directory = Path(self.temp.name)
+        self.budget = Budget(self.directory, "owner-one")
+
+    def tearDown(self):
+        self.budget.close()
+        self.temp.cleanup()
+
+    def seed(self, remaining=102, reset=2000, resource="core"):
+        token = self.budget.acquire(resource, now=1000)
+        self.budget.finish(token, resource, headers(remaining, reset, resource), started=1000, now=1001)
+
+    def test_atomic_reservations_protect_the_floor(self):
+        self.seed()
+        self.budget.acquire("core", now=1002)
+        other = Budget(self.directory, "owner-one")
+        try:
+            other.acquire("core", now=1002)
+            with self.assertRaises(Deferred):
+                other.acquire("core", now=1002)
+        finally:
+            other.close()
+
+    def test_stale_and_missing_state_allow_only_one_observation(self):
+        self.budget.acquire("core", now=1000)
+        with self.assertRaises(Deferred):
+            self.budget.acquire("core", now=1001)
+
+    def test_unknown_completion_does_not_deadlock_bootstrap(self):
+        token = self.budget.acquire("core", now=1000)
+        self.budget.finish(token, "core", {}, started=1000, now=1001)
+        probe = self.budget.acquire("core", now=1002)
+        self.budget.finish(probe, "core", headers(), started=1002, now=1003)
+        self.assertEqual(self.budget.db.execute("SELECT COUNT(*) FROM reservation").fetchone()[0], 0)
+
+    def test_late_header_never_increases_remaining(self):
+        self.seed(150)
+        token = self.budget.acquire("core", now=1002)
+        self.budget.finish(token, "core", headers(4000), started=1002, now=1003)
+        self.assertEqual(self.budget.db.execute("SELECT remaining FROM quota").fetchone()[0], 150)
+
+    def test_reset_requires_a_new_response_not_a_new_allowance(self):
+        self.seed(0, 1010)
+        with self.assertRaises(Deferred):
+            self.budget.acquire("core", now=1009)
+        token = self.budget.acquire("core", now=1011)
+        with self.assertRaises(Deferred):
+            self.budget.acquire("core", now=1011)
+        self.budget.finish(token, "core", headers(4999, 4600), started=1011, now=1012)
+        self.budget.acquire("core", now=1013)
+
+    def test_small_search_allowance_is_not_treated_as_core(self):
+        self.seed(10, resource="search")
+        self.budget.acquire("search", now=1002)
+
+    def test_scope_and_resource_isolation(self):
+        self.seed(0)
+        other = Budget(self.directory, "owner-two")
+        try:
+            other.acquire("core", now=1002)
+            self.budget.acquire("search", now=1002)
+        finally:
+            other.close()
+
+    def test_token_rotation_does_not_invent_a_quota_owner(self):
+        with patch.dict(os.environ, {"GH_TOKEN": "fixture-one"}):
+            first = scope_key("github.com")
+        with patch.dict(os.environ, {"GH_TOKEN": "fixture-two"}):
+            self.assertEqual(first, scope_key("github.com"))
+
+    def test_owner_configuration_cannot_split_one_credential_budget(self):
+        self.seed(0)
+        other = Budget(self.directory, "new-owner-name", "owner-one")
+        try:
+            with self.assertRaises(Deferred):
+                other.acquire("core", now=1002)
+            with self.assertRaises(Deferred):
+                self.budget.acquire("core", now=1002)
+        finally:
+            other.close()
+
+    def test_other_credential_response_cannot_erase_unknown_spend(self):
+        self.seed()
+        reservation = self.budget.acquire("core", now=1002)
+        self.budget.finish(reservation, "core", {}, started=1002, now=1003)
+        other = Budget(self.directory, "owner-one", "different-credential")
+        try:
+            probe = other.acquire("core", now=1004)
+            other.finish(probe, "core", headers(), started=1004, now=1005)
+            self.assertEqual(other.db.execute("SELECT COUNT(*) FROM reservation").fetchone()[0], 1)
+        finally:
+            other.close()
+
+    def test_uncertain_execution_keeps_debt(self):
+        self.seed()
+        token = self.budget.acquire("core", now=1002)
+        self.budget.finish(token, "core", {}, started=1002, now=1003)
+        self.budget.acquire("core", now=1004)
+        with self.assertRaises(Deferred):
+            self.budget.acquire("core", now=1004)
+
+    def test_unsupported_cached_and_opaque_shapes_remain_native(self):
+        for args in (["api", "graphql"], ["api", "rate_limit"],
+                     ["api", "user", "--cache", "1h"],
+                     ["api", "user", "--paginate"],
+                     ["api", "user", "-H", "X-Gh-Cache-Ttl: 1h"],
+                     ["api", "user", "-H", "Authorization: fixture"],
+                     ["pr", "checks", "--watch"]):
+            self.assertIsNone(governor.request_shape(args))
+
+    def test_header_split_preserves_binary_body(self):
+        body = b"\x00body\r\nHTTP/1.1 body text\n"
+        stream = io.BytesIO(b"HTTP/2.0 200 OK\r\nX-Ratelimit-Remaining: 12\r\n\r\n" + body)
+        status, values, offset = governor.included_headers(stream)
+        self.assertEqual(status, 200)
+        self.assertEqual(values["x-ratelimit-remaining"], "12")
+        stream.seek(offset)
+        self.assertEqual(stream.read(), body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/tests/test-gh-transport-budget.py
+++ b/.agents/scripts/tests/test-gh-transport-budget.py
@@ -137,8 +137,31 @@ class AdmissionTests(unittest.TestCase):
                      ["api", "user", "--paginate"],
                      ["api", "user", "-H", "X-Gh-Cache-Ttl: 1h"],
                      ["api", "user", "-H", "Authorization: fixture"],
+                     ["api", "user", "-X", "POST"],
+                     ["api", "user", "-f", "value=one"],
+                     ["api", "user", "--input", "/dev/fd/9"],
+                     ["api", "user", "-X", "GET", "-F", "q=@/dev/fd/9"],
+                     ["api", "//foreign.invalid/user"],
                      ["pr", "checks", "--watch"]):
             self.assertIsNone(governor.request_shape(args))
+
+    def test_read_parameters_do_not_change_method_or_authority(self):
+        with patch.dict(os.environ, {"GH_HOST": "github.com", "GH_DEBUG": ""}):
+            self.assertIsNotNone(governor.request_shape(
+                ["api", "repos/owner/repo/issues?since=2026-09-04T00:00:00Z"]
+            ))
+            self.assertIsNotNone(governor.request_shape(
+                ["api", "user", "--method", "GET", "-f", "value=one"]
+            ))
+
+    def test_native_child_uses_the_hashed_credential_without_parent_export(self):
+        with patch.dict(os.environ, {}, clear=True), patch(
+            "gh_transport_budget.subprocess.check_output", return_value=b"fixture-credential\n"
+        ):
+            fingerprint, authenticated, environment = governor.credential_identity("fixture-gh", "github.com")
+            self.assertTrue(authenticated and len(fingerprint) == 64)
+            self.assertTrue(environment.get("GH_TOKEN") == "fixture-credential")
+            self.assertNotIn("GH_TOKEN", os.environ)
 
     def test_header_split_preserves_binary_body(self):
         body = b"\x00body\r\nHTTP/1.1 body text\n"

--- a/.agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh
@@ -44,12 +44,12 @@ gh() {
 		TEST_GH_POST_COUNT=$((TEST_GH_POST_COUNT + 1))
 		return 0
 	fi
-	if [[ "$subcommand" != "api" || "$endpoint" != "repos/marcusquinn/aidevops/issues/26635/comments?per_page=100" ]]; then
+	if [[ "$subcommand" != "api" || "$endpoint" != "repos/marcusquinn/aidevops/issues/26635/comments?per_page=100&since="* || "$*" != *"--paginate --slurp"* ]]; then
 		printf 'unexpected gh call: %s\n' "$*" >&2
 		return 1
 	fi
-	printf '%s\n' "${TEST_GH_COMMENTS_JSON:-[]}"
-	return 0
+	printf '%s\n' "${TEST_GH_COMMENTS_JSON-[]}"
+	return "${TEST_GH_COMMENTS_RC:-0}"
 }
 
 load_lib() {
@@ -70,7 +70,7 @@ test_recent_marker_blocks_dispatch() {
 		DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS="21600" \
 		_dispatch_recent_dirty_worktree_marker_active "26635" "marcusquinn/aidevops"
 	local rc=$?
-	if [[ "$rc" -eq 0 ]]; then
+	if [[ "$rc" -eq 0 && "$_DISPATCH_DIRTY_MARKER_STATE" == block:* ]]; then
 		print_result "recent dirty marker blocks dispatch" 0
 		return 0
 	fi
@@ -226,6 +226,49 @@ test_large_comment_payload_uses_stream_transport() {
 	return 0
 }
 
+test_paginated_and_unknown_marker_evidence() {
+	local recent='{"created_at":"2026-07-05T22:22:12Z","body":"WORKER_DIRTY_WORKTREE runner_key=runner-page-two"}'
+	local resolved='{"created_at":"2026-07-05T22:40:00Z","body":"WORKER_DIRTY_WORKTREE_RESOLVED"}'
+	local rc=0
+	TEST_GH_COMMENTS_JSON="[[],[${recent}]]" AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH=1783291032 \
+		DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS=21600 \
+		_dispatch_recent_dirty_worktree_marker_active 26635 marcusquinn/aidevops || rc=$?
+	if [[ "$rc" -eq 0 && "$_DISPATCH_DIRTY_MARKER_STATE" == *runner_key=runner-page-two ]]; then
+		print_result "recent marker on a later page is not missed" 0
+	else
+		print_result "recent marker on a later page is not missed" 1
+	fi
+	local bad_data=""
+	for bad_data in '' '{}' '[{"body":"WORKER_DIRTY_WORKTREE"}]' \
+		'[{"created_at":"2026-07-05T22:22:12","body":"WORKER_DIRTY_WORKTREE"}]'; do
+		rc=0
+		TEST_GH_COMMENTS_JSON="$bad_data" _dispatch_recent_dirty_worktree_marker_active 26635 marcusquinn/aidevops || rc=$?
+		if [[ "$rc" -eq 0 && "$_DISPATCH_DIRTY_MARKER_STATE" == unknown ]]; then
+			print_result "incomplete marker evidence holds instead of clearing" 0
+		else
+			print_result "incomplete marker evidence holds instead of clearing" 1 "$bad_data"
+		fi
+	done
+	rc=0
+	TEST_GH_COMMENTS_JSON='[]' TEST_GH_COMMENTS_RC=1 \
+		_dispatch_recent_dirty_worktree_marker_active 26635 marcusquinn/aidevops || rc=$?
+	if [[ "$rc" -eq 0 && "$_DISPATCH_DIRTY_MARKER_STATE" == unknown ]]; then
+		print_result "API failure cannot become verified empty comments" 0
+	else
+		print_result "API failure cannot become verified empty comments" 1
+	fi
+	rc=0
+	TEST_GH_COMMENTS_JSON="[[${resolved}],[${recent}]]" AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH=1783291032 \
+		DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS=21600 \
+		_dispatch_recent_dirty_worktree_marker_active 26635 marcusquinn/aidevops || rc=$?
+	if [[ "$rc" -eq 1 && "$_DISPATCH_DIRTY_MARKER_STATE" == clear ]]; then
+		print_result "marker resolution uses timestamps rather than response order" 0
+	else
+		print_result "marker resolution uses timestamps rather than response order" 1
+	fi
+	return 0
+}
+
 test_prelaunch_lease_failure_logs_durable_reason() {
 	local fixture_dir=""
 	fixture_dir=$(mktemp -d)
@@ -301,6 +344,7 @@ main() {
 	test_later_resolution_clears_marker
 	test_expired_marker_does_not_block
 	test_large_comment_payload_uses_stream_transport
+	test_paginated_and_unknown_marker_evidence
 	test_prelaunch_lease_failure_logs_durable_reason
 	test_expired_marker_clears_once_with_audit
 	test_marker_without_runner_key_stays_blocked

--- a/.agents/scripts/tests/test-pulse-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-issue-reconcile.sh
@@ -917,6 +917,42 @@ test_gh22802_oimp_lookup_requires_merged_at() {
 	return 0
 }
 
+# Exercise the real REST adapter: a canned mixed list hid the incompatible
+# closed/merged selector and its scan-until-unmerged pagination cost.
+test_oimp_uses_merged_adapter_population() {
+	local helper_def="" tmp_dir="" result=""
+	helper_def=$(sed -n '/^_build_oimp_lookup_for_slug()/,/^}$/p' "${RECONCILE_SH}")
+	tmp_dir=$(mktemp -d)
+	result=$(HOME="$tmp_dir" AIDEVOPS_GH_API_INSTRUMENT_DISABLE=1 bash -c '
+		source "$1/shared-gh-wrappers.sh"
+		eval "$2"
+		calls="$3/calls"
+		: >"$calls"
+		gh_record_call() { return 0; }
+		_rest_api_call() {
+			local endpoint="$4"
+			local page="${endpoint##*page=}"
+			printf "request\n" >>"$calls"
+			if [[ "$page" -gt 3 ]]; then
+				printf "[]\n"
+				return 0
+			fi
+			jq -cn --argjson page "$page" "[range((\$page-1)*100+1;\$page*100+1) | {number:.,merged_at:\"2026-09-04T00:00:00Z\",body:(if . == 1 then \"Resolves #42\" else \"\" end)}]" || return 1
+			return 0
+		}
+		_gh_pr_list_merged() { _rest_pr_list "$@"; return $?; }
+		lookup=$(_build_oimp_lookup_for_slug owner/repo)
+		printf "lookup=%s\ncalls=%s\n" "$lookup" "$(wc -l <"$calls" | tr -d " ")"
+	' _ "${SCRIPT_DIR}/.." "$helper_def" "$tmp_dir" 2>/dev/null)
+	rm -rf "$tmp_dir"
+	if [[ "$result" == $'lookup=|42=1|\ncalls=2' ]]; then
+		_pass "merged reconciliation uses two relevant REST pages, not a discarded unmerged-history scan"
+	else
+		_fail "merged reconciliation adapter population/call budget mismatch: $result"
+	fi
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Test 14 (t2985): grep-based lookup avoids prefix-substring false matches
 # ---------------------------------------------------------------------------
@@ -1355,6 +1391,7 @@ test_t2984_time_budget_present
 test_t2984_budget_env_validation
 test_t2985_oimp_lookup_builder
 test_gh22802_oimp_lookup_requires_merged_at
+test_oimp_uses_merged_adapter_population
 test_t2985_oimp_lookup_no_prefix_collision
 test_t2985_action_oimp_single_signature
 test_gh25896_oimp_closes_consolidated_successor

--- a/.agents/scripts/tests/test-pulse-merge-dirty-queue.py
+++ b/.agents/scripts/tests/test-pulse-merge-dirty-queue.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Queue lifecycle and caller-PID tests; no GitHub calls or production state."""
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+SPEC = importlib.util.spec_from_file_location("dirty_queue", SCRIPTS / "pulse-merge-dirty-queue.py")
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+class QueueTests(unittest.TestCase):
+    def setUp(self):
+        root = Path(os.environ.get("AIDEVOPS_TEMP_DIR", str(Path.home() / ".aidevops/.agent-workspace/tmp")))
+        root.mkdir(parents=True, exist_ok=True)
+        self.temp = tempfile.TemporaryDirectory(prefix="merge-queue-test-", dir=root)
+        self.directory = Path(self.temp.name)
+        self.queue = module.Queue(self.directory)
+
+    def tearDown(self):
+        self.queue.db.close()
+        self.temp.cleanup()
+
+    def test_burst_and_case_aliases_coalesce(self):
+        self.assertEqual(self.queue.enqueue("Owner/Repo", 42, 1000), "wake")
+        first = self.queue.row("owner/repo", 42)["generation"]
+        self.assertEqual(self.queue.enqueue("owner/repo", 42, 1001), "coalesced")
+        self.assertNotEqual(first, self.queue.row("owner/repo", 42)["generation"])
+        self.assertEqual(self.queue.db.execute("SELECT count(*) FROM work").fetchone()[0], 1)
+        self.assertEqual(self.queue.priority("OWNER/REPO", 1002), "|42|")
+
+    def test_new_event_survives_old_completion(self):
+        self.queue.enqueue("owner/repo", 42, 1000)
+        receipt = self.queue.claim("owner/repo", 42, os.getpid(), 1001)
+        self.queue.enqueue("owner/repo", 42, 1002)
+        self.queue.finish(receipt, True)
+        row = self.queue.row("owner/repo", 42)
+        self.assertNotEqual(row["generation"], receipt["generation"])
+        self.assertEqual(row["nonce"], "")
+        current = self.queue.claim("owner/repo", 42, os.getpid(), 1003)
+        self.queue.finish(current, True)
+        self.assertIsNone(self.queue.row("owner/repo", 42))
+
+    def test_live_owner_cannot_be_replaced_by_elapsed_time(self):
+        self.queue.enqueue("owner/repo", 42, 1000)
+        self.queue.claim("owner/repo", 42, os.getpid(), 1001)
+        self.assertIsNone(self.queue.claim("owner/repo", 42, os.getpid(), 1000 + module.RETENTION_SECONDS * 2))
+
+    def test_dead_owner_recovery_fences_old_ack(self):
+        self.queue.enqueue("owner/repo", 42, 1000)
+        old = self.queue.claim("owner/repo", 42, os.getpid(), 1001)
+        self.queue.db.execute("UPDATE work SET pid=2147483647 WHERE pr=42")
+        new = self.queue.claim("owner/repo", 42, os.getpid(), 1002)
+        with self.assertRaises(ValueError):
+            self.queue.finish(old, True)
+        self.assertEqual(self.queue.row("owner/repo", 42)["nonce"], new["nonce"])
+
+    def test_poll_leases_do_not_invent_dirty_hints(self):
+        receipt = self.queue.claim("owner/repo", 42, os.getpid(), 1000)
+        self.assertEqual(self.queue.priority("owner/repo", 1001), "")
+        self.queue.finish(receipt, False)
+        self.assertIsNone(self.queue.row("owner/repo", 42))
+
+    def test_capacity_preserves_active_work(self):
+        self.queue.enqueue("owner/repo", 42, 1000)
+        self.queue.claim("owner/repo", 42, os.getpid(), 1001)
+        with patch.object(module, "MAX_HINTS", 1), self.assertRaises(ValueError):
+            self.queue.enqueue("owner/repo", 43, 1000 + module.RETENTION_SECONDS * 2)
+        self.assertIsNotNone(self.queue.row("owner/repo", 42))
+
+    def test_unhandled_hints_remain_available_to_polling(self):
+        self.queue.enqueue("owner/repo", 42, 1000)
+        receipt = self.queue.claim("owner/repo", 42, os.getpid(), 1001)
+        self.queue.finish(receipt, False)
+        self.assertEqual(self.queue.priority("owner/repo", 1002), "|42|")
+        self.assertEqual(self.queue.row("owner/repo", 42)["nonce"], "")
+
+    def test_shell_claim_is_owned_by_the_live_caller(self):
+        environment = {**os.environ, "AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED": "1",
+                       "AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_DIR": str(self.directory)}
+        script = '''
+set -eu
+source "$1"
+_PULSE_MERGE_QUEUE_CONTEXT=""
+_PULSE_MERGE_QUEUE_OWNED=0
+_PULSE_MERGE_QUEUE_DIRTY=0
+_pulse_merge_queue_begin Owner/Repo 42 event ""
+printf '%s\\n' "$_PULSE_MERGE_QUEUE_CONTEXT"
+IFS= read -r release
+_pulse_merge_queue_finish 1
+'''
+        # /bin/bash exercises the macOS Bash3.2 PID fallback, not just BASHPID.
+        child = subprocess.Popen(["/bin/bash", "-c", script, "_", str(SCRIPTS / "pulse-merge-dirty-queue.sh")],
+                                 env=environment, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE, text=True)
+        try:
+            receipt = json.loads(child.stdout.readline())
+            self.assertEqual(receipt["pid"], child.pid)
+            self.assertIsNone(self.queue.claim("owner/repo", 42, os.getpid(), 1001))
+            stdout, stderr = child.communicate("release\n", timeout=10)
+            self.assertEqual(child.returncode, 0, stderr + stdout)
+        finally:
+            if child.poll() is None:
+                child.kill()
+                child.communicate()
+
+    def test_poll_refresh_and_event_borrow_keep_one_fresh_read(self):
+        source = (SCRIPTS / "pulse-merge.sh").read_text()
+        definitions = "\n".join(
+            re.search(r"(?ms)^" + name + r"\(\) \{.*?^\}", source)[0]
+            for name in ("_process_single_ready_pr", "process_pr")
+        )
+        common = r'''
+set -eu
+source "$1"
+eval "$2"
+LOGFILE="$3/merge.log"
+_pulse_merge_ready_pr_json_fields() { printf 'number,state,headRefOid'; return 0; }
+_pmp_normalize_pr_lifecycle_state_into() { local name="$1" value="$2"; printf -v "$name" '%s' "$value"; return 0; }
+gh_pr_view() {
+    [[ "${AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE:-0}" == 1 ]] || return 1
+    printf 'read\n' >>"$READ_LOG"
+    printf '{"number":42,"state":"OPEN","headRefOid":"fresh"}\n'
+    return 0
+}
+_pmp_stage_parse_and_validate() { [[ "$pr_obj" == *fresh* ]] || return 1; return 10; }
+_pmp_stage_handle_conflict() { return 10; }
+_pmp_stage_review_and_gates() { return 10; }
+_pmp_stage_required_checks() { return 10; }
+_pmp_stage_pre_merge() { return 10; }
+_pmp_stage_admin_merge() { return 10; }
+_pmp_stage_ruleset_fallback() { return 10; }
+_pmp_stage_finalize_merge() { return 0; }
+if [[ "$4" == event ]]; then
+    process_pr owner/repo 42
+else
+    _process_single_ready_pr owner/repo '{"number":42,"state":"OPEN","headRefOid":"stale"}'
+fi
+'''
+        for mode in ("poll", "event"):
+            with self.subTest(mode=mode):
+                self.queue.enqueue("owner/repo", 42, 1000)
+                read_log = self.directory / (mode + "-reads")
+                environment = {**os.environ, "AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED": "1",
+                               "AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_DIR": str(self.directory),
+                               "READ_LOG": str(read_log), "DRY_RUN": "0"}
+                result = subprocess.run(
+                    ["/bin/bash", "-c", common, "_", str(SCRIPTS / "pulse-merge-dirty-queue.sh"),
+                     definitions, str(self.directory), mode],
+                    env=environment, text=True, capture_output=True, timeout=15,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(read_log.read_text().splitlines(), ["read"])
+                self.assertIsNone(self.queue.row("owner/repo", 42))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
@@ -133,6 +133,13 @@ sorted_numbers=$(_pmp_sort_prs_by_backlog_priority "$unsorted_json" | jq -r '[.[
 assert_eq "2: backlog sort processes merge-ready then fix-needed before lower-value buckets" \
 	"1,3,2,4,5" "$sorted_numbers"
 
+second_ready=$(printf '%s' "$merge_ready_pr" | jq -c '.number = 6')
+_pulse_merge_queue_priority_keys() { printf '|6|5|'; return 0; }
+sorted_numbers=$(_pmp_sort_prs_by_backlog_priority "[$human_pr,$dirty_pr,$checks_in_progress_pr,$small_fix_pr,$merge_ready_pr,$second_ready]" owner/repo | jq -r '[.[].number] | join(",")')
+assert_eq "2b: dirty hints break ties without overriding readiness priorities" \
+	"6,1,3,2,4,5" "$sorted_numbers"
+unset -f _pulse_merge_queue_priority_keys
+
 : >"$LOGFILE"
 _pmp_log_pr_backlog_counts "owner/repo" "$unsorted_json"
 log_line=$(grep 'PR backlog owner/repo:' "$LOGFILE" 2>/dev/null || true)

--- a/.agents/scripts/tests/test-pulse-merge-webhook-invalidation.py
+++ b/.agents/scripts/tests/test-pulse-merge-webhook-invalidation.py
@@ -550,7 +550,7 @@ class WebhookInvalidationTests(unittest.TestCase):
         self.assertEqual([], self.records)
 
     def _dispatch_receiver_records(
-        self, records: list[str], *, fail_collection: bool = False
+        self, records: list[str], *, fail_collection: bool = False, use_queue: bool = False
     ) -> list[str]:
         actions = self.root / "actions.txt"
         actions.write_text("\n".join(records) + "\n", encoding="utf-8")
@@ -558,6 +558,9 @@ class WebhookInvalidationTests(unittest.TestCase):
         evidence_log = self.root / "dispatch-evidence.log"
         script = r'''
 source "$RECEIVER_PATH"
+if [[ "$USE_QUEUE" == 1 ]]; then
+    source "$QUEUE_LIB"
+fi
 gh_record_efficiency_evidence() {
     local name="$1"
     local value="$2"
@@ -595,6 +598,9 @@ wait
                 "CALL_LOG": str(call_log),
                 "EVIDENCE_LOG": str(evidence_log),
                 "FAIL_COLLECTION": "1" if fail_collection else "0",
+                "USE_QUEUE": "1" if use_queue else "0",
+                "QUEUE_LIB": str(SCRIPTS_DIR / "pulse-merge-dirty-queue.sh"),
+                "AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_DIR": str(self.root / "queue"),
                 "HOME": str(self.root / "home"),
                 "RECEIVER_PATH": str(RECEIVER_PATH),
                 "WEBHOOK_CONF": str(SCRIPTS_DIR.parent / "configs" / "webhook-receiver.conf"),
@@ -662,6 +668,24 @@ wait
         )
         self.assertIn("webhook.missed_recoveries|1", self.dispatch_evidence)
         self.assertNotIn("webhook.invalidations|1", self.dispatch_evidence)
+
+    def test_successful_later_invalidation_cannot_clear_delivery_failure(self) -> None:
+        calls = self._dispatch_receiver_records(
+            [
+                f"DELIVERY v1 received-ms {int(time.time() * 1000)}",
+                "INVALIDATE v1 collection prs owner/repo",
+                f"INVALIDATE v1 checks owner/repo {'c' * 40}",
+                "PROCESS_PR owner/repo 12",
+            ],
+            fail_collection=True,
+        )
+        self.assertEqual(["collection|prs|owner/repo", f"checks|owner/repo|{'c' * 40}"], calls)
+
+    def test_receiver_coalesces_repeated_pr_wakes(self) -> None:
+        calls = self._dispatch_receiver_records(
+            ["PROCESS_PR owner/repo 12"] * 3, use_queue=True
+        )
+        self.assertEqual(["process|owner/repo|12"], calls)
 
     def test_receiver_rejects_unknown_protocol_before_process_pr(self) -> None:
         calls = self._dispatch_receiver_records(

--- a/tests/test-peer-productivity-monitor.sh
+++ b/tests/test-peer-productivity-monitor.sh
@@ -598,6 +598,23 @@ EOF
 }
 test_rewrite_drops_authenticated_self_entry
 
+test_observation_failure_preserves_state() {
+	printf '{"alice":{"current_action":"honour"}}\n' >"$STATE_FILE"
+	printf 'DISPATCH_OVERRIDE_ALICE="honour"\n' >"$OVERRIDE_CONF"
+	cp "$STATE_FILE" "$TEST_DIR/peer-state-before"
+	cp "$OVERRIDE_CONF" "$TEST_DIR/peer-config-before"
+	_self_login() { printf 'self-runner'; return 0; }
+	discover_and_observe() { return 1; }
+	cmd_observe
+	if cmp -s "$STATE_FILE" "$TEST_DIR/peer-state-before" && cmp -s "$OVERRIDE_CONF" "$TEST_DIR/peer-config-before"; then
+		pass "incomplete cycle preserves state and dispatch overrides byte-for-byte"
+	else
+		fail "incomplete cycle changed peer state or dispatch overrides"
+	fi
+	return 0
+}
+test_observation_failure_preserves_state
+
 # ============================================================================
 section "Observe cycle removes stale self state"
 # ============================================================================

--- a/todo/plans/github-api-efficiency-transport-2026-09.md
+++ b/todo/plans/github-api-efficiency-transport-2026-09.md
@@ -1,0 +1,69 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2026 Marcus Quinn -->
+
+# Freshness-safe GitHub API efficiency
+
+## Objective and authority
+
+Implement the reviewed GitHub API efficiency improvements in the primary
+interactive session through verified PR, merge, and explicitly authorised
+release. No background implementation workers. Reduce requests per completed
+unit of work, not merely requests per hour by suppressing useful work.
+
+## Evidence and constraints
+
+The reviewed observation window recorded 148,398 transport attempts, including
+126,595 REST-core attempts and 17,190 unknown quota costs. These are not exact
+HTTP totals or proven single-principal usage. A live `/rate_limit` projection
+disagreed with the headers of an actual REST request; resource-owned response
+headers take precedence. Existing conditional snapshots, single-flight, check
+caches and verified webhook invalidation must be reused rather than duplicated.
+
+Freshness invariants:
+
+- Unknown, failed, incomplete, truncated or out-of-order state is never an empty
+  result, a permission grant, a satisfied dependency or a successful check.
+- Discovery snapshots are not final action-boundary attestations. Keep fresh
+  lock/trust/dependency/check/head verification before dispatch or merge.
+- Permission-scoped cache identity is distinct from shared quota-owner identity.
+  Token rotation must neither grant a fresh user allowance nor cross visibility.
+- Honour primary resets and secondary Retry-After; an error must not trigger an
+  alternate transport or a mutation retry whose outcome is unknown.
+- Event-driven fast paths retain bounded authoritative polling recovery. Event
+  absence is not evidence of freshness without verified coverage and a repair
+  deadline. Do not lengthen safety-sensitive cache TTLs.
+- Preserve CLI stdout, exit status, signatures, auth policy and pagination
+  completeness. Raw requests and wrapper requests share transport controls
+  without duplicate reservation or recursive probes.
+- Never claim measured quota savings from unknown counters. Keep benchmark
+  completeness and correctness gates; separate live diagnostics from immutable
+  completed-cycle evidence.
+
+## Implementation units
+
+All units are owned by the primary session. Implementation concurrency is one;
+independent bounded research/review may use at most two read-only children.
+
+| Unit | Scope / owning files | Dependencies | Tier | Verification |
+|---|---|---|---|---|
+| API-01 | Central transport cooldown, scoped authoritative admission and response reconciliation: `gh`, `gh-native-transport-lib.sh`, `gh-quota-attribution-lib.sh`, shared request/cooldown state | None | thinking | Existing shim/cooldown/request-state suites plus focused fake-transport checks for raw-call suppression, scope isolation, stale observations and concurrent admission |
+| API-02 | Idempotent conversation locks: `pulse-dispatch-core.sh`, `approval-helper.sh` | None | standard | Existing conversation-lock and approval suites; unchanged locked issue makes no mutation while launch still verifies the lock |
+| API-03 | Bounded shared reconciliation/comment/peer projections: `pulse-issue-reconcile.sh`, `pulse-dispatch-lib.sh`, `peer-productivity-monitor.sh` | API-01 | thinking | Existing suites and request-count assertions; failure/partial data cannot authorise action or replace prior valid state |
+| API-04 | Durable event-driven fast scheduling: webhook receiver/server, merge routine/pass | API-01 | thinking | Existing webhook/replay/merge suites; duplicate coalescing, concurrent new event, missing coverage, stale entries and polling repair |
+| API-05 | Cost-aware semantically equivalent read routing using existing projections/fallbacks | API-01, API-03 | thinking | Existing REST equivalence suites; cached/no-op path and bounded query cost; no GraphQL-only fields silently dropped |
+| API-06 | Attribution and publication ownership: transport instrumentation, batch prefetch, efficiency evidence/report docs | API-01 | standard | Existing instrumentation, fixed-cutoff and benchmark suites; in-progress diagnostics cannot overwrite completed-cycle proof |
+| API-07 | Integrated runtime verification, independent review, PR/CI/merge/release/deploy | All | thinking | Scoped ShellCheck/Python checks, exact-head required CI, independent high-risk review, observed release/deployment receipts |
+
+Paths in the table are relative to `.agents/scripts/` unless qualified.
+Any newly required helper will live beside its owning script; its exact name
+will be recorded with implementation evidence before review.
+
+## Rollout and proof
+
+Ship independently reviewable commits with existing conservative TTL and
+freshness limits. Do not enable remote/fleet authority without a configured
+trusted coordinator; expose unknown or unsupported transport cost honestly.
+Retain rollback controls and polling wherever coverage cannot be proven.
+Verify functional request reductions with deterministic call counts, then use
+matched non-overlapping production windows for performance claims. A release
+is not a claim that a multi-day efficiency soak has passed.

--- a/todo/plans/github-api-efficiency-transport-2026-09.md
+++ b/todo/plans/github-api-efficiency-transport-2026-09.md
@@ -67,3 +67,37 @@ Retain rollback controls and polling wherever coverage cannot be proven.
 Verify functional request reductions with deterministic call counts, then use
 matched non-overlapping production windows for performance claims. A release
 is not a claim that a multi-day efficiency soak has passed.
+
+## Evidence-driven implementation refinements (GH#31221)
+
+- Reconciliation's actual query was incompatible with its consumer: it requested
+  closed-unmerged PRs, then required merged evidence. The real REST adapter
+  could scan a large merged history to collect the wrong population. Correcting
+  the selector and preferring server-side CLOSED filtering removes this waste
+  without a new historical-content cache. A real-adapter fixture verifies the
+  intended merged lookup in two pages; canned list mocks had hidden the defect.
+- An initial count-only peer query was implemented and measured at one GraphQL
+  point. During implementation, upstream #31247 independently removed peer
+  request fan-out and corrected dispatch-ownership/freshness semantics. Rebase
+  preserved that newer per-repository implementation rather than shipping an
+  obsolete origin-label-based counter. Additional failure/time guards remain.
+- Dirty-marker checks use a fresh server-side hold-window filter and complete
+  pagination instead of caching a negative result or inspecting only the first
+  hundred comments. Unknown evidence holds; timestamps, not response order,
+  establish resolution. No content-cache TTL was increased.
+- Normal authenticated GET admission is scoped and atomic locally. Other CLI
+  shapes, mutations and exact-capture mode retain their native paths and common
+  cooldown. This is not an unproven distributed quota broker or a claim of
+  complete normal-mode wire accounting. See
+  `.agents/reference/github-api-transport.md` for boundaries and rollback.
+- Verified PR wakes use bounded durable hints, shared logical leases and
+  generation-fenced acknowledgement. Dirty candidates refresh metadata and
+  only break ties inside readiness categories. A failed invalidation stays
+  latched across the entire delivery. Existing polling cadence remains intact.
+- Receiver configuration could not resolve its webhook secret in the observed
+  runtime. Activation/coverage is not assumed, and polling is not slowed.
+- Completed-cycle evidence has one publisher. Ad-hoc live diagnostics do not
+  overwrite its report/sidecar pair. Production percentage claims still require
+  complete, matched evidence; functional tests are not a substitute for a soak.
+
+Issue #31221 and its exact-head PR/release receipts own delivery status.


### PR DESCRIPTION
## Summary

Resolves #31221.

Reduce unnecessary GitHub API work without adding a new content cache or weakening fresh action-boundary checks.

- Correct merged-PR reconciliation's CLOSED/MERGED mismatch. The old selector could scan merged history to collect unmerged PRs, then discard every result. The real-adapter fixture now returns the intended lookup in two pages.
- Prefer native server-side CLOSED filtering under healthy GraphQL rather than low-selectivity REST scans; retain equivalent low-budget fallback.
- Avoid repeated conversation-lock mutations while retaining fresh lock verification. Preserve upstream #31247's per-repository peer observations and current ownership/freshness semantics.
- Fetch only the relevant dirty-worktree comment window, paginate it completely, and hold on missing/malformed evidence instead of falsely clearing recovery state.
- Apply shared cooldown at the native shim boundary. Add scoped local admission and response-header observations for compatible authenticated GETs, with pinned child credentials and native fallback for other CLI shapes.
- Coalesce verified PR wakes with durable generation-fenced hints and per-PR logical leases shared with polling. Refresh dirty metadata, preserve readiness priorities, and latch invalidation failures across a delivery.
- Keep completed-cycle report/sidecar publication separate from live diagnostics.

## Implementation context

Core files: `gh`, `gh-native-transport-lib.sh`, `gh-api-instrument.sh`, `gh-transport-controls.sh`, `gh-transport-governor.py`, `gh_transport_budget.py`, `pulse-issue-reconcile.sh`, `pulse-dispatch-core.sh`, `pulse-dispatch-lib.sh`, `pulse-dirty-worktree-marker.py`, `pulse-merge-dirty-queue.{py,sh}`, and the merge/receiver entrypoints under `.agents/scripts/`.

Reference patterns are the existing REST equivalence adapters, shared cooldown, exact-head merge preflight, and verified webhook invalidation. The implementation plan is `todo/plans/github-api-efficiency-transport-2026-09.md`; operational boundaries and rollback are documented in `.agents/reference/github-api-transport.md`.

## Verification

- `.agents/scripts/linters-local.sh`: passed after rebase; no new required-gate violations. Historical debt and shfmt advisories remain non-blocking.
- Transport budget 15/15; queue 9/9; signed webhook/invalidation 26/26.
- Instrumentation 244/244; shim 159/159; REST equivalence 103/103.
- Reconciliation 31/31; dirty-marker recovery 17/17; conversation locks 8/8.
- PR JSON contract 6/6; backlog priority 18/18; peer monitoring 57/57.
- Tests exercise actual REST translation, local concurrency/owner fencing, new-event-during-processing preservation, inherited caller PID on macOS Bash3.2, fresh metadata without duplicate reads, error/partial-data handling, and unchanged polling safety.

## Runtime Testing

`runtime-verified`: normal shim entrypoint exercised with a live read-only GitHub request; current GraphQL field/cost semantics and paginated `since` comments verified with read-only calls. Production receiver dispatch is exercised through signed fixtures and the real receiver/queue code, without mutating real PRs. No live override configuration was changed during verification.

## Review evidence

Independent high-risk closeout review found no material P0/P1 defects in reviewed head `72c42b832c0d1a0b47016645134d1a1a174c16c2`. Evidence schema `aidevops.review-evidence/v1`, digest `478e6ff4fa7fcfee7683a5e2a17e40a13aa29b0f465c4def23703c7946ed2129`.

## Boundaries and rollout

Polling cadence and content-cache TTLs are unchanged. Missing webhook secret/coverage does not authorize reducing polling or assuming event delivery. Local admission is not distributed fleet coordination. Opaque native transports and exact-capture mode retain their existing native paths; normal final-response observations are not a claim of complete wire accounting. Production percentage savings require matched, complete observation windows and are not claimed here.

The interactive user explicitly authorized full-loop through release. Publication follows verified merge and the canonical release lane; this branch does not directly bump or publish a version.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.313 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 7h 14m and 1,716,211 tokens on this with the user in an interactive session.