### PR TITLE
GH#31356: fix: Bound and resume multi-repository stats work

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -457,6 +457,54 @@ _prioritize_health_repo_entries() {
 	return 0
 }
 
+# Use the same canonical operator key as publication. Attempts are separate
+# from successful refresh state: retrying a failed/missing dashboard must not
+# make it look fresh, but must give the next stale repository a turn.
+_health_schedule_cache_file() {
+	local slug="$1" runner="$2" identity
+	identity=$(_dashboard_identity_aliases "$runner")
+	identity="${identity%%$'\n'*}"
+	identity=$(_sanitize_runner_identity_for_cache "${identity:-$runner}")
+	printf '%s/.aidevops/logs/health-issue-%s-%s\n' "$HOME" "$identity" "${slug//\//-}"
+	return 0
+}
+
+_order_health_repo_entries() {
+	local entries="$1" runner="$2" slug path cache state epoch attempted rank=0
+	while IFS='|' read -r slug path; do
+		[[ -n "$slug" ]] || continue
+		cache=$(_health_schedule_cache_file "$slug" "$runner")
+		state="" epoch=0 attempted=0
+		if [[ -f "${cache}.refresh-state" ]]; then
+			IFS='|' read -r state epoch <"${cache}.refresh-state" || true
+		fi
+		[[ "$epoch" =~ ^[0-9]{1,11}$ ]] || epoch=0
+		epoch=$((10#$epoch))
+		if [[ -f "${cache}.attempt" ]]; then
+			read -r attempted <"${cache}.attempt" || true
+		fi
+		[[ "$attempted" =~ ^[0-9]{1,11}$ ]] || attempted=0
+		attempted=$((10#$attempted))
+		[[ "$attempted" -le "$epoch" ]] || epoch="$attempted"
+		printf '%s\t%s\t%s|%s\n' "$epoch" "$rank" "$slug" "$path"
+		rank=$((rank + 1))
+	done <<<"$entries" | LC_ALL=C sort -n -k1,1 -k2,2 | cut -f3-
+	return 0
+}
+
+_refresh_health_repo_bounded() {
+	local slug="$1" cache repo_timeout
+	cache=$(_health_schedule_cache_file "$slug" "$_HEALTH_SCHEDULE_RUNNER")
+	[[ "$(date +%s)" -lt "$((_HEALTH_WORK_DEADLINE - 2))" ]] || return 124
+	mkdir -p "${cache%/*}" || return 1
+	date +%s >"${cache}.attempt" || return 1
+	repo_timeout=$(_stats_seconds "${STATS_HEALTH_REPO_TIMEOUT:-60}" 60)
+	[[ "$repo_timeout" -gt 0 ]] || repo_timeout=60
+	_stats_run_bounded "$repo_timeout" \
+		"$_HEALTH_WORK_DEADLINE" _update_health_issue_for_repo "$@"
+	return $?
+}
+
 #######################################
 # Refresh the first priority dashboard before optional aggregate work.
 # Arguments:
@@ -473,7 +521,7 @@ _refresh_priority_health_issue() {
 	# Emit the attempted slug even on failure so the best-effort caller can skip
 	# an immediate retry while continuing with the remaining repositories.
 	printf '%s\n' "$priority_slug"
-	_update_health_issue_for_repo "$priority_slug" "$priority_path" "" "" "" || update_ec=$?
+	_refresh_health_repo_bounded "$priority_slug" "$priority_path" "" "" "" || update_ec=$?
 	if [[ "$update_ec" -ne 0 ]]; then
 		echo "[stats] Health issue update failed for priority ${priority_slug}" >>"$LOGFILE"
 		return "$update_ec"
@@ -499,6 +547,10 @@ _health_dashboard_optional_work_has_budget() {
 	[[ "$refresh_start_epoch" =~ ^[0-9]+$ ]] || return 1
 	[[ "$timeout_seconds" =~ ^[0-9]+$ ]] || timeout_seconds="600"
 	[[ "$optional_reserve_seconds" =~ ^[0-9]+$ ]] || optional_reserve_seconds="120"
+	if [[ -n "${_HEALTH_WORK_DEADLINE:-}" ]]; then
+		[[ "$(date +%s)" -lt "$((_HEALTH_WORK_DEADLINE - 2))" ]]
+		return $?
+	fi
 	latest_start_epoch=$((timeout_seconds - optional_reserve_seconds))
 	[[ "$latest_start_epoch" -gt 0 ]] || return 1
 	now_epoch=$(date +%s)
@@ -547,6 +599,29 @@ _build_cross_repo_health_summaries() {
 	return 0
 }
 
+# Serialize the existing out-variable interface across the bounded child.
+_health_summaries_json() {
+	local activity="" sessions="" people=""
+	_build_cross_repo_health_summaries "$1" activity sessions people
+	jq -cn --arg activity "$activity" --arg sessions "$sessions" --arg people "$people" \
+		'{activity:$activity,sessions:$sessions,people:$people}'
+	return $?
+}
+
+_health_routine_repo_entries() {
+	local runner="$1" entries
+	[[ -f "$REPOS_JSON" ]] || return 0
+	entries=$(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$REPOS_JSON" 2>/dev/null) || return 1
+	[[ -n "$entries" ]] || return 0
+	entries=$(_stats_run_bounded 60 "$_HEALTH_WORK_DEADLINE" _filter_routine_eligible_repo_entries "$entries" "$runner") || {
+		echo "[stats] Health dashboard permission preflight deferred/failed" >>"$LOGFILE"
+		return 1
+	}
+	entries=$(_order_health_repo_entries "$entries" "$runner")
+	_prioritize_health_repo_entries "$entries"
+	return 0
+}
+
 #######################################
 # Update health issues for ALL pulse-enabled repos
 #
@@ -562,33 +637,23 @@ update_health_issues() {
 		echo "[stats] update_health_issues: dry-run, skipping" >>"$LOGFILE"
 		return 0
 	fi
+	local _HEALTH_WORK_DEADLINE _HEALTH_SCHEDULE_RUNNER=""
+	_HEALTH_WORK_DEADLINE=$(_stats_work_deadline)
+	_HEALTH_WORK_DEADLINE=$((_HEALTH_WORK_DEADLINE - $(_stats_seconds "${STATS_OPTIONAL_WORK_RESERVE_SECONDS:-120}" 120)))
 	command -v gh &>/dev/null || return 0
-	gh auth status &>/dev/null 2>&1 || return 0
-
-	local repos_json="$REPOS_JSON"
-	if [[ ! -f "$repos_json" ]]; then
-		return 0
-	fi
-
-	local repo_entries
-	repo_entries=$(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null || echo "")
-
-	if [[ -z "$repo_entries" ]]; then
-		return 0
-	fi
+	_stats_run_bounded 15 "$_HEALTH_WORK_DEADLINE" gh auth status &>/dev/null || return 0
 
 	local routine_runner_user
-	routine_runner_user=$(aidevops_repo_state_current_user)
+	routine_runner_user=$(_stats_run_bounded 15 "$_HEALTH_WORK_DEADLINE" aidevops_repo_state_current_user) || routine_runner_user=""
 	if [[ -z "$routine_runner_user" ]]; then
 		echo "[stats] Health dashboard skipped: could not resolve authenticated GitHub user" >>"$LOGFILE"
 		return 0
 	fi
 
-	repo_entries=$(_filter_routine_eligible_repo_entries "$repo_entries" "$routine_runner_user")
-	if [[ -z "$repo_entries" ]]; then
-		return 0
-	fi
-	repo_entries=$(_prioritize_health_repo_entries "$repo_entries")
+	local repo_entries
+	repo_entries=$(_health_routine_repo_entries "$routine_runner_user") || return 0
+	[[ -n "$repo_entries" ]] || return 0
+	_HEALTH_SCHEDULE_RUNNER="$routine_runner_user"
 
 	local refresh_start_epoch
 	refresh_start_epoch=$(date +%s)
@@ -612,19 +677,32 @@ update_health_issues() {
 	fi
 
 	# Refresh person-stats cache if stale (t1426: hourly, not every pulse)
-	_refresh_person_stats_cache || true
+	local aggregate_timeout
+	aggregate_timeout=$(_stats_seconds "${STATS_HEALTH_AGGREGATE_TIMEOUT:-30}" 30)
+	_stats_run_bounded "$aggregate_timeout" "$_HEALTH_WORK_DEADLINE" _refresh_person_stats_cache ||
+		echo "[stats] Health dashboard person cache deferred/failed" >>"$LOGFILE"
 
 	local cross_repo_md=""
 	local cross_repo_session_time_md=""
 	local cross_repo_person_stats_md=""
-	_build_cross_repo_health_summaries "$repo_entries" \
-		cross_repo_md cross_repo_session_time_md cross_repo_person_stats_md
+	local summaries=""
+	if summaries=$(_stats_run_bounded "$aggregate_timeout" "$_HEALTH_WORK_DEADLINE" _health_summaries_json "$repo_entries"); then
+		cross_repo_md=$(jq -r '.activity' <<<"$summaries")
+		cross_repo_session_time_md=$(jq -r '.sessions' <<<"$summaries")
+		cross_repo_person_stats_md=$(jq -r '.people' <<<"$summaries")
+	else
+		echo "[stats] Health dashboard aggregate summaries deferred/failed" >>"$LOGFILE"
+	fi
 
 	while IFS='|' read -r slug path; do
 		[[ -z "$slug" ]] && continue
 		[[ "$slug" == "${priority_slug:-}" ]] && continue
+		if ! _health_dashboard_optional_work_has_budget "$refresh_start_epoch"; then
+			echo "[stats] Health dashboard repository pass deferred: reserved quality/cleanup budget" >>"$LOGFILE"
+			break
+		fi
 		update_ec=0
-		_update_health_issue_for_repo "$slug" "$path" "$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md" || update_ec=$?
+		_refresh_health_repo_bounded "$slug" "$path" "$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md" || update_ec=$?
 		if [[ "$update_ec" -eq 75 || "$update_ec" -eq 124 ]]; then
 			echo "[stats] Health issue update deferred for ${slug} (rc=${update_ec})" >>"$LOGFILE"
 			deferred=$((deferred + 1))

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -67,6 +67,94 @@ fi
 
 # --- Orchestrator functions ---
 
+# Atomic progress under the wrapper's existing single-writer PID ownership.
+# Store visited slug|path identities, not a remaining count alone: additions,
+# removals, moves and permission changes must not silently lose repositories.
+_quality_sweep_save_cursor() {
+	local cursor="$1" state="$2" temporary
+	temporary=$(mktemp "${cursor}.XXXXXX") || return 1
+	if ! printf '%s\n' "$state" >"$temporary" || ! mv -f "$temporary" "$cursor"; then
+		rm -f "$temporary"
+		return 1
+	fi
+	return 0
+}
+
+_quality_sweep_attempt() {
+	local cursor="$1" state="$2"
+	shift 2
+	_quality_sweep_save_cursor "$cursor" "$state" || return 1
+	_quality_sweep_for_repo "$@"
+	return $?
+}
+
+_quality_sweep_batch() {
+	local entries="$1" runner="$2" deadline="$3"
+	local cursor="${QUALITY_SWEEP_STATE_DIR}/cursor.json" state pending entry slug path
+	local result=0 attempted=0 remaining=0 repo_timeout next_state observed
+	mkdir -p "$QUALITY_SWEEP_STATE_DIR" || return 1
+	state=$(jq -ce --arg runner "$runner" '
+		select(.version == 1 and .runner == $runner and .complete == false) |
+		select(.visited | type == "array") |
+		select(all(.visited[]; type == "string"))' "$cursor" 2>/dev/null) || {
+		[[ ! -f "$cursor" ]] || echo "[stats] Quality sweep cursor reset: completed, changed operator, or invalid state" >>"$LOGFILE"
+		state=$(jq -cn --arg runner "$runner" '{version:1,runner:$runner,visited:[],complete:false,remaining:0}')
+	}
+	pending=$(jq -Rn --argjson state "$state" '[inputs | select(length > 0)] | unique |
+		map(select(. as $entry | $state.visited | index($entry) | not)) | .[]' <<<"$entries" | jq -sr 'join("\n")') || return 1
+	remaining=$(jq -Rn '[inputs | select(length > 0)] | length' <<<"$pending")
+	state=$(jq -c --argjson remaining "$remaining" '.remaining=$remaining' <<<"$state")
+	_quality_sweep_save_cursor "$cursor" "$state" || return 1
+	repo_timeout=$(_stats_seconds "${QUALITY_SWEEP_REPO_TIMEOUT:-120}" 120)
+	[[ "$repo_timeout" -gt 0 ]] || repo_timeout=120
+	while IFS= read -r entry; do
+		[[ -n "$entry" ]] || continue
+		if [[ "$(date +%s)" -ge "$((deadline - 2))" ]]; then
+			echo "[stats] Quality sweep partial: attempted=$attempted remaining=$remaining; cleanup budget reserved" >>"$LOGFILE"
+			return 0
+		fi
+		IFS='|' read -r slug path <<<"$entry"
+		# Persist admission before execution so an outer kill cannot pin every
+		# later scheduler invocation behind the same hanging first repository.
+		next_state=$(jq -c --arg entry "$entry" --argjson remaining "$((remaining - 1))" \
+			'.visited += [$entry] | .last_attempt=$entry | .remaining=$remaining' <<<"$state")
+		result=0
+		_stats_run_bounded "$repo_timeout" "$deadline" _quality_sweep_attempt "$cursor" "$next_state" "$slug" "$path" || result=$?
+		observed=$(jq -c . "$cursor") || return 1
+		if [[ "$observed" != "$next_state" ]]; then
+			echo "[stats] Quality sweep partial: repository not admitted (rc=${result}); cursor unchanged" >>"$LOGFILE"
+			[[ "$result" -eq 124 ]] && return 0
+			return 1
+		fi
+		state="$next_state"
+		remaining=$((remaining - 1))
+		attempted=$((attempted + 1))
+		if [[ "$result" -ne 0 ]]; then
+			echo "[stats] Quality sweep attempt deferred/failed for ${slug} (rc=${result}); advancing cursor" >>"$LOGFILE"
+		fi
+	done <<<"$pending"
+	# Mark closed before the timestamp: interruption can repeat work, never
+	# reuse a completed visited set to skip tomorrow's sweep entirely.
+	state=$(jq -c '.complete=true' <<<"$state")
+	_quality_sweep_save_cursor "$cursor" "$state" || return 1
+	date +%s >"$QUALITY_SWEEP_LAST_RUN" || return 1
+	echo "[stats] Quality sweep complete: $attempted repo(s) attempted this batch; all eligible repositories visited" >>"$LOGFILE"
+	return 0
+}
+
+_quality_sweep_eligible_entries() {
+	local entries="$1" runner="$2" slug path
+	while IFS='|' read -r slug path; do
+		[[ -n "$slug" && -d "$path" ]] || continue
+		if aidevops_can_run_repo_routines "$slug" "$runner"; then
+			printf '%s|%s\n' "$slug" "$path"
+		else
+			echo "[stats] Quality sweep skipped for ${slug}: ${runner} is not maintainer-equivalent" >>"$LOGFILE"
+		fi
+	done <<<"$entries"
+	return 0
+}
+
 #######################################
 # Daily Code Quality Sweep
 #
@@ -94,6 +182,9 @@ run_daily_quality_sweep() {
 		echo "[stats] run_daily_quality_sweep: dry-run, skipping" >>"$LOGFILE"
 		return 0
 	fi
+	local sweep_deadline
+	sweep_deadline=$(_stats_work_deadline)
+	sweep_deadline=$((sweep_deadline - $(_stats_seconds "${QUALITY_SWEEP_CLEANUP_RESERVE_SECONDS:-5}" 5)))
 	# Time-of-day gate — only run during Anthropic's 2x usage boost hours.
 	# Claude doubles usage allowance outside peak: for UK/GMT that's 18:00-11:59
 	# (standard 1x is only 12:00-17:59). Weekends are 2x all day, all timezones.
@@ -137,7 +228,7 @@ run_daily_quality_sweep() {
 	fi
 
 	command -v gh &>/dev/null || return 0
-	gh auth status &>/dev/null 2>&1 || return 0
+	_stats_run_bounded 15 "$sweep_deadline" gh auth status &>/dev/null || return 0
 
 	local repos_json="$REPOS_JSON"
 	if [[ ! -f "$repos_json" ]]; then
@@ -152,7 +243,7 @@ run_daily_quality_sweep() {
 	fi
 
 	local routine_runner_user
-	routine_runner_user=$(aidevops_repo_state_current_user)
+	routine_runner_user=$(_stats_run_bounded 15 "$sweep_deadline" aidevops_repo_state_current_user) || routine_runner_user=""
 	if [[ -z "$routine_runner_user" ]]; then
 		echo "[stats] Quality sweep skipped: could not resolve authenticated GitHub user" >>"$LOGFILE"
 		return 0
@@ -160,23 +251,14 @@ run_daily_quality_sweep() {
 
 	echo "[stats] Starting daily code quality sweep..." >>"$LOGFILE"
 
-	local swept=0
-	while IFS='|' read -r slug path; do
-		[[ -z "$slug" ]] && continue
-		[[ ! -d "$path" ]] && continue
-		if ! aidevops_can_run_repo_routines "$slug" "$routine_runner_user"; then
-			echo "[stats] Quality sweep skipped for ${slug}: ${routine_runner_user} is not maintainer-equivalent" >>"$LOGFILE"
-			continue
-		fi
-		_quality_sweep_for_repo "$slug" "$path" || true
-		swept=$((swept + 1))
-	done <<<"$repo_entries"
+	local eligible_entries=""
+	eligible_entries=$(_stats_run_bounded 60 "$sweep_deadline" _quality_sweep_eligible_entries "$repo_entries" "$routine_runner_user") || {
+		echo "[stats] Quality sweep permission preflight deferred/failed; cursor unchanged" >>"$LOGFILE"
+		return 0
+	}
 
-	# Update timestamp
-	date +%s >"$QUALITY_SWEEP_LAST_RUN"
-
-	echo "[stats] Quality sweep complete: $swept repo(s) swept" >>"$LOGFILE"
-	return 0
+	_quality_sweep_batch "$eligible_entries" "$routine_runner_user" "$sweep_deadline"
+	return $?
 }
 
 #######################################

--- a/.agents/scripts/stats-shared.sh
+++ b/.agents/scripts/stats-shared.sh
@@ -22,6 +22,76 @@
 [[ -n "${_STATS_SHARED_LOADED:-}" ]] && return 0
 _STATS_SHARED_LOADED=1
 
+# Bounded decimal configuration: reject overflow and normalize leading zeroes.
+_stats_seconds() {
+	local value="$1" fallback="$2"
+	[[ "$value" =~ ^[0-9]{1,9}$ ]] || value="$fallback"
+	printf '%s\n' "$((10#$value))"
+	return 0
+}
+
+# The wrapper already reserves 30s for its own cleanup. Standalone callers get
+# the same finite ceiling; phases must resolve it once, not per repository.
+_stats_work_deadline() {
+	local now deadline seconds
+	now=$(date +%s)
+	seconds=$(_stats_seconds "${STATS_TIMEOUT:-600}" 600)
+	deadline=$((now + seconds - 30))
+	if [[ "${AIDEVOPS_GH_DEADLINE_EPOCH:-}" =~ ^[0-9]{1,11}$ ]]; then
+		[[ "$((10#$AIDEVOPS_GH_DEADLINE_EPOCH))" -lt "$deadline" ]] && deadline="$((10#$AIDEVOPS_GH_DEADLINE_EPOCH))"
+	fi
+	printf '%s\n' "$deadline"
+	return 0
+}
+
+# Bound an entire shell function, not only its GitHub calls. Functions retain
+# the caller's loaded libraries/configuration in the child, but variable changes
+# do not return to the parent. Disk state/stdout are the explicit output channel.
+# Nested gh timeout process groups must also die, rather than escaping a kill
+# directed only at the immediate group. Freeze parents before discovering their
+# children so they cannot spawn replacements during cleanup.
+# Args: maximum seconds, absolute deadline, command and arguments. 124=deferred.
+_stats_run_bounded() {
+	local seconds="$1" deadline="$2"
+	shift 2
+	local now end_epoch child_pid result=0 child_result=0 scratch
+	now=$(date +%s)
+	[[ "$deadline" -gt "$((now + 2))" && "$seconds" -gt 0 ]] || return 124
+	end_epoch=$((now + seconds))
+	[[ "$end_epoch" -lt "$((deadline - 2))" ]] || end_epoch=$((deadline - 2))
+	scratch=$(mktemp -d "${TMPDIR:-/tmp}/stats-batch.XXXXXX") || return 1
+	(
+		trap - EXIT
+		export TMPDIR="$scratch"
+		export AIDEVOPS_GH_DEADLINE_EPOCH="$end_epoch"
+		"$@"
+	) &
+	child_pid=$!
+	while kill -0 "$child_pid" 2>/dev/null; do
+		now=$(date +%s)
+		if [[ "$now" -ge "$end_epoch" ]]; then
+			_stats_kill_bounded_tree "$child_pid"
+			result=124
+			break
+		fi
+		sleep 0.2
+	done
+	wait "$child_pid" 2>/dev/null || child_result=$?
+	[[ "$result" -eq 124 ]] || result="$child_result"
+	rm -rf "$scratch"
+	return "$result"
+}
+
+_stats_kill_bounded_tree() {
+	local pid="$1" child
+	kill -STOP "$pid" 2>/dev/null || return 0
+	while IFS= read -r child; do
+		[[ -z "$child" ]] || _stats_kill_bounded_tree "$child"
+	done < <(pgrep -P "$pid" 2>/dev/null || true)
+	kill -KILL "$pid" 2>/dev/null || true
+	return 0
+}
+
 #######################################
 # Validate a repo slug matches the expected owner/repo format.
 # Rejects path traversal, quotes, and other injection vectors.

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -448,6 +448,41 @@ else
 	fail "health dashboard supports an explicit priority repository override" "entries=${priority_entries}"
 fi
 
+# GH#31356: persisted canonical refresh/attempt ordering, without forged freshness.
+schedule_entries=$'owner/new|/repo/new\nowner/old|/repo/old\nowner/missing|/repo/missing'
+new_cache=$(_health_schedule_cache_file owner/new github-user)
+old_cache=$(_health_schedule_cache_file owner/old github-user)
+printf 'active|200\n' >"${new_cache}.refresh-state"
+printf 'idle|100\n' >"${old_cache}.refresh-state"
+ordered=$(_order_health_repo_entries "$schedule_entries" github-user)
+if [[ "$ordered" == $'owner/missing|/repo/missing\nowner/old|/repo/old\nowner/new|/repo/new' ]]; then
+	pass "missing then oldest canonical refresh states run first"
+else
+	fail "missing then oldest canonical refresh states run first" "$ordered"
+fi
+missing_cache=$(_health_schedule_cache_file owner/missing github-user)
+printf '300\n' >"${missing_cache}.attempt"
+ordered=$(_order_health_repo_entries "$schedule_entries" github-user)
+if [[ "$ordered" == $'owner/old|/repo/old\nowner/new|/repo/new\nowner/missing|/repo/missing' && ! -e "${missing_cache}.refresh-state" ]]; then
+	pass "failed or skipped attempt yields to other stale dashboards without claiming freshness"
+else
+	fail "failed or skipped attempt yields to other stale dashboards" "$ordered"
+fi
+printf 'invalid|not-an-epoch\n' >"${new_cache}.refresh-state"
+ordered=$(_order_health_repo_entries "$schedule_entries" github-user)
+if [[ "$ordered" == $'owner/new|/repo/new\nowner/old|/repo/old\nowner/missing|/repo/missing' ]]; then
+	pass "invalid refresh timestamp is treated as missing"
+else
+	fail "invalid refresh timestamp is treated as missing" "$ordered"
+fi
+_HEALTH_WORK_DEADLINE=$(date +%s)
+if _health_dashboard_optional_work_has_budget "$(date +%s)"; then
+	fail "optional admission uses aggregate deadline not a restarted phase clock"
+else
+	pass "optional admission uses aggregate deadline not a restarted phase clock"
+fi
+unset _HEALTH_WORK_DEADLINE
+
 : >"$GH_CALLS"
 export HEALTH_FIXTURE=label_hygiene
 gh() {

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -242,7 +242,7 @@ test_priority_dashboard_precedes_optional_cross_repo_work() {
 	local dashboard_script priority_line cache_line
 	dashboard_script="${SCRIPT_DIR}/../stats-health-dashboard.sh"
 	priority_line=$(grep -nE "^[[:space:]]*(if[[:space:]]+)?priority_slug=[\$]\(_refresh_priority_health_issue \"[\$]repo_entries\"\)" "$dashboard_script" | head -1 | cut -d: -f1)
-	cache_line=$(grep -nE '^[[:space:]]*_refresh_person_stats_cache \|\| true' "$dashboard_script" | head -1 | cut -d: -f1)
+	cache_line=$(grep -nE '^[[:space:]]*_stats_run_bounded .* _refresh_person_stats_cache' "$dashboard_script" | head -1 | cut -d: -f1) || cache_line=""
 	if [[ -n "$priority_line" && -n "$cache_line" && "$priority_line" -lt "$cache_line" ]]; then
 		print_result "priority dashboard refresh precedes optional cross-repo work" 0
 		return 0
@@ -329,7 +329,8 @@ test_dashboard_update_failure_not_swallowed() {
 			"stats-wrapper.sh still swallows update_health_issues failures with '|| true'"
 		return 0
 	fi
-	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*_stats_wrapper_run_health_update[[:space:]]*\|\|[[:space:]]*return[[:space:]]+\$\?[[:space:]]*$'; then
+	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*_stats_wrapper_run_health_update[[:space:]]*\|\|[[:space:]]*health_ec=\$\?' &&
+		printf '%s' "$production_snippet" | grep -qF "return \"\$health_ec\""; then
 		print_result "dashboard update failures propagate to stats-wrapper trap" 0
 		return 0
 	fi

--- a/.agents/scripts/tests/test-stats-wrapper-timeout.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-timeout.sh
@@ -244,6 +244,99 @@ test_healthy_update_runs_health_then_quality_once() {
 	return 0
 }
 
+test_resumable_quality_batches() {
+	local batch_home
+	batch_home=$(mktemp -d "${TMPDIR:-/tmp}/stats-resume.XXXXXX") || return 1
+	if (
+		export HOME="$batch_home" LOGFILE="$batch_home/stats.log"
+		export QUALITY_SWEEP_STATE_DIR="$batch_home/state" QUALITY_SWEEP_LAST_RUN="$batch_home/last-run"
+		export QUALITY_SWEEP_REPO_TIMEOUT=3
+		local scripts="${SCRIPT_DIR}/.."
+		local SCRIPT_DIR="$scripts"
+		# shellcheck source=../shared-constants.sh
+		source "$scripts/shared-constants.sh"
+		# shellcheck source=../worker-lifecycle-common.sh
+		source "$scripts/worker-lifecycle-common.sh"
+		# shellcheck source=../stats-functions.sh
+		source "$scripts/stats-functions.sh"
+		_quality_sweep_for_repo() {
+			printf '%s\n' "$1" >>"$HOME/attempts"
+			if [[ "$1" == owner/a ]]; then
+				printf '%s\n' "$TMPDIR" >"$HOME/scratch"
+				sleep 30 &
+				printf '%s\n' "$!" >"$HOME/descendant"
+				wait "$!"
+			fi
+			return 0
+		}
+		local entries=$'owner/a|/a\nowner/b|/b\nowner/c|/c' now descendant scratch
+		now=$(date +%s)
+		_quality_sweep_batch "$entries" tester "$((now + 5))" || exit 1
+		[[ ! -f "$QUALITY_SWEEP_LAST_RUN" ]] || exit 2
+		jq -e '.remaining == 2 and .complete == false and .visited == ["owner/a|/a"]' "$QUALITY_SWEEP_STATE_DIR/cursor.json" || {
+			jq . "$QUALITY_SWEEP_STATE_DIR/cursor.json"
+			exit 3
+		}
+		descendant=$(<"$HOME/descendant")
+		if kill -0 "$descendant" 2>/dev/null; then
+			# Some hosts briefly retain reparented zombies; they cannot run work.
+			[[ "$(ps -p "$descendant" -o stat=)" == *Z* ]] || exit 4
+		fi
+		scratch=$(<"$HOME/scratch")
+		[[ ! -d "$scratch" ]] || exit 5
+		grep -q 'rc=124' "$LOGFILE" || exit 6
+		# Config changes: retain progress, remove c, and add d without losing it.
+		now=$(date +%s)
+		_quality_sweep_batch $'owner/a|/a\nowner/b|/b\nowner/d|/d' tester "$((now + 10))" || exit 7
+		[[ "$(<"$HOME/attempts")" == $'owner/a\nowner/b\nowner/d' ]] || exit 8
+		[[ -s "$QUALITY_SWEEP_LAST_RUN" ]] || exit 9
+		jq -e '.complete == true and .remaining == 0' "$QUALITY_SWEEP_STATE_DIR/cursor.json" || exit 10
+		# A completed cycle must not skip the next day; corrupt state also resets.
+		_quality_sweep_batch 'owner/b|/b' tester "$((now + 10))" || exit 11
+		printf 'corrupt\n' >"$QUALITY_SWEEP_STATE_DIR/cursor.json"
+		_quality_sweep_batch 'owner/d|/d' tester "$((now + 10))" || exit 12
+		[[ "$(<"$HOME/attempts")" == $'owner/a\nowner/b\nowner/d\nowner/b\nowner/d' ]] || exit 13
+		_batch_failure() { return 75; }
+		local failure=0
+		_stats_run_bounded 1 "$((now + 10))" _batch_failure || failure=$?
+		[[ "$failure" -eq 75 ]] || exit 14
+		# Expired admission must not invoke work or advance the cursor.
+		_quality_sweep_batch 'owner/e|/e' tester "$now" || exit 15
+		jq -e '.visited == [] and .remaining == 1' "$QUALITY_SWEEP_STATE_DIR/cursor.json" || exit 16
+		_test_stats_preflight_deadlines || exit 17
+	); then
+		pass "quality batches resume, reconcile configuration, bound descendants and retain diagnostics"
+	else
+		fail "quality batches resume, reconcile configuration, bound descendants and retain diagnostics" "fixture exit=$?"
+	fi
+	rm -rf "$batch_home"
+	return 0
+}
+
+_test_stats_preflight_deadlines() {
+	local REPOS_JSON="$HOME/repos.json" start elapsed
+	local STATS_OPTIONAL_WORK_RESERVE_SECONDS=0 QUALITY_SWEEP_CLEANUP_RESERVE_SECONDS=0
+	local QUALITY_SWEEP_OFFPEAK=0 QUALITY_SWEEP_INTERVAL=0 AIDEVOPS_GH_DEADLINE_EPOCH
+	# Both public paths must bound raw permission lookups, not just tool runs.
+	jq -n --arg path "$HOME" '{initialized_repos:[{slug:"owner/slow",path:$path,pulse:true}]}' >"$REPOS_JSON"
+	gh() { return 0; }
+	aidevops_repo_state_current_user() { printf 'tester\n'; return 0; }
+	aidevops_can_run_repo_routines() { sleep 30; return 0; }
+	start=$(date +%s)
+	AIDEVOPS_GH_DEADLINE_EPOCH=$((start + 5))
+	update_health_issues || return 1
+	elapsed=$(($(date +%s) - start))
+	[[ "$elapsed" -lt 6 ]] || return 2
+	grep -q 'Health dashboard permission preflight deferred/failed' "$LOGFILE" || return 3
+	start=$(date +%s)
+	AIDEVOPS_GH_DEADLINE_EPOCH=$((start + 5))
+	run_daily_quality_sweep || return 4
+	elapsed=$(($(date +%s) - start))
+	[[ "$elapsed" -lt 6 ]] || return 5
+	grep -q 'Quality sweep permission preflight deferred/failed' "$LOGFILE" || return 6
+	return 0
+}
+
 main_test() {
 	test_timeout_kills_work_and_cleans_pidfile
 	test_normal_completion_cleans_pidfile
@@ -252,6 +345,7 @@ main_test() {
 	test_function_write_times_out_before_outer_ceiling
 	test_failed_health_update_still_runs_quality_sweep_once
 	test_healthy_update_runs_health_then_quality_once
+	test_resumable_quality_batches
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 }


### PR DESCRIPTION
## Summary

Make scheduled stats work fair and resumable when all managed repositories cannot fit into one wrapper invocation.

- Order dashboards by canonical-operator refresh/attempt age, preserving the explicit priority override. Attempts never overwrite successful freshness state.
- Bound whole repository work, authentication/permission preflight, person-cache refresh and aggregate rendering against the existing wrapper deadline. Reserve time for quality work and cleanup; retain the outer watchdog.
- Persist a quality-sweep cursor atomically, reconcile current slug/path identities, advance after bounded failures, and write the daily timestamp only when the full eligible cycle has been admitted.
- Freeze each process before discovering/killing descendants to avoid spawning replacements during timeout cleanup. Remove attempt-owned temporary artifacts.

Resolves #31356

## Files and scope

- `.agents/scripts/stats-health-dashboard.sh`: fair ordering and bounded dashboard orchestration.
- `.agents/scripts/stats-quality-sweep.sh`: resumable, configuration-aware quality batches.
- `.agents/scripts/stats-shared.sh`: small shared deadline/child-containment primitives used by both existing orchestrators, avoiding duplicate implementations.
- Existing focused tests: `test-health-dashboard-identity-aliases.sh`, `test-stats-wrapper-timeout.sh`, `test-stats-wrapper-headless-export.sh`.

The wrapper, scheduler, maintainer authorization checks, privacy filters and remediation gates are unchanged. The headless test now recognizes the bounded cache call and the preserved-health-status behavior already introduced by #31089.

## Runtime Testing

- **Risk level:** High — bounded child processes and persistent batch state.
- **Verification:** runtime-verified using isolated shell fixtures running the production orchestration/functions, with mocked external services. No production GitHub dashboard writes or reporter-host deployment were performed during development.
- All six focused suites passed: timeout/batch (8), headless/order (13), maintainer guard (1), serialization (28), identity/fairness (36), characterization (14): **100 assertions/test cases**, including a hanging repository, descendant cleanup, configuration add/remove, corrupt/completed cursor, expired admission, and slow permission preflight.
- ShellCheck on all six changed files: zero findings.
- `.agents/scripts/linters-local.sh`: exit 0, including Bash 3.2 compatibility, function-size, nesting, portability and secret checks. Historical formatting/string-literal advisories remain non-blocking; unrelated formatting was intentionally not swept into this fix.

## Decisions and independent review

The independent advisory review identified unbounded preflight and a descendant-spawn cleanup race; both were repaired and exercised by focused tests. The remaining suggested distinction between durable admission and the immediately following tool call was evaluated and rejected as an exactly-once requirement outside this best-effort scheduler contract: admission intentionally persists inside the admitted child before tool execution, so interruption cannot indefinitely pin later repositories. A visited entry means **attempt admitted**, never successful analysis. Errors/timeouts stay visible, no clean tool result is fabricated, and the next daily cycle retries every eligible repository. Moving that marker one function frame deeper would retain the same interruption window rather than provide transactional external-tool execution.

Defaults: whole health repository 60s, each optional health aggregate/cache phase 30s, quality repository 120s, existing health reserve 120s, quality cleanup reserve 5s in addition to the wrapper's existing 30s. All work is capped again by remaining absolute time. Repository-specific positive caps can be overridden with `STATS_HEALTH_REPO_TIMEOUT`, `STATS_HEALTH_AGGREGATE_TIMEOUT`, and `QUALITY_SWEEP_REPO_TIMEOUT`.

Rollback: revert these changes; the previous code ignores the new attempt/cursor files. Existing successful-refresh and daily timestamp formats are preserved.

## Release intent

The maintainer explicitly requested full-loop through patch release in the initiating interactive session. Release will use the canonical guarded release entry point after exact-head CI/review and observed merge, followed by publication/postflight/deployment verification. A live Linux/systemd canary on the reporter's installation is not claimed; development ran on macOS and publication checks remain separate.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.319 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 44m and 256,352 tokens on this with the user in an interactive session.