### PR TITLE
GH#31367: preserve quota blockers in Pulse cycle health

### DIFF
--- a/.agents/scripts/pulse-budget-priority.sh
+++ b/.agents/scripts/pulse-budget-priority.sh
@@ -263,6 +263,12 @@ _pulse_defer_budget_priority_stage() {
 	priority=$(_pulse_stage_priority_class "$stage")
 	local graphql_mode="${AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS:-$_PULSE_BUDGET_MODE_UNKNOWN}"
 	local rest_mode="${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS:-$_PULSE_BUDGET_MODE_UNKNOWN}"
+	# Optional housekeeping deferral is not a blocked objective. Progress-stage
+	# deferral is: preserve its cause even when statistics are unavailable.
+	# Keep the identity stable as remaining quota changes within the same mode.
+	if [[ "$priority" == "progress" ]] && declare -F _pulse_cycle_state_note_blocker >/dev/null 2>&1; then
+		_pulse_cycle_state_note_blocker rest-core-quota pulse-budget "$rest_mode" || true
+	fi
 	echo "[pulse-wrapper] budget-priority: deferred ${priority} stage '${stage}' (graphql=${graphql_mode}:${AIDEVOPS_PULSE_GRAPHQL_BUDGET_REMAINING:-?}/${AIDEVOPS_PULSE_GRAPHQL_BUDGET_LIMIT:-?}@${AIDEVOPS_PULSE_GRAPHQL_BUDGET_THRESHOLD:-?}, rest=${rest_mode}:${AIDEVOPS_PULSE_REST_CORE_BUDGET_REMAINING:-?}/${AIDEVOPS_PULSE_REST_CORE_BUDGET_LIMIT:-?}@${AIDEVOPS_PULSE_REST_CORE_BUDGET_ADAPTIVE_THRESHOLD:-?}, hard_floor=${AIDEVOPS_PULSE_REST_CORE_BUDGET_HARD_FLOOR:-?}, progress_start_floor=${AIDEVOPS_PULSE_REST_CORE_BUDGET_PROGRESS_START_FLOOR:-?})" >>"$LOGFILE"
 	if ! declare -F pulse_stats_increment >/dev/null 2>&1; then
 		return 0

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -23,7 +23,7 @@ CYCLE_STATE_BLOCKER_KINDS = {
     'dispatch-no-work-rate', 'runner-health', 'merge-authority', 'review-gate',
     'review-bot-threads', 'required-review-threads', 'checks-active',
     'checks-failed', 'quiet-period', 'snapshot-unavailable', 'head-changed',
-    'interrupted',
+    'interrupted', 'rest-core-quota',
 }
 
 

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -62,7 +62,7 @@ _pulse_cycle_state_blocker_is_valid() {
 	"$PULSE_CYCLE_STATE_BLOCKER_NONE" | session-gate | dedup | preflight-failed | stop-requested | \
 		dispatch-no-work-rate | runner-health | merge-authority | review-gate | \
 		review-bot-threads | required-review-threads | checks-active | \
-		checks-failed | quiet-period | snapshot-unavailable | head-changed | interrupted)
+		checks-failed | quiet-period | snapshot-unavailable | head-changed | interrupted | rest-core-quota)
 		return 0
 		;;
 	esac

--- a/.agents/scripts/tests/test-pulse-cycle-state-contract.sh
+++ b/.agents/scripts/tests/test-pulse-cycle-state-contract.sh
@@ -216,6 +216,30 @@ else
 	fail "production consumer accepts the real producer output"
 fi
 
+# Exercise the real budget producer through terminal publication and the reader.
+# Statistics are intentionally absent: lifecycle evidence must not depend on them.
+# shellcheck source=../pulse-budget-priority.sh
+source "${SOURCE_DIR}/pulse-budget-priority.sh"
+_PULSE_HEALTH_PRS_MERGED=0
+_pulse_cycle_state_start
+write_pulse_health_file
+AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS=emergency
+_pulse_defer_budget_priority_stage dispatch_max
+_pulse_record_cycle_outcome 1
+_pulse_cycle_state_write_terminal_if_current
+assert_health "quota-deferred progress is blocked rather than idle" '
+	.cycle_state.outcome == "blocked"
+	and .cycle_state.blocker.kind == "rest-core-quota"
+'
+python3 "${SOURCE_DIR}/pulse-current-state.py" \
+	"${HOME}/.aidevops/logs" "$PWD" 900 1 "$SOURCE_DIR" "${TMP_DIR}/review-state" \
+	>"$consumer_output"
+if jq -e '.cycle_state.availability == "available" and .cycle_state.blocker.kind == "rest-core-quota"' "$consumer_output" >/dev/null; then
+	pass "production consumer accepts quota blocker"
+else
+	fail "production consumer accepts quota blocker"
+fi
+
 if [[ ! -e "${HOME}/.aidevops/logs/pulse-cycle-state.json" ]]; then
 	pass "lifecycle state does not create a parallel runtime artifact"
 else

--- a/.agents/scripts/tests/test-pulse-graphql-budget-priority.sh
+++ b/.agents/scripts/tests/test-pulse-graphql-budget-priority.sh
@@ -170,6 +170,16 @@ export GH_REST_CORE_RESET="$(($(date +%s) + 3600))"
 export GH_REST_CORE_REMAINING=100
 rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
 _pulse_set_rest_core_budget_priority
+_pulse_cycle_state_set_blocker none
+_pulse_run_budget_priority_stage dashboard_freshness_check false
+[[ "$_PULSE_CYCLE_BLOCKER_KIND" == "none" ]]
+_pulse_run_budget_priority_stage dispatch_max false
+[[ "$_PULSE_BUDGET_STAGE_DEFERRED" == "1" ]]
+[[ "$_PULSE_CYCLE_BLOCKER_KIND" == "rest-core-quota" ]]
+quota_fingerprint="$_PULSE_CYCLE_BLOCKER_FINGERPRINT"
+_pulse_cycle_state_set_blocker none
+_pulse_run_budget_priority_stage deterministic_merge_pass false
+[[ "$_PULSE_CYCLE_BLOCKER_FINGERPRINT" == "$quota_fingerprint" ]]
 [[ "${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS}" == "emergency" ]]
 _pulse_should_defer_budget_priority_stage "deterministic_merge_pass"
 _pulse_should_defer_budget_priority_stage "approval_merge_trigger"
@@ -193,6 +203,10 @@ fi
 unset GH_REST_CORE_UNKNOWN
 export GH_REST_CORE_REMAINING=5000
 rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
+_pulse_cycle_state_set_blocker none
+_pulse_run_budget_priority_stage dispatch_max true
+[[ "$_PULSE_BUDGET_STAGE_DEFERRED" == "0" ]]
+[[ "$_PULSE_CYCLE_BLOCKER_KIND" == "none" ]]
 
 unset -f _cb_rate_limit_json
 TIMEOUT_CALL_LOG="${TMP_DIR}/timeout-calls.log"


### PR DESCRIPTION
## Summary

Record REST quota deferral of progress stages as a typed cycle blocker, not unexplained idle. Update pulse-budget-priority.sh, pulse-logging.sh, pulse-current-state.py and existing budget/cycle contract tests.

## Files Changed

.agents/scripts/pulse-budget-priority.sh, .agents/scripts/pulse-current-state.py, .agents/scripts/pulse-logging.sh, .agents/scripts/tests/test-pulse-cycle-state-contract.sh, .agents/scripts/tests/test-pulse-graphql-budget-priority.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — ShellCheck clean; budget-priority suite passes; cycle-state producer-to-reader suite 19/19 passes; git diff --check clean. Direct closeout review of bundle 8ce797ab80a373b03cbf605a33546c8888ecf279e763d16230d4fdc6c1635d2e found no blocking defect. Runtime-verified with hermetic production producer/consumer tests.

Resolves #31367


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.319 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 12m and 146,177 tokens on this with the user in an interactive session.