### PR TITLE
GH#31289: fix secret inventory cleanup lifetime

### DIFF
--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -594,14 +594,17 @@ cmd_list() {
 }
 
 # Emit validated secret-name metadata without invoking any value-reading command.
-cmd_inventory() {
+# A subshell keeps the EXIT trap and its local paths scoped to this command.
+cmd_inventory() (
 	local gopass_status="missing"
 	local credentials_status="missing"
 	local names_file=""
+	local sorted_file=""
 	local count=0
 
-	names_file=$(mktemp)
-	trap 'rm -f "$names_file"' EXIT
+	names_file=$(mktemp) || return 1
+	sorted_file="${names_file}.sorted"
+	trap 'rm -f "${names_file:-}" "${sorted_file:-}"' EXIT
 
 	if command -v gopass &>/dev/null; then
 		gopass_status="error"
@@ -613,7 +616,10 @@ cmd_inventory() {
 				[[ -z "$secret_path" ]] && continue
 				case "$secret_path" in
 				"${GOPASS_PREFIX}/"*) inventory_add_name "${secret_path#"${GOPASS_PREFIX}/"}" "$names_file" || return 1 ;;
-				*) print_error "Invalid gopass inventory path" >&2; return 1 ;;
+				*)
+					print_error "Invalid gopass inventory path" >&2
+					return 1
+					;;
 				esac
 			done <<<"$listing"
 		fi
@@ -642,7 +648,6 @@ cmd_inventory() {
 		done <"$credential_file"
 	done < <(resolve_credential_files)
 
-	local sorted_file="${names_file}.sorted"
 	sort -u "$names_file" >"$sorted_file"
 	mv "$sorted_file" "$names_file"
 	count=$(wc -l <"$names_file" | tr -d ' ')
@@ -661,10 +666,8 @@ cmd_inventory() {
 	done <"$names_file"
 	printf ']}\n'
 
-	rm -f "$names_file"
-	trap - EXIT
 	return 0
-}
+)
 
 inventory_add_name() {
 	local name="$1"

--- a/.agents/scripts/tests/test-secret-helper.sh
+++ b/.agents/scripts/tests/test-secret-helper.sh
@@ -106,13 +106,16 @@ EOF
 test_inventory_is_names_only_deterministic_json() {
 	setup
 	trap 'teardown' RETURN
+	local inventory_tmp="$TEST_DIR/inventory-tmp"
+	mkdir -p "$inventory_tmp"
 	local output=""
-	output=$(HOME="$TEST_DIR/home" bash "$HELPER" inventory)
+	output=$(TMPDIR="$inventory_tmp" HOME="$TEST_DIR/home" bash "$HELPER" inventory)
 
-	if [[ "$output" == '{"version":1,"backends":{"gopass":"available","credentials":"missing"},"secrets":[{"name":"ALPHA_KEY","status":"configured"},{"name":"ZETA_KEY","status":"configured"}]}' && "$output" != *"actual-secret-value"* ]]; then
+	if [[ "$output" == '{"version":1,"backends":{"gopass":"available","credentials":"missing"},"secrets":[{"name":"ALPHA_KEY","status":"configured"},{"name":"ZETA_KEY","status":"configured"}]}' &&
+		"$output" != *"actual-secret-value"* ]] && rmdir "$inventory_tmp"; then
 		print_result "inventory emits deterministic names-only JSON" 0
 	else
-		print_result "inventory emits deterministic names-only JSON" 1 "$output"
+		print_result "inventory emits deterministic names-only JSON" 1 "Output or temporary-file cleanup mismatch: $output"
 	fi
 	return 0
 }
@@ -122,16 +125,51 @@ test_inventory_rejects_malformed_gopass_name() {
 	trap 'teardown' RETURN
 	cat >"$TEST_DIR/bin/gopass" <<'EOF'
 #!/usr/bin/env bash
-if [[ "${1:-}" == "ls" ]]; then printf '%s\n' 'aidevops/../ESCAPE'; exit 0; fi
+printf '%s\n' "${1:-}" >>"${AIDEVOPS_TEST_DIR}/gopass_calls"
+case "${1:-}" in
+	ls) printf '%s\n' 'aidevops/../ESCAPE'; exit 0 ;;
+	show) printf '%s' 'actual-secret-value'; exit 0 ;;
+	*) exit 1 ;;
+esac
+EOF
+	chmod +x "$TEST_DIR/bin/gopass"
+	local inventory_tmp="$TEST_DIR/inventory-tmp"
+	mkdir -p "$inventory_tmp"
+	local output_file="$TEST_DIR/inventory-error.log"
+	local exit_code=0
+	TMPDIR="$inventory_tmp" HOME="$TEST_DIR/home" bash "$HELPER" inventory >"$output_file" 2>&1 || exit_code=$?
+	local output=""
+	output=$(<"$output_file")
+	if [[ "$exit_code" -ne 0 && "$output" == *"Invalid secret inventory name"* &&
+		"$output" != *"unbound variable"* && "$output" != *"actual-secret-value"* ]] &&
+		! grep -q '^show$' "$TEST_DIR/gopass_calls" && rmdir "$inventory_tmp"; then
+		print_result "inventory rejects malformed gopass names" 0
+	else
+		print_result "inventory rejects malformed gopass names" 1 \
+			"Expected deterministic validation failure without value reads, secondary nounset errors, or leaked temporary files"
+	fi
+	return 0
+}
+
+test_inventory_cleans_up_after_gopass_listing_failure() {
+	setup
+	trap 'teardown' RETURN
+	cat >"$TEST_DIR/bin/gopass" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "ls" ]]; then exit 23; fi
 exit 1
 EOF
 	chmod +x "$TEST_DIR/bin/gopass"
-	local exit_code=0
-	HOME="$TEST_DIR/home" bash "$HELPER" inventory >/dev/null 2>&1 || exit_code=$?
-	if [[ "$exit_code" -ne 0 ]]; then
-		print_result "inventory rejects malformed gopass names" 0
+	local inventory_tmp="$TEST_DIR/inventory-tmp"
+	mkdir -p "$inventory_tmp"
+	local output=""
+	output=$(TMPDIR="$inventory_tmp" HOME="$TEST_DIR/home" bash "$HELPER" inventory)
+	if [[ "$output" == '{"version":1,"backends":{"gopass":"error","credentials":"missing"},"secrets":[]}' ]] &&
+		rmdir "$inventory_tmp"; then
+		print_result "inventory cleans temporary files after gopass listing failure" 0
 	else
-		print_result "inventory rejects malformed gopass names" 1 "Expected failure"
+		print_result "inventory cleans temporary files after gopass listing failure" 1 \
+			"Output or temporary-file cleanup mismatch: $output"
 	fi
 	return 0
 }
@@ -419,6 +457,7 @@ main() {
 	test_multiline_gopass_injection_preserves_embedded_newlines
 	test_inventory_is_names_only_deterministic_json
 	test_inventory_rejects_malformed_gopass_name
+	test_inventory_cleans_up_after_gopass_listing_failure
 	test_inventory_requires_owner_only_credentials
 
 	echo ""


### PR DESCRIPTION
## Summary

Scope inventory cleanup to the command subprocess so invalid discovered names retain their actionable validation error without a nounset cascade; verify normal and backend-failure cleanup without reading secret values.

## Files Changed

.agents/scripts/secret-helper.sh, .agents/scripts/tests/test-secret-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: 12/12 secret-helper regressions pass under macOS Bash 3.2, including slash-bearing invalid names, normal inventory, backend listing failure, value-read exclusion, and temporary-file cleanup; ShellCheck, shfmt, secretlint, portability, Bash 3.2 compatibility, complexity gates, and changed-file preflight pass.

Resolves #31289


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.316 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 22m and 203,282 tokens on this with the user in an interactive session.