### PR TITLE
GH#31290: exclude runtime state from full-loop staging

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -865,17 +865,35 @@ _validate_commit_and_pr_inputs() {
 
 # --- Staging & Commit ---
 
-# Stage all changes and commit with the given message.
+# Stage product changes without relying on repository-specific ignore rules.
+# Refuse pre-staged runtime changes rather than silently altering the index.
+_stage_product_changes() {
+	local path=""
+	local -a runtime_paths=(".agents/loop-state" ".agents/.full-loop-cleanup-deferred")
+	local -a protected_paths=() stage_paths=(":(top)**")
+	for path in "${runtime_paths[@]}"; do
+		protected_paths+=(":(top,literal)${path}")
+		stage_paths+=(":(top,exclude,literal)${path}")
+	done
+	if ! git diff --cached --quiet -- "${protected_paths[@]}"; then
+		print_error "Runtime state is staged, or its index check failed; unstage runtime paths before retrying."
+		return 1
+	fi
+	if ! git add -A -- "${stage_paths[@]}"; then
+		print_error "git add failed while excluding runtime state"
+		return 1
+	fi
+	return 0
+}
+
+# Stage product changes and commit with the given message.
 # Skips commit if nothing staged but commits exist ahead of the remote default branch.
 # Returns 1 on failure.
 _stage_and_commit() {
 	local commit_message="$1"
 
 	print_info "Staging and committing changes..."
-	if ! git add -A; then
-		print_error "git add failed"
-		return 1
-	fi
+	_stage_product_changes || return 1
 
 	if git diff --cached --quiet 2>/dev/null; then
 		local base_branch="" base_ref="" ahead=""

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -870,10 +870,12 @@ _validate_commit_and_pr_inputs() {
 _stage_product_changes() {
 	local path=""
 	local -a runtime_paths=(".agents/loop-state" ".agents/.full-loop-cleanup-deferred")
-	local -a protected_paths=() stage_paths=(":(top)**")
+	local -a protected_paths=() stage_paths=(":/")
 	for path in "${runtime_paths[@]}"; do
 		protected_paths+=(":(top,literal)${path}")
-		stage_paths+=(":(top,exclude,literal)${path}")
+		# A singleton glob matches the exact dot while preventing Git from
+		# rejecting an ignored literal exclusion as an explicitly added path.
+		stage_paths+=(":(top,exclude)[.]${path#.}" ":(top,exclude)[.]${path#.}/**")
 	done
 	if ! git diff --cached --quiet -- "${protected_paths[@]}"; then
 		print_error "Runtime state is staged, or its index check failed; unstage runtime paths before retrying."

--- a/.agents/scripts/tests/test-full-loop-wip-finalization.sh
+++ b/.agents/scripts/tests/test-full-loop-wip-finalization.sh
@@ -296,11 +296,15 @@ test_orchestrator_finalizes_before_validation() {
 }
 
 test_runtime_state_is_not_committed() {
-	local repo_dir="${TEST_ROOT}/runtime-exclusion"
+	local ignored="${1:-false}"
+	local repo_dir="${TEST_ROOT}/runtime-exclusion-${ignored}"
 	make_repo "$repo_dir" || return 1
 	(
 		set -e
 		cd "$repo_dir" || exit 1
+		if [[ "$ignored" == true ]]; then
+			printf '.agents/loop-state/\n' >.gitignore
+		fi
 		mkdir -p .agents/loop-state/nested .agents/product subdir
 		printf 'runtime\n' >.agents/loop-state/full-loop.local.state
 		printf 'nested runtime\n' >.agents/loop-state/nested/state
@@ -319,7 +323,7 @@ test_runtime_state_is_not_committed() {
 		[[ -f .agents/loop-state/full-loop.local.state ]]
 		[[ -f .agents/.full-loop-cleanup-deferred ]]
 	) >/dev/null 2>&1
-	print_result 'subdirectory staging commits product files but preserves untracked runtime state' "$?"
+	print_result "subdirectory staging preserves runtime state (ignored=${ignored})" "$?"
 	return 0
 }
 
@@ -348,6 +352,7 @@ test_prestaged_runtime_fails_closed() {
 }
 
 test_runtime_state_is_not_committed
+test_runtime_state_is_not_committed true
 test_prestaged_runtime_fails_closed
 test_single_wip_is_finalized
 test_buried_wip_squashes_branch_range
@@ -359,8 +364,8 @@ test_base_drift_fails_closed_without_reverting_upstream
 test_orchestrator_finalizes_before_validation
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
-if [[ "$TESTS_RUN" -ne 10 ]]; then
-	printf '%sFAIL%s expected 10 tests to execute\n' "$TEST_RED" "$TEST_RESET"
+if [[ "$TESTS_RUN" -ne 11 ]]; then
+	printf '%sFAIL%s expected 11 tests to execute\n' "$TEST_RED" "$TEST_RESET"
 	exit 1
 fi
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1

--- a/.agents/scripts/tests/test-full-loop-wip-finalization.sh
+++ b/.agents/scripts/tests/test-full-loop-wip-finalization.sh
@@ -295,6 +295,60 @@ test_orchestrator_finalizes_before_validation() {
 	return 0
 }
 
+test_runtime_state_is_not_committed() {
+	local repo_dir="${TEST_ROOT}/runtime-exclusion"
+	make_repo "$repo_dir" || return 1
+	(
+		set -e
+		cd "$repo_dir" || exit 1
+		mkdir -p .agents/loop-state/nested .agents/product subdir
+		printf 'runtime\n' >.agents/loop-state/full-loop.local.state
+		printf 'nested runtime\n' >.agents/loop-state/nested/state
+		printf 'cleanup\n' >.agents/.full-loop-cleanup-deferred
+		printf 'legitimate\n' >.agents/product/config.md
+		printf 'product\n' >>tracked.txt
+		printf 'already staged\n' >staged.txt
+		git add staged.txt
+		cd subdir || exit 1
+		_stage_and_commit 'fix: product only'
+		cd .. || exit 1
+		[[ "$(git show HEAD:tracked.txt)" == $'base\nproduct' ]]
+		[[ "$(git show HEAD:staged.txt)" == 'already staged' ]]
+		[[ "$(git show HEAD:.agents/product/config.md)" == 'legitimate' ]]
+		[[ -z "$(git ls-files .agents/loop-state .agents/.full-loop-cleanup-deferred)" ]]
+		[[ -f .agents/loop-state/full-loop.local.state ]]
+		[[ -f .agents/.full-loop-cleanup-deferred ]]
+	) >/dev/null 2>&1
+	print_result 'subdirectory staging commits product files but preserves untracked runtime state' "$?"
+	return 0
+}
+
+test_prestaged_runtime_fails_closed() {
+	local repo_dir="${TEST_ROOT}/prestaged-runtime"
+	make_repo "$repo_dir" || return 1
+	(
+		set -e
+		cd "$repo_dir" || exit 1
+		mkdir -p .agents/loop-state
+		printf 'runtime\n' >.agents/loop-state/full-loop.local.state
+		printf 'product\n' >staged.txt
+		git add .agents/loop-state staged.txt
+		local original_head="" original_index=""
+		original_head=$(git rev-parse HEAD)
+		original_index=$(git write-tree)
+		if _stage_and_commit 'fix: must reject runtime' >failure.log 2>&1; then
+			exit 1
+		fi
+		grep -q 'Runtime state is staged' failure.log
+		[[ "$(git rev-parse HEAD)" == "$original_head" ]]
+		[[ "$(git write-tree)" == "$original_index" ]]
+	) >/dev/null 2>&1
+	print_result 'pre-staged runtime fails visibly without changing HEAD or index' "$?"
+	return 0
+}
+
+test_runtime_state_is_not_committed
+test_prestaged_runtime_fails_closed
 test_single_wip_is_finalized
 test_buried_wip_squashes_branch_range
 test_no_wip_preserves_history
@@ -305,8 +359,8 @@ test_base_drift_fails_closed_without_reverting_upstream
 test_orchestrator_finalizes_before_validation
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
-if [[ "$TESTS_RUN" -ne 8 ]]; then
-	printf '%sFAIL%s expected 8 tests to execute\n' "$TEST_RED" "$TEST_RESET"
+if [[ "$TESTS_RUN" -ne 10 ]]; then
+	printf '%sFAIL%s expected 10 tests to execute\n' "$TEST_RED" "$TEST_RESET"
 	exit 1
 fi
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Protect final staging with root-anchored runtime exclusions and reject pre-staged runtime changes without altering the index. Preserve legitimate .agents content.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/tests/test-full-loop-wip-finalization.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: real Git fixture commits from a subdirectory preserve product files with and without ignore rules; pre-staged runtime fails with unchanged index and HEAD. WIP 11, default-branch 3, runtime-risk 27, linkage 4 and alias checks pass; ShellCheck clean.

Resolves #31290


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.316 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 25m and 120,831 tokens on this with the user in an interactive session.