### PR TITLE
GH#31261: Preserve API deferral through full-loop verification

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -25,6 +25,7 @@
 _FULL_LOOP_COMMIT_LIB_LOADED=1
 _FULL_LOOP_CHECK_PENDING="pending"
 _FULL_LOOP_CHECK_INDETERMINATE="indeterminate"
+_FULL_LOOP_CHECK_DEFERRED="api-deferred"
 _FULL_LOOP_TRUE="true"
 FULL_LOOP_COMPLETION_BOOKKEEPING_AUDIT=""
 FULL_LOOP_COMPLETION_BOOKKEEPING_FILES=""
@@ -134,6 +135,11 @@ _full_loop_query_required_checks() {
 		else
 			FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="GitHub API cooldown is active"
 		fi
+	elif [[ "$required_checks_stderr" == *"error_kind=github-api-read-deferred"* ]]; then
+		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="github-api-read-deferred"
+		FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="retry-when-capacity-returns"
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="github-api-read-deferred"
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="GitHub API read capacity is deferred; preserve the PR and retry when capacity returns"
 	fi
 
 	if [[ "$required_rc" -eq 1 && -z "$required_checks" && -n "$pr_head_ref" && "$required_checks_stderr" == "$expected_no_required_checks" ]]; then
@@ -243,6 +249,24 @@ _full_loop_reconcile_stale_coderabbit_review() {
 	return 0
 }
 
+# Keep transport backpressure distinct from CI or malformed-evidence failures.
+_full_loop_record_check_read_failure() {
+	local pr_number="$1"
+	local verified_head="$2"
+	FULL_LOOP_PR_CHECK_STATUS="$_FULL_LOOP_CHECK_INDETERMINATE"
+	case "$FULL_LOOP_PRE_MERGE_BLOCKER_KIND" in
+	github-api-cooldown | github-api-read-deferred) FULL_LOOP_PR_CHECK_STATUS="$_FULL_LOOP_CHECK_DEFERRED" ;;
+	esac
+	export FULL_LOOP_PR_CHECK_STATUS
+	_full_loop_persist_pr_check_evidence "$FULL_LOOP_PR_CHECK_STATUS" "$verified_head" "$FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE" || true
+	if [[ "$FULL_LOOP_PR_CHECK_STATUS" == "$_FULL_LOOP_CHECK_DEFERRED" ]]; then
+		print_info "PR #${pr_number} verification deferred (${FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL}); no CI failure, repair or duplicate implementation is established"
+	else
+		print_error "PR #${pr_number} required-check evidence is indeterminate (${FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL})"
+	fi
+	return 0
+}
+
 _full_loop_verify_pr_readiness() {
 	local pr_number="$1"
 	local repo="$2"
@@ -277,10 +301,7 @@ _full_loop_verify_pr_readiness() {
 
 	local required_checks=""
 	_full_loop_query_required_checks "$pr_number" "$repo" "$pr_head_ref" || {
-		FULL_LOOP_PR_CHECK_STATUS="$_FULL_LOOP_CHECK_INDETERMINATE"
-		export FULL_LOOP_PR_CHECK_STATUS
-		_full_loop_persist_pr_check_evidence "$FULL_LOOP_PR_CHECK_STATUS" "$verified_head" "$FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE" || true
-		print_error "PR #${pr_number} required-check evidence is indeterminate (${FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL})"
+		_full_loop_record_check_read_failure "$pr_number" "$verified_head"
 		return 1
 	}
 	required_checks="$FULL_LOOP_REQUIRED_CHECKS_JSON"

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -288,7 +288,7 @@ _required_contexts_for_default_branch_uncached() {
 	local default_branch="" default_branch_rc=0
 	default_branch=$(_pmrc_gh_read gh api "repos/${repo_slug}" --jq '.default_branch' 2>/dev/null) || default_branch_rc=$?
 	if [[ "$default_branch_rc" -ne 0 || -z "$default_branch" ]]; then
-		aidevops_log_line "[pulse-merge] _required_contexts_for_default_branch: failed to resolve default branch for ${repo_slug} — caller will fail closed (t2922)"
+		aidevops_log_line "[pulse-merge] _required_contexts_for_default_branch: failed to resolve default branch for ${repo_slug} (read_exit=${default_branch_rc}, output_bytes=${#default_branch}) — caller will fail closed (t2922)"
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-full-loop-remote-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-remote-evidence.sh
@@ -124,7 +124,7 @@ run_gate() {
 set -euo pipefail
 SCRIPT_DIR='${ROOT}/helpers'
 print_error() { printf 'ERROR %s\n' "\$*"; return 0; }
-print_info() { return 0; }
+print_info() { printf 'INFO %s\n' "\$*"; return 0; }
 print_warning() { return 0; }
 print_success() { return 0; }
 source '${SCRIPTS_DIR}/full-loop-helper-commit.sh'
@@ -159,6 +159,10 @@ gh_pr_checks_exact_json() {
 			printf '%s\n' 'gh_pr_checks_exact_json: error_kind=github-api-cooldown expires_at=1893456000 operation=pull-request-identity-read' >&2
 			return 2
 			;;
+		read-deferred)
+			printf '%s\n' 'gh_pr_checks_exact_json: error_kind=github-api-read-deferred operation=pull-request-identity-read' >&2
+			return 2
+			;;
 		changed-wording)
 			printf "%s\n" "no required checks configured for the 'remote-branch' branch" >&2
 			return 1
@@ -177,7 +181,10 @@ gh_pr_checks_exact_json() {
 			;;
 	esac
 }
-cmd_pre_merge_gate 42 testorg/testrepo
+gate_rc=0
+cmd_pre_merge_gate 42 testorg/testrepo || gate_rc=\$?
+printf 'CHECK_STATUS=%s\n' "\${FULL_LOOP_PR_CHECK_STATUS:-unset}"
+exit "\$gate_rc"
 RUNNER
 	chmod +x "$runner"
 	if [[ "$output_mode" == "visible" ]]; then
@@ -234,6 +241,17 @@ if [[ "$cooldown_rc" -ne 0 && "$cooldown_output" == *"GitHub API cooldown is act
 	printf 'PASS cooldown evidence remains truthful through the readiness gate\n'
 else
 	printf 'FAIL cooldown evidence was collapsed: rc=%s output=%s\n' "$cooldown_rc" "$cooldown_output"
+	exit 1
+fi
+
+deferred_rc=0
+deferred_output=$(run_gate read-deferred visible 2>&1) || deferred_rc=$?
+if [[ "$deferred_rc" -ne 0 && "$deferred_output" == *"CHECK_STATUS=api-deferred"* &&
+	"$deferred_output" == *"GitHub API read capacity is deferred"* &&
+	"$deferred_output" != *"required-check evidence is indeterminate"* ]]; then
+	printf 'PASS local read admission deferral stays distinct from CI failure and malformed evidence\n'
+else
+	printf 'FAIL read admission deferral lost its classification: rc=%s output=%s\n' "$deferred_rc" "$deferred_output"
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

Resolves #31261.

- Preserve `github-api-read-deferred` from the exact-check reader instead of collapsing it to a generic indeterminate check error.
- Persist `api-deferred` verification status for local read admission deferral or GitHub cooldown, with an explicit keep-the-PR/retry action. Do not establish CI failure or duplicate implementation work from missing capacity.
- Keep all merge/readiness/trust checks fail-closed; no quota override, changed transport policy, or unchecked merge fallback.
- Report only the underlying read exit and output length when default-branch metadata cannot be resolved.

## Root-cause evidence

During closeout of PR #31248, both deployed and worktree helpers reported failed default-branch resolution. The added safe diagnostic established underlying `read_exit=75`, not a GitHub missing-repository response. Invoking the current sibling shim directly produced `deferred: REST resource reserve is protected`.

The current transport's local admission state had a conservative core remaining value of 100/5000 and a future reset. The interactive session's pinned v3.32.311 shim predates the newer REST governor, explaining why direct session reads and the newer helper path behaved differently. Direct successful reads are not permission to bypass the newer helper's reserve. This PR changes classification/diagnostics, not the quota state; it makes no claim that the protected observation should be discarded or that GitHub was down.

## Files

- `.agents/scripts/full-loop-helper-commit.sh`: query classification, typed state, and factored failure reporting.
- `.agents/scripts/pulse-merge-required-checks.sh`: secret-free underlying read evidence.
- `.agents/scripts/tests/test-full-loop-remote-evidence.sh`: deferred-state regression through the real pre-merge gate.

## Runtime Testing

Risk: high; `runtime-verified` with the existing isolated helper fixtures.

- `bash .agents/scripts/tests/test-full-loop-remote-evidence.sh`: 17 checks passed, including deferral, cooldown, pending, failure, malformed evidence, missing cost, draft/closed PR and terminal success.
- `bash .agents/scripts/tests/test-gh-pr-checks-exact-json.sh`: 41 passed.
- `.agents/scripts/linters-local.sh --changed`: all required checks passed, including targeted efficient full-loop orchestration tests, ShellCheck, secret scan, whitespace and complexity/portability ratchets.
- Live diagnosis used read-only calls; no merge was used to reproduce the failure and no quota settings/state were modified.

## Independent review

Clean independent closeout at `0792df5e53a33ff27f804cf56b54012287712320`. Evidence schema `aidevops.review-evidence/v1`, SHA-256 `22d93879146dea7c0949b609ee0094b71edf0a32f5f3bb9dd68b38277d2aead4`, prompt-injection scan clean.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.316 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 14h 36m and 2,416,242 tokens on this with the user in an interactive session.