### PR TITLE
GH#31356: fix stats dashboard and sweep starvation

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -458,6 +458,44 @@ _prioritize_health_repo_entries() {
 }
 
 #######################################
+# Order dashboards from least-recently refreshed to most-recently refreshed.
+# Missing refresh state sorts first. This prevents repositories near the end of
+# repos.json from starving when a bounded stats cycle cannot refresh every
+# eligible dashboard. The explicit priority repository is applied afterwards.
+# Arguments:
+#   $1 - newline-delimited slug|path entries
+#   $2 - authenticated GitHub user
+# Output: entries ordered oldest-first, preserving input order for equal ages
+#######################################
+_order_health_repo_entries_by_refresh_age() {
+	local repo_entries="$1"
+	local runner_user="$2"
+	local identity_lines="" canonical_identity="" canonical_identity_cache_safe=""
+	local slug="" path="" slug_safe="" refresh_state_file="" refresh_state="" refresh_epoch="0"
+	local position=0
+
+	identity_lines=$(_dashboard_identity_aliases "$runner_user")
+	canonical_identity=$(printf '%s\n' "$identity_lines" | sed -n '1p')
+	[[ -n "$canonical_identity" ]] || canonical_identity="$runner_user"
+	canonical_identity_cache_safe=$(_sanitize_runner_identity_for_cache "$canonical_identity")
+
+	while IFS='|' read -r slug path; do
+		[[ -z "$slug" ]] && continue
+		slug_safe="${slug//\//-}"
+		refresh_state_file="${HOME}/.aidevops/logs/health-issue-${canonical_identity_cache_safe}-${slug_safe}.refresh-state"
+		refresh_state=""
+		refresh_epoch="0"
+		if [[ -f "$refresh_state_file" ]]; then
+			IFS='|' read -r refresh_state refresh_epoch <"$refresh_state_file" 2>/dev/null || refresh_epoch="0"
+		fi
+		[[ "$refresh_epoch" =~ ^[0-9]+$ ]] || refresh_epoch="0"
+		printf '%020d\t%08d\t%s|%s\n' "$refresh_epoch" "$position" "$slug" "$path"
+		position=$((position + 1))
+	done <<<"$repo_entries" | sort -n -k1,1 -k2,2 | cut -f3-
+	return 0
+}
+
+#######################################
 # Refresh the first priority dashboard before optional aggregate work.
 # Arguments:
 #   $1 - priority-ordered newline-delimited slug|path entries
@@ -588,6 +626,7 @@ update_health_issues() {
 	if [[ -z "$repo_entries" ]]; then
 		return 0
 	fi
+	repo_entries=$(_order_health_repo_entries_by_refresh_age "$repo_entries" "$routine_runner_user")
 	repo_entries=$(_prioritize_health_repo_entries "$repo_entries")
 
 	local refresh_start_epoch
@@ -623,6 +662,11 @@ update_health_issues() {
 	while IFS='|' read -r slug path; do
 		[[ -z "$slug" ]] && continue
 		[[ "$slug" == "${priority_slug:-}" ]] && continue
+		if ! _health_dashboard_optional_work_has_budget "$refresh_start_epoch"; then
+			echo "[stats] Health dashboard repository pass stopped before ${slug}: preserving wrapper cleanup budget" >>"$LOGFILE"
+			deferred=$((deferred + 1))
+			break
+		fi
 		update_ec=0
 		_update_health_issue_for_repo "$slug" "$path" "$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md" || update_ec=$?
 		if [[ "$update_ec" -eq 75 || "$update_ec" -eq 124 ]]; then

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -68,6 +68,159 @@ fi
 # --- Orchestrator functions ---
 
 #######################################
+# Rotate repository entries to resume after the last attempted repository.
+# Arguments:
+#   $1 - newline-delimited slug|path entries
+#   $2 - last attempted repository slug
+# Output: entries after the cursor, then entries through the cursor
+#######################################
+_quality_sweep_resume_entries() {
+	local repo_entries="$1"
+	local cursor_slug="$2"
+
+	if [[ -z "$cursor_slug" ]]; then
+		printf '%s\n' "$repo_entries"
+		return 0
+	fi
+	printf '%s\n' "$repo_entries" | awk -F'|' -v cursor="$cursor_slug" '
+		{
+			entries[NR] = $0
+			separator = index($0, "|")
+			entry_slug = separator ? substr($0, 1, separator - 1) : $0
+			if (entry_slug == cursor) cursor_line = NR
+		}
+		END {
+			if (!cursor_line) {
+				for (i = 1; i <= NR; i++) print entries[i]
+				exit
+			}
+			for (i = cursor_line + 1; i <= NR; i++) print entries[i]
+			for (i = 1; i <= cursor_line; i++) print entries[i]
+		}'
+	return 0
+}
+
+#######################################
+# Return success when a persisted cursor slug still exists in the current set.
+# Arguments:
+#   $1 - newline-delimited slug|path entries
+#   $2 - cursor repository slug
+#######################################
+_quality_sweep_cursor_exists() {
+	local repo_entries="$1"
+	local cursor_slug="$2"
+	local slug="" path=""
+
+	while IFS='|' read -r slug path; do
+		[[ "$slug" == "$cursor_slug" ]] && return 0
+	done <<<"$repo_entries"
+	return 1
+}
+
+#######################################
+# Return the safe wall-clock budget for one repository sweep. The aggregate
+# GitHub deadline reserves cleanup time for the parent stats wrapper.
+# Output: seconds available, or 0 when the batch should stop
+#######################################
+_quality_sweep_repo_budget_seconds() {
+	local repo_timeout="${STATS_QUALITY_SWEEP_REPO_TIMEOUT:-120}"
+	local cleanup_reserve="${STATS_QUALITY_SWEEP_CLEANUP_RESERVE_SECONDS:-30}"
+	local deadline_epoch="${AIDEVOPS_GH_DEADLINE_EPOCH:-}"
+	local now_epoch="" available_seconds=""
+
+	[[ "$repo_timeout" =~ ^[0-9]+$ && "$repo_timeout" -gt 0 ]] || repo_timeout="120"
+	[[ "$cleanup_reserve" =~ ^[0-9]+$ ]] || cleanup_reserve="30"
+	if [[ ! "$deadline_epoch" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$repo_timeout"
+		return 0
+	fi
+	now_epoch=$(date +%s)
+	available_seconds=$((deadline_epoch - now_epoch - cleanup_reserve))
+	if [[ "$available_seconds" -le 0 ]]; then
+		printf '0\n'
+		return 0
+	fi
+	[[ "$available_seconds" -lt "$repo_timeout" ]] && repo_timeout="$available_seconds"
+	printf '%s\n' "$repo_timeout"
+	return 0
+}
+
+#######################################
+# Run a resumable, bounded batch of quality sweeps.
+# Arguments:
+#   $1 - newline-delimited slug|path entries
+#   $2 - authenticated GitHub user
+# Sets: _QUALITY_SWEEP_BATCH_SWEPT, _QUALITY_SWEEP_BATCH_REMAINING
+#######################################
+_run_quality_sweep_repo_batch() {
+	local repo_entries="$1"
+	local routine_runner_user="$2"
+	local cursor_file="${QUALITY_SWEEP_STATE_DIR}/.quality-sweep-cursor"
+	local cursor_slug="" cursor_total="" remaining="" total_entries="" ordered_entries=""
+	local slug="" path="" repo_budget="0" repo_ec=0 repo_attempted=0 cursor_invalid=0
+
+	mkdir -p "$QUALITY_SWEEP_STATE_DIR"
+	total_entries=$(printf '%s\n' "$repo_entries" | awk -F'|' '$1 != "" { count++ } END { print count + 0 }')
+	remaining="$total_entries"
+	if [[ -f "$cursor_file" ]]; then
+		IFS='|' read -r cursor_slug remaining cursor_total <"$cursor_file" 2>/dev/null || {
+			cursor_slug=""
+			remaining="$total_entries"
+			cursor_total=""
+		}
+	fi
+	if [[ ! "$remaining" =~ ^[0-9]+$ || "$remaining" -le 0 || "$remaining" -gt "$total_entries" ||
+		"$cursor_total" != "$total_entries" ]]; then
+		cursor_invalid=1
+	elif [[ -n "$cursor_slug" ]] && ! _quality_sweep_cursor_exists "$repo_entries" "$cursor_slug"; then
+		cursor_invalid=1
+	fi
+	if [[ "$cursor_invalid" -eq 1 ]]; then
+		cursor_slug=""
+		remaining="$total_entries"
+	fi
+	ordered_entries=$(_quality_sweep_resume_entries "$repo_entries" "$cursor_slug")
+
+	_QUALITY_SWEEP_BATCH_SWEPT=0
+	_QUALITY_SWEEP_BATCH_REMAINING="$remaining"
+	while IFS='|' read -r slug path; do
+		[[ -z "$slug" || "$_QUALITY_SWEEP_BATCH_REMAINING" -le 0 ]] && break
+		repo_budget=$(_quality_sweep_repo_budget_seconds)
+		if [[ "$repo_budget" -le 0 ]]; then
+			echo "[stats] Quality sweep batch deferred before ${slug}: preserving wrapper cleanup budget" >>"$LOGFILE"
+			break
+		fi
+
+		repo_ec=0
+		repo_attempted=0
+		if [[ ! -d "$path" ]]; then
+			:
+		elif ! aidevops_can_run_repo_routines "$slug" "$routine_runner_user"; then
+			echo "[stats] Quality sweep skipped for ${slug}: ${routine_runner_user} is not maintainer-equivalent" >>"$LOGFILE"
+		elif declare -F _gh_run_bounded_function >/dev/null 2>&1; then
+			repo_attempted=1
+			_gh_run_bounded_function "$repo_budget" _quality_sweep_for_repo "$slug" "$path" || repo_ec=$?
+		else
+			repo_attempted=1
+			_quality_sweep_for_repo "$slug" "$path" || repo_ec=$?
+		fi
+		if [[ "$repo_attempted" -eq 0 ]]; then
+			:
+		elif [[ "$repo_ec" -eq 124 ]]; then
+			echo "[stats] Quality sweep timed out for ${slug} after ${repo_budget}s; continuing next cycle" >>"$LOGFILE"
+		elif [[ "$repo_ec" -ne 0 ]]; then
+			echo "[stats] Quality sweep failed for ${slug} (rc=${repo_ec}); continuing next cycle" >>"$LOGFILE"
+		else
+			_QUALITY_SWEEP_BATCH_SWEPT=$((_QUALITY_SWEEP_BATCH_SWEPT + 1))
+		fi
+
+		_QUALITY_SWEEP_BATCH_REMAINING=$((_QUALITY_SWEEP_BATCH_REMAINING - 1))
+		printf '%s|%s|%s\n' "$slug" "$_QUALITY_SWEEP_BATCH_REMAINING" "$total_entries" >"$cursor_file"
+	done <<<"$ordered_entries"
+	return 0
+}
+
+#######################################
 # Daily Code Quality Sweep
 #
 # Runs once per 24h (guarded by timestamp file). For each pulse-enabled
@@ -160,19 +313,16 @@ run_daily_quality_sweep() {
 
 	echo "[stats] Starting daily code quality sweep..." >>"$LOGFILE"
 
-	local swept=0
-	while IFS='|' read -r slug path; do
-		[[ -z "$slug" ]] && continue
-		[[ ! -d "$path" ]] && continue
-		if ! aidevops_can_run_repo_routines "$slug" "$routine_runner_user"; then
-			echo "[stats] Quality sweep skipped for ${slug}: ${routine_runner_user} is not maintainer-equivalent" >>"$LOGFILE"
-			continue
-		fi
-		_quality_sweep_for_repo "$slug" "$path" || true
-		swept=$((swept + 1))
-	done <<<"$repo_entries"
+	_run_quality_sweep_repo_batch "$repo_entries" "$routine_runner_user"
+	local swept="${_QUALITY_SWEEP_BATCH_SWEPT:-0}"
+	local remaining="${_QUALITY_SWEEP_BATCH_REMAINING:-0}"
+	if [[ "$remaining" -gt 0 ]]; then
+		echo "[stats] Quality sweep batch incomplete: $swept repo(s) swept, $remaining repo(s) remain" >>"$LOGFILE"
+		return 0
+	fi
 
 	# Update timestamp
+	rm -f "${QUALITY_SWEEP_STATE_DIR}/.quality-sweep-cursor"
 	date +%s >"$QUALITY_SWEEP_LAST_RUN"
 
 	echo "[stats] Quality sweep complete: $swept repo(s) swept" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -448,6 +448,16 @@ else
 	fail "health dashboard supports an explicit priority repository override" "entries=${priority_entries}"
 fi
 
+printf '%s\n' 'active|300' >"${HOME}/.aidevops/logs/health-issue-canonical-operator-owner-new.refresh-state"
+printf '%s\n' 'idle|100' >"${HOME}/.aidevops/logs/health-issue-canonical-operator-owner-old.refresh-state"
+age_ordered_entries=$(_order_health_repo_entries_by_refresh_age \
+	$'owner/new|/repo/new\nowner/missing|/repo/missing\nowner/old|/repo/old' "github-user")
+if [[ "$age_ordered_entries" == $'owner/missing|/repo/missing\nowner/old|/repo/old\nowner/new|/repo/new' ]]; then
+	pass "health dashboard orders least-recently refreshed repositories first"
+else
+	fail "health dashboard orders least-recently refreshed repositories first" "entries=${age_ordered_entries}"
+fi
+
 : >"$GH_CALLS"
 export HEALTH_FIXTURE=label_hygiene
 gh() {

--- a/.agents/scripts/tests/test-stats-routine-maintainer-guard.sh
+++ b/.agents/scripts/tests/test-stats-routine-maintainer-guard.sh
@@ -83,6 +83,14 @@ _quality_sweep_for_repo() {
 	return 0
 }
 
+_gh_run_bounded_function() {
+	local timeout_seconds="$1"
+	shift
+	[[ "$timeout_seconds" -gt 0 ]] || return 124
+	"$@"
+	return $?
+}
+
 run_daily_quality_sweep
 
 if [[ ! -f "$called_file" ]]; then
@@ -100,4 +108,10 @@ if ! grep -q '^other/maintain|' "$called_file"; then
 	exit 1
 fi
 
-printf 'PASS stats routines require maintainer-equivalent access\n'
+resume_entries=$(_quality_sweep_resume_entries $'owner/one|/one\nowner/two|/two\nowner/three|/three' "owner/two")
+if [[ "$resume_entries" != $'owner/three|/three\nowner/one|/one\nowner/two|/two' ]]; then
+	printf 'FAIL quality sweep cursor does not resume after the last attempted repo\n'
+	exit 1
+fi
+
+printf 'PASS stats routines require maintainer-equivalent access and resume bounded batches\n'

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -294,6 +294,28 @@ test_slow_priority_dashboard_skips_optional_cross_repo_work() {
 	return 0
 }
 
+test_repository_loop_preserves_cleanup_budget() {
+	local production_snippet loop_snippet
+	production_snippet=$(awk '
+		/^update_health_issues\(\) \{/ { in_production=1 }
+		in_production { print }
+		in_production && /^}$/ { exit }
+	' "$HEALTH_DASHBOARD_SCRIPT")
+	loop_snippet=$(printf '%s\n' "$production_snippet" | awk '
+		/^[[:space:]]*while IFS=.*slug path/ { in_loop=1 }
+		in_loop { print }
+		in_loop && /^[[:space:]]*done <<<.*repo_entries/ { exit }
+	')
+	if printf '%s\n' "$loop_snippet" | grep -qE '^[[:space:]]*if ! _health_dashboard_optional_work_has_budget "[$]refresh_start_epoch"; then' &&
+		printf '%s\n' "$loop_snippet" | grep -qE '^[[:space:]]*break[[:space:]]*$'; then
+		print_result "dashboard repository loop preserves wrapper cleanup budget" 0
+		return 0
+	fi
+	print_result "dashboard repository loop preserves wrapper cleanup budget" 1 \
+		"Expected the repository loop to stop before exhausting the aggregate deadline"
+	return 0
+}
+
 test_dashboard_freshness_precedes_maintenance() {
 	local dashboard_script production_snippet update_line maintenance_line
 	dashboard_script="${SCRIPT_DIR}/../stats-health-dashboard.sh"
@@ -329,7 +351,8 @@ test_dashboard_update_failure_not_swallowed() {
 			"stats-wrapper.sh still swallows update_health_issues failures with '|| true'"
 		return 0
 	fi
-	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*_stats_wrapper_run_health_update[[:space:]]*\|\|[[:space:]]*return[[:space:]]+\$\?[[:space:]]*$'; then
+	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*_stats_wrapper_run_health_update[[:space:]]*\|\|[[:space:]]*health_ec=\$\?[[:space:]]*$' &&
+		printf '%s' "$production_snippet" | grep -qE "^[[:space:]]*return \"\\\$health_ec\"[[:space:]]*$"; then
 		print_result "dashboard update failures propagate to stats-wrapper trap" 0
 		return 0
 	fi
@@ -384,6 +407,7 @@ main_test() {
 	test_priority_dashboard_precedes_optional_cross_repo_work
 	test_priority_failure_continues_remaining_repos
 	test_slow_priority_dashboard_skips_optional_cross_repo_work
+	test_repository_loop_preserves_cleanup_budget
 	test_dashboard_freshness_precedes_maintenance
 	test_dashboard_update_failure_not_swallowed
 	test_transient_dashboard_tempfail_is_deferred


### PR DESCRIPTION
## Summary

- order health dashboards by their persisted refresh age before applying any explicit priority override
- stop optional dashboard iteration while the stats wrapper still has cleanup budget
- make daily quality sweeps resumable across scheduler runs with a topology-validated cursor and bounded per-repository execution

## Incident evidence

An installation with 21 pulse-enabled repositories repeatedly exhausted the 600-second stats-wrapper ceiling. Early repositories refreshed repeatedly while a later dashboard remained stale for 20 days. Prioritizing that dashboard refreshed it, but the daily quality sweep then consumed the remaining deadline and still produced exit 124.

After this change, two 180-second deployed canaries refreshed the affected dashboard, timed out one slow quality repository without failing the wrapper, advanced the quality cursor to the next repository, and logged `Finished` in 120 seconds.

## Verification

- `shellcheck` on all five changed shell files
- `bash .agents/scripts/tests/test-stats-wrapper-timeout.sh`
- `bash .agents/scripts/tests/test-stats-wrapper-headless-export.sh`
- `bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh`
- `bash .agents/scripts/tests/test-stats-routine-maintainer-guard.sh`
- `bash .agents/scripts/tests/test-quality-sweep-serialization.sh`
- `.agents/scripts/linters-local.sh`
- pre-commit and pre-push hooks
- `setup.sh --non-interactive --stage agents`, deployed/source comparison, and deployed wrapper self-check

Resolves #31356

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.317 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol
