### PR TITLE
GH#31266: preserve detached worker Git authentication

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -1202,10 +1202,18 @@ _dsi_launch_worker() {
 		cmd+=(--agent "$agent_name")
 	fi
 
+	# Validate the exact producer envelope synchronously in the same runtime
+	# entrypoint. A known local rejection must not create another detached child.
+	# The preflight flag is command-local, never inherited by the real launch.
+	mkdir -p "$_DSI_LOG_DIR"
+	if ! AIDEVOPS_GIT_AUTH_PREFLIGHT_ONLY=1 "${cmd[@]}" >>"$worker_log" 2>&1; then
+		_dsi_err "Worker Git authentication preflight rejected; evidence retained in launcher log"
+		return 1
+	fi
+
 	# Run in background, redirect stdout/stderr to worker_log so caller
 	# doesn't block. Capture launch PID (the env wrapper, which then
 	# exec's the helper).
-	mkdir -p "$_DSI_LOG_DIR"
 	nohup "${cmd[@]}" >>"$worker_log" 2>&1 &
 	local pid=$!
 	disown "$pid" 2>/dev/null || true

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -779,24 +779,48 @@ prepare_headless_git_auth_sandbox_env() {
 	local expected_askpass="${SCRIPT_DIR}/github-auth-askpass.sh"
 	local token_helper="${SCRIPT_DIR}/worker-token-helper.sh"
 	local normalized_origin=""
-	[[ "$repo_slug" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || { _headless_git_auth_reject repository_invalid; return 1; }
-	normalized_origin=$(_normalize_headless_github_origin "$expected_origin") || { _headless_git_auth_reject origin_invalid; return 1; }
-	[[ "$normalized_origin" == "https://github.com/${repo_slug}" ]] || { _headless_git_auth_reject repository_mismatch; return 1; }
+	[[ "$repo_slug" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || {
+		_headless_git_auth_reject repository_invalid
+		return 1
+	}
+	normalized_origin=$(_normalize_headless_github_origin "$expected_origin") || {
+		_headless_git_auth_reject origin_invalid
+		return 1
+	}
+	[[ "$normalized_origin" == "https://github.com/${repo_slug}" ]] || {
+		_headless_git_auth_reject repository_mismatch
+		return 1
+	}
 	# aidevops:trust-boundary — accept path aliases only for the very same trusted
 	# helper, then pin the sandbox value to the runtime's own path. Never execute
 	# the incoming path to establish its identity.
-	[[ -x "$askpass" && -x "$expected_askpass" && "$askpass" -ef "$expected_askpass" ]] || { _headless_git_auth_reject askpass_mismatch; return 1; }
-	[[ -x "$token_helper" ]] || { _headless_git_auth_reject validator_unavailable; return 1; }
-	[[ "${GIT_TERMINAL_PROMPT:-}" == "0" ]] || { _headless_git_auth_reject terminal_prompt_enabled; return 1; }
+	[[ -x "$askpass" && -x "$expected_askpass" && "$askpass" -ef "$expected_askpass" ]] || {
+		_headless_git_auth_reject askpass_mismatch
+		return 1
+	}
+	[[ -x "$token_helper" ]] || {
+		_headless_git_auth_reject validator_unavailable
+		return 1
+	}
+	[[ "${GIT_TERMINAL_PROMPT:-}" == "0" ]] || {
+		_headless_git_auth_reject terminal_prompt_enabled
+		return 1
+	}
 	[[ -n "${GIT_AUTHOR_NAME:-}" && -n "${GIT_AUTHOR_EMAIL:-}" &&
 		"${GIT_COMMITTER_NAME:-}" == "$GIT_AUTHOR_NAME" &&
 		"${GIT_COMMITTER_EMAIL:-}" == "$GIT_AUTHOR_EMAIL" &&
 		"$GIT_AUTHOR_NAME" != *$'\n'* && "$GIT_AUTHOR_EMAIL" != *$'\n'* &&
-		"$GIT_AUTHOR_NAME" != *$'\r'* && "$GIT_AUTHOR_EMAIL" != *$'\r'* ]] || { _headless_git_auth_reject identity_invalid; return 1; }
+		"$GIT_AUTHOR_NAME" != *$'\r'* && "$GIT_AUTHOR_EMAIL" != *$'\r'* ]] || {
+		_headless_git_auth_reject identity_invalid
+		return 1
+	}
 	# aidevops:trust-boundary — only a locally validated, repository-bound token
 	# contract may cross the clean worker sandbox.
 	"$token_helper" validate --token-file "$token_file" --repo "$repo_slug" --local-only \
-		>/dev/null 2>&1 || { _headless_git_auth_reject token_invalid; return 1; }
+		>/dev/null 2>&1 || {
+		_headless_git_auth_reject token_invalid
+		return 1
+	}
 	export GIT_ASKPASS="$expected_askpass"
 	export _AIDEVOPS_HEADLESS_GIT_AUTH_ENV_CONFIGURED=1
 	return 0

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -758,9 +758,19 @@ _normalize_headless_github_origin() {
 	return 0
 }
 
+_headless_git_auth_reject() {
+	# Reasons are fixed literals from local gates, never credential/metadata values.
+	local reason="$1"
+	_HEADLESS_GIT_AUTH_REJECTION="$reason"
+	printf 'worker_git_auth_rejected reason=%s\n' "$_HEADLESS_GIT_AUTH_REJECTION" >&2
+	return 1
+}
+
 prepare_headless_git_auth_sandbox_env() {
 	local role="${1:-worker}"
 	local token_file="${AIDEVOPS_GIT_AUTH_TOKEN_FILE:-}"
+	unset _AIDEVOPS_HEADLESS_GIT_AUTH_ENV_CONFIGURED
+	_HEADLESS_GIT_AUTH_REJECTION=""
 	[[ "$role" == "worker" ]] || return 0
 	[[ -n "$token_file" ]] || return 0
 	local expected_origin="${AIDEVOPS_GIT_AUTH_EXPECTED_ORIGIN:-}"
@@ -769,19 +779,25 @@ prepare_headless_git_auth_sandbox_env() {
 	local expected_askpass="${SCRIPT_DIR}/github-auth-askpass.sh"
 	local token_helper="${SCRIPT_DIR}/worker-token-helper.sh"
 	local normalized_origin=""
-	[[ "$repo_slug" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || return 1
-	normalized_origin=$(_normalize_headless_github_origin "$expected_origin") || return 1
-	[[ "$normalized_origin" == "https://github.com/${repo_slug}" ]] || return 1
-	[[ "$askpass" == "$expected_askpass" && -x "$askpass" && -x "$token_helper" ]] || return 1
-	[[ "${GIT_TERMINAL_PROMPT:-}" == "0" ]] || return 1
-	[[ -n "${GIT_AUTHOR_NAME:-}" && -n "${GIT_AUTHOR_EMAIL:-}" ]] || return 1
-	[[ "${GIT_COMMITTER_NAME:-}" == "$GIT_AUTHOR_NAME" ]] || return 1
-	[[ "${GIT_COMMITTER_EMAIL:-}" == "$GIT_AUTHOR_EMAIL" ]] || return 1
-	[[ "$GIT_AUTHOR_NAME" != *$'\n'* && "$GIT_AUTHOR_EMAIL" != *$'\n'* ]] || return 1
+	[[ "$repo_slug" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || { _headless_git_auth_reject repository_invalid; return 1; }
+	normalized_origin=$(_normalize_headless_github_origin "$expected_origin") || { _headless_git_auth_reject origin_invalid; return 1; }
+	[[ "$normalized_origin" == "https://github.com/${repo_slug}" ]] || { _headless_git_auth_reject repository_mismatch; return 1; }
+	# aidevops:trust-boundary — accept path aliases only for the very same trusted
+	# helper, then pin the sandbox value to the runtime's own path. Never execute
+	# the incoming path to establish its identity.
+	[[ -x "$askpass" && -x "$expected_askpass" && "$askpass" -ef "$expected_askpass" ]] || { _headless_git_auth_reject askpass_mismatch; return 1; }
+	[[ -x "$token_helper" ]] || { _headless_git_auth_reject validator_unavailable; return 1; }
+	[[ "${GIT_TERMINAL_PROMPT:-}" == "0" ]] || { _headless_git_auth_reject terminal_prompt_enabled; return 1; }
+	[[ -n "${GIT_AUTHOR_NAME:-}" && -n "${GIT_AUTHOR_EMAIL:-}" &&
+		"${GIT_COMMITTER_NAME:-}" == "$GIT_AUTHOR_NAME" &&
+		"${GIT_COMMITTER_EMAIL:-}" == "$GIT_AUTHOR_EMAIL" &&
+		"$GIT_AUTHOR_NAME" != *$'\n'* && "$GIT_AUTHOR_EMAIL" != *$'\n'* &&
+		"$GIT_AUTHOR_NAME" != *$'\r'* && "$GIT_AUTHOR_EMAIL" != *$'\r'* ]] || { _headless_git_auth_reject identity_invalid; return 1; }
 	# aidevops:trust-boundary — only a locally validated, repository-bound token
 	# contract may cross the clean worker sandbox.
 	"$token_helper" validate --token-file "$token_file" --repo "$repo_slug" --local-only \
-		>/dev/null 2>&1 || return 1
+		>/dev/null 2>&1 || { _headless_git_auth_reject token_invalid; return 1; }
+	export GIT_ASKPASS="$expected_askpass"
 	export _AIDEVOPS_HEADLESS_GIT_AUTH_ENV_CONFIGURED=1
 	return 0
 }

--- a/.agents/scripts/headless-runtime-run.sh
+++ b/.agents/scripts/headless-runtime-run.sh
@@ -119,6 +119,14 @@ _prepare_cmd_run_environment() {
 		print_error "Repository-bound worker Git authentication failed prelaunch validation"
 		return 1
 	fi
+	# Manual dispatch runs this identical consumer gate before spawning. Return
+	# before detach, model selection, ownership transfer, or credential cleanup:
+	# the dispatcher retains the token until readiness transfers it to the worker.
+	if [[ "${AIDEVOPS_GIT_AUTH_PREFLIGHT_ONLY:-0}" == "1" ]]; then
+		_cmd_run_stop=1
+		_cmd_run_return_status=0
+		return 0
+	fi
 	_ensure_valid_launch_cwd "$work_dir" || return 1
 	_validate_issue_worker_env_contract "$role" "$session_key" "$work_dir" "$title" "$prompt" || return 1
 	_recover_deleted_cwd_before_launch "$work_dir" "cmd_run" || return 1

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -1228,6 +1228,18 @@ FIXTURE
 		command git -C "$root/repo" remote add origin https://github.com/owner/repo.git
 		_dsi_prepare_worker_git_auth owner/repo "$root/repo" fixture || exit 1
 		[[ -n "$_DSI_GIT_AUTH_TOKEN_FILE" ]] || exit 1
+		# Exercise the real cmd_run/import path too, stopping before any model or
+		# worktree ownership side effects. Preflight must not revoke the token.
+		env AIDEVOPS_GIT_AUTH_PREFLIGHT_ONLY=1 WORKER_REPO_SLUG=owner/repo \
+			AIDEVOPS_GIT_AUTH_TOKEN_FILE="$_DSI_GIT_AUTH_TOKEN_FILE" \
+			AIDEVOPS_GIT_AUTH_EXPECTED_ORIGIN="$_DSI_GIT_AUTH_EXPECTED_ORIGIN" \
+			GIT_ASKPASS="$_DSI_ASKPASS_HELPER" GIT_TERMINAL_PROMPT=0 \
+			GIT_AUTHOR_NAME="$_DSI_GIT_AUTHOR_NAME" GIT_AUTHOR_EMAIL="$_DSI_GIT_AUTHOR_EMAIL" \
+			GIT_COMMITTER_NAME="$_DSI_GIT_AUTHOR_NAME" GIT_COMMITTER_EMAIL="$_DSI_GIT_AUTHOR_EMAIL" \
+			"$FIXTURE_SCRIPTS/headless-runtime-helper.sh" run --role worker \
+			--session-key "$FIXTURE_SESSION" --dir "$root/repo" --title fixture \
+			--prompt fixture --detach >"$root/preflight.log" 2>&1 || exit 1
+		[[ -f "$_DSI_GIT_AUTH_TOKEN_FILE" && ! -f "/tmp/worker-${FIXTURE_SESSION}.log" ]] || exit 1
 		local pid="" attempt=0
 		pid=$(_dsi_launch_worker "$FIXTURE_SESSION" "$root/repo" fixture fixture standard '' '' "$root/launch.log" 1 owner/repo fixture) || exit 1
 		[[ "$pid" =~ ^[0-9]+$ ]] || exit 1

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -1158,6 +1158,10 @@ test_launch_worker_forwards_github_login() {
 }
 
 test_launch_worker_forwards_bounded_git_auth() {
+	# shellcheck source=./test-headless-runtime-contract-tests.sh
+	source "${BASH_SOURCE[0]%/*}/test-headless-runtime-contract-tests.sh"
+	test_repository_bound_git_auth_contract
+	test_detached_git_auth_envelope
 	local failed=1
 	if grep -Fq 'AIDEVOPS_GIT_AUTH_TOKEN_FILE="$_DSI_GIT_AUTH_TOKEN_FILE"' "$HELPER_PATH" &&
 		grep -Fq 'AIDEVOPS_GIT_AUTH_EXPECTED_ORIGIN="$_DSI_GIT_AUTH_EXPECTED_ORIGIN"' "$HELPER_PATH" &&
@@ -1167,6 +1171,87 @@ test_launch_worker_forwards_bounded_git_auth() {
 		failed=0
 	fi
 	print_result "worker launch forwards bounded Git auth without token argv" "$failed"
+	return 0
+}
+
+test_detached_git_auth_envelope() {
+	local root="" result=0
+	root=$(mktemp -d)
+	root=$(cd "$root" && pwd -P)
+	_test_git_auth_token_fixture "$root/home"
+	cat >"$root/token-helper" <<'FIXTURE'
+#!/usr/bin/env bash
+case "$1" in
+create) printf '%s' "$HOME/.aidevops/.agent-workspace/tokens/worker-fixture.token" ;;
+validate) exec "$FIXTURE_SCRIPTS/worker-token-helper.sh" "$@" --local-only ;;
+revoke) exec "$FIXTURE_SCRIPTS/worker-token-helper.sh" "$@" ;;
+*) exit 1 ;;
+esac
+FIXTURE
+	cat >"$root/runtime" <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$FIXTURE_SCRIPTS"
+source "$SCRIPT_DIR/headless-runtime-lib.sh"
+source "$SCRIPT_DIR/headless-runtime-run.sh"
+source "$SCRIPT_DIR/headless-runtime-worker-prepare.sh"
+# Only unrelated worker setup is stubbed; authentication, detach, and cleanup
+# are production functions, executed in fresh processes with the real envelope.
+_hrff_capture_external_outcome_contract() { return 0; }
+_ensure_valid_launch_cwd() { return 0; }
+_validate_issue_worker_env_contract() { return 0; }
+_recover_deleted_cwd_before_launch() { return 0; }
+aidevops_init_temp_workspace() { return 0; }
+role=worker private_workload=0 detach=0
+session_key="$FIXTURE_SESSION" work_dir="$WORKER_WORKTREE_PATH" title=fixture prompt=fixture
+_cmd_run_stop=0
+for arg in "$@"; do [[ "$arg" != --detach ]] || detach=1; done
+shift
+_prepare_cmd_run_environment "$@" || exit 1
+[[ "$_cmd_run_stop" != 1 ]] || exit 0
+[[ -f "$AIDEVOPS_GIT_AUTH_TOKEN_FILE" ]] || exit 1
+_headless_git_auth_sandbox_env_is_normalized || exit 1
+printf '%s\n' ready >"$FIXTURE_ROOT/ready"
+cleanup_headless_git_auth
+printf '%s\n' cleaned >"$FIXTURE_ROOT/cleaned"
+FIXTURE
+	chmod 700 "$root/runtime" "$root/token-helper"
+	(
+		export HOME="$root/home" FIXTURE_ROOT="$root"
+		export FIXTURE_SCRIPTS="$_DSI_SCRIPT_DIR" FIXTURE_SESSION="git-auth-fixture-$$"
+		_DSI_HEADLESS="$root/runtime"
+		_DSI_TOKEN_HELPER="$root/token-helper"
+		_DSI_ASKPASS_HELPER="$_DSI_SCRIPT_DIR/../scripts/github-auth-askpass.sh"
+		_DSI_LOG_DIR="$root/logs"
+		mkdir -p "$root/repo"
+		command git -C "$root/repo" init -q
+		command git -C "$root/repo" remote add origin https://github.com/owner/repo.git
+		_dsi_prepare_worker_git_auth owner/repo "$root/repo" fixture || exit 1
+		[[ -n "$_DSI_GIT_AUTH_TOKEN_FILE" ]] || exit 1
+		local pid="" attempt=0
+		pid=$(_dsi_launch_worker "$FIXTURE_SESSION" "$root/repo" fixture fixture standard '' '' "$root/launch.log" 1 owner/repo fixture) || exit 1
+		[[ "$pid" =~ ^[0-9]+$ ]] || exit 1
+		for ((attempt = 0; attempt < 50; attempt++)); do
+			[[ ! -f "$root/cleaned" ]] || break
+			sleep 0.1
+		done
+		[[ -f "$root/ready" && -f "$root/cleaned" && ! -e "$_DSI_GIT_AUTH_TOKEN_FILE" ]] || exit 1
+		rm -f "$root/ready" "$root/cleaned" "/tmp/worker-${FIXTURE_SESSION}.log"
+		_test_git_auth_token_fixture "$HOME"
+		_dsi_prepare_worker_git_auth owner/repo "$root/repo" fixture || exit 1
+		_DSI_GIT_AUTH_EXPECTED_ORIGIN=https://github.com/owner/other
+		for attempt in 1 2; do
+			if _dsi_launch_worker "$FIXTURE_SESSION" "$root/repo" fixture fixture standard '' '' "$root/rejected.log" 1 owner/repo fixture; then exit 1; fi
+		done
+		[[ ! -f "$root/ready" && ! -f "/tmp/worker-${FIXTURE_SESSION}.log" ]] || exit 1
+		[[ -f "$_DSI_GIT_AUTH_TOKEN_FILE" ]] || exit 1
+		[[ "$(grep -c 'reason=repository_mismatch' "$root/rejected.log")" == 2 ]] || exit 1
+		! grep -q 'fixture-only-not-a-credential' "$root/launch.log" "$root/rejected.log" || exit 1
+		_dsi_revoke_worker_git_auth
+		[[ ! -f "$HOME/.aidevops/.agent-workspace/tokens/worker-fixture.token" && -f "$root/rejected.log" ]] || exit 1
+	) || result=1
+	rm -rf "$root"
+	print_result "producer envelope survives detached readiness; cleanup follows readiness and repeated local failures never detach" "$result"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-headless-runtime-contract-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-contract-tests.sh
@@ -8,6 +8,69 @@
 [[ -n "${_TEST_HEADLESS_RUNTIME_CONTRACT_TESTS_LOADED:-}" ]] && return 0
 _TEST_HEADLESS_RUNTIME_CONTRACT_TESTS_LOADED=1
 
+# Shared synthetic fixture: no account credentials, API calls, or model sessions.
+_test_git_auth_token_fixture() {
+	local fixture_home="$1"
+	local token_dir="${fixture_home}/.aidevops/.agent-workspace/tokens"
+	mkdir -p "$token_dir"
+	chmod 700 "$token_dir"
+	printf '%s' 'fixture-only-not-a-credential' >"${token_dir}/worker-fixture.token"
+	printf '%s\n' '{"repo":"owner/repo","strategy":"delegated","expires_at":"2099-01-01T00:00:00Z"}' >"${token_dir}/worker-fixture.meta"
+	chmod 600 "${token_dir}/worker-fixture.token" "${token_dir}/worker-fixture.meta"
+	return 0
+}
+
+test_repository_bound_git_auth_contract() {
+	local root="" scripts="" result=0
+	root=$(mktemp -d)
+	root=$(cd "$root" && pwd -P)
+	scripts=$(cd "${BASH_SOURCE[0]%/*}/.." && pwd -P)
+	_test_git_auth_token_fixture "$root"
+	(
+		export HOME="$root"
+		local SCRIPT_DIR="$scripts"
+		# shellcheck source=../headless-runtime-lib.sh
+		source "$scripts/headless-runtime-lib.sh"
+		export WORKER_REPO_SLUG=owner/repo
+		export AIDEVOPS_GIT_AUTH_TOKEN_FILE="$root/.aidevops/.agent-workspace/tokens/worker-fixture.token"
+		export AIDEVOPS_GIT_AUTH_EXPECTED_ORIGIN=https://github.com/owner/repo
+		export GIT_ASKPASS="$scripts/../scripts/github-auth-askpass.sh" GIT_TERMINAL_PROMPT=0
+		export GIT_AUTHOR_NAME=fixture GIT_AUTHOR_EMAIL=fixture@example.invalid
+		export GIT_COMMITTER_NAME=fixture GIT_COMMITTER_EMAIL=fixture@example.invalid
+		prepare_headless_git_auth_sandbox_env worker || exit 1
+		[[ "$GIT_ASKPASS" == "$scripts/github-auth-askpass.sh" ]] || exit 1
+		_headless_git_auth_sandbox_env_is_normalized || exit 1
+		local reason="" output=""
+		for reason in repository_mismatch askpass_mismatch identity_invalid token_invalid; do
+			output=$(
+				exec 2>&1
+				case "$reason" in
+				repository_mismatch) export WORKER_REPO_SLUG=owner/other ;;
+				askpass_mismatch) export GIT_ASKPASS=/bin/true ;;
+				identity_invalid) export GIT_COMMITTER_NAME=other ;;
+				token_invalid) chmod 644 "$AIDEVOPS_GIT_AUTH_TOKEN_FILE" ;;
+				esac
+				if prepare_headless_git_auth_sandbox_env worker; then exit 1; fi
+				[[ -z "${_AIDEVOPS_HEADLESS_GIT_AUTH_ENV_CONFIGURED:-}" ]] || exit 1
+			) || exit 1
+			[[ "$output" == "worker_git_auth_rejected reason=$reason" ]] || exit 1
+		done
+		chmod 600 "$AIDEVOPS_GIT_AUTH_TOKEN_FILE"
+		cleanup_headless_git_auth
+		[[ ! -e "$root/.aidevops/.agent-workspace/tokens/worker-fixture.token" ]] || exit 1
+		export AIDEVOPS_GIT_AUTH_TOKEN_FILE="$root/.aidevops/.agent-workspace/tokens/worker-fixture.token"
+		export GIT_ASKPASS="$scripts/github-auth-askpass.sh" GIT_TERMINAL_PROMPT=0
+		export GIT_AUTHOR_NAME=fixture GIT_AUTHOR_EMAIL=fixture@example.invalid
+		export GIT_COMMITTER_NAME=fixture GIT_COMMITTER_EMAIL=fixture@example.invalid
+		export AIDEVOPS_GIT_AUTH_EXPECTED_ORIGIN=https://github.com/owner/repo
+		if prepare_headless_git_auth_sandbox_env worker 2>"$root/rejection"; then exit 1; fi
+		[[ "$(<"$root/rejection")" == 'worker_git_auth_rejected reason=token_invalid' ]] || exit 1
+	) || result=1
+	rm -rf "$root"
+	print_result "repository-bound contract normalizes exact helper aliases and rejects invalid/revoked fixtures without secrets" "$result"
+	return 0
+}
+
 test_appends_escalation_contract() {
 	local prompt='/full-loop Implement issue #14964'
 	local output

--- a/.agents/scripts/worker-token-helper.sh
+++ b/.agents/scripts/worker-token-helper.sh
@@ -421,7 +421,10 @@ create_token_file() {
 
 _file_uid() {
 	local path="$1"
-	stat -f '%u' "$path" 2>/dev/null || stat -c '%u' "$path" 2>/dev/null
+	# GNU stat -f can emit filesystem data before failing on the BSD format
+	# argument. Dispatch by the already-detected platform, never concatenate a
+	# failed probe's stdout with the actual UID. %u is shared by GNU and BSD.
+	_stat_batch '%u' "$path"
 	return $?
 }
 


### PR DESCRIPTION
## Summary

Resolves #31266.

- Fix a reproduced Linux authentication defect: the BSD-first UID probe emitted GNU filesystem output before falling back, contaminating the ownership comparison. Use the existing platform-dispatched stat helper instead; ownership and mode checks remain mandatory.
- Accept AskPass path aliases only when they reference the runtime's exact trusted executable, then normalize the sandbox value. Reject other executables, mismatched repository/identity, and invalid token artifacts with fixed, secret-free typed diagnostics.
- Run the exact producer environment through the runtime's authentication preflight synchronously before spawning. Repeated unchanged local rejections do not detach; launcher evidence remains available and existing attempt cleanup retains ownership of the rejected token.
- Preserve the credential across preflight and detached startup; synthetic tests prove cleanup occurs after readiness. No token values enter process arguments, diagnostics, or repository configuration.

## Files Changed

Only the six paths declared by the issue:

- `.agents/scripts/dispatch-single-issue-helper.sh`
- `.agents/scripts/headless-runtime-run.sh`
- `.agents/scripts/headless-runtime-lib.sh`
- `.agents/scripts/worker-token-helper.sh`
- `.agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- `.agents/scripts/tests/test-headless-runtime-contract-tests.sh`

## Runtime Testing

- **Risk level:** critical
- **Verification:** runtime-verified — synthetic credentials only, no model sessions or live smoke dispatch.
- Manual-dispatch suite: **83 passed, 0 failed**, including the real `headless-runtime-helper.sh run` preflight/import path and production producer, detach, validator, and cleanup functions across fresh processes. Only unrelated downstream worker setup is stubbed in the detached fixture.
- Headless-runtime suite: **273 passed, 0 failed**.
- ShellCheck 0.9.0: zero violations across all six scoped files. Pre-commit and pre-push checks pass.

Reproduce with `env -i PATH=/usr/bin:/bin HOME=<test-home> bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh` and the same command for `test-headless-runtime-helper.sh`; both harnesses allocate disposable test homes. Isolating inherited runner settings avoids unrelated host-sensitive-temp failures and an intermittent existing GraphQL mock fallback failure. No host configuration or safety gate was changed.

The Linux UID defect is established by the existing AskPass fixture failing before the fix and passing afterward, plus GNU `stat -f` emitting filesystem text for the BSD probe. This does **not** claim to prove the cause of the original production incident. No live retry of another issue was performed.

## Review and Deferred Existing Findings

Independent read-only security/correctness review found no blocking introduced defects in the final bundle. Two confirmed pre-existing observations remain outside this repair:

1. Readiness can trust a stale deterministic detached log before child liveness (`dispatch-single-issue-helper.sh`, `_dsi_wait_for_worker_readiness`; producer in `headless-runtime-worker-prepare.sh`, `_detach_worker`). Follow-up verification: seed an old readiness marker and launch a non-ready child; require attempt-bound readiness evidence. The detach producer is outside this brief's Files Scope.
2. Direct callers can retain a scoped token on an error after auth validation but before worker cleanup traps are armed (`headless-runtime-run.sh`, `_prepare_cmd_run_environment`; trap setup in `headless-runtime-worker-prepare.sh`). Manual dispatch already compensates through its failure reset. Follow-up verification: inject a cwd/setup failure in a direct invocation and prove narrowly owned token cleanup without revoking a detached child's token.

These are not changed or claimed solved here; no unrelated fixes, protocol changes for #31239, releases, or production credential operations are included.

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.314 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-6-astra spent 28m and 152,107 tokens on this as a headless worker.