### PR TITLE
GH#31282: stabilize unchanged-base Qlty scan consensus

### DIFF
--- a/.agents/scripts/qlty-regression-helper.sh
+++ b/.agents/scripts/qlty-regression-helper.sh
@@ -118,7 +118,7 @@ run_qlty_sarif() {
 	# --all: scan all files; --sarif: JSON output;
 	# --no-snippets: compact; --quiet: suppress progress.
 	# qlty exits non-zero when smells exist — SARIF still written to stdout.
-	# Qlty 0.619.0-0.636.0 can emit intermittent similar-code findings while
+	# Qlty 0.619.0-0.643.0 can emit intermittent similar-code findings while
 	# warming an empty cache. Accept the first matching identity set from up to
 	# three scans so one transient pass cannot create or hide a regression.
 	(cd "$_dir" && XDG_CACHE_HOME="$_cache_dir" "$QLTY_BIN" smells --all --sarif --no-snippets --quiet) \
@@ -135,6 +135,11 @@ run_qlty_sarif() {
 			"1:rc=$_first_rc,count=$(scan_result_count "$_first");2:rc=$_second_rc,count=$(scan_result_count "$_second")"
 		return 1
 	fi
+	# Exclude only unrelated duplicate-code clusters before testing scan
+	# consensus. Qlty 0.643.0 can reshuffle those clusters on every scan;
+	# changed-file clusters remain in the comparison and still block a PR.
+	scope_current_scan_similar_code "$_first" || return 1
+	scope_current_scan_similar_code "$_second" || return 1
 	if cmp -s <(normalized_identities "$_first") <(normalized_identities "$_second"); then
 		mv "$_second" "$_out"
 		log "qlty identities stabilized after 2 scans for $_dir"
@@ -147,6 +152,7 @@ run_qlty_sarif() {
 			"1:rc=$_first_rc,count=$(scan_result_count "$_first");2:rc=$_second_rc,count=$(scan_result_count "$_second");3:rc=$_third_rc,count=$(scan_result_count "$_third")"
 		return 1
 	fi
+	scope_current_scan_similar_code "$_third" || return 1
 	if cmp -s <(normalized_identities "$_first") <(normalized_identities "$_third") ||
 		cmp -s <(normalized_identities "$_second") <(normalized_identities "$_third"); then
 		mv "$_third" "$_out"
@@ -254,6 +260,18 @@ scope_similar_code_to_changed_files() {
 	_after=$(count_smells "$_sarif")
 	log "diff-scoped similar-code findings for $(basename "$_sarif"): before=$_before after=$_after"
 	return 0
+}
+
+# Scope duplicate-code findings before scan consensus when comparing different
+# trees. Same-tree scans retain every identity so the parity guard stays strict.
+scope_current_scan_similar_code() {
+	local _sarif="$1"
+	if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ] ||
+		[ "${BASE_TREE:-}" = "${HEAD_TREE:-}" ]; then
+		return 0
+	fi
+	scope_similar_code_to_changed_files "$BASE_SHA" "$HEAD_SHA" "$_sarif"
+	return $?
 }
 
 emit_scan_metadata() {

--- a/.agents/scripts/tests/test-qlty-regression-helper.sh
+++ b/.agents/scripts/tests/test-qlty-regression-helper.sh
@@ -117,6 +117,16 @@ if [ "${QLTY_STUB_MODE:-parity}" = "never-stable" ]; then
 	printf '{"runs":[{"results":[{"ruleId":"qlty:unstable","locations":[{"physicalLocation":{"artifactLocation":{"uri":"attempt-%s.sh"}}}]}]}]}\n' "$run_count"
 	exit 0
 fi
+if [ "${QLTY_STUB_MODE:-parity}" = "diff-unstable-unrelated" ]; then
+	run_count=0
+	if [ -f "$XDG_CACHE_HOME/run-count" ]; then
+		run_count=$(cat "$XDG_CACHE_HOME/run-count")
+	fi
+	run_count=$((run_count + 1))
+	printf '%s\n' "$run_count" >"$XDG_CACHE_HOME/run-count"
+	printf '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"unrelated-%s.py"}}}]}]}]}\n' "$run_count"
+	exit 0
+fi
 if [ "${QLTY_STUB_MODE:-parity}" = "topology-sensitive" ]; then
 	if [ "$(basename "$PWD")" = "repo" ]; then
 		printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"direct-only.sh"}}}]}]}]}'
@@ -198,6 +208,13 @@ metadata_output=$(cd "$REPO" && "$HELPER" --base HEAD^ --head HEAD 2>&1)
 metadata_rc=$?
 assert_rc "metadata-only commit diff-scopes unchanged source findings" "0" "$metadata_rc"
 assert_contains "metadata-only scan reports zero delta" "base: 0  head: 0  delta: 0" "$metadata_output"
+
+QLTY_STUB_MODE=diff-unstable-unrelated
+export QLTY_STUB_MODE
+diff_unstable_output=$(cd "$REPO" && "$HELPER" --base HEAD^ --head HEAD 2>&1)
+diff_unstable_rc=$?
+assert_rc "unrelated duplicate-code noise is scoped before consensus" "0" "$diff_unstable_rc"
+assert_contains "unrelated duplicate-code noise stabilizes after scoping" "identities stabilized after 2 scans" "$diff_unstable_output"
 
 QLTY_STUB_MODE=unchanged-file-regression
 export QLTY_STUB_MODE


### PR DESCRIPTION
## Summary

Scopes unrelated duplicate-code findings before consensus while retaining changed-file clusters and same-tree parity checks.

## Files Changed

.agents/scripts/qlty-regression-helper.sh, .agents/scripts/tests/test-qlty-regression-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash -n and ShellCheck passed; bash .agents/scripts/tests/test-qlty-regression-helper.sh passed all 32 cases, including unstable unrelated duplicate identities, changed-file regressions, failed scans, and same-tree mismatches.

Resolves #31282


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.316 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 3m and 74,616 tokens on this as a headless worker.