### PR TITLE
GH#31259: fix complexity stall sweep Files Scope

### DIFF
--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -311,10 +311,15 @@ The simplification debt count has not decreased in the last $((${COMPLEXITY_LLM_
 
 ### Worker Guidance
 
-- Target files: \`.agents/scripts/pulse-simplification-scan.sh\`, \`.agents/scripts/complexity-scan-helper.sh\`, \`.agents/scripts/pulse-dispatch-engine.sh\`, and matching tests under \`.agents/scripts/tests/\`.
+- Only edit the files authorized in Files Scope below. Other helpers may be read for context; demonstrated defects outside this scope require a separate follow-up, not expanded edits.
 - Reference pattern: keep the inline sweep guard consistent with \`complexity-scan-helper.sh sweep-check\`, especially the recent-closure throughput check before filing a stall issue.
 - Do not close debt issues solely because they are old. Close only when current repo evidence shows the file is deleted, already simplified, or duplicated.
 - Verification: run \`.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh\` plus ShellCheck on changed shell scripts.
+
+### Files Scope
+
+- EDIT: \`.agents/scripts/pulse-simplification-scan.sh\`
+- EDIT: \`.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh\`
 
 ### Confidence: low
 

--- a/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
@@ -377,6 +377,16 @@ test_llm_sweep_meta_review_is_not_measured_debt() {
 		print_result "_complexity_run_llm_sweep: meta review stays outside measured debt" 1 \
 			"list=${list_args}; create=${create_args}"
 	fi
+	local scope expected_scope
+	scope="${create_args#*$'### Files Scope\n'}"
+	scope="${scope%%$'\n### '*}"
+	expected_scope=$'\n- EDIT: `.agents/scripts/pulse-simplification-scan.sh`\n- EDIT: `.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh`\n'
+	if [[ "$create_args" == *$'\n### Files Scope\n'* && "$scope" == "$expected_scope" ]]; then
+		print_result "_complexity_run_llm_sweep: canonical scope authorizes only generator and regression test" 0
+	else
+		print_result "_complexity_run_llm_sweep: canonical scope authorizes only generator and regression test" 1 \
+			"expected exact two-file scope, got: ${scope}"
+	fi
 	unset GH_ISSUE_LIST_JSON _COMPLEXITY_SCAN_SKIP_REVIEW_GATE
 	return 0
 }


### PR DESCRIPTION
## Summary

Generated complexity-stall-sweep briefs now declare canonical Files Scope containing only .agents/scripts/pulse-simplification-scan.sh and .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh. Broad target guidance is replaced with an explicit scope boundary. Existing generated-body test asserts exact scope while retaining meta-quality-debt label checks.

## Files Changed

.agents/scripts/pulse-simplification-scan.sh, .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Bash 5.2.21; ShellCheck 0.9.0. bash .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh: 19/19 passed. shellcheck .agents/scripts/pulse-simplification-scan.sh .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh: passed. Regression red/green: new assertion failed before generator fix (18 pass/1 fail), passes after fix. git diff --check and pre-commit/pre-push hooks passed. Direct low-risk diff review confirms only two scoped files changed and all throughput, active-dispatch, capacity, cleanup and scanner thresholds remain unchanged.

Resolves #31259


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.314 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-6-astra spent 4m and 63,478 tokens on this as a headless worker.
