### PR TITLE
GH#31351: Keep Search quota exhaustion from freezing unrelated work

### DIFF
--- a/.agents/reference/github-api-transport.md
+++ b/.agents/reference/github-api-transport.md
@@ -41,6 +41,13 @@ charged twice, but cooldown is rechecked immediately before dispatch. Local-only
 commands remain usable without fabricated HTTP attempts. `gh search` is a REST
 search operation, not a GraphQL query.
 
+Unambiguous primary Search exhaustion (HTTP 200/403, `remaining=0`, resource
+`search`, a valid reset, no Retry-After or secondary/abuse message) holds only
+Search. Its `.primary-search` cooldown uses the server reset and is checked before
+raw shim and REST-wrapper search requests. Expired primary headers cannot create
+a new global delay. Existing global cooldowns are never cleared by this path;
+429, Retry-After, secondary/abuse and ambiguous evidence retain global protection.
+
 Native execution errors without a usable HTTP response stop alternate
 transports. A successful HTTP response which cannot reproduce a requested local
 projection retains the existing semantically equivalent read fallback. Native

--- a/.agents/scripts/gh-transport-controls.sh
+++ b/.agents/scripts/gh-transport-controls.sh
@@ -22,6 +22,7 @@ _gh_transport_preflight() {
 	# the actual cooldown at dispatch; skip only a duplicate ramp reservation.
 	local AIDEVOPS_GH_READ_RAMP_OVERRIDE="${AIDEVOPS_GH_READ_RAMP_OVERRIDE:-0}"
 	[[ "${AIDEVOPS_GH_WRAPPER_PREFLIGHT:-0}" != 1 ]] || AIDEVOPS_GH_READ_RAMP_OVERRIDE=1
+	_gh_search_cooldown_preflight "$@" || return $?
 	_gh_secondary_cooldown_preflight "$op_class"
 	return $?
 }
@@ -100,6 +101,7 @@ _gh_transport_run_rest() {
 			"$(_shim_transport_page "$@")" "$retry" "$outcome" "$status" "$elapsed" "$cost" \
 			"${AIDEVOPS_GH_AUTH_MODE:-}" "$pool" "${AIDEVOPS_GH_ROUTE_DECISION:-rest-response-owned}" "$remaining"
 		[[ "$status" == x ]] || response="HTTP/1.1 ${status}"$'\n'
+		[[ "$resource" == x ]] || response="${response}x-ratelimit-resource: ${resource}"$'\n'
 		[[ "$remaining" == x ]] || response="${response}x-ratelimit-remaining: ${remaining}"$'\n'
 		[[ "$reset" == x ]] || response="${response}x-ratelimit-reset: ${reset}"$'\n'
 		[[ "$retry_after" == x ]] || response="${response}retry-after: ${retry_after}"$'\n'

--- a/.agents/scripts/shared-gh-secondary-cooldown.sh
+++ b/.agents/scripts/shared-gh-secondary-cooldown.sh
@@ -827,6 +827,43 @@ _gh_secondary_cooldown_rest_reset_at() {
 	return 1
 }
 
+_gh_search_cooldown_preflight() {
+	local arg="" search_request=0
+	for arg in "$@"; do
+		case "$arg" in search | search/* | /search/*) search_request=1 ;; esac
+	done
+	[[ "$search_request" -eq 1 ]] || return 0
+	local AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE}.primary-search"
+	if _gh_secondary_cooldown_active; then
+		printf '[gh-cooldown] primary-search active=true; unrelated API resources remain available\n' >&2
+		return 75
+	fi
+	return 0
+}
+
+_gh_search_primary_response() {
+	local response="$1"
+	shift
+	local status="" remaining="" resource="" reset="" now=""
+	status=$(_gh_secondary_cooldown_status "$response")
+	case "$status" in 200 | 403) ;; *) return 1 ;; esac
+	remaining=$(_gh_secondary_cooldown_header_value "$response" "x-ratelimit-remaining")
+	resource=$(_gh_secondary_cooldown_header_value "$response" "x-ratelimit-resource")
+	[[ "$remaining" == "0" && "$resource" == "search" ]] || return 1
+	[[ -z "$(_gh_secondary_cooldown_header_value "$response" "retry-after")" ]] || return 1
+	_gh_secondary_cooldown_detect "$response" && return 1
+	reset=$(_gh_secondary_cooldown_header_value "$response" "x-ratelimit-reset")
+	now=$(_gh_secondary_cooldown_now)
+	[[ "$reset" =~ ^[0-9]{1,10}$ && "$reset" -le $((now + 3600)) ]] || return 1
+	# A successful last search request is primary-resource evidence, not abuse.
+	# Already-reset headers do not authorize a fabricated five-minute global hold.
+	[[ "$reset" -gt "$now" ]] || return 0
+	local AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE}.primary-search"
+	_gh_secondary_cooldown_write_until "github-search-primary-exhausted" "$response" "$reset" \
+		"primary-search" "$_GH_SECONDARY_COOLDOWN_ACTION_CREATED" "$@"
+	return $?
+}
+
 _gh_secondary_cooldown_record_response_if_needed() {
 	local rc="$1"
 	local response_text="${2:-}"
@@ -842,6 +879,9 @@ _gh_secondary_cooldown_record_response_if_needed() {
 	local body_classification=""
 	local expires_at=""
 
+	if _gh_search_primary_response "$response_text" "$method_arg" "$endpoint_arg" "$query_shape_arg" "$operation_arg" "$wrapper_arg" "$pulse_stage_arg"; then
+		return 0
+	fi
 	status="$(_gh_secondary_cooldown_status "$response_text")"
 	remaining="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-remaining")"
 	retry_after="$(_gh_secondary_cooldown_header_value "$response_text" "retry-after")"

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -198,6 +198,9 @@ _rest_pr_view_cache_emit_if_fresh() {
 #######################################
 _rest_api_call() {
 	local _class="$1"; shift
+	if declare -F _gh_search_cooldown_preflight >/dev/null 2>&1; then
+		_gh_search_cooldown_preflight "$@" || return $?
+	fi
 	local _pool="rest-core"
 	local _arg
 	for _arg in "$@"; do

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -93,6 +93,7 @@ reset_case() {
 	: >"$CALL_LOG"
 	: >"$ERR_LOG"
 	rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE"
+	rm -f "${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE}.primary-search"
 	rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE"
 	rm -f "$AIDEVOPS_GH_READ_RAMP_STATE_FILE"
 	unset GH_SECONDARY_FAIL GH_REST_CORE_403_FAIL GH_CORE_RATE_LIMIT_RESET GH_SEARCH_RATE_LIMIT_RESET GH_HEADER_LIMIT_FAIL GH_GENERIC_403_FAIL GH_ABUSE_403_FAIL GH_PRIMARY_REMAINING_ZERO_FAIL GH_PRIMARY_REMAINING_ZERO_SUCCESS GH_LARGE_SUCCESS AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_LINES AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_BYTES AIDEVOPS_GH_READ_RAMP_BUDGET AIDEVOPS_GH_READ_RAMP_BOOT_SECS AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS AIDEVOPS_GH_READ_RAMP_OVERRIDE AIDEVOPS_GH_AUTH_MODE AIDEVOPS_GH_AUTH_PRINCIPAL AIDEVOPS_GH_COOLDOWN_OPERATION AIDEVOPS_GH_COOLDOWN_WRAPPER AIDEVOPS_GH_COOLDOWN_STAGE AIDEVOPS_GH_API_POOL AIDEVOPS_GH_ROUTE_DECISION 2>/dev/null || true
@@ -479,6 +480,46 @@ test_read_ramp_does_not_defer_writes() {
 	return 1
 }
 
+test_primary_search_isolation() {
+	local now="" response="" status="" rc=0
+	# Exercise both transport boundaries with the same persisted resource hold.
+	# shellcheck source=../gh-transport-controls.sh
+	source "${SCRIPT_DIR}/gh-transport-controls.sh"
+	for status in 200 403; do
+		reset_case
+		now=$(_gh_secondary_cooldown_now)
+		response=$(printf 'HTTP/2 %s\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Resource: search\r\nX-RateLimit-Reset: %s\r\n\r\n{}\n' "$status" "$((now + 30))")
+		_gh_secondary_cooldown_record_if_needed 0 "$response" GET /search/issues
+		[[ ! -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]] || return 1
+		[[ -f "${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE}.primary-search" ]] || return 1
+		_gh_transport_preflight api repos/owner/repo || return 1
+		_gh_transport_preflight api graphql || return 1
+		rc=0
+		_gh_transport_preflight search issues fixture >/dev/null 2>&1 || rc=$?
+		[[ "$rc" -eq 75 ]] || return 1
+		rc=0
+		_rest_api_call read gh api /search/issues >/dev/null 2>&1 || rc=$?
+		[[ "$rc" -eq 75 && ! -s "$CALL_LOG" ]] || return 1
+	done
+	printf 'PASS primary Search 200/403 holds only search at both transport boundaries without HTTP\n'
+	return 0
+}
+
+test_search_expiry_and_secondary_precedence() {
+	local now="" response=""
+	reset_case
+	now=$(_gh_secondary_cooldown_now)
+	response=$(printf 'HTTP/2 200\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Resource: search\r\nX-RateLimit-Reset: %s\r\n\r\n{}\n' "$((now - 1))")
+	_gh_secondary_cooldown_record_if_needed 0 "$response" GET /search/issues
+	[[ ! -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" && ! -f "${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE}.primary-search" ]] || return 1
+	response=$(printf 'HTTP/2 403\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Resource: search\r\nX-RateLimit-Reset: %s\r\nRetry-After: 30\r\n\r\n{"message":"secondary rate limit"}\n' "$((now + 30))")
+	_gh_secondary_cooldown_record_if_needed 1 "$response" GET /search/issues
+	[[ -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]] || return 1
+	if _gh_transport_preflight api repos/owner/repo >/dev/null 2>&1; then return 1; fi
+	printf 'PASS expired Search primary evidence cannot create global hold; genuine secondary remains global\n'
+	return 0
+}
+
 test_secondary_response_writes_cooldown
 test_header_response_writes_retry_after_cooldown
 test_generic_403_diagnostic_distinguishes_forbidden
@@ -498,3 +539,5 @@ test_event_trim_enforces_bytes_below_line_cap
 test_boot_ramp_defers_after_per_minute_budget
 test_cooldown_recovery_ramp_defers_after_budget
 test_read_ramp_does_not_defer_writes
+test_primary_search_isolation
+test_search_expiry_and_secondary_precedence

--- a/todo/search-quota-isolation.md
+++ b/todo/search-quota-isolation.md
@@ -1,0 +1,38 @@
+# Keep primary Search exhaustion resource-scoped
+
+## What
+
+Prevent the small Search API allowance from imposing a global secondary cooldown
+on unrelated REST and GraphQL work. Part of user-authorized productivity recovery
+and release, following #31343 and #31348.
+
+## Reproducer
+
+**Symptom command**: invoke `_gh_secondary_cooldown_record_if_needed` with a
+successful HTTP 200 response containing `X-RateLimit-Remaining: 0`,
+`X-RateLimit-Resource: search`, no Retry-After and a reset that just elapsed.
+
+**Actual output**: the shared state records `github-api-rate-limit-remaining-zero`
+and adds a five-minute global cooldown. A live observation identified the producer
+as `_rest_search_collect_items`; no secondary-limit or abuse response was present.
+
+## How
+
+Recognize only unambiguous primary Search exhaustion. Persist its actual reset in
+a separate resource-scoped cooldown and enforce it before raw shim/REST search
+calls. Other resources remain usable. Real secondary/abuse/Retry-After/429 and
+unknown evidence retain the existing global fail-closed behavior. Never clear an
+existing global cooldown or use status JSON as a quota grant.
+
+## Files Scope
+
+- `.agents/scripts/shared-gh-secondary-cooldown.sh`
+- `.agents/scripts/gh-transport-controls.sh`
+- `.agents/scripts/shared-gh-wrappers-rest-fallback.sh`
+- Existing cooldown/shim/REST fallback tests and transport reference.
+
+## Verification
+
+Hermetic HTTP 200/403 primary Search fixtures, expired reset, missing resource,
+secondary response, Retry-After and no-HTTP repeated search tests. Run ShellCheck,
+Qlty, existing cooldown, shim and fallback suites. Preserve real quota safety.


### PR DESCRIPTION
## Summary

Recognize unambiguous primary Search exhaustion and persist only a Search-scoped cooldown at the actual server reset. Enforce both raw shim and REST-wrapper search admission before HTTP. Preserve response resource metadata through the governor error classifier. Expired primary reset evidence no longer creates a fabricated global delay. Real global cooldowns, 429, Retry-After, abuse and ambiguous evidence remain protected.

## Files Changed

.agents/reference/github-api-transport.md, .agents/scripts/gh-transport-controls.sh, .agents/scripts/shared-gh-secondary-cooldown.sh, .agents/scripts/shared-gh-wrappers-rest-fallback.sh, .agents/scripts/tests/test-gh-secondary-cooldown.sh, todo/search-quota-isolation.md

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Existing cooldown suite plus new HTTP200/403 primary-isolation, expiry and secondary-precedence cases pass. 159 shim assertions and103 REST fallback assertions pass. ShellCheck and Qlty check pass; targeted Qlty smells empty. Independent read-only review found no P0/P1/P2 defects. Reproducer from live successful Search quota response captured in issue brief.

Resolves #31351


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 1h 38m and 771,349 tokens on this with the user in an interactive session.