### PR TITLE
GH#31348: Remove productivity recovery complexity regressions

### DIFF
--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -20,6 +20,8 @@ import uuid
 from contextlib import contextmanager
 from pathlib import Path
 
+from gh_transport_recovery import admission_status, mark_dead_reservations, probe_recovers, reserve_probe_allowed
+
 
 class Deferred(Exception):
     """No safe admission is currently available."""
@@ -173,22 +175,7 @@ class Budget:
         now = time.time() if now is None else now
         reservation = uuid.uuid4().hex
         with self.transaction():
-            # A dead executor is uncertain spend, not free quota. Converting it
-            # to debt permits a later serialized observation to recover safely.
-            for identity, pid, birth in self.db.execute(
-                "SELECT id,pid,birth FROM reservation WHERE scope=? AND uncertain=0",
-                (self.scope,),
-            ).fetchall():
-                try:
-                    os.kill(pid, 0)
-                    current_birth = self.birth if pid == os.getpid() else process_birth(pid)
-                    if birth and current_birth and birth != current_birth:
-                        raise ProcessLookupError
-                except ProcessLookupError:
-                    self.db.execute(
-                        "UPDATE reservation SET uncertain=1,started=? WHERE id=?",
-                        (now, identity),
-                    )
+            mark_dead_reservations(self, now, process_birth)
             row = self.db.execute(
                 "SELECT remaining,reset,observed,blocked_until,quota_limit FROM quota "
                 "WHERE scope=? AND resource=?", (self.scope, resource)
@@ -209,8 +196,7 @@ class Budget:
                     "SELECT started FROM revalidation WHERE scope=? AND resource=?",
                     (self.scope, resource),
                 ).fetchone()
-                if (resource != "core" or active or row[0] - total <= 1
-                        or now - max(row[2], probe[0] if probe else row[2]) < 60):
+                if resource != "core" or not reserve_probe_allowed(row, active, total, probe, now):
                     raise Deferred(
                         f"REST resource reserve is protected (remaining={row[0]}, "
                         f"reserved={total}, floor={floor}, reset={int(row[1])})"
@@ -249,22 +235,10 @@ class Budget:
                 ).fetchone()
                 available, reset_at = int(remaining), int(reset)
                 blocked_until = 0.0
-                probe = self.db.execute(
-                    "SELECT reservation_id FROM revalidation WHERE scope=? AND resource=?",
-                    (self.scope, resource),
-                ).fetchone()
-                own = self.db.execute(
-                    "SELECT started,credential FROM reservation WHERE id=? AND scope=? AND resource=?",
-                    (reservation, self.scope, resource),
-                ).fetchone()
-                owners = sum(self._root(binding[0]) == self.scope for binding in
-                             self.db.execute("SELECT scope FROM binding").fetchall())
                 # A serialized reserve probe may repair stale evidence only for
                 # one bound credential. Shared/ambiguous owners and late replies
                 # retain conservative accounting. /rate_limit is never a grant.
-                recovered = (row and probe and own and owners == 1
-                             and own[1] == self.credential and reservation == probe[0]
-                             and own[0] >= row[2] and reset_at >= row[1])
+                recovered = probe_recovers(self, reservation, resource, row, reset_at)
                 if row and row[1] > now and not recovered:
                     # Late responses and unresolved owners with different reset
                     # epochs cannot restore quota observed to have been spent.
@@ -298,45 +272,6 @@ class Budget:
 
     def close(self) -> None:
         self.db.close()
-
-
-def admission_status(directory: Path, scope: str) -> dict:
-    """Read local core admission evidence without credentials, HTTP or mutations."""
-    path = directory / "admission.sqlite3"
-    if not path.is_file() or path.is_symlink():
-        return {"state": "unknown"}
-    db = sqlite3.connect(path.as_uri() + "?mode=ro", uri=True, timeout=2)
-    try:
-        for _ in range(256):
-            alias = db.execute("SELECT target FROM alias WHERE scope=?", (scope,)).fetchone()
-            if not alias:
-                break
-            scope = alias[0]
-        else:
-            return {"state": "unknown"}
-        row = db.execute(
-            "SELECT remaining,reset,observed,blocked_until,quota_limit FROM quota "
-            "WHERE scope=? AND resource='core'", (scope,),
-        ).fetchone()
-        if not row:
-            return {"state": "unknown"}
-        reserved = db.execute(
-            "SELECT COUNT(*) FROM reservation WHERE scope=? AND resource='core'", (scope,),
-        ).fetchone()[0]
-        now = time.time()
-        floor = min(100, max(1, row[4] // 10))
-        state = "available"
-        if row[3] > now:
-            state = "cooldown"
-        elif row[1] <= now or row[2] > now:
-            state = "unknown"
-        elif row[0] - reserved <= floor:
-            state = "reserve"
-        return {"state": state, "source": "local_response_headers", "remaining": row[0],
-                "limit": row[4], "reserved": reserved, "floor": floor,
-                "reset": int(row[1]), "observation_age_seconds": max(0, int(now - row[2]))}
-    finally:
-        db.close()
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/gh_transport_recovery.py
+++ b/.agents/scripts/gh_transport_recovery.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Bounded recovery predicates and read-only REST admission diagnostics."""
+
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+
+def mark_dead_reservations(budget, now, process_birth):
+    """A dead executor remains uncertain spend; caller owns the transaction."""
+    for identity, pid, birth in budget.db.execute(
+        "SELECT id,pid,birth FROM reservation WHERE scope=? AND uncertain=0",
+        (budget.scope,),
+    ).fetchall():
+        try:
+            os.kill(pid, 0)
+            current_birth = budget.birth if pid == os.getpid() else process_birth(pid)
+            if birth and current_birth and birth != current_birth:
+                raise ProcessLookupError
+        except ProcessLookupError:
+            budget.db.execute("UPDATE reservation SET uncertain=1,started=? WHERE id=?",
+                              (now, identity))
+
+
+def reserve_probe_allowed(row, active, total, previous, now):
+    if active or row[0] - total <= 1:
+        return False
+    last_probe = previous[0] if previous else row[2]
+    return now - max(row[2], last_probe) >= 60
+
+
+def probe_recovers(budget, reservation, resource, row, reset_at):
+    """Called inside the existing transaction; never changes quota or ownership."""
+    if not row:
+        return False
+    probe = budget.db.execute(
+        "SELECT reservation_id FROM revalidation WHERE scope=? AND resource=?",
+        (budget.scope, resource),
+    ).fetchone()
+    own = budget.db.execute(
+        "SELECT started,credential FROM reservation WHERE id=? AND scope=? AND resource=?",
+        (reservation, budget.scope, resource),
+    ).fetchone()
+    if not probe or not own:
+        return False
+    if own[1] != budget.credential or reservation != probe[0]:
+        return False
+    owners = sum(budget._root(binding[0]) == budget.scope for binding in
+                 budget.db.execute("SELECT scope FROM binding").fetchall())
+    if owners != 1:
+        return False
+    return own[0] >= row[2] and reset_at >= row[1]
+
+
+def admission_status(directory: Path, scope: str) -> dict:
+    """Read local core admission evidence without credentials, HTTP or mutations."""
+    path = directory / "admission.sqlite3"
+    if not path.is_file() or path.is_symlink():
+        return {"state": "unknown"}
+    db = sqlite3.connect(path.as_uri() + "?mode=ro", uri=True, timeout=2)
+    try:
+        for _ in range(256):
+            alias = db.execute("SELECT target FROM alias WHERE scope=?", (scope,)).fetchone()
+            if not alias:
+                break
+            scope = alias[0]
+        else:
+            return {"state": "unknown"}
+        row = db.execute(
+            "SELECT remaining,reset,observed,blocked_until,quota_limit FROM quota "
+            "WHERE scope=? AND resource='core'", (scope,),
+        ).fetchone()
+        if not row:
+            return {"state": "unknown"}
+        reserved = db.execute(
+            "SELECT COUNT(*) FROM reservation WHERE scope=? AND resource='core'", (scope,),
+        ).fetchone()[0]
+        now = time.time()
+        floor = min(100, max(1, row[4] // 10))
+        state = "available"
+        if row[3] > now:
+            state = "cooldown"
+        elif row[1] <= now or row[2] > now:
+            state = "unknown"
+        elif row[0] - reserved <= floor:
+            state = "reserve"
+        return {"state": state, "source": "local_response_headers", "remaining": row[0],
+                "limit": row[4], "reserved": reserved, "floor": floor,
+                "reset": int(row[1]), "observation_age_seconds": max(0, int(now - row[2]))}
+    finally:
+        db.close()

--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -238,8 +238,9 @@ def _count_issue(
         and not assigned
         and not blocked
         and not dependency_inconsistent
-        and not labels & {"status:in-progress", "status:claimed", "status:queued"}
     )
+    lifecycle_active = bool(labels & {"status:in-progress", "status:claimed", "status:queued"})
+    available_candidate = available_candidate and not lifecycle_active
     excluded_persistent_dashboard = bool(labels & PERSISTENT_DASHBOARD_LABELS)
     aggregate["excluded_persistent_dashboard"] += int(
         available_candidate and excluded_persistent_dashboard

--- a/.agents/scripts/tests/test-gh-shim-transport-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-transport-cases.sh
@@ -4,7 +4,7 @@
 # Sourced by the existing hermetic gh shim harness after legacy-path coverage.
 
 printf '\nTest 27: shared raw transport controls and response-owned quota\n'
-for library in gh-transport-controls.sh gh-transport-governor.py gh_transport_budget.py shared-gh-secondary-cooldown.sh; do
+for library in gh-transport-controls.sh gh-transport-governor.py gh_transport_budget.py gh_transport_recovery.py shared-gh-secondary-cooldown.sh; do
 	cp "${REPO_DIR}/.agents/scripts/${library}" "${TMP}/scripts/${library}"
 done
 mkdir -p "${TMP}/governor/tmp"

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -351,6 +351,9 @@ COMMON_ENV=(
 	"PULSE_CHECK_CAPTURE=${TEST_ROOT}/capture.txt"
 	"PULSE_CHECK_PULSE_HEALTH_FILE=${TEST_ROOT}/missing-pulse-health.json"
 	"AIDEVOPS_GH_TRANSPORT_STATE_DIR=${TEST_ROOT}/transport-state"
+	"AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE=${TEST_ROOT}/secondary-cooldown.json"
+	"AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE=${TEST_ROOT}/secondary-events.jsonl"
+	"AIDEVOPS_GH_READ_RAMP_STATE_FILE=${TEST_ROOT}/read-ramp.state"
 )
 
 printf '%s=== pulse-check-helper.sh tests ===%s\n' "$TEST_BLUE" "$TEST_NC"

--- a/todo/pulse-productivity-quality.md
+++ b/todo/pulse-productivity-quality.md
@@ -1,0 +1,25 @@
+# Remove productivity-recovery quality regressions before release
+
+## What
+
+Remove the four new Qlty smells reported on #31347 before releasing #31343.
+This is an interactive follow-up in the same user-authorized release lifecycle.
+
+## Reproducer
+
+Qlty 0.643.0 reports boolean-logic, file-complexity and function-complexity in
+`.agents/scripts/gh_transport_budget.py`, and boolean-logic in
+`.agents/scripts/pulse-check-queue-scan.py`. The report is verified locally.
+
+## How and Files Scope
+
+Extract bounded recovery predicates and read-only diagnostics into
+`.agents/scripts/gh_transport_recovery.py`, retain the public Budget interface,
+and simplify queue eligibility conditions. Update the existing hermetic shim
+fixture to copy the required module. No policy change or threshold override.
+
+## Verification
+
+Run existing transport budget (23 cases), shim (159 assertions), Pulse Check
+(122 assertions), Qlty targeted smells/check and scoped ShellCheck. Preserve
+reserve cadence, alias merging, request identity and read-only diagnostics.


### PR DESCRIPTION
## Summary

Extract recovery predicates and read-only diagnostics into gh_transport_recovery.py, preserve Budget API and transaction boundaries, simplify queue eligibility and isolate hermetic tests from live cooldown state. Removes all four new Qlty smells introduced by #31347 without a threshold override. Ref #31343.

## Files Changed

.agents/scripts/gh_transport_budget.py, .agents/scripts/gh_transport_recovery.py, .agents/scripts/pulse-check-queue-scan.py, .agents/scripts/tests/test-gh-shim-transport-cases.sh, .agents/scripts/tests/test-pulse-check-helper.sh, todo/pulse-productivity-quality.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Qlty 0.643.0 targeted check passes; targeted smells now only two pre-existing findings. 23 budget tests, 159 shim assertions and 122 Pulse Check assertions pass, including under a live unrelated cooldown. Independent exact-commit refactor review clean: a6875229aff88bb9743578f6e63b2bd6efd16f1987a0e765fbba64bc8a6b4fb0. Scoped ShellCheck passed.

Resolves #31348


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 1h 16m and 738,540 tokens on this with the user in an interactive session.