### PR TITLE
GH#31271: fix Codacy A-grade monitoring and maintenance safeguards

### DIFF
--- a/.agents/scripts/stats-quality-sweep-tools.sh
+++ b/.agents/scripts/stats-quality-sweep-tools.sh
@@ -10,6 +10,7 @@
 # below the 1500-line gate.
 #
 # Usage: source "${SCRIPT_DIR}/stats-quality-sweep-tools.sh"
+# Read-only Codacy report: bash stats-quality-sweep-tools.sh codacy OWNER/REPO REPO_PATH
 #
 # Dependencies:
 #   - shared-constants.sh (print_error, print_info, _sanitize_markdown, etc.)
@@ -330,6 +331,8 @@ _sweep_sonarcloud_diagnostics() {
 	return 0
 }
 
+_CODACY_HEALTHY_STATE="HEALTHY"
+
 _codacy_telemetry_is_valid() {
 	local grade="$1"
 	local issue_count="$2"
@@ -338,9 +341,26 @@ _codacy_telemetry_is_valid() {
 	local analysed_sha="$5"
 	local remote_sha="$6"
 
-	[[ -n "$grade" ]] && [[ "$issue_count" =~ ^[0-9]+$ ]] &&
+	[[ "$grade" =~ ^[A-F]$ ]] && [[ "$issue_count" =~ ^[0-9]+$ ]] &&
 		[[ "$analysed_loc" =~ ^[1-9][0-9]*$ ]] && [[ "$complex_files" =~ ^[0-9]+$ ]] &&
-		[[ "$analysed_sha" =~ ^[0-9a-fA-F]{7,40}$ ]] && [[ "$remote_sha" =~ ^[0-9a-fA-F]{7,40}$ ]]
+		[[ "$analysed_sha" =~ ^[0-9a-f]{40}$ ]] && [[ "$remote_sha" =~ ^[0-9a-f]{40}$ ]]
+}
+
+_codacy_summary_fields() {
+	local summary_response="$1"
+
+	# API v3.1.0: the repository summary is wrapped in data, not top-level.
+	jq -er '
+		def count: type == "number" and . >= 0 and . == floor;
+		def text: type == "string";
+		.data | select(type == "object") |
+		select(.gradeLetter | text and test("^[A-F]$")) |
+		select(.issuesCount | count) | select(.loc | count and . > 0) |
+		select(.complexFilesCount | count) |
+		select(.lastAnalysedCommit.sha | text and test("^[0-9a-f]{40}$")) |
+		select(.branch.name | text and length > 0) |
+		[.gradeLetter, .issuesCount, .loc, .complexFilesCount, .lastAnalysedCommit.sha] | @tsv
+	' <<<"$summary_response" 2>/dev/null
 }
 
 _codacy_read_healthy_state() {
@@ -359,22 +379,20 @@ _codacy_read_healthy_state() {
 
 _codacy_policy_drift() {
 	local issues_response="$1"
-	local json_number_type="number"
-	local drift_rules=("Bandit_B404" "ESLint8_es-x_no-modules" "ESLint8_es-x_no-block-scoped-variables" "ESLint8_es-x_no-trailing-commas")
-	local drift_output="" rule rule_count
 
-	for rule in "${drift_rules[@]}"; do
-		rule_count=$(jq -r --arg rule "$rule" --arg number_type "$json_number_type" '
-			if (.patternTotals[$rule]? | type) == $number_type then .patternTotals[$rule]
-			elif (.patterns[$rule]? | type) == $number_type then .patterns[$rule]
-			elif (.facets.patterns[$rule]? | type) == $number_type then .facets.patterns[$rule]
-			else [.data[]? | select((.patternId // .pattern // .ruleId // .rule // "") == $rule)] | length
-			end
-		' <<<"$issues_response" 2>/dev/null || echo "")
-		[[ "$rule_count" =~ ^[0-9]+$ ]] || rule_count=0
-		((rule_count > 0)) && drift_output="${drift_output}  - \`${rule}\`: ${rule_count}\n"
-	done
-	printf '%s' "$drift_output"
+	# Only an aggregate overview can establish absence. An issue-search page
+	# (even one with pagination.total) cannot prove a policy rule is absent.
+	jq -e '
+		.data.counts.patterns | type == "array" and all(.[];
+			(.id | type == "string") and
+			(.total | type == "number" and . >= 0 and . == floor))
+	' <<<"$issues_response" >/dev/null 2>&1 || return 1
+	jq -r '
+		["Bandit_B404", "ESLint8_es-x_no-modules",
+		 "ESLint8_es-x_no-block-scoped-variables", "ESLint8_es-x_no-trailing-commas"] as $rules |
+		.data.counts.patterns[] | select(.id as $id | $rules | index($id)) |
+		select(.total > 0) | "  - `\(.id)`: \(.total)"
+	' <<<"$issues_response"
 	return 0
 }
 
@@ -392,14 +410,14 @@ _codacy_classify_health() {
 		printf '%s' "$health_unknown"
 	elif [[ "$analysed_sha" != "$remote_sha" ]]; then
 		printf '%s' "STALE_ANALYSIS"
-	elif [[ -z "$previous_loc" || -z "$previous_sha" ]]; then
-		printf '%s' "BASELINE_UNKNOWN"
-	elif ((analysed_loc * 100 < previous_loc * 80)); then
+	elif [[ -n "$previous_loc" && -n "$previous_sha" ]] && ((analysed_loc * 100 < previous_loc * 80)); then
 		printf '%s' "INDEX_DEGRADED"
 	elif [[ -n "$drift_output" ]]; then
 		printf '%s' "POLICY_DRIFT"
+	elif [[ -z "$previous_loc" || -z "$previous_sha" ]]; then
+		printf '%s' "BASELINE_UNKNOWN"
 	else
-		printf '%s' "HEALTHY"
+		printf '%s' "$_CODACY_HEALTHY_STATE"
 	fi
 	return 0
 }
@@ -427,13 +445,32 @@ _codacy_save_healthy_state() {
 	return 1
 }
 
+_codacy_grade_target() {
+	local grade="$1"
+	local health_state="$2"
+
+	case "$health_state" in
+	UNKNOWN | STALE_ANALYSIS) printf '%s' "UNVERIFIED" ;;
+	*)
+		if [[ "$grade" != "A" ]]; then
+			printf '%s' "BELOW_TARGET"
+		elif [[ "$health_state" == "$_CODACY_HEALTHY_STATE" ]]; then
+			printf '%s' "AT_TARGET"
+		else
+			printf '%s' "UNVERIFIED"
+		fi
+		;;
+	esac
+	return 0
+}
+
 #######################################
 # Run Codacy API check for a repo.
 #
 # Arguments:
 #   $1 - repo slug
 #   $2 - local repository path (used to resolve the remote default SHA)
-# Output: codacy_section markdown to stdout (empty if unavailable)
+# Output: codacy_section markdown to stdout (UNKNOWN if unavailable)
 #######################################
 _sweep_codacy() {
 	local repo_slug="$1"
@@ -444,45 +481,50 @@ _sweep_codacy() {
 	if command -v gopass &>/dev/null; then
 		codacy_token=$(gopass show -o "aidevops/CODACY_API_TOKEN" 2>/dev/null || echo "")
 	fi
-	[[ -z "$codacy_token" ]] && return 0
+	if [[ -z "$codacy_token" ]]; then
+		printf '### Codacy\n\n- **Analysis health**: UNKNOWN\n- **Grade target**: A / UNVERIFIED\n- Codacy API credentials unavailable; no analysis verified.\n'
+		return 0
+	fi
 
 	local codacy_org="${repo_slug%%/*}"
 	local codacy_repo="${repo_slug##*/}"
-	local summary_response issues_response
+	local summary_response issues_response summary_fields overview_body
 	summary_response=$(curl -sS --fail --connect-timeout 5 --max-time 20 -H "api-token: ${codacy_token}" \
-		"https://app.codacy.com/api/v3/analysis/organizations/gh/${codacy_org}/repositories/${codacy_repo}?branch=main" 2>/dev/null || echo "")
+		"https://app.codacy.com/api/v3/analysis/organizations/gh/${codacy_org}/repositories/${codacy_repo}" 2>/dev/null || echo "")
+	local grade="" issue_count="" analysed_loc="" complex_files="" analysed_sha="" remote_sha
+	if summary_fields=$(_codacy_summary_fields "$summary_response"); then
+		IFS=$'\t' read -r grade issue_count analysed_loc complex_files analysed_sha <<<"$summary_fields"
+	fi
+	overview_body=$(jq -c '{branchName: .data.branch.name}' <<<"$summary_response" 2>/dev/null || echo '{}')
 	issues_response=$(curl -sS --fail --connect-timeout 5 --max-time 20 -H "api-token: ${codacy_token}" \
-		"https://app.codacy.com/api/v3/analysis/organizations/gh/${codacy_org}/repositories/${codacy_repo}/issues/search" \
-		-X POST -H "Content-Type: application/json" -d '{"limit":100}' 2>/dev/null || echo "")
-
-	local grade issue_count analysed_loc complex_files analysed_sha remote_sha
-	grade=$(jq -r '.grade // .quality.grade // .metrics.grade // empty' <<<"$summary_response" 2>/dev/null || echo "")
-	issue_count=$(jq -r '.pagination.total // .total // empty' <<<"$issues_response" 2>/dev/null || echo "")
-	analysed_loc=$(jq -r '.totalLinesOfCode // .analysedLinesOfCode // .analyzedLinesOfCode // .metrics.totalLinesOfCode // .metrics.loc // empty' <<<"$summary_response" 2>/dev/null || echo "")
-	complex_files=$(jq -r '.complexFiles // .complexFileCount // .metrics.complexFiles // empty' <<<"$summary_response" 2>/dev/null || echo "")
-	analysed_sha=$(jq -r '.lastAnalyzedCommit // .lastAnalysedCommit // .lastAnalysis.commit.uuid // .lastAnalysis.commit.hash // .commit.uuid // .commit.hash // empty' <<<"$summary_response" 2>/dev/null || echo "")
-	remote_sha=$(git -C "$repo_path" ls-remote origin HEAD 2>/dev/null | cut -f1)
+		"https://app.codacy.com/api/v3/analysis/organizations/gh/${codacy_org}/repositories/${codacy_repo}/issues/overview" \
+		-X POST -H "Content-Type: application/json" -d "$overview_body" 2>/dev/null || echo "")
+	remote_sha=$(git -C "$repo_path" ls-remote origin HEAD 2>/dev/null | cut -f1) || remote_sha=""
 
 	local slug_safe="${repo_slug//\//-}"
 	local state_file="${QUALITY_SWEEP_STATE_DIR}/${slug_safe}.codacy-health.json"
 	local previous_state previous_loc previous_sha drift_output health_state
 	previous_state=$(_codacy_read_healthy_state "$state_file")
 	IFS='|' read -r previous_loc previous_sha <<<"$previous_state"
-	drift_output=$(_codacy_policy_drift "$issues_response")
-	if _codacy_telemetry_is_valid "$grade" "$issue_count" "$analysed_loc" "$complex_files" "$analysed_sha" "$remote_sha"; then
+	if drift_output=$(_codacy_policy_drift "$issues_response") &&
+		_codacy_telemetry_is_valid "$grade" "$issue_count" "$analysed_loc" "$complex_files" "$analysed_sha" "$remote_sha"; then
 		health_state=$(_codacy_classify_health true "$analysed_sha" "$remote_sha" "$previous_loc" "$previous_sha" "$analysed_loc" "$drift_output" "$health_unknown")
 	else
 		health_state="$health_unknown"
 	fi
-	if [[ "$health_state" == "BASELINE_UNKNOWN" || "$health_state" == "HEALTHY" ]] &&
-		! _codacy_save_healthy_state "$state_file" "$grade" "$issue_count" "$analysed_loc" "$complex_files" "$analysed_sha"; then
-		health_state="$health_unknown"
+	if [[ "$health_state" == "BASELINE_UNKNOWN" || "$health_state" == "$_CODACY_HEALTHY_STATE" ]]; then
+		# Repeated small drops must not ratchet a healthy denominator downward.
+		# Retain the whole prior sample, not old LOC/SHA with new issue metrics.
+		if [[ -z "$previous_loc" || -z "$previous_sha" ]] || ((analysed_loc >= previous_loc)); then
+			_codacy_save_healthy_state "$state_file" "$grade" "$issue_count" "$analysed_loc" "$complex_files" "$analysed_sha" || health_state="$health_unknown"
+		fi
 	fi
 
 	printf '### Codacy\n\n- **Grade**: %s\n- **Open issues**: %s\n- **Analysed LOC**: %s\n- **Complex files**: %s\n- **Analysed SHA**: %s\n- **Analysis health**: %s\n' \
 		"${grade:-$health_unknown}" "${issue_count:-$health_unknown}" "${analysed_loc:-$health_unknown}" \
 		"${complex_files:-$health_unknown}" "${analysed_sha:-$health_unknown}" "$health_state"
-	[[ -n "$drift_output" ]] && printf '\n**Policy drift:**\n%b' "$drift_output"
+	printf -- '- **Grade target**: A / %s\n' "$(_codacy_grade_target "$grade" "$health_state")"
+	[[ -n "$drift_output" ]] && printf '\n**Policy drift:**\n%s\n' "$drift_output"
 	printf -- '- **Dashboard**: https://app.codacy.com/gh/%s/%s/dashboard\n' "$codacy_org" "$codacy_repo"
 	return 0
 }
@@ -702,3 +744,16 @@ _Auto-generated by stats-wrapper.sh daily quality sweep. The supervisor will rev
 COMMENT
 	return 0
 }
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	if [[ "${1:-}" != "codacy" || "$#" -ne 3 ]]; then
+		printf 'Usage: bash stats-quality-sweep-tools.sh codacy OWNER/REPO REPO_PATH\n' >&2
+		exit 2
+	fi
+	if [[ ! "$2" =~ ^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ || ! -d "$3" ]]; then
+		printf 'A repository slug and existing local repository directory are required\n' >&2
+		exit 2
+	fi
+	QUALITY_SWEEP_STATE_DIR="${QUALITY_SWEEP_STATE_DIR:-${HOME}/.aidevops/logs/quality-sweep-state}"
+	_sweep_codacy "$2" "$3"
+fi

--- a/.agents/scripts/tests/test-codacy-health-sweep.sh
+++ b/.agents/scripts/tests/test-codacy-health-sweep.sh
@@ -48,34 +48,48 @@ SUMMARY_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 REMOTE_SHA="$SUMMARY_SHA"
 MODE="healthy"
 LOC=1000
+GRADE="B"
+BRANCH="trunk"
 
 gopass() {
+	[[ "$MODE" == "missing-token" ]] && return 1
 	printf 'test-token'
 	return 0
 }
 
 git() {
+	[[ "$MODE" == "remote-failure" ]] && return 1
 	printf '%s\tHEAD\n' "$REMOTE_SHA"
 	return 0
 }
 
 curl() {
 	local arguments="$*"
+	printf '%s\n' "$arguments" >>"${TMP_HOME}/requests"
 	if [[ "$MODE" == "api-failure" ]]; then
 		return 1
 	fi
-	if [[ "$arguments" == *"issues/search"* ]]; then
-		if [[ "$MODE" == "policy-drift" ]]; then
-			printf '%s' '{"pagination":{"total":17},"patternTotals":{"Bandit_B404":69}}'
-		else
-			printf '%s' '{"pagination":{"total":17},"patternTotals":{}}'
-		fi
+	if [[ "$arguments" == *"issues/overview"* ]]; then
+		[[ "$arguments" == *"-X POST"* && "$arguments" == *"\"branchName\":\"${BRANCH}\""* ]] || return 2
+		case "$MODE" in
+		policy-drift)
+			printf '%s' '{"data":{"counts":{"patterns":[{"id":"Bandit_B404","title":"Import subprocess","total":76},{"id":"ESLint8_es-x_no-modules","total":84},{"id":"ESLint8_es-x_no-block-scoped-variables","total":56},{"id":"ESLint8_es-x_no-trailing-commas","total":40}]}}}'
+			;;
+		overview-failure) return 1 ;;
+		overview-missing) printf '%s' '{"data":{"counts":{}}}' ;;
+		overview-invalid) printf '%s' '{"data":{"counts":{"patterns":[{"id":"Bandit_B404","total":"76"}]}}}' ;;
+		search-page) printf '%s' '{"data":[],"pagination":{"total":2468,"cursor":"2"}}' ;;
+		*) printf '%s' '{"data":{"counts":{"patterns":[]}}}' ;;
+		esac
 		return 0
 	fi
 	if [[ "$MODE" == "malformed" ]]; then
 		printf '%s' '{"grade":"B"}'
 	else
-		printf '{"grade":"B","totalLinesOfCode":%s,"complexFiles":4,"lastAnalyzedCommit":"%s"}' "$LOC" "$SUMMARY_SHA"
+		# Redacted shape from the public API v3.1.0 summary, 2026-09-05.
+		jq -cn --arg grade "$GRADE" --arg sha "$SUMMARY_SHA" --arg branch "$BRANCH" --argjson loc "$LOC" \
+			'{data:{grade:88,gradeLetter:$grade,issuesCount:2468,loc:$loc,complexFilesCount:54,
+			lastAnalysedCommit:{sha:$sha},branch:{name:$branch,isDefault:true}}}'
 	fi
 	return 0
 }
@@ -83,30 +97,97 @@ curl() {
 # shellcheck source=/dev/null
 source "${SCRIPTS_DIR}/stats-quality-sweep-tools.sh"
 
+MODE="policy-drift"
 RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
 STATE_FILE="${QUALITY_SWEEP_STATE_DIR}/owner-repo.codacy-health.json"
+assert_contains "first observation detects policy drift" "$RESULT" "**Analysis health**: POLICY_DRIFT"
+if [[ -e "$STATE_FILE" ]]; then
+	printf 'FAIL first drift observation must not seed a baseline\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+MODE="healthy"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
 assert_contains "first valid sample is baseline unknown" "$RESULT" "**Analysis health**: BASELINE_UNKNOWN"
 assert_json_value "first valid sample stores healthy LOC" "$STATE_FILE" '.healthy_loc' "1000"
+assert_contains "live grade letter parsed rather than numeric score" "$RESULT" "**Grade**: B"
+assert_contains "issue count comes from summary" "$RESULT" "**Open issues**: 2468"
+assert_contains "live LOC field parsed" "$RESULT" "**Analysed LOC**: 1000"
+assert_contains "live complex files field parsed" "$RESULT" "**Complex files**: 54"
+assert_contains "nested analysed SHA parsed" "$RESULT" "**Analysed SHA**: $SUMMARY_SHA"
+assert_contains "B grade is explicitly below target" "$RESULT" "**Grade target**: A / BELOW_TARGET"
+
+if command grep -qE 'branch=main|issues/search' "${TMP_HOME}/requests"; then
+	printf 'FAIL requests must use default-branch summary and aggregate overview\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
 
 RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
 assert_contains "matching baseline is healthy" "$RESULT" "**Analysis health**: HEALTHY"
+
+GRADE="A"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "current healthy A is at target" "$RESULT" "**Grade target**: A / AT_TARGET"
 
 REMOTE_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
 assert_contains "stale SHA never renders healthy" "$RESULT" "**Analysis health**: STALE_ANALYSIS"
 assert_json_value "stale SHA retains baseline" "$STATE_FILE" '.healthy_loc' "1000"
+assert_contains "stale A is not verified at target" "$RESULT" "**Grade target**: A / UNVERIFIED"
 
 REMOTE_SHA="$SUMMARY_SHA"
+GRADE="B"
+LOC=900
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "small LOC change remains comparable" "$RESULT" "**Analysis health**: HEALTHY"
+assert_json_value "small LOC drop cannot ratchet denominator down" "$STATE_FILE" '.healthy_loc' "1000"
+assert_json_value "retained baseline metrics remain one coherent sample" "$STATE_FILE" '.grade' "A"
+GRADE="A"
+LOC=800
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "exactly 80 percent is not degraded" "$RESULT" "**Analysis health**: HEALTHY"
+assert_json_value "successive small drops retain high-water baseline" "$STATE_FILE" '.healthy_loc' "1000"
 LOC=799
 RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
 assert_contains "LOC below 80 percent is degraded" "$RESULT" "**Analysis health**: INDEX_DEGRADED"
 assert_json_value "degraded LOC retains baseline" "$STATE_FILE" '.healthy_loc' "1000"
+assert_contains "degraded A is not verified at target" "$RESULT" "**Grade target**: A / UNVERIFIED"
 
 LOC=1000
 MODE="policy-drift"
 RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
 assert_contains "documented rule renders policy drift" "$RESULT" "**Analysis health**: POLICY_DRIFT"
-assert_contains "documented rule includes exact count" "$RESULT" "\`Bandit_B404\`: 69"
+assert_contains "documented rule includes exact aggregate count" "$RESULT" "\`Bandit_B404\`: 76"
+assert_contains "ES modules policy drift includes exact count" "$RESULT" "\`ESLint8_es-x_no-modules\`: 84"
+assert_contains "block-scoped variables drift includes exact count" "$RESULT" "\`ESLint8_es-x_no-block-scoped-variables\`: 56"
+assert_contains "trailing commas drift includes exact count" "$RESULT" "\`ESLint8_es-x_no-trailing-commas\`: 40"
+assert_contains "drifting A is not verified at target" "$RESULT" "**Grade target**: A / UNVERIFIED"
+
+for MODE in overview-failure overview-missing overview-invalid search-page; do
+	RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+	assert_contains "$MODE is unknown, not healthy or zero findings" "$RESULT" "**Analysis health**: UNKNOWN"
+	assert_contains "$MODE preserves available summary evidence" "$RESULT" "**Open issues**: 2468"
+	assert_json_value "$MODE retains baseline" "$STATE_FILE" '.healthy_loc' "1000"
+done
+
+MODE="healthy"
+GRADE="unexpected-grade"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "invalid grade fails closed" "$RESULT" "**Grade**: UNKNOWN"
+GRADE="A"
+LOC=0
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "zero LOC fails closed" "$RESULT" "**Analysis health**: UNKNOWN"
+LOC=1000
+REMOTE_SHA=""
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "missing remote SHA fails closed" "$RESULT" "**Analysis health**: UNKNOWN"
+REMOTE_SHA="$SUMMARY_SHA"
+
+MODE="remote-failure"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "failed Git transport renders UNKNOWN under strict mode" "$RESULT" "**Analysis health**: UNKNOWN"
+assert_json_value "failed Git transport retains baseline" "$STATE_FILE" '.healthy_loc' "1000"
 
 MODE="malformed"
 RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
@@ -117,6 +198,24 @@ MODE="api-failure"
 RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
 assert_contains "API failure is unknown" "$RESULT" "**Analysis health**: UNKNOWN"
 assert_json_value "API failure retains baseline" "$STATE_FILE" '.healthy_loc' "1000"
+
+MODE="missing-token"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "missing credentials are visible, not an omitted report" "$RESULT" "**Analysis health**: UNKNOWN"
+assert_contains "missing credentials cannot verify A" "$RESULT" "**Grade target**: A / UNVERIFIED"
+assert_json_value "missing credentials retain baseline" "$STATE_FILE" '.healthy_loc' "1000"
+
+MODE="healthy"
+QUALITY_SWEEP_STATE_DIR="${TMP_HOME}/not-a-directory"
+printf 'unwritable state parent\n' >"$QUALITY_SWEEP_STATE_DIR"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo" 2>/dev/null)
+assert_contains "state write failure is unknown" "$RESULT" "**Analysis health**: UNKNOWN"
+assert_contains "state write failure cannot verify A" "$RESULT" "**Grade target**: A / UNVERIFIED"
+
+if bash "${SCRIPTS_DIR}/stats-quality-sweep-tools.sh" >"${TMP_HOME}/usage" 2>&1; then
+	printf 'FAIL direct CLI must reject missing arguments\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
 
 rm -rf "$TMP_HOME"
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1

--- a/.agents/tools/code-review/codacy.md
+++ b/.agents/tools/code-review/codacy.md
@@ -33,9 +33,9 @@ tools:
 
 **Current gate (PR and commits):** max 10 new issues, minimum severity Warning.
 
-**Rationale (GH#4910, t1489):** Originally 0 max new issues. Tripped 4x during extract-function refactoring — new helper functions add complexity counts, subprocess calls trigger Bandit warnings. Project grade stays A; these aren't real regressions. Raised to 10 Warning+ to absorb refactoring noise while blocking genuine issues.
+**Historical rationale (GH#4910, t1489):** Originally 0 max new issues. Tripped 4x during extract-function refactoring — new helper functions add complexity counts, subprocess calls trigger Bandit warnings. The grade remained A during that investigation. Raised to 10 Warning+ to absorb refactoring noise; this historical decision does not establish today's grade or justify ignoring genuine new findings.
 
-**Do not revert to 0.** Threshold 0 makes extract-function refactoring impossible without manual Codacy dashboard intervention per PR. The project grade (A) is the meaningful quality signal, not per-PR new-issue count.
+**Do not change thresholds merely to improve a badge.** Evaluate the live project grade, analysis completeness, and individual findings together. A passing per-PR issue-count gate does not establish an A-grade repository.
 
 ## Local Pre-Push Checks (GH#4939)
 
@@ -45,12 +45,12 @@ tools:
 |-------|-------------------|---------|----------|------|
 | `function-complexity` | Function length | >50 lines | >100 lines | `function-complexity` |
 | `nesting-depth` | Cyclomatic complexity | >5 levels | >8 levels | `nesting-depth` |
-| `file-size` | File length | >800 lines | >1500 lines | `file-size` |
+| `file-size` | Non-README Markdown length | >500 lines | New violations | `file-size` |
 | `python-complexity` | Lizard CCN | >8 (advisory) | — | `python-complexity` |
 
 `python-complexity` runs Lizard (same tool Codacy uses) and Pyflakes locally.
 
-Gates are set above current baseline to catch regressions. Reduce thresholds as existing debt is paid down (via code-simplifier issues). Also covers Python files in `.agents/scripts/` for file-size checks.
+Use the checked-in linter and CI policy as the authority for thresholds. Pay down existing debt through bounded fixes; do not increase allowances to pass a quality campaign.
 
 CI enforcement: `.github/workflows/code-quality.yml` runs the same checks on every PR via the `complexity-check` job, blocking merges that exceed thresholds.
 
@@ -78,23 +78,88 @@ curl -s -H "api-token: $CODACY_API_TOKEN" -H "Content-Type: application/json" \
 
 The daily quality sweep reads the repository summary and issue overview without
 changing Codacy settings. It renders grade, issue count, analysed LOC, complex
-files, analysed SHA, and one explicit state:
+files, analysed SHA, an analysis-health state, and a separate A-grade target.
+
+For a read-only remote report without posting to GitHub or running other scanners:
+
+```bash
+bash .agents/scripts/stats-quality-sweep-tools.sh codacy OWNER/REPO /path/to/repo
+```
+
+The command uses the existing Codacy account token from secure storage. It only
+updates the local healthy-sample file when the evidence permits it. Override
+`QUALITY_SWEEP_STATE_DIR` to isolate a diagnostic run from daily-sweep state.
+
+The verified API v3.1.0 contracts are:
+
+- Repository summary: `GET /analysis/organizations/gh/{owner}/repositories/{repo}`;
+  fields are `data.gradeLetter`, `data.issuesCount`, `data.loc`,
+  `data.complexFilesCount`, and `data.lastAnalysedCommit.sha`.
+- Issue overview: `POST /analysis/organizations/gh/{owner}/repositories/{repo}/issues/overview`
+  with `{"branchName":"<summary branch>"}`; complete rule counts are under
+  `data.counts.patterns[]` as `id` and `total`. A first search page is not an
+  aggregate and must never establish zero policy drift.
+- The summary defaults to Codacy's configured default branch, not a hard-coded
+  `main`. Its analysed SHA must match `git ls-remote origin HEAD`.
 
 | State | Meaning | Operator response |
 |-------|---------|-------------------|
-| `BASELINE_UNKNOWN` | A current analysis was recorded, but no trusted prior sample exists. | Wait for the next sweep before comparing LOC. |
-| `HEALTHY` | The analysed SHA matches the remote default head and LOC is at least 80% of the prior healthy sample. | Treat the telemetry as comparable. |
+| `BASELINE_UNKNOWN` | A current, drift-free analysis was recorded, but no trusted prior sample exists. | Independently check indexing scope before relying on the new baseline. |
+| `HEALTHY` | The analysed SHA matches the remote default head, LOC is at least 80% of the healthy high-water sample, and overview data is valid and drift-free. | Treat the telemetry as comparable; this does not mean grade A. |
 | `STALE_ANALYSIS` | Codacy analysed a different commit from the remote default head. | Request/retry analysis; do not compare findings yet. |
 | `INDEX_DEGRADED` | Current analysed LOC is below 80% of the last healthy sample. | Investigate Codacy indexing; the healthy denominator is retained. |
 | `POLICY_DRIFT` | A documented-noise rule has a non-zero overview count. | Investigate coding-standard drift; do not change external settings from the sweep. |
 | `UNKNOWN` | An API, parse, remote-SHA, or state-write failure prevented a trustworthy classification. | Resolve telemetry failure and retain the previous baseline. |
 
 Healthy samples are stored atomically in `QUALITY_SWEEP_STATE_DIR` per repository.
-Stale, degraded, malformed, and API-failure samples never replace that baseline.
+Stale, degraded, policy-drift, malformed, and API-failure samples never replace
+that baseline, including on first observation. Small LOC drops retain the entire
+prior sample, so successive drops cannot gradually normalize a collapsed index.
+An intentional analysis-scope reduction requires an independently verified new
+baseline; do not erase state merely to clear an index warning.
 The documented-noise rules are `Bandit_B404`, `ESLint8_es-x_no-modules`,
 `ESLint8_es-x_no-block-scoped-variables`, and
 `ESLint8_es-x_no-trailing-commas`; their counts are observational evidence, not
 permission to alter Codacy, Bandit, ESLint, or exclusions.
+
+The separate **Grade target** is `A / AT_TARGET`, `A / BELOW_TARGET`, or
+`A / UNVERIFIED`. Only a current A with `HEALTHY` analysis is verified at target.
+A current B–F remains below target even if indexing or policy needs investigation;
+stale, invalid, or incomplete telemetry cannot verify the target.
+
+## Restoring and maintaining A
+
+1. **Verify the denominator first.** Compare the live summary with
+   `GET /analysis/organizations/gh/{owner}/repositories/{repo}/commit-statistics?days=10`
+   and the corresponding Git changes. On 2026-08-29 the aidevops index dropped from
+   814,993 to 285,591 LOC while findings changed from 2,361 to 2,356. Do not describe
+   such a discontinuity as thousands of newly introduced defects.
+2. **Recover indexing through authorised Codacy operations.** The documented
+   `POST /organizations/gh/{owner}/repositories/{repo}/reanalyzeCommit` accepts
+   `{"commitUuid":"<verified SHA>","cleanCache":true}`. Verify the completed
+   analysis and restored scope, not just an accepted request. A 403 is an access
+   blocker: use an authorised account or Codacy support, not repeated requests,
+   synthetic source edits, or expanded exclusions.
+3. **Triage genuine findings in small batches.** Start with security/error findings,
+   then high-density complexity, duplication and unused-code hotspots. Inspect
+   actual callsites and preserve behaviour. Incorrect language-version rules need
+   a documented configuration correction, not obsolete rewrites or blanket ignores.
+   Codacy's configuration file cannot enable/disable tools; verify actual tool
+   settings rather than assuming `engines.*.enabled` entries take effect.
+4. **Prevent new debt.** Run scoped local lint and applicable existing tests, review
+   exact-head Codacy annotations, and retain required PR gates. A tolerated new-issue
+   count is not a daily debt budget. The daily sweep must surface below-target and
+   unknown states for investigation, with deduplicated, owner-assigned remediation.
+5. **Verify publication honestly.** Record the analysed SHA and live grade after
+   merge/release. Keep the live badge visible; never substitute a hard-coded A or
+   zero-findings claim. A release can deliver safeguards without proving restoration:
+   report any unresolved service-side blocker separately and keep that objective open.
+
+Sources: [API schema](https://api.codacy.com/api/api-docs/swagger.yaml),
+[Codacy configuration](https://docs.codacy.com/repositories-configure/codacy-configuration-file/),
+[quality metrics](https://docs.codacy.com/faq/code-analysis/which-metrics-does-codacy-calculate/).
+Codacy's numeric grade boundaries and metric weights are not published there;
+use `gradeLetter` rather than inventing a numeric A cutoff.
 
 **Updating quality gate via API:**
 

--- a/README.md
+++ b/README.md
@@ -1357,7 +1357,7 @@ The setup script offers to install these tools automatically.
 - **[Vaultwarden](https://github.com/dani-garcia/vaultwarden)**: Password and secrets management
 - **[SonarCloud](https://sonarcloud.io/)**: Security and quality analysis (A-grade ratings)
 - **[CodeFactor](https://www.codefactor.io/)**: Code quality metrics (A+ score)
-- **[Codacy](https://www.codacy.com/)**: Multi-tool analysis (0 findings)
+- **[Codacy](https://www.codacy.com/)**: Multi-tool analysis with a live quality badge and daily A-grade monitoring
 - **[CodeRabbit](https://coderabbit.ai/)**: AI-powered code reviews
 - **[Snyk](https://snyk.io/)**: Security vulnerability scanning
 - **[Socket](https://socket.dev/)**: Dependency security and supply chain protection


### PR DESCRIPTION
## Summary

Repair Codacy v3 summary and aggregate policy parsing, preserve healthy index baselines, expose A-grade target and missing telemetry, add a read-only diagnostic command, and replace the stale zero-findings claim. Files: stats-quality-sweep-tools.sh, test-codacy-health-sweep.sh, codacy.md, README.md.

## Files Changed

.agents/scripts/stats-quality-sweep-tools.sh, .agents/scripts/tests/test-codacy-health-sweep.sh, .agents/tools/code-review/codacy.md, README.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused Codacy health tests and 28 sweep serialization tests pass; scoped ShellCheck/shfmt and linters-local.sh --changed pass. Live CLI matches B grade, 2468 findings, 435202 LOC, 54 complex files, and policy counts 76/84/56/40. Independent advisory review found no further defects; review bundle ec3694dc5c96e091ed9c91097920592d3d84a24e992db9a64ddd0568b56576ab.

Resolves #31271


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.315 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 37m and 368,652 tokens on this with the user in an interactive session.