### PR TITLE
GH#31278: route Playwriter through scoped agent

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -31,6 +31,7 @@ subagents:
   - toon
   # Browser/testing
   - playwright
+  - playwriter
   - stagehand
   - pagespeed
   # Git platforms

--- a/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-activation-tool.mjs
@@ -281,7 +281,7 @@ async function executeMcpActivation(args, allowed, options) {
   }
 
   return action === "connect"
-    ? `Connected MCP ${name}. Continue on the next step with its tools.`
+    ? `Connected MCP ${name}. Lifecycle readiness does not grant its tools to the current agent; continue in the dedicated ${name} agent, where its tool permissions are scoped.`
     : `Disconnected MCP ${name}.`;
 }
 

--- a/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
@@ -69,6 +69,12 @@ test("registers only the explicit MCP activation profiles", () => {
   assert.doesNotMatch(config.agent.quickfile.prompt, /browser tab/i);
 });
 
+test("keeps Playwriter reachable from the Build+ routing profile", () => {
+  const buildPlus = readFileSync(join(AGENTS_DIR, "build-plus.md"), "utf8");
+
+  assert.match(buildPlus, /^\s+- playwriter$/m);
+});
+
 test("pins legacy Playwriter commands while preserving custom commands", () => {
   const legacyCommands = [
     ["npx", "playwriter@latest"],
@@ -476,7 +482,7 @@ printf 'named screenshot' >"$output_dir/review-home-desktop.png"
 
   assert.match(
     await activation.execute({ action: "connect", name: "playwright" }),
-    /Connected MCP playwright/,
+    /Connected MCP playwright.*does not grant its tools.*dedicated playwright agent/,
   );
   const managedDir = runtime.workspaces.playwright.directory;
   assert.deepEqual(readdirSync(canonical), []);


### PR DESCRIPTION
## Summary

Make MCP lifecycle success messaging truthful and expose the dedicated Playwriter subagent through Build+ routing without globally granting browser tools.

## Files Changed

.agents/build-plus.md, .agents/plugins/opencode-aidevops/mcp-activation-tool.mjs, .agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 27 MCP activation tests pass; transformed Build+ task permissions include playwriter; changed-file linters pass; branch review bundle 81e4152cbed9e12800003ac2e0c577f4a102a133767679f32a07cfeb884b073d is clean.

Resolves #31278


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 17m and 517,807 tokens on this with the user in an interactive session.