### PR TITLE
GH#31331: Add managed on-demand Blender Lab MCP

### DIFF
--- a/.agents/plugins/opencode-aidevops/agent-mcp-tools.mjs
+++ b/.agents/plugins/opencode-aidevops/agent-mcp-tools.mjs
@@ -36,6 +36,7 @@ const AGENT_MCP_TOOLS = {
   socket: ["socket_*"],
   // UI
   shadcn: ["shadcn_*"],
+  blender: ["blender-lab_*"],
   // Data / accounting
   outscraper: ["outscraper_*"],
   mainwp: ["localwp_*"],

--- a/.agents/plugins/opencode-aidevops/mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-registry.mjs
@@ -401,6 +401,27 @@ function getMcpRegistry() {
       description: "Multi-account QuickFile UK accounting",
     },
     {
+      name: "blender-lab",
+      type: "local",
+      command: [
+        "python3",
+        "-I",
+        join(homedir(), ".aidevops", "agents", "scripts", "blender-lab-mcp-launcher.py"),
+      ],
+      eager: false,
+      toolPattern: "blender-lab_*",
+      globallyEnabled: false,
+      activationAgent: "blender",
+      agentSource: ["tools", "design", "blender.md"],
+      activationGuidance: [
+        "Before connecting, require explicit operator approval and an already isolated Blender environment; never set the launcher consent flags yourself.",
+        "On first use, have the operator run blender-lab-mcp-launcher.py prepare inside that environment before connecting to avoid installation timeouts.",
+        "If prerequisites or consent are missing, report the launcher diagnostic; never fall back to uvx blender-mcp or launch Blender automatically.",
+      ],
+      modelTier: "standard",
+      description: "Official Blender Lab MCP with opt-in isolated provisioning",
+    },
+    {
       name: "amazon-order-history",
       type: "local",
       command: [

--- a/.agents/plugins/opencode-aidevops/tests/test-blender-mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-blender-mcp-registry.mjs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { applyAgentMcpTools } from "../agent-mcp-tools.mjs";
+import { registerOnDemandMcpAgents } from "../config-agent-profiles.mjs";
+import { createMcpActivationTool } from "../mcp-activation-tool.mjs";
+import { getOnDemandMcpAgents, registerMcpServers } from "../mcp-registry.mjs";
+
+test("Blender registers disabled without executing or installing anything", () => {
+  const config = { mcp: {}, tools: {} };
+  registerMcpServers(config);
+  assert.deepEqual(config.mcp["blender-lab"], {
+    type: "local",
+    command: ["python3", "-I", join(homedir(), ".aidevops", "agents", "scripts", "blender-lab-mcp-launcher.py")],
+    enabled: false,
+  });
+  assert.equal(config.tools["blender-lab_*"], false);
+  config.mcp["blender-lab"].enabled = true;
+  registerMcpServers(config);
+  assert.equal(config.mcp["blender-lab"].enabled, false);
+});
+
+test("only the bounded Blender agent gets Blender tools", () => {
+  const config = { agent: { build: { tools: {} } } };
+  registerOnDemandMcpAgents(config, fileURLToPath(new URL("../../..", import.meta.url)));
+  applyAgentMcpTools(config);
+  assert.equal(config.agent.blender.tools["blender-lab_*"], true);
+  assert.equal(config.agent.blender.tools.aidevops_mcp, true);
+  assert.equal(config.agent.build.tools["blender-lab_*"], undefined);
+  assert.match(config.agent.blender.prompt, /never set the launcher consent flags yourself/);
+  assert.match(config.agent.blender.prompt, /prepare/);
+  assert.equal(config.tools.aidevops_mcp, false);
+});
+
+test("Blender is allowlisted for explicit connect and disconnect", async () => {
+  const calls = [];
+  const schema = { describe() { return this; } };
+  const activation = createMcpActivationTool((definition) => definition, {
+    enum() { return schema; },
+  }, {
+    allowedNames: getOnDemandMcpAgents().map((entry) => entry.name),
+    client: {
+      async connect(request) { calls.push(["connect", request.path.name]); return {}; },
+      async disconnect(request) { calls.push(["disconnect", request.path.name]); return {}; },
+      async status() { return { data: { "blender-lab": { status: "connected" } } }; },
+    },
+  });
+  assert.match(await activation.execute({ action: "connect", name: "blender-lab" }), /Connected MCP/);
+  assert.match(await activation.execute({ action: "disconnect", name: "blender-lab" }), /Disconnected MCP/);
+  assert.deepEqual(calls, [["connect", "blender-lab"], ["disconnect", "blender-lab"]]);
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
@@ -36,8 +36,8 @@ test("registers only the explicit MCP activation profiles", () => {
   const config = {};
   const count = registerOnDemandMcpAgents(config, AGENTS_DIR);
 
-  assert.equal(count, 3);
-  assert.deepEqual(Object.keys(config.agent), ["playwriter", "playwright", "quickfile"]);
+  assert.equal(count, 4);
+  assert.deepEqual(Object.keys(config.agent), ["playwriter", "playwright", "quickfile", "blender"]);
   assert.equal(config.tools.aidevops_mcp, false);
   assert.equal(config.agent.playwriter.mode, "subagent");
   assert.equal(config.agent.playwriter.tools.aidevops_mcp, true);

--- a/.agents/scripts/blender-lab-mcp-launcher.py
+++ b/.agents/scripts/blender-lab-mcp-launcher.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Opt-in official Blender Lab MCP provisioning and stdio launch.
+
+Consent flags are operator attestations, not sandbox detection. Both Blender
+and this process must already be inside the operator's isolated environment.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+REVISION = "4309a39646e644261624bfcd2bca669b343b7621"
+SOURCE = (
+    "git+https://projects.blender.org/lab/blender_mcp.git@"
+    + REVISION
+    + "#subdirectory=mcp"
+)
+
+
+def require_consent():
+    """Fail before probing, downloading, or executing external programs."""
+    # aidevops:trust-boundary -- never infer approval from MCP registration.
+    if (os.environ.get("AIDEVOPS_BLENDER_ISOLATED") != "1"
+            or os.environ.get("AIDEVOPS_BLENDER_CODE_EXECUTION") != "approved"):
+        raise ValueError(
+            "Blender Lab executes unguarded Python. Inside an isolated system only, "
+            "the operator must set AIDEVOPS_BLENDER_ISOLATED=1 and "
+            "AIDEVOPS_BLENDER_CODE_EXECUTION=approved before starting the client. "
+            "These attestations do not create or verify a sandbox."
+        )
+
+
+def connection_settings():
+    host = os.environ.get("BLENDER_MCP_HOST", "127.0.0.1")
+    # Use literal loopback only: do not trust localhost DNS or arbitrary hosts.
+    if host not in ("127.0.0.1", "::1"):
+        raise ValueError("BLENDER_MCP_HOST must be literal loopback (127.0.0.1 or ::1)")
+    port = int(os.environ.get("BLENDER_MCP_PORT", "9876"))
+    if not 1 <= port <= 65535:
+        raise ValueError("BLENDER_MCP_PORT must be between 1 and 65535")
+    return host, port
+
+
+def prerequisites():
+    uv = shutil.which("uv")
+    if not uv:
+        raise ValueError("Install uv in the isolated system before using Blender Lab MCP")
+    if not shutil.which("git"):
+        raise ValueError("Install Git in the isolated system for pinned source provisioning")
+    blender = os.environ.get("BLENDER_EXECUTABLE") or shutil.which("blender")
+    mac_blender = Path("/Applications/Blender.app/Contents/MacOS/Blender")
+    if not blender and sys.platform == "darwin" and mac_blender.is_file():
+        blender = str(mac_blender)
+    if not blender:
+        raise ValueError("Install Blender 5.1+ and its official MCP add-on; set BLENDER_EXECUTABLE if needed")
+    result = subprocess.run(
+        [blender, "--factory-startup", "--disable-autoexec", "--background", "--version"],
+        capture_output=True, text=True, timeout=15, check=True,
+    )
+    version = re.search(r"^Blender (\d+)\.(\d+)", result.stdout, re.MULTILINE)
+    if not version or tuple(map(int, version.groups())) < (5, 1):
+        raise ValueError("Blender 5.1 or newer is required by the official MCP add-on")
+    return uv
+
+
+def launch_environment(host, port):
+    # Do not let inherited uv/Git overrides or Python import hooks select a
+    # different package. This is provenance hygiene, not host isolation.
+    env = {key: value for key, value in os.environ.items()
+           if not key.startswith(("UV_", "GIT_", "PYTHON"))}
+    env["BLENDER_MCP_HOST"] = host
+    env["BLENDER_MCP_PORT"] = str(port)
+    env["PYTHONNOUSERSITE"] = "1"
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    return env
+
+
+def run(action):
+    require_consent()
+    host, port = connection_settings()
+    uv = prerequisites()
+    if action != "prepare":
+        try:
+            with socket.create_connection((host, port), timeout=2):
+                pass
+        except OSError as exc:
+            raise ValueError(
+                "Start the official MCP add-on bridge in Blender on the configured "
+                "loopback port. No server package was installed or launched."
+            ) from exc
+    if action == "check":
+        print("Prerequisites and TCP reachability verified; add-on identity is not verified.")
+        return 0
+    command = [
+        uv, "tool", "run", "--no-config", "--isolated", "--python", "3.11",
+        "--from", SOURCE, "blender-mcp",
+    ]
+    if action == "prepare":
+        # Prewarm deliberately before MCP connection to avoid client startup
+        # timeouts on the first Git/Python/dependency download. No Blender UI/bridge.
+        command.append("--help")
+    else:
+        command.extend(["--transport", "stdio"])
+    os.execvpe(uv, command, launch_environment(host, port))
+    return 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("run", "check", "prepare"), default="run", nargs="?")
+    args = parser.parse_args()
+    try:
+        return run(args.action)
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        # Keep protocol stdout clean and avoid relaying untrusted child output.
+        detail = str(exc) if isinstance(exc, ValueError) else type(exc).__name__
+        print("Blender Lab MCP: " + detail, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/scripts/blender-lab-mcp-launcher.py
+++ b/.agents/scripts/blender-lab-mcp-launcher.py
@@ -38,9 +38,9 @@ def require_consent():
 
 def connection_settings():
     host = os.environ.get("BLENDER_MCP_HOST", "127.0.0.1")
-    # Use literal loopback only: do not trust localhost DNS or arbitrary hosts.
-    if host not in ("127.0.0.1", "::1"):
-        raise ValueError("BLENDER_MCP_HOST must be literal loopback (127.0.0.1 or ::1)")
+    # Upstream uses AF_INET; reject IPv6 as well as DNS/arbitrary hosts.
+    if host != "127.0.0.1":
+        raise ValueError("BLENDER_MCP_HOST must be literal IPv4 loopback (127.0.0.1)")
     port = int(os.environ.get("BLENDER_MCP_PORT", "9876"))
     if not 1 <= port <= 65535:
         raise ValueError("BLENDER_MCP_PORT must be between 1 and 65535")

--- a/.agents/scripts/tests/test-blender-lab-mcp-launcher.py
+++ b/.agents/scripts/tests/test-blender-lab-mcp-launcher.py
@@ -68,6 +68,7 @@ if '--help' not in sys.argv:
 
     def test_non_loopback_and_invalid_ports_fail_without_provisioning(self):
         for host, port in (("localhost", "9876"), ("0.0.0.0", "9876"),
+                           ("::1", "9876"),
                            ("example.invalid", "9876"), ("127.0.0.1", "0"),
                            ("127.0.0.1", "65536"), ("127.0.0.1", "abc")):
             with self.subTest(host=host, port=port):

--- a/.agents/scripts/tests/test-blender-lab-mcp-launcher.py
+++ b/.agents/scripts/tests/test-blender-lab-mcp-launcher.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exercise the real launcher process with offline executable fixtures."""
+
+import json
+import socket
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+LAUNCHER = Path(__file__).resolve().parents[1] / "blender-lab-mcp-launcher.py"
+
+
+class BlenderLauncherTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="blender-launcher-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.marker = self.root / "uv-called.json"
+        self.env = {
+            "PATH": str(self.root), "HOME": str(self.root),
+            "AIDEVOPS_BLENDER_ISOLATED": "1",
+            "AIDEVOPS_BLENDER_CODE_EXECUTION": "approved",
+            "TEST_MARKER": str(self.marker),
+        }
+        self.executable("blender", "print('Blender 5.1.0')")
+        self.executable("git", "pass")
+        self.executable("uv", """
+import json, os, sys
+from pathlib import Path
+Path(os.environ['TEST_MARKER']).write_text(json.dumps({
+    'args': sys.argv[1:], 'env': dict(os.environ)
+}))
+if '--help' not in sys.argv:
+    sys.stdout.write(sys.stdin.read())
+""")
+
+    def executable(self, name, code):
+        path = self.root / name
+        path.write_text(f"#!{sys.executable}\n{code}\n", encoding="utf-8")
+        path.chmod(0o700)
+
+    def invoke(self, *args, payload=""):
+        return subprocess.run(
+            [sys.executable, "-I", str(LAUNCHER), *args],
+            input=payload, capture_output=True, text=True, env=self.env, timeout=10, check=False,
+        )
+
+    def bridge(self):
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(2)
+        self.addCleanup(listener.close)
+        self.env["BLENDER_MCP_PORT"] = str(listener.getsockname()[1])
+
+    def test_missing_consent_stops_before_executables(self):
+        for flag in ("AIDEVOPS_BLENDER_ISOLATED", "AIDEVOPS_BLENDER_CODE_EXECUTION"):
+            with self.subTest(flag=flag):
+                original = self.env.pop(flag)
+                result = self.invoke("prepare")
+                self.env[flag] = original
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("unguarded Python", result.stderr)
+                self.assertEqual(result.stdout, "")
+                self.assertFalse(self.marker.exists())
+
+    def test_non_loopback_and_invalid_ports_fail_without_provisioning(self):
+        for host, port in (("localhost", "9876"), ("0.0.0.0", "9876"),
+                           ("example.invalid", "9876"), ("127.0.0.1", "0"),
+                           ("127.0.0.1", "65536"), ("127.0.0.1", "abc")):
+            with self.subTest(host=host, port=port):
+                self.env.update(BLENDER_MCP_HOST=host, BLENDER_MCP_PORT=port)
+                self.assertNotEqual(self.invoke("prepare").returncode, 0)
+                self.assertFalse(self.marker.exists())
+
+    def test_old_blender_fails(self):
+        self.executable("blender", "print('Blender 4.5.0')")
+        result = self.invoke("prepare")
+        self.assertIn("5.1 or newer", result.stderr)
+        self.assertFalse(self.marker.exists())
+
+    def test_missing_uv_fails(self):
+        (self.root / "uv").unlink()
+        self.assertIn("Install uv", self.invoke("prepare").stderr)
+
+    def test_bridge_unavailable_does_not_install(self):
+        # Reserve a port without listening so no unrelated service can answer.
+        with socket.socket() as reserved:
+            reserved.bind(("127.0.0.1", 0))
+            self.env["BLENDER_MCP_PORT"] = str(reserved.getsockname()[1])
+            result = self.invoke()
+        self.assertIn("Start the official MCP add-on", result.stderr)
+        self.assertEqual(result.stdout, "")
+        self.assertFalse(self.marker.exists())
+
+    def test_prepare_uses_official_pin_and_ignores_package_overrides(self):
+        self.env.update(UV_OVERRIDE="bad.txt", PYTHONPATH="untrusted", UV_CONFIG_FILE="bad.toml")
+        self.env.update(GIT_CONFIG_COUNT="1", GIT_CONFIG_KEY_0="url.bad.insteadOf",
+                        GIT_CONFIG_VALUE_0="https://projects.blender.org/", GIT_CONFIG_GLOBAL="bad.gitconfig")
+        result = self.invoke("prepare")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        call = json.loads(self.marker.read_text())
+        self.assertIn("--isolated", call["args"])
+        self.assertIn("--no-config", call["args"])
+        self.assertEqual(call["args"][-2:], ["blender-mcp", "--help"])
+        source = call["args"][call["args"].index("--from") + 1]
+        self.assertEqual(source, "git+https://projects.blender.org/lab/blender_mcp.git@"
+                         "4309a39646e644261624bfcd2bca669b343b7621#subdirectory=mcp")
+        for name in ("UV_OVERRIDE", "PYTHONPATH", "UV_CONFIG_FILE", "GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0"):
+            self.assertNotIn(name, call["env"])
+        self.assertEqual(call["env"]["GIT_CONFIG_NOSYSTEM"], "1")
+        self.assertEqual(call["env"]["GIT_CONFIG_GLOBAL"], "/dev/null")
+
+    def test_check_probes_without_installing(self):
+        self.bridge()
+        result = self.invoke("check")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("identity is not verified", result.stdout)
+        self.assertFalse(self.marker.exists())
+
+    def test_run_preserves_stdio(self):
+        self.bridge()
+        payload = '{"jsonrpc":"2.0","id":1}\n'
+        result = self.invoke(payload=payload)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, payload)
+        self.assertEqual(result.stderr, "")
+        call = json.loads(self.marker.read_text())
+        self.assertEqual(call["args"][-3:], ["blender-mcp", "--transport", "stdio"])
+        self.assertEqual(call["env"]["BLENDER_MCP_HOST"], "127.0.0.1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -39,7 +39,7 @@ seo/seo-audit-skill/aeo-geo-patterns/,seo/seo-audit-skill/aeo-geo-patterns subag
 seo/seo-audit-skill/,seo/seo-audit-skill subagents,ai-writing-detection
 seo/,seo subagents,seo-audit|seo-export|seo-fanout|seo-geo|seo-hallucination-defense|seo-opportunities|seo-optimize|seo-optimizer|seo-regex|seo-sro|seo-write|serper|site-crawler|sro-grounding|tech-stack|transcript-seo|upscale|video-schema
 seo/video-schema/,seo/video-schema subagents,clip-key-moments|faqpage-video|howto-video|property-reference|speakable|validation|videoobject
-seo/,seo subagents,video-seo
+seo/,seo subagents,video-seo|youtube-description-link-acquisition
 services/accounting/,services/accounting subagents,quickfile
 services/analytics/,services/analytics subagents,google-analytics
 services/communications/,services/communications subagents,bitchat|convos|cross-channel-conversation-continuity|discord|google-chat|imessage|matrix-bot|matterbridge|msteams|nextcloud-talk|nostr|privacy-comparison|signal|simplex|slack|telegram|telfon|twilio|urbit|whatsapp|xmtp
@@ -65,7 +65,7 @@ services/networking/,services/networking subagents,netbird|nostr-vpn|obscuravpn|
 services/outreach/,services/outreach subagents,cold-outreach|infraforge|instantly|leadsforge|manyreach|smartlead|warmforge
 services/payments/,services/payments subagents,procurement|revenuecat|stripe|superwall
 tools/accessibility/,tools/accessibility subagents,accessibility-audit|accessibility
-tools/ai-assistants/,tools/ai-assistants subagents,agno|buzz-team-interface|capsolver|claude-code|compare-models|datasets|fallback-chains|headless-dispatch|models-composer2|models-flash|models-gemini-reviewer|models-gpt-reviewer|models-haiku|models-opus|models-pro|models-README|models-sonnet|openclaw|opencode-server|overview|research-only|response-scoring|runners-code-reviewer|runners-README|runners-seo-analyst
+tools/ai-assistants/,tools/ai-assistants subagents,agno|buzz-team-interface|capsolver|claude-code|codex-cli|compare-models|datasets|fallback-chains|frontier-harness-eval|headless-dispatch|models-composer2|models-flash|models-gemini-reviewer|models-gpt-reviewer|models-haiku|models-opus|models-pro|models-README|models-sonnet|openclaw|opencode-server|overview|research-only|response-scoring|runners-code-reviewer|runners-README|runners-seo-analyst|runtime-launchers
 tools/ai-generation/,tools/ai-generation subagents,comfy-cli
 tools/ai-orchestration/,tools/ai-orchestration subagents,autogen|crewai|langflow|openprose|overview|packaging
 tools/animation/,tools/animation subagents,animejs
@@ -101,7 +101,7 @@ tools/deployment/,tools/deployment subagents,agent-skills
 tools/deployment/cloudron-app-packaging-skill/,tools/deployment/cloudron-app-packaging-skill subagents,addons-ref|manifest-ref
 tools/deployment/cloudron-app-packaging-skill/manifest-ref/,tools/deployment/cloudron-app-packaging-skill/manifest-ref subagents,01-overview|02-ports|03-addons|04-metadata|05-behavior|06-post-install|07-versioning
 tools/deployment/,tools/deployment subagents,cloudron-app-packaging|cloudron-git-reference|coolify-cli|coolify-setup|coolify|daytona|fly-io|hosting-comparison|uncloud|vercel
-tools/design/,tools/design subagents,brand-identity|colour-palette|design-inspiration|design-md-from-links|design-md|open-design-ingestion|open-design|report-presentation|ui-ux-inspiration
+tools/design/,tools/design subagents,blender|brand-identity|colour-palette|design-inspiration|design-md-from-links|design-md|open-design-ingestion|open-design|report-presentation|ui-ux-inspiration
 tools/diagrams/mermaid-diagrams-skill/,tools/diagrams/mermaid-diagrams-skill subagents,advanced|architecture|cheatsheet|class-er|data-charts|flowcharts|sequence|state-journey
 tools/document/,tools/document subagents,docstrange|document-creation|document-extraction|extraction-schemas
 tools/document/extraction-schemas/,tools/document/extraction-schemas subagents,01-design-principles|02-purchase-invoice|03-expense-receipt|04-credit-note|05-sales-invoice|06-generic-receipt|07-quickfile-mapping|08-vat-handling|09-nominal-codes|10-classification|11-pipeline-integration|12-validation
@@ -138,7 +138,7 @@ tools/ui/nothing-design-skill/,tools/ui/nothing-design-skill subagents,01-philos
 tools/ui/nothing-design-skill/tokens/,tools/ui/nothing-design-skill/tokens subagents,01-typography|02-color|03-spacing|04-motion|05-iconography|06-dot-matrix
 tools/ui/,tools/ui subagents,react-context|react-doctor|react-email|shadcn|tailwind-css|ui-skills|wxt
 tools/verification/,tools/verification subagents,parallel-verify
-tools/video/,tools/video subagents,create-onboarding-video|remotion-3d|remotion-animations|remotion-assets|remotion-audio|remotion-calculate-metadata|remotion-can-decode|remotion-charts|remotion-compositions|remotion-display-captions|remotion-extract-frames|remotion-fonts|remotion-get-audio-duration|remotion-get-video-dimensions|remotion-get-video-duration|remotion-gifs|remotion-images|remotion-import-srt-captions|remotion-lottie|remotion-measuring-dom-nodes|remotion-measuring-text|remotion-sequencing|remotion-tailwind|remotion-text-animations|remotion-timing|remotion-transcribe-captions|remotion-transitions|remotion-trimming|remotion-videos|remotion|video-editor|video-prompt-design|yt-dlp
+tools/video/,tools/video subagents,create-onboarding-video|remotion-3d|remotion-animations|remotion-assets|remotion-audio|remotion-calculate-metadata|remotion-can-decode|remotion-charts|remotion-compositions|remotion-display-captions|remotion-extract-frames|remotion-fonts|remotion-get-audio-duration|remotion-get-video-dimensions|remotion-get-video-duration|remotion-gifs|remotion-images|remotion-import-srt-captions|remotion-lottie|remotion-measuring-dom-nodes|remotion-measuring-text|remotion-sequencing|remotion-tailwind|remotion-text-animations|remotion-timing|remotion-transcribe-captions|remotion-transitions|remotion-trimming|remotion-videos|remotion|video-editor|video-prompt-design|video-use-runtime|yt-dlp
 tools/vision/,tools/vision subagents,create-screenshots|image-editing|image-generation|image-understanding|overview
 tools/voice/,tools/voice subagents,buzz|cloud-tts-apis|cloud-voice-agents|hyprwhspr|ios-shortcut|local-tts-models|pipecat-opencode|qwen3-tts|speech-to-speech|transcription|voice-ai-models|voice-models|voiceink-shortcut
 tools/,tools subagents,wordpress

--- a/.agents/tools/design/blender.md
+++ b/.agents/tools/design/blender.md
@@ -65,7 +65,7 @@ These flags are operator attestations, **not sandbox verification**. Never set t
 
 `prepare` prewarms the official package and Python 3.11 environment without requiring a running bridge; it may download Python, source and dependencies. It runs only the package's help command and never starts the MCP server. First-time downloads can exceed MCP startup timeouts, so prepare before connecting. This is package isolation, not OS isolation. The launcher clears inherited uv/Python source overrides and ignores uv config files; it never falls back to the community package.
 
-Open a disposable scene in Blender, enable the **official** add-on, leave auto-start off and start its bridge on `127.0.0.1:9876`. Only literal loopback (`127.0.0.1` or `::1`) is accepted by the launcher. An alternative port must match `BLENDER_MCP_PORT` in the client's inherited environment. Then run:
+Open a disposable scene in Blender, enable the **official** add-on, leave auto-start off and start its bridge on `127.0.0.1:9876`. Only literal IPv4 loopback (`127.0.0.1`) is accepted: the pinned upstream bridge client uses `AF_INET`, not IPv6. An alternative port must match `BLENDER_MCP_PORT` in the client's inherited environment. Then run:
 
 ```bash
 python3 -I ~/.aidevops/agents/scripts/blender-lab-mcp-launcher.py check

--- a/.agents/tools/design/blender.md
+++ b/.agents/tools/design/blender.md
@@ -9,6 +9,8 @@ tools:
   glob: false
   grep: true
   webfetch: true
+  aidevops_mcp: true
+  blender-lab_*: true
 ---
 
 <!-- SPDX-License-Identifier: MIT -->
@@ -32,7 +34,7 @@ Prefer the [Blender Lab MCP](https://www.blender.org/lab/mcp-server/) for the Bl
 
 **Package collision:** both projects use the package and executable name `blender-mcp`. The official source exports `blmcp:main`; the community source lives under `blender_mcp`. Bare `uvx blender-mcp` selects the community package, not Blender Lab. Keep separate virtual environments, absolute executable paths and client names. Never mix their add-ons or assume wire compatibility. Stop one add-on before starting the other on the same port.
 
-This support consists of agent guidance and manually applied MCP templates. It does not install Blender, enable an add-on, start a server, or add a registry-approved `aidevops_mcp` activation target.
+Setup/update deploys a managed launcher and the OpenCode plugin registers `blender-lab` disabled. Only the bounded `blender` agent receives its tools and on-demand `aidevops_mcp` activation. No Blender process, add-on or Python server is installed or started at framework startup. The launcher provisions the official pinned source through an isolated uv tool environment on approved first use, then reuses uv's cache. An aidevops update changes the source only when the reviewed launcher pin changes; transitive dependencies are not fully locked.
 
 ## Security Prerequisite
 
@@ -46,6 +48,34 @@ Blender's warning is explicit: generated Python can remove data or send it remot
 - For the community alternative, set `DISABLE_TELEMETRY=true` and `BLENDER_MCP_SAFE_MODE=1` if explicitly selected. Its script validation is not an OS security boundary. External asset/generation services remain opt-in and may have licence, credential or billing requirements.
 
 ## Official Setup (Inside the Isolated System)
+
+### Managed Provisioning (Recommended)
+
+Install Blender 5.1+, its matching official MCP add-on, Python 3, Git and uv inside the isolated system. The launcher checks the Blender binary version but does not install or open the Blender UI. Set `BLENDER_EXECUTABLE` to the full binary path if it is not on PATH; the standard macOS app path is also detected.
+
+Before starting OpenCode in that system, the **operator**, not the agent, must explicitly attest isolation and approve unguarded code execution:
+
+```bash
+export AIDEVOPS_BLENDER_ISOLATED=1
+export AIDEVOPS_BLENDER_CODE_EXECUTION=approved
+python3 -I ~/.aidevops/agents/scripts/blender-lab-mcp-launcher.py prepare
+```
+
+These flags are operator attestations, **not sandbox verification**. Never set them automatically, in setup/update, or in generated config. They must reach the client process environment (GUI-launched clients may not inherit a terminal's exports). To revoke consent, unset both variables and restart the client; disconnect any existing MCP and stop the add-on immediately. Do not store them on a sensitive general-purpose host.
+
+`prepare` prewarms the official package and Python 3.11 environment without requiring a running bridge; it may download Python, source and dependencies. It runs only the package's help command and never starts the MCP server. First-time downloads can exceed MCP startup timeouts, so prepare before connecting. This is package isolation, not OS isolation. The launcher clears inherited uv/Python source overrides and ignores uv config files; it never falls back to the community package.
+
+Open a disposable scene in Blender, enable the **official** add-on, leave auto-start off and start its bridge on `127.0.0.1:9876`. Only literal loopback (`127.0.0.1` or `::1`) is accepted by the launcher. An alternative port must match `BLENDER_MCP_PORT` in the client's inherited environment. Then run:
+
+```bash
+python3 -I ~/.aidevops/agents/scripts/blender-lab-mcp-launcher.py check
+```
+
+`check` validates consent, dependencies, Blender version and TCP reachability without downloading or launching the server. Reachability is not add-on identity or compatibility verification: confirm the official add-on in Blender and inspect the actual tool list after MCP initialization. A community bridge on the same port is not interchangeable.
+
+In OpenCode, use the `blender` agent. After confirming prerequisites and user approval, call `aidevops_mcp` with `action: connect`, `name: blender-lab`; use its tools on the following step, then disconnect when finished. Missing consent, dependencies, old Blender or an unavailable bridge fail closed with stderr diagnostics before provisioning. Relay the diagnostic rather than repeatedly reconnecting, changing consent flags, or launching Blender automatically. The generic MCP activation reset does not authorize bypassing a launcher refusal.
+
+### Manual Source Installation (Alternative)
 
 1. Install Blender 5.1 or newer and the matching MCP add-on using the [official installation page](https://www.blender.org/lab/mcp-server/). Install from the Blender Lab repository or its release archive, not the community `addon.py`.
 2. Inspect a reviewed revision of the official source. The commands below use the revision inspected for this guide; review newer revisions before changing the pin. Verify the package in `mcp/pyproject.toml` declares `blender-mcp = "blmcp:main"`.
@@ -66,13 +96,13 @@ Blender's warning is explicit: generated Python can remove data or send it remot
 
 ### OpenCode
 
-Use repository template `configs/blender-lab-opencode-config.json.txt`. Replace its executable placeholder and merge it into a project-local `opencode.json`, preserving existing settings. It starts disabled and requests approval for `blender-lab_*` tools. After confirming isolation and consent, explicitly enable it for the Blender session. Quit and restart OpenCode after config changes. Disable it again when finished.
+With the aidevops plugin, registration is automatic after setup/update and an OpenCode restart; do not enable it globally or edit generated MCP entries. The registry preserves user-owned custom commands while resetting this server to disabled at startup. If you previously applied the manual direct-executable template, remove that old `blender-lab` entry after backing up your config to adopt the managed launcher; retained custom commands do not receive launcher checks.
 
-This is a user-managed server, not an aidevops plugin-registry entry. Do not call `aidevops_mcp connect` for it or modify generated managed MCP entries. Do not relax unrelated permissions to make it work.
+For standalone OpenCode without the plugin, repository template `configs/blender-lab-opencode-config.json.txt` points at the same launcher with a placeholder path. Replace it, merge while preserving other settings, and explicitly enable it only for an approved isolated session. Quit and restart OpenCode after config changes. Without the plugin's on-demand agent, use the client's manual MCP controls. Do not relax unrelated permissions.
 
 ### Other MCP Clients
 
-Use repository template `configs/blender-lab-mcp-config.json.txt` for clients accepting `mcpServers` with `command`, `args` and `env` (for example Claude Desktop). Replace the absolute executable placeholder before registration. These clients may start a registered server immediately: only apply the template after isolation and approval. This is not an OpenCode or Codex config format; translate using the active client's documented schema instead of copying incompatible JSON.
+Use repository template `configs/blender-lab-mcp-config.json.txt` for clients accepting `mcpServers` with `command`, `args` and `env` (for example Claude Desktop). Replace the absolute launcher placeholder before registration. These clients may start a registered server immediately: only apply the template after isolation and approval. This is not an OpenCode or Codex config format; translate using the active client's documented schema instead of copying incompatible JSON. Other clients retain their own activation lifecycle; automatic on-demand agent registration here is OpenCode-specific.
 
 ## Verification and Working Pattern
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ aidevops uninstall        # Remove aidevops
 
 ### Optional Blender Lab MCP
 
-[Blender MCP guidance](.agents/tools/design/blender.md) covers source-specific setup, scene analysis, Python API lookup, and the distinction between Blender's Lab project and the independent community `blender-mcp` package. Includes opt-in [OpenCode](configs/blender-lab-opencode-config.json.txt) and [MCP client](configs/blender-lab-mcp-config.json.txt) templates. Nothing is installed or activated automatically: Blender executes generated Python without protective guards, so use an isolated system and disposable scene copies.
+[Blender MCP guidance](.agents/tools/design/blender.md) covers managed setup, scene analysis, Python API lookup, and the distinction between Blender's Lab project and the independent community `blender-mcp` package. Setup/update registers the OpenCode MCP disabled; the `blender` agent connects only on demand. A consent-gated launcher provisions the pinned official source in an isolated uv environment on approved first use. Blender and its add-on remain separate prerequisites. Because generated Python runs without protective guards, explicit operator consent and an isolated system with disposable scene copies are required. Includes standalone [OpenCode](configs/blender-lab-opencode-config.json.txt) and [MCP client](configs/blender-lab-mcp-config.json.txt) templates.
 
 ### Optional Design Artifact Studio
 

--- a/configs/blender-lab-mcp-config.json.txt
+++ b/configs/blender-lab-mcp-config.json.txt
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "blender-lab": {
-      "command": "/ABSOLUTE/PATH/TO/blender-lab-venv/bin/blender-mcp",
-      "args": ["--transport", "stdio"],
+      "command": "python3",
+      "args": ["-I", "/ABSOLUTE/PATH/TO/.aidevops/agents/scripts/blender-lab-mcp-launcher.py"],
       "env": {
         "BLENDER_MCP_HOST": "127.0.0.1",
         "BLENDER_MCP_PORT": "9876"

--- a/configs/blender-lab-opencode-config.json.txt
+++ b/configs/blender-lab-opencode-config.json.txt
@@ -4,9 +4,9 @@
     "blender-lab": {
       "type": "local",
       "command": [
-        "/ABSOLUTE/PATH/TO/blender-lab-venv/bin/blender-mcp",
-        "--transport",
-        "stdio"
+        "python3",
+        "-I",
+        "/ABSOLUTE/PATH/TO/.aidevops/agents/scripts/blender-lab-mcp-launcher.py"
       ],
       "enabled": false,
       "environment": {


### PR DESCRIPTION
## Summary

Add official-source consent-gated launcher, disabled registry registration and bounded Blender activation profile following QuickFile. Update client templates, guide, README and regenerated subagent index.

## Files Changed

.agents/plugins/opencode-aidevops/agent-mcp-tools.mjs, .agents/plugins/opencode-aidevops/mcp-registry.mjs, .agents/plugins/opencode-aidevops/tests/test-blender-mcp-registry.mjs, .agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs, .agents/scripts/blender-lab-mcp-launcher.py, .agents/scripts/tests/test-blender-lab-mcp-launcher.py, .agents/subagent-index.toon, .agents/tools/design/blender.md, README.md, configs/blender-lab-mcp-config.json.txt, configs/blender-lab-opencode-config.json.txt

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — 8 launcher subprocess tests passed with offline Blender/uv fixtures and loopback TCP listener: consent rejection, endpoint validation, old/missing prerequisites, bridge failure, pinned provisioning, uv/Git/Python override isolation and stdio propagation. 31 MCP registry and lifecycle tests passed. Ruff, Markdownlint, JSON checks and git diff --check passed. Independent standard-tier security review accepted the revised launcher after Git config isolation fix. Direct bundle b00fc5e0e90fbb1313aa4b18f4bf4a8c062e1f30e5afbcbed06a986bd8a0e64c reviewed. No live Blender scene or upstream installation was performed.

Resolves #31331


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.316 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 3h 46m and 199,409 tokens on this with the user in an interactive session.