### PR TITLE
GH#31219: simplify failed launch recovery recording

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -674,6 +674,20 @@ recover_failed_launch_state() {
 		"$ledger_helper" "${fail_args[@]}" >/dev/null 2>&1 || true
 	fi
 
+	_record_released_launch_failure "$issue_number" "$repo_slug" "$self_login" "$failure_reason" "$crash_type"
+	return 0
+}
+
+# Record recovery side effects only after ownership release has been verified
+# and the exact ledger attempt has been marked failed.
+# Args: issue number, repo slug, self login, failure reason, crash type
+_record_released_launch_failure() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="$3"
+	local failure_reason="$4"
+	local crash_type="$5"
+
 	# t2394: Invalidate stale cross-runner claims immediately (see helper below).
 	_post_launch_recovery_claim_released "$issue_number" "$repo_slug" "$self_login" "$failure_reason"
 	# t3197: Write a per-issue dispatch cooldown marker so other runners


### PR DESCRIPTION
## Summary

Recover the exact same-file extraction from closed PR #31243 and retained commit 8a3753bf, without its unrelated Qlty gate edits. Only .agents/scripts/pulse-cleanup.sh changes. Ownership verification, exact ledger attempt handling, and recording side-effect order are unchanged. A replacement PR avoids rewriting the retained recovery branch.

## Files Changed

.agents/scripts/pulse-cleanup.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with existing test-post-launch-in-progress-recovery.sh, test-no-worker-process-fix.sh (28 passed), test-pulse-wrapper-characterization.sh (42 passed), and test-pulse-cleanup-unregister.sh. bash -n and shellcheck clean. complexity-regression-helper.sh check --base origin/main --head HEAD: base=1, head=0, new=0. qlty-regression-helper.sh --base origin/main --head HEAD: base=70, head=70, delta=0. git diff --check clean. Independent closeout review found no defects; local bundle b9b6ba91ae143a352eabf6427eb7058ad5be2dd835847aa97c6a1a4f9f1b020d.

Resolves #31219


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.315 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 9m and 79,365 tokens on this with the user in an interactive session.