### PR TITLE
GH#31232: Reject stale release aggregation merge bases

### DIFF
--- a/.agents/scripts/release-provenance-helper.sh
+++ b/.agents/scripts/release-provenance-helper.sh
@@ -97,6 +97,38 @@ _release_provenance_verify_pr_record() {
 	return 0
 }
 
+# Fence new publication only: historical signed tags must remain readable for
+# authorization-gap evidence and later legitimate-release reconciliation.
+_release_provenance_verify_aggregate_base() {
+	local repo_slug="$1"
+	local aggregate_pr="$2"
+	local merge_sha="$3"
+	local pr_json=""
+	local reviewed_head=""
+	local merge_parent=""
+	local comparison=""
+
+	pr_json=$(_release_provenance_pr_json "$repo_slug" "$aggregate_pr") || return 1
+	reviewed_head=$(jq -er '.headRefOid | select(test("^[0-9a-f]{40}$"))' <<<"$pr_json") || return 1
+	merge_parent=$(git rev-parse "${merge_sha}^1" 2>/dev/null) || return 1
+	# Use immutable SHA endpoints rather than fetching a mutable PR branch into
+	# shared refs. The merge parent must already belong to the reviewed ancestry;
+	# matching trees alone misses empty/metadata-only source PRs.
+	comparison=$(gh api "repos/${repo_slug}/compare/${reviewed_head}...${merge_parent}" 2>/dev/null) || {
+		_release_provenance_error "cannot verify reviewed base of aggregation PR #${aggregate_pr}"
+		return 1
+	}
+	#aidevops:trust-boundary
+	if ! jq -e --arg head "$reviewed_head" --arg parent "$merge_parent" '
+		.base_commit.sha == $head and .merge_base_commit.sha == $parent
+		and .ahead_by == 0 and (.status == "behind" or .status == "identical")
+	' <<<"$comparison" >/dev/null; then
+		_release_provenance_error "aggregation PR #${aggregate_pr} inherited unreviewed default-branch commits; prepare a fresh exact-tip aggregation with the complete source set"
+		return 1
+	fi
+	return 0
+}
+
 _release_provenance_expected_sources() {
 	local requested_pr="$1"
 	local raw_sources="$2"
@@ -271,6 +303,7 @@ _release_provenance_resolve_source() {
 		return 1
 	}
 	_release_provenance_verify_pr_record "$repo_slug" "$branch_name" "$aggregate_pr" "$release_head" "$release_head" || return 1
+	_release_provenance_verify_aggregate_base "$repo_slug" "$aggregate_pr" "$release_head" || return 1
 	if [[ "$requested_pr" == "$aggregate_pr" && "$requested_merge" == "$release_head" ]]; then
 		found_requested=true
 	fi

--- a/.agents/scripts/tests/test-release-provenance-helper.sh
+++ b/.agents/scripts/tests/test-release-provenance-helper.sh
@@ -177,6 +177,10 @@ AGG_THIRD=$(git -C "$AGG_REPO" rev-parse HEAD)
 git -C "$AGG_REPO" commit -q --allow-empty -m 'fourth authorized source merge'
 AGG_FOURTH=$(git -C "$AGG_REPO" rev-parse HEAD)
 git -C "$AGG_REPO" commit -q --allow-empty -m 'unreviewed automated synchronization'
+AGG_BASE=$(git -C "$AGG_REPO" rev-parse HEAD)
+AGG_TREE=$(git -C "$AGG_REPO" rev-parse 'HEAD^{tree}')
+AGG_REVIEWED_HEAD=$(git -C "$AGG_REPO" commit-tree "$AGG_TREE" -p "$AGG_BASE" -m 'reviewed aggregate branch')
+AGG_STALE_HEAD=$(git -C "$AGG_REPO" commit-tree "$AGG_TREE" -p "$AGG_THIRD" -m 'aggregate prepared before late source')
 git -C "$AGG_REPO" commit -q --allow-empty -m "reviewed aggregate source
 
 Aidevops-Release-Aggregator-PR: 99
@@ -192,13 +196,26 @@ if [[ "\${1:-}" == "pr" ]]; then
 	43) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-26T01:00:00Z","baseRefName":"main","headRefOid":"second-head","mergeCommit":{"oid":"${AGG_SECOND}"}}' ;;
 	44) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-26T02:00:00Z","baseRefName":"main","headRefOid":"third-head","mergeCommit":{"oid":"${AGG_THIRD}"}}' ;;
 	45) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-26T03:00:00Z","baseRefName":"main","headRefOid":"fourth-head","mergeCommit":{"oid":"${AGG_FOURTH}"}}' ;;
-	99) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-27T00:00:00Z","baseRefName":"main","headRefOid":"aggregate-head","mergeCommit":{"oid":"${AGGREGATE_MERGE}"}}' ;;
-	100) printf '{"state":"MERGED","mergedAt":"2026-07-28T00:00:00Z","baseRefName":"main","headRefOid":"complete-head","mergeCommit":{"oid":"%s"}}\n' "\${COMPLETE_AGGREGATE_MERGE:?}" ;;
+	99) printf '{"state":"MERGED","mergedAt":"2026-07-27T00:00:00Z","baseRefName":"main","headRefOid":"%s","mergeCommit":{"oid":"${AGGREGATE_MERGE}"}}\n' "\${AGG_TEST_REVIEWED_HEAD:-${AGG_REVIEWED_HEAD}}" ;;
+	100) printf '{"state":"MERGED","mergedAt":"2026-07-28T00:00:00Z","baseRefName":"main","headRefOid":"${AGGREGATE_MERGE}","mergeCommit":{"oid":"%s"}}\n' "\${COMPLETE_AGGREGATE_MERGE:?}" ;;
 	*) exit 1 ;;
 	esac
 	exit 0
 fi
 case "\${2:-}" in
+repos/test/aggregate/compare/*)
+	[[ "\${AGG_TEST_COMPARE_FAILURE:-false}" != true ]] || exit 1
+	comparison="\${2##*/}"
+	base="\${comparison%%...*}"
+	parent="\${comparison#*...}"
+	merge_base=\$(git -C "${AGG_REPO}" merge-base "\$base" "\$parent") || exit 1
+	ahead=\$(git -C "${AGG_REPO}" rev-list --count "\$base..\$parent") || exit 1
+	status=behind
+	[[ "\$ahead" == 0 ]] || status=ahead
+	[[ "\$merge_base" == "\$base" || "\$merge_base" == "\$parent" ]] || status=diverged
+	[[ "\$base" != "\$parent" ]] || status=identical
+	printf '{"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"},"ahead_by":%s,"status":"%s"}\n' "\$base" "\$merge_base" "\$ahead" "\$status"
+	;;
 repos/test/aggregate/git/ref/tags/v2.0.0)
 	printf '{"object":{"type":"tag","sha":"%s"}}\n' "\$(git -C "${AGG_REPO}" rev-parse refs/tags/v2.0.0)"
 	;;
@@ -220,6 +237,31 @@ jq -e --arg merge "$AGGREGATE_MERGE" --arg original "$AGG_ORIGINAL" '
 	and .aggregated_sources == [{pr:42,merge:$original}]
 ' <<<"$aggregate_json" >/dev/null
 printf 'PASS reviewed aggregation manifest recovers an authorized historical source\n'
+
+# The prepared source list and trusted caller input can both be stale. A later
+# empty reviewed PR changes ancestry without changing the tree, so a tree-only
+# check or comparison of those two identical source lists cannot catch the gap.
+for requested_pr in 42 99; do
+	if (
+		cd "$AGG_REPO" || exit 1
+		AGG_TEST_REVIEWED_HEAD="$AGG_STALE_HEAD" PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
+			bash "$HELPER" resolve-source --source-pr "$requested_pr" --repo test/aggregate
+	) >"${TEST_ROOT}/stale-aggregate-error" 2>&1; then
+		printf 'FAIL stale reviewed aggregate accepted for source %s\n' "$requested_pr"
+		exit 1
+	fi
+	grep -q 'inherited unreviewed default-branch commits' "${TEST_ROOT}/stale-aggregate-error"
+done
+printf 'PASS late merged sources block both historical-source and aggregate-self publication\n'
+if (
+	cd "$AGG_REPO" || exit 1
+	AGG_TEST_COMPARE_FAILURE=true PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
+		bash "$HELPER" resolve-source --source-pr 42 --repo test/aggregate
+) >/dev/null 2>&1; then
+	printf 'FAIL unavailable aggregate ancestry evidence was accepted\n'
+	exit 1
+fi
+printf 'PASS unavailable aggregate ancestry evidence fails closed\n'
 
 if (
 	cd "$AGG_REPO" || exit 1


### PR DESCRIPTION
## Summary

Add a pre-publication ancestry fence in release-provenance-helper.sh: the aggregate merge first parent must already be in the merged PR head ancestry. Both source-PR and aggregate-self calls reject stale reviewed bases, including identical-tree late merges. Extend test-release-provenance-helper.sh with realistic divergent branch fixtures and API failure coverage.

## Files Changed

.agents/scripts/release-provenance-helper.sh, .agents/scripts/tests/test-release-provenance-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: bash .agents/scripts/tests/test-release-provenance-helper.sh and bash .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh pass; scoped ShellCheck, shfmt -d, and git diff --check pass. Live read-only GitHub comparison for aggregate 31227 confirms ahead_by=2 and status=diverged. Local review bundle ace6bd9504d8d3e263af58d97df1d8c8068a566c71101613892bad1eede00fe7; independent review plus direct inspection performed.

Resolves #31232


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.315 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 14m and 98,377 tokens on this with the user in an interactive session.