### PR TITLE
GH#31261: docs: prepare v3.32.317 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add opt-in Blender Lab MCP guidance and a pinned video-use runtime with render verification.
+
+### Changed
+
+- Enforce product-worker reservations with verified occupancy and conservative capacity borrowing.
+- Retire the global peak-hours worker cap and refresh callable-module, webhook, and architecture guidance.
+- Simplify the GitHub transport governor while preserving resource reservations and API deferral boundaries.
+
+### Fixed
+
+- Resume corrected blocked draft checkpoints with fenced ownership instead of restarting preserved work.
+- Distinguish GitHub API read-capacity deferrals from failed CI or malformed verification evidence.
+- Bind blocker recovery to allowlisted reasons and relevant brief or code revisions.
+- Reject release aggregations that inherit unreviewed default-branch commits after their reviewed snapshot.
+- Preserve initial-model fallback behavior and stabilize unchanged-base Qlty and worker-launch checks.
+- Propagate interactive claim failures and normalize reserved release-successor intent.
+- Align README and hero inventory counts with the callable module set.
+- Simplify failed launch recovery recording without weakening ownership evidence.
+
 ## [3.32.316] - 2026-09-05
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Add curated release notes for every merged change after v3.32.316.
- Keep the changelog durable on `main` before the metadata-only release aggregation.

## Files

- `CHANGELOG.md`: populate the Unreleased Added, Changed, and Fixed sections.

## Verification

- `.agents/scripts/linters-local.sh` passed.
- `git diff --check origin/main...HEAD` passed.

## Delivery

After merge, the exact-tip release aggregation will include this PR and preserve
the existing PR #31315 release lane. Publication remains delegated to the
canonical patch/incremental release helper.

Ref #31261

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.316 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol
