### PR TITLE
GH#31317: Propagate failed interactive claims

### DIFF
--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -376,7 +376,7 @@ _isc_cmd_claim() {
 	# Transition to in-review with atomic self-assign. The helper preserves the
 	# deferred-comment contract for canonical-rooted issue starts.
 	_isc_apply_new_claim "$issue" "$slug" "$worktree_path" "$user" "$defer_comment"
-	return 0
+	return $?
 }
 
 # -----------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -347,6 +347,21 @@ else
 	print_result "claim writes stamp file" 1 "(rc=$claim_rc, stamp=$STAMP_FILE exists=$([[ -f "$STAMP_FILE" ]] && echo yes || echo no))"
 fi
 
+# A failed mutation must propagate through `_isc_cmd_claim`, including when
+# invoked in a conditional command substitution where `set -e` cannot do so.
+FAILED_CLAIM_STAMP="$HOME/.aidevops/.agent-workspace/interactive-claims/testowner-testrepo-31317.json"
+rm -f "$FAILED_CLAIM_STAMP"
+failed_claim_out=$(STUB_GH_EDIT_FAILS=1 \
+	_isc_cmd_claim 31317 testowner/testrepo --worktree /tmp/wt-failed 2>&1)
+failed_claim_rc=$?
+if [[ $failed_claim_rc -ne 0 && ! -f "$FAILED_CLAIM_STAMP" ]] &&
+	printf '%s' "$failed_claim_out" | grep -q 'ownership transition failed.*no stamp written'; then
+	print_result "GH#31317: failed new claim propagates from conditional caller without a stamp" 0
+else
+	print_result "GH#31317: failed new claim propagates from conditional caller without a stamp" 1 \
+		"(rc=$failed_claim_rc, stamp=$([[ -f "$FAILED_CLAIM_STAMP" ]] && echo yes || echo no), out=${failed_claim_out:0:300})"
+fi
+
 # Validate stamp schema
 if [[ -f "$STAMP_FILE" ]]; then
 	stamp_issue=$(jq -r '.issue' "$STAMP_FILE" 2>/dev/null)

--- a/.agents/scripts/tests/test-interactive-start-helper.sh
+++ b/.agents/scripts/tests/test-interactive-start-helper.sh
@@ -66,6 +66,9 @@ fi
 cat >"${stub_dir}/interactive-session-helper.sh" <<'STUB'
 #!/usr/bin/env bash
 printf 'claim cwd=%s marker=%s args=%s\n' "$(pwd -P)" "${AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION:-0}" "$*" >>"$CALL_LOG"
+if [[ "${STUB_CLAIM_FAILS:-0}" == "1" && "$1" == "claim" ]]; then
+	exit 1
+fi
 exit 0
 STUB
 
@@ -148,6 +151,15 @@ assert_log_line "full-loop cwd=${linked_worktree} marker=1 args=start GH#42 loca
 assert_log_line "claim cwd=${linked_worktree} marker=1 args=claim 43 owner/repo --implementing --defer-comment"
 assert_log_line "claim cwd=${linked_worktree} marker=1 args=claim 43 owner/repo --implementing --worktree ${linked_worktree}"
 assert_log_line "full-loop cwd=${linked_worktree} marker=1 args=start GH#43 queued fix --background"
+
+: >"$call_log"
+if STUB_CLAIM_FAILS=1 PATH="${stub_dir}:$PATH" \
+	"$helper" --issue 31317 --repo owner/repo --task "failed claim" </dev/null >/dev/null 2>&1; then
+	fail "failed initial claim reached success"
+fi
+if grep -q '^pre-edit \|^full-loop ' "$call_log"; then
+	fail "failed initial claim reached pre-edit or full-loop startup"
+fi
 
 for invalid_mode in missing malformed unsafe-canonical unregistered duplicate failure; do
 	: >"$call_log"


### PR DESCRIPTION
## Summary

Preserved failed new-claim exit codes so issue-started full loops stop before worktree setup.

## Files Changed

.agents/scripts/interactive-session-helper-commands.sh, .agents/scripts/tests/test-interactive-session-claim.sh, .agents/scripts/tests/test-interactive-start-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime verified with bash .agents/scripts/tests/test-interactive-session-claim.sh and bash .agents/scripts/tests/test-interactive-start-helper.sh; ShellCheck passed for all changed shell files.

Resolves #31317


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.316 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 4m and 110,019 tokens on this as a headless worker.