### PR TITLE
GH#31327: Verify successor ref absence before creation

### DIFF
--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -1340,6 +1340,25 @@ _full_loop_successor_complete_manifest() {
 	return 0
 }
 
+# Return a verified successor SHA, 2 for an explicit 404, or 1 for uncertainty.
+# The branch override is local to this read; later CAS still targets the lane.
+_full_loop_successor_branch_head() {
+	local repo="$1"
+	local branch_name="$2"
+	local _AIDEVOPS_RELEASE_LANE_BRANCH="$branch_name"
+	local head="" read_rc=0
+	head=$(_release_lane_remote_head "$repo") || read_rc=$?
+	if [[ "$read_rc" -eq 2 ]]; then
+		return 2
+	fi
+	if [[ "$read_rc" -ne 0 || ! "$head" =~ $_FULL_LOOP_AGGREGATE_RECOVERY_SHA40_REGEX ]]; then
+		printf 'Successor aggregation refused: branch identity is unavailable or malformed\n' >&2
+		return 1
+	fi
+	printf '%s\n' "$head"
+	return 0
+}
+
 _full_loop_successor_create_commit() {
 	local repo="$1"
 	local parent="$2"
@@ -1403,6 +1422,7 @@ _full_loop_release_refresh_aggregate() {
 	local branch_name=""
 	local owner="${repo%%/*}"
 	local branch_head=""
+	local branch_head_rc=0
 	local initial_commit=""
 	local successor_json=""
 	local successor_pr=""
@@ -1435,8 +1455,9 @@ _full_loop_release_refresh_aggregate() {
 	branch_name="release/aggregate-successor-${stale_pr}-${base_sha:0:12}"
 	release_lane_begin_aggregate_successor "$repo" "$stale_pr" "$base_sha" \
 		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$branch_name" || return 1
-	branch_head=$(gh api "repos/${repo}/git/ref/heads/${branch_name}" --jq '.object.sha // empty' 2>/dev/null || true)
-	if [[ -z "$branch_head" ]]; then
+	branch_head=$(_full_loop_successor_branch_head "$repo" "$branch_name") || branch_head_rc=$?
+	[[ "$branch_head_rc" -eq 0 || "$branch_head_rc" -eq 2 ]] || return 1
+	if [[ "$branch_head_rc" -eq 2 ]]; then
 		initial_commit=$(_full_loop_successor_create_commit "$repo" "$base_sha" \
 			"chore(release): open successor aggregation for #${stale_pr}") || return 1
 		payload=$(jq -cn --arg ref "refs/heads/${branch_name}" --arg sha "$initial_commit" '{ref:$ref,sha:$sha}') || return 1

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -156,7 +156,7 @@ printf 'PASS lane uncertainty blocks authorization expansion before mutation\n'
 	old_authorization='42@2222222222222222222222222222222222222222'
 	expanded_authorization="${old_authorization},43@3333333333333333333333333333333333333333"
 	authorization="$old_authorization"
-	lane_phase=remote-publication
+	lane_phase="remote-publication"
 	auth_write_mode=success
 	: >"$transaction_log"
 	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$expanded_authorization"
@@ -204,7 +204,7 @@ printf 'PASS lane uncertainty blocks authorization expansion before mutation\n'
 	}
 	release_lane_restore_aggregate_recovery() {
 		printf 'restore-lane\n' >>"$transaction_log"
-		lane_phase=remote-publication
+		lane_phase="remote-publication"
 		return 0
 	}
 	_full_loop_recovery_begin_state_transaction test/repo 42 v1.2.3
@@ -212,7 +212,7 @@ printf 'PASS lane uncertainty blocks authorization expansion before mutation\n'
 	[[ "$authorization" == "$expanded_authorization" && "$lane_phase" == "aggregation-recovery" ]]
 
 	authorization="$old_authorization"
-	lane_phase=remote-publication
+	lane_phase="remote-publication"
 	auth_write_mode=failure
 	: >"$transaction_log"
 	if _full_loop_recovery_begin_state_transaction test/repo 42 v1.2.3; then
@@ -1350,6 +1350,7 @@ printf 'PASS failed pre-publication preparation admits only reviewed direct or a
 (
 	real_git=$(type -P git)
 	source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
+	source "${SCRIPT_DIR}/release-lane-helper.sh"
 	git() {
 		"$real_git" "$@"
 		return $?
@@ -1361,7 +1362,7 @@ Aidevops-Release-Aggregates: 42@2222222222222222222222222222222222222222'
 	manifest=$(_full_loop_successor_manifest_from_body 99 "$stale_body")
 	[[ "$manifest" == '42@2222222222222222222222222222222222222222' ]]
 	if _full_loop_successor_manifest_from_body 100 "$stale_body" >/dev/null 2>&1; then
-			exit 1
+		exit 1
 	fi
 	signed_body=$'Release audit\n\n<!-- aidevops:sig -->\n---\nFixture audit metadata\n\n'"$stale_body"
 	[[ "$(_full_loop_successor_manifest_from_body 99 "$signed_body")" == "$manifest" ]]
@@ -1369,7 +1370,31 @@ Aidevops-Release-Aggregates: 42@2222222222222222222222222222222222222222'
 		exit 1
 	fi
 	gh() {
-		local endpoint="$2"
+		local endpoint="" arg="" status=""
+		for arg in "$@"; do
+			[[ "$arg" != repos/* ]] || endpoint="$arg"
+		done
+		if [[ "$endpoint" == repos/test/repo/git/ref/heads/release/* ]]; then
+			case "${REF_MODE:-missing}" in
+			existing) printf '%s\n' 4444444444444444444444444444444444444444; return 0 ;;
+			malformed) printf '{"message":"bad metadata"}\n'; return 0 ;;
+			empty) return 0 ;;
+			missing) status=404 ;;
+			unauthorized) status=401 ;;
+			forbidden) status=403 ;;
+			*) status=503 ;;
+			esac
+			if [[ " $* " == *" --include "* ]]; then
+				printf 'HTTP/2.0 %s response\n\n' "$status"
+			else
+				printf '{"message":"Not Found","status":"%s"}\n' "$status"
+			fi
+			return 1
+		fi
+		if [[ "$endpoint" == repos/test/repo/git/refs ]]; then
+			printf 'branch-created\n' >>"$TEST_ROOT/successor-order"
+			return 0
+		fi
 		if [[ "$endpoint" == repos/test/repo/pulls/99 ]]; then
 			jq -nc --arg body "$signed_body" '{number:99,state:"open",base:{ref:"main"},head:{sha:"1111111111111111111111111111111111111111"},body:$body}'
 			return 0
@@ -1393,7 +1418,14 @@ Aidevops-Release-Aggregates: 42@2222222222222222222222222222222222222222'
 		local command_name="${1:-}"
 		shift
 		case "$command_name" in
-		fetch) return 0 ;;
+		fetch)
+			local remote="${1:-}" ref="${2:-}"
+			: "$remote"
+			if [[ "$ref" != main ]]; then
+				printf 'branch-fetch\n' >>"$TEST_ROOT/successor-order"
+				return 1 # Stop after proving branch-create/fetch ordering.
+			fi
+			return 0 ;;
 		rev-parse) printf '%s\n' 3333333333333333333333333333333333333333 ;;
 		interpret-trailers) "$real_git" interpret-trailers "$@" ;;
 		*) return 1 ;;
@@ -1422,8 +1454,27 @@ Aidevops-Release-Aggregates: 42@2222222222222222222222222222222222222222'
 		if _full_loop_release_refresh_aggregate test/repo 99 >/dev/null 2>&1; then exit 1; fi
 		[[ ! -f "$TEST_ROOT/successor-mutation-boundary" ]]
 	done
+	lane_intent=42
+	release_lane_begin_aggregate_successor() { return 0; }
+	_full_loop_successor_create_commit() {
+		printf 'commit-created\n' >>"$TEST_ROOT/successor-order"
+		printf '%s\n' 4444444444444444444444444444444444444444
+		return 0
+	}
+	for REF_MODE in missing existing unavailable unauthorized forbidden malformed empty; do
+		: >"$TEST_ROOT/successor-order"
+		_full_loop_release_refresh_aggregate test/repo 99 >/dev/null 2>&1 || true
+		order=$(tr '\n' ' ' <"$TEST_ROOT/successor-order")
+		case "$REF_MODE" in
+		missing) [[ "$order" == 'commit-created branch-created branch-fetch ' ]] ;;
+		existing) [[ "$order" == 'branch-fetch ' ]] ;;
+		*) [[ -z "$order" ]] ;;
+		esac
+		[[ "$_AIDEVOPS_RELEASE_LANE_BRANCH" == aidevops/release-lane ]]
+	done
 )
 printf 'PASS successor manifest preserves stale sources and adds uniquely mapped main merges\n'
 printf 'PASS successor resolves PR-only reserved intent and Markdown footers before mutation, rejecting unknown, duplicate, and conflicting intent\n'
+printf 'PASS successor ref reads distinguish verified absence, existing identity, and uncertainty before branch mutation\n'
 
 exit 0


### PR DESCRIPTION
## Summary

Resolves #31327.

Use verified ref state rather than nonempty command output when creating or adopting an aggregation-successor branch. A GitHub 404 can emit nonempty JSON despite `--jq`; the previous `|| true` path treated that error payload as an existing ref and skipped creation.

- Reuse the existing lane ref reader's explicit-404 distinction.
- Require a valid immutable SHA for presence; reject unavailable or malformed evidence.
- Limit successor-branch shadowing to the read helper so subsequent CAS still targets the canonical release lane.
- Preserve all existing manifest, ancestry/tree, ownership and publication gates.

## Files and verification

Only `.agents/scripts/full-loop-release-aggregate-recovery.sh` and its existing test suite change. The full suite now exercises the actual successor entrypoint and actual ref reader through branch-create/fetch ordering, then stops before later mutation. It covers nonempty404 JSON, existing SHA, 401/403/503, malformed/empty successful responses, and unchanged canonical lane identity.

## Runtime Testing

Risk: high; runtime-verified using isolated fixtures. The full aggregate-recovery suite passes, as do ShellCheck and all required `.agents/scripts/linters-local.sh --changed` checks. No real branch, tag or lane was modified by tests.

Independent closeout at `21e72082f99fff952f11f2398036699fd22f2cd3` found no introduced P0/P1/P2 blocker. Evidence bundle SHA-256 `f4d8983c5136c11c71ae8654edd1a4ed4cb3581d510cf5428b4a3d3ac719eb1e`, scanner clean.

## Recovery boundary

The original source31315 release is already fenced in aggregation-successor-preparing with no tag and no allocated successor PR. Its ordinary-merge guard is intentionally active. The primary may use this committed, independently reviewed helper to resume that metadata-only transaction and restore its normal lane phase, then complete this PR's guarded merge. No tag/package publication uses unmerged source, and no manual lane reset or unchecked branch creation is permitted.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.316 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 16h 40m and 4,153,575 tokens on this with the user in an interactive session.