### PR TITLE
GH#31372: provision bounded in-worktree dependency sources

### DIFF
--- a/.agents/reference/dispatch-blockers.md
+++ b/.agents/reference/dispatch-blockers.md
@@ -36,6 +36,41 @@ transitions to `~/.aidevops/logs/worker-progress-blockers.jsonl`. Diagnose the
 label and its exact local reason with `pulse-diagnose-helper.sh issue <N> --repo
 <owner/repo>`; removing the label does not alter or bypass grant verification.
 
+### Bounded dependency-read remediation (GH#31372)
+
+Before worker launch, the existing restore controller may provision npm/pnpm
+dependency sources into its registered linked worktree. Root restore defaults to
+`auto`; `WORKTREE_NODE_MODULES_RESTORE_ROOT_ENABLED=0` still disables it. Each
+snapshot is limited to 64 MiB and 20,000 entries, with at most two successful
+package directories per restore. `WORKTREE_NODE_MODULES_RESTORE_MAX_BYTES` can
+lower (not raise) the byte ceiling. Missing dependencies, unsupported install
+metadata, stale package/lock identities, foreign owners, writable shared sources,
+credential-bearing paths and escaping links cause a skip, never an installation
+or external-directory grant. Canonical npm hidden-lock and pnpm installed-lock
+metadata are required; Bun/Yarn-only trees remain unprovisioned.
+
+The path reuses the restore controller, registry and lock machinery. Security
+review ruled out whole-directory `fast_cp`: a changing source could exceed its
+preflight size during copying. The bounded copier pins source directories with
+no-follow descriptors, enforces limits during copying, and validates a private
+staged snapshot before promotion. This trades CoW speed for a hard resource bound.
+
+For an already denied dependency read, `worker-permission-helper.sh` adds an
+owned-recovery instruction to the existing request-specific, deduplicated
+permission dossier. The pattern is only a candidate for investigation, never a
+trusted source path or authority. Broad external `bash`, credentials and mixed
+requests remain held. Preserve the original request and audit evidence, commits,
+branch, checkpoint PR and runtime session. Provisioning may not displace a live
+or foreign owner, including a dead owner without an explicit ownership transfer.
+
+**Current limitation:** both the dispatch label gate and historical signed-grant
+gate require request-specific approval. There is no unsigned supersession path.
+The AI brief owner/coordinator owns assessment of the in-boundary alternative and
+any authorized exact-checkpoint continuation; a copy alone does not clear either
+gate. Repeated unchanged evidence uses the same permission request rather than
+new comments, grants or replacement workers. Verify with dependency fixtures,
+permission broker/helper tests and dispatch permission/history fixtures.
+
 ### Conditional Dispatch Blocks (require active claim state)
 
 These labels DO NOT block dispatch on their own. They become blockers only when combined with an active claim signal — see "Claim-State Blockers" below.

--- a/.agents/reference/dispatch-blockers.md
+++ b/.agents/reference/dispatch-blockers.md
@@ -46,14 +46,20 @@ package directories per restore. `WORKTREE_NODE_MODULES_RESTORE_MAX_BYTES` can
 lower (not raise) the byte ceiling. Missing dependencies, unsupported install
 metadata, stale package/lock identities, foreign owners, writable shared sources,
 credential-bearing paths and escaping links cause a skip, never an installation
-or external-directory grant. Canonical npm hidden-lock and pnpm installed-lock
-metadata are required; Bun/Yarn-only trees remain unprovisioned.
+or external-directory grant. Canonical npm hidden-lock and pnpm v9 installed-lock
+metadata are required, with complete matching package inventories (including
+physical resolution roots, not just manifests). Unsupported YAML serializations,
+partial/platform-filtered installations and Bun/Yarn-only trees remain
+unprovisioned rather than receiving a weaker identity check.
 
 The path reuses the restore controller, registry and lock machinery. Security
 review ruled out whole-directory `fast_cp`: a changing source could exceed its
 preflight size during copying. The bounded copier pins source directories with
 no-follow descriptors, enforces limits during copying, and validates a private
-staged snapshot before promotion. This trades CoW speed for a hard resource bound.
+staged snapshot before atomic no-replace promotion. Source and output directories
+are descriptor-pinned. Promotion requires Linux `renameat2` or macOS
+`renameatx_np`; other platforms skip safely. This trades CoW speed for a hard
+resource bound and performs multiple bounded reads to verify snapshot identity.
 
 For an already denied dependency read, `worker-permission-helper.sh` adds an
 owned-recovery instruction to the existing request-specific, deduplicated

--- a/.agents/scripts/_worktree_dependency_identity.py
+++ b/.agents/scripts/_worktree_dependency_identity.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Filesystem and installed-package identity checks for controller provisioning."""
+
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess  # nosec B404 -- fixed read-only Git plumbing, never a shell.
+from contextlib import contextmanager
+
+
+class Rejected(ValueError):
+    """A dependency snapshot cannot safely be provisioned."""
+
+
+@contextmanager
+def open_directory(path):
+    """Pin every directory component without following a racing symlink."""
+    fd = os.open("/", os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        for part in Path(os.path.abspath(path)).parts[1:]:
+            child = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd)
+            os.close(fd)
+            fd = child
+        yield fd
+    finally:
+        os.close(fd)
+
+
+def trusted(info):
+    if info.st_uid != os.getuid() or info.st_mode & 0o022:
+        raise Rejected("foreign-or-shared-source")
+
+
+def object_json(data):
+    result = json.loads(data)
+    if not isinstance(result, dict):
+        raise Rejected("invalid-object-metadata")
+    return result
+
+
+def pnpm_inventory(lock):
+    """Accept only pnpm's simple v9 packages map, not arbitrary YAML features."""
+    text = lock.decode("utf-8")
+    if not re.search(r"(?m)^lockfileVersion: ['\"]?9\.0['\"]?$", text):
+        raise Rejected("unsupported-pnpm-lock")
+    packages = {pnpm_package_key(line) for line in pnpm_package_lines(text)}
+    if not packages:
+        raise Rejected("missing-pnpm-inventory")
+    return packages
+
+
+def pnpm_package_lines(text):
+    section = False
+    for line in text.splitlines():
+        if line == "packages:":
+            section = True
+            continue
+        if not section:
+            continue
+        if line and not line.startswith(" "):
+            return
+        if line.startswith("  ") and not line.startswith("   "):
+            yield line
+
+
+def pnpm_package_key(line):
+    match = re.fullmatch(r"  ['\"]?(@?[a-zA-Z0-9_./-]+@[0-9][a-zA-Z0-9.+_-]*)['\"]?:", line)
+    if not match:
+        raise Rejected("unsupported-pnpm-package-key")
+    return match[1]
+
+
+def regular_bytes(path, limit=8 * 1024 * 1024):
+    path = Path(path)
+    with open_directory(path.parent) as parent:
+        fd = os.open(path.name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=parent)
+    with os.fdopen(fd, "rb") as source:
+        info = os.fstat(source.fileno())
+        trusted(info)
+        if not stat.S_ISREG(info.st_mode) or info.st_size > limit:
+            raise Rejected("invalid-or-oversized-file")
+        data = source.read(limit + 1)
+        if len(data) > limit:
+            raise Rejected("byte-budget-exceeded")
+        return data
+
+
+def contained_path(path):
+    """Reject symlink components, including dangling links, before any read."""
+    path = Path(os.path.abspath(path))
+    for parent in [*reversed(path.parents), path]:
+        if parent.is_symlink():
+            raise Rejected("symlink-component")
+    return path
+
+
+def git(path, *args):
+    executable = shutil.which("git")
+    if executable is None:
+        raise Rejected("git-unavailable")
+    return subprocess.check_output(  # nosec B603 -- fixed rev-parse arguments; path is data-only argv.
+        [executable, "-C", str(path), *args], stderr=subprocess.DEVNULL,
+        timeout=10, text=True,
+    ).strip()
+
+
+def repository_identity(repo, worktree):
+    repo, worktree = contained_path(repo), contained_path(worktree)
+    if repo == worktree or git(worktree, "rev-parse", "--show-toplevel") != str(worktree):
+        raise Rejected("not-linked-worktree")
+    if git(repo, "rev-parse", "--show-toplevel") != str(repo):
+        raise Rejected("not-repository-root")
+    common = [git(p, "rev-parse", "--path-format=absolute", "--git-common-dir")
+              for p in (repo, worktree)]
+    if (common[0] != common[1] or not (worktree / ".git").is_file()
+            or not (repo / ".git").is_dir()):
+        raise Rejected("foreign-repository")
+    trusted(repo.stat())
+    trusted(worktree.parent.stat())
+    trusted(worktree.stat())
+    return repo, worktree
+
+
+def package_directories(repo, worktree, relative):
+    if relative.is_absolute() or ".." in relative.parts:
+        raise Rejected("invalid-package-path")
+    source, dest = [contained_path(p / relative) for p in (repo, worktree)]
+    for base in (repo, worktree):
+        current = base
+        for part in relative.parts:
+            current /= part
+            trusted(current.stat())
+    return source, dest
+
+
+def matching_package(source, dest):
+    package = regular_bytes(source / "package.json")
+    if package != regular_bytes(dest / "package.json"):
+        raise Rejected("stale-package-identity")
+    parsed = object_json(package)
+    if not parsed.get("name"):
+        raise Rejected("missing-package-identity")
+    return parsed
+
+
+def matching_lock(source, dest):
+    locks = [name for name in ("package-lock.json", "pnpm-lock.yaml")
+             if (source / name).exists() or (dest / name).exists()]
+    if len(locks) != 1:
+        raise Rejected("missing-or-ambiguous-supported-lock")
+    name = locks[0]
+    lock = regular_bytes(source / name)
+    if lock != regular_bytes(dest / name):
+        raise Rejected("stale-lock-identity")
+    return name, lock
+
+
+def identity(repo, worktree, relative):
+    repo, worktree = repository_identity(repo, worktree)
+    source, dest = package_directories(repo, worktree, relative)
+    parsed = matching_package(source, dest)
+    name, lock = matching_lock(source, dest)
+    modules = contained_path(source / "node_modules")
+    if name == "pnpm-lock.yaml":
+        installed = contained_path(modules / ".pnpm" / "lock.yaml")
+        if regular_bytes(installed) != lock:
+            raise Rejected("stale-installed-lock")
+        inventory = ("pnpm", pnpm_inventory(lock))
+    else:
+        inventory = ("npm", npm_inventory(source, modules, lock, parsed))
+    return modules, inventory
+
+
+def npm_inventory(source, modules, lock, parsed):
+    expected = object_json(lock).get("packages")
+    installed = object_json(regular_bytes(modules / ".package-lock.json")).get("packages")
+    if not isinstance(expected, dict) or not isinstance(installed, dict) or not installed:
+        raise Rejected("missing-installed-identity")
+    validate_root_lock(expected.get(""), parsed)
+    if set(expected) - {""} != set(installed):
+        raise Rejected("incomplete-installed-inventory")
+    for location, metadata in installed.items():
+        validate_npm_package(source, location, metadata, expected[location])
+    return set(installed)
+
+
+def validate_root_lock(root_package, parsed):
+    if not isinstance(root_package, dict):
+        raise Rejected("stale-root-lock-identity")
+    keys = ("name", "version", "dependencies", "devDependencies", "optionalDependencies")
+    if any(parsed.get(key) != root_package.get(key) for key in keys):
+        raise Rejected("stale-root-lock-identity")
+
+
+def validate_npm_package(source, location, metadata, expected):
+    if not isinstance(metadata, dict) or metadata != expected:
+        raise Rejected("stale-installed-lock")
+    if not location.startswith("node_modules/") or ".." in Path(location).parts:
+        raise Rejected("invalid-installed-path")
+    manifest = object_json(regular_bytes(contained_path(source / location / "package.json")))
+    if not manifest.get("name") or not manifest.get("version") or manifest["version"] != metadata.get("version"):
+        raise Rejected("stale-installed-package")

--- a/.agents/scripts/_worktree_dependency_snapshot.py
+++ b/.agents/scripts/_worktree_dependency_snapshot.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Bounded no-follow traversal of inventory-backed dependency sources."""
+
+import hashlib
+import os
+from pathlib import Path
+import stat
+from contextlib import ExitStack, contextmanager
+
+from _worktree_dependency_identity import Rejected, contained_path, object_json, open_directory, regular_bytes, trusted
+
+
+def safe_entry_name(name):
+    lower = name.lower()
+    sensitive = {".git", ".ssh", ".aws", ".npmrc", ".netrc", ".pypirc", "credentials.json"}
+    if lower in sensitive or lower.startswith(".env") or lower.endswith((".pem", ".key", ".p12", ".pfx")):
+        raise Rejected("credential-bearing-path")
+
+
+def metadata_entry(name, mode):
+    if name in {".bin", ".pnpm"}:
+        return stat.S_ISDIR(mode)
+    files = {".package-lock.json", ".modules.yaml", ".pnpm-workspace-state-v1.json"}
+    return name in files and stat.S_ISREG(mode)
+
+
+def package_position(path):
+    return path.parent.name == "node_modules" or (
+        path.parent.name.startswith("@") and path.parent.parent.name == "node_modules")
+
+
+def resolution_root(path, mode):
+    namespace = path.name.startswith("@") and stat.S_ISDIR(mode)
+    if path.parent.name == "node_modules":
+        return not (namespace or metadata_entry(path.name, mode))
+    return package_position(path)
+
+
+@contextmanager
+def directory_at(parent, name):
+    fd = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=parent)
+    try:
+        yield fd
+    finally:
+        os.close(fd)
+
+
+class Snapshot:
+    """One bounded traversal with pinned source and destination descriptors."""
+
+    def __init__(self, root, max_bytes, max_entries, inventory):
+        self.root = contained_path(root)
+        self.max_bytes = max_bytes
+        self.max_entries = max_entries
+        self.inventory = inventory
+        self.total = 0
+        self.count = 0
+        self.records = {}
+        self.seen_packages = set()
+
+    def walk(self, fd, relative, output, depth=0):
+        trusted(os.fstat(fd))
+        if depth > 64:
+            raise Rejected("depth-budget-exceeded")
+        with os.scandir(fd) as entries:
+            for entry in entries:
+                self.visit(fd, relative / entry.name, output, entry.stat(follow_symlinks=False), depth)
+
+    def visit(self, fd, rel, output, info, depth):
+        self.count += 1
+        if self.count > self.max_entries:
+            raise Rejected("entry-budget-exceeded")
+        safe_entry_name(rel.name)
+        self.check_package_root(rel, info.st_mode)
+        if stat.S_ISLNK(info.st_mode):
+            self.copy_link(fd, rel, output)
+        elif stat.S_ISDIR(info.st_mode):
+            self.copy_directory(fd, rel, output, depth)
+        elif stat.S_ISREG(info.st_mode):
+            self.copy_file(fd, rel, output)
+        else:
+            raise Rejected("special-file")
+
+    def resolved_inside(self, rel):
+        resolved = (self.root / rel).resolve(strict=True)
+        if not resolved.is_relative_to(self.root):
+            raise Rejected("escaping-package-root")
+        return resolved
+
+    def inventory_key(self, package_path, manifest):
+        if self.inventory[0] == "npm":
+            key = str(package_path)
+        else:
+            key = f"{manifest.get('name')}@{manifest.get('version')}"
+        if key not in self.inventory[1]:
+            raise Rejected("unrecorded-package")
+        return key
+
+    def check_package_root(self, rel, mode):
+        package_root = Path("node_modules") / rel
+        if not self.inventory or not resolution_root(package_root, mode):
+            return
+        if not (stat.S_ISDIR(mode) or stat.S_ISLNK(mode)):
+            raise Rejected("unrecorded-module-file")
+        manifest = object_json(regular_bytes(self.resolved_inside(rel) / "package.json"))
+        self.inventory_key(package_root, manifest)
+
+    def copy_link(self, fd, rel, output):
+        target = os.readlink(rel.name, dir_fd=fd)
+        if os.path.isabs(target):
+            raise Rejected("escaping-dependency-link")
+        self.resolved_inside(rel)
+        self.records[str(rel)] = b"link\0" + target.encode()
+        if output is not None:
+            os.symlink(target, rel.name, dir_fd=output)
+
+    def copy_directory(self, fd, rel, output, depth):
+        with ExitStack() as stack:
+            child = stack.enter_context(directory_at(fd, rel.name))
+            target = None
+            if output is not None:
+                os.mkdir(rel.name, mode=0o755, dir_fd=output)
+                target = stack.enter_context(directory_at(output, rel.name))
+            self.records[str(rel)] = b"dir\0"
+            self.walk(child, rel, target, depth + 1)
+
+    def read_payload(self, fd, name):
+        source_fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=fd)
+        with os.fdopen(source_fd, "rb") as source:
+            before = os.fstat(source_fd)
+            trusted(before)
+            if not stat.S_ISREG(before.st_mode) or before.st_size > self.max_bytes - self.total:
+                raise Rejected("byte-budget-exceeded")
+            data = source.read(self.max_bytes - self.total + 1)
+            self.total += len(data)
+            after = os.fstat(source_fd)
+            if self.total > self.max_bytes or (before.st_size, before.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
+                raise Rejected("changed-or-oversized-source")
+        return data, before.st_mode & 0o755
+
+    def record_package(self, rel, data):
+        package_path = Path("node_modules") / rel.parent
+        if self.inventory and rel.name == "package.json" and package_position(package_path):
+            key = self.inventory_key(package_path, object_json(data))
+            self.seen_packages.add(key)
+
+    def copy_file(self, fd, rel, output):
+        data, mode = self.read_payload(fd, rel.name)
+        self.record_package(rel, data)
+        self.records[str(rel)] = b"file\0" + str(mode).encode() + hashlib.sha256(data).digest()
+        if output is None:
+            return
+        destination_fd = os.open(rel.name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                                 0o600, dir_fd=output)
+        with os.fdopen(destination_fd, "wb") as destination:
+            destination.write(data)
+            os.fchmod(destination_fd, mode)
+
+    def scan(self, copy_to):
+        with ExitStack() as stack:
+            fd = stack.enter_context(open_directory(self.root))
+            output_fd = None
+            if copy_to is not None:
+                output_fd = stack.enter_context(open_directory(copy_to))
+                trusted(os.fstat(output_fd))
+            self.walk(fd, Path(), output_fd)
+        if self.count == 0:
+            raise Rejected("missing-dependencies")
+        if self.inventory and self.seen_packages != self.inventory[1]:
+            raise Rejected("incomplete-package-inventory")
+        digest = hashlib.sha256()
+        for name, value in sorted(self.records.items()):
+            digest.update(name.encode() + b"\0" + value)
+        return f"{digest.hexdigest()} {self.total} {self.count}"
+
+
+def snapshot(root, max_bytes, max_entries, copy_to=None, inventory=None):
+    return Snapshot(root, max_bytes, max_entries, inventory).scan(copy_to)

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -537,7 +537,17 @@ _dlw_restore_worktree_deps() {
 	local _pkg_dir=""
 	local _restored=0
 	local _max_dirs="${WORKTREE_NODE_MODULES_RESTORE_MAX_DIRS:-2}"
-	local _restore_root="${WORKTREE_NODE_MODULES_RESTORE_ROOT_ENABLED:-0}"
+	local _restore_root="${WORKTREE_NODE_MODULES_RESTORE_ROOT_ENABLED:-auto}"
+	# Share the controller's bounded, identity-checked copy implementation.
+	if ! declare -F _provision_worktree_node_modules >/dev/null 2>&1; then
+		local SCRIPT_DIR=""
+		SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+		# shellcheck source=worktree-helper-add.sh
+		if ! source "${SCRIPT_DIR}/worktree-helper-add.sh"; then
+			_dlw_node_modules_restore_release_lock "$_lock_dir"
+			return 0
+		fi
+	fi
 	[[ "$_max_dirs" =~ ^[0-9]+$ ]] || _max_dirs=2
 	while IFS= read -r _pkg_dir; do
 		if ((_restored >= _max_dirs)); then
@@ -548,7 +558,7 @@ _dlw_restore_worktree_deps() {
 		local _rel_dir=""
 		_rel_dir="${_dir#"$worktree_path"}" || continue
 		# _rel_dir is now e.g. "/.opencode" or "" (for root package.json)
-		if [[ -z "$_rel_dir" && "$_restore_root" != "1" ]]; then
+		if [[ -z "$_rel_dir" && "$_restore_root" != "1" && "$_restore_root" != "auto" ]]; then
 			_dlw_remove_generated_root_node_tool_link "$worktree_path" "$repo_path"
 			echo "[dispatch_with_dedup] Skipping root node_modules restore for ${worktree_path} (set WORKTREE_NODE_MODULES_RESTORE_ROOT_ENABLED=1 to enable)" >>"$LOGFILE"
 			continue
@@ -556,11 +566,11 @@ _dlw_restore_worktree_deps() {
 		local _src_nm="${repo_path}${_rel_dir}/node_modules"
 		local _dst_nm="${worktree_path}${_rel_dir}/node_modules"
 		if [[ -d "$_src_nm" && ! -d "$_dst_nm" ]]; then
-			# t2889: fast_cp uses APFS clonefile / btrfs reflink CoW
-			# where available — sub-second copy, near-zero disk delta.
-			fast_cp "$_src_nm" "$_dst_nm" 2>/dev/null || true
-			_restored=$((_restored + 1))
-			echo "[dispatch_with_dedup] Restored node_modules: ${_rel_dir:-/} ($(du -sh "$_dst_nm" 2>/dev/null | cut -f1))" >>"$LOGFILE"
+			if _provision_worktree_node_modules "$worktree_path" "$repo_path" "${_rel_dir#/}" >>"$LOGFILE" 2>&1; then
+				_restored=$((_restored + 1))
+			else
+				echo "[dispatch_with_dedup] Dependency provisioning unavailable; no external permission granted" >>"$LOGFILE"
+			fi
 		fi
 	done < <(find "$worktree_path" -maxdepth 3 -name "package.json" -not -path "*/node_modules/*" 2>/dev/null)
 	_dlw_node_modules_restore_release_lock "$_lock_dir"

--- a/.agents/scripts/tests/test-maintenance-selector-contract.sh
+++ b/.agents/scripts/tests/test-maintenance-selector-contract.sh
@@ -78,7 +78,7 @@ required_functions = {
         "_compute_worker_success_rates",
         "_refresh_person_stats_cache",
     ],
-    ".agents/scripts/stats-health-dashboard.sh": ["update_health_issues"],
+    ".agents/scripts/stats-health-dashboard.sh": ["_health_routine_repo_entries"],
     ".agents/scripts/stats-quality-sweep.sh": ["run_daily_quality_sweep"],
     ".agents/scripts/repo-aidevops-health-helper.sh": ["_check_version_bumps"],
 }

--- a/.agents/scripts/tests/test-worker-permission-helper.sh
+++ b/.agents/scripts/tests/test-worker-permission-helper.sh
@@ -87,6 +87,23 @@ if [[ "$rendered_capabilities" != *'Routine tool discovery should use `command -
 	printf 'known tool-bin read omitted command-based recovery guidance\n' >&2
 	exit 1
 fi
+if [[ "$rendered_capabilities" != *'no unsigned supersession path'* ]]; then
+	printf 'dependency read omitted owned recovery and signed-hold limitation\n' >&2
+	exit 1
+fi
+executing_envelope="${test_root}/executing-envelope.json"
+jq '.capabilities |= map(.tool = "bash" | .patterns = ["~/**"])' "$envelope_file" >"$executing_envelope"
+if [[ "$(permission_render_capabilities "$executing_envelope")" == *'Owned recovery:'* ]]; then
+	printf 'broad external bash was misclassified as a dependency read\n' >&2
+	exit 1
+fi
+# Existing request IDs own unchanged recovery; do not create another comment.
+(
+	gh_issue_view() { printf '{"labels":[]}\n'; return 0; }
+	permission_request_already_posted() { return 0; }
+	gh_issue_comment() { printf 'duplicate request comment\n' >&2; return 1; }
+	permission_post_request "$single_capture" 123 owner/repo issue-123 "$PWD" >/dev/null
+)
 printf '{invalid-json\n' >"${test_root}/invalid-envelope.json"
 if permission_render_capabilities "${test_root}/invalid-envelope.json" >/dev/null 2>&1; then
 	printf 'permission capability rendering hid a jq failure\n' >&2

--- a/.agents/scripts/tests/test-worktree-dependency-provision.py
+++ b/.agents/scripts/tests/test-worktree-dependency-provision.py
@@ -8,11 +8,17 @@ import json
 import os
 from pathlib import Path
 import shutil
-import subprocess
+import subprocess  # nosec B404 -- fixed offline fixture programs only.
+import sys
 import tempfile
 import unittest
 
 SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+GIT = shutil.which("git")
+BASH = shutil.which("bash")
+if not GIT or not BASH:
+    raise RuntimeError("Git and Bash are required for fixture verification")
 SPEC = importlib.util.spec_from_file_location("provision", SCRIPTS / "worktree-dependency-provision.py")
 provision = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(provision)
@@ -45,7 +51,8 @@ class ProvisionTests(unittest.TestCase):
 
     @staticmethod
     def git(path, *args):
-        return subprocess.check_output(["git", "-C", str(path), *args], stderr=subprocess.DEVNULL, text=True).strip()
+        return subprocess.check_output(  # nosec B603 -- resolved Git and fixture-owned argv, no shell.
+            [GIT, "-C", str(path), *args], stderr=subprocess.DEVNULL, text=True).strip()
 
     @staticmethod
     def write(path, value):
@@ -74,7 +81,10 @@ _dlw_restore_worktree_deps "$2" "$3"
                "WORKTREE_NODE_MODULES_RESTORE_ROOT_ENABLED": root,
                "WORKTREE_NODE_MODULES_RESTORE_ENABLED": "1",
                "WORKTREE_NODE_MODULES_RESTORE_MAX_BYTES": budget}
-        subprocess.run(["bash", "-c", script, "fixture", str(SCRIPTS), str(self.wt), str(self.repo)],
+        # Fixed shell program above; all parameters are isolated fixture paths.
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
+        subprocess.run(  # nosec B603 -- resolved Bash, fixed fixture program and fixture-only argv.
+            [BASH, "-c", script, "fixture", str(SCRIPTS), str(self.wt), str(self.repo)],
                        env=env, check=True, capture_output=True, text=True, timeout=20)
 
     def test_bounded_read_and_repeat_preserve_checkpoint(self):
@@ -233,7 +243,9 @@ _dlw_restore_worktree_deps "$2" "$3"
     def test_malformed_lock_is_redacted(self):
         for parent in (self.repo, self.wt):
             self.write(parent / "package-lock.json", [])
-        result = subprocess.run(["python3", str(SCRIPTS / "worktree-dependency-provision.py"),
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
+        result = subprocess.run(  # nosec B603 -- current interpreter, fixed helper and fixture-owned arguments.
+            [sys.executable, str(SCRIPTS / "worktree-dependency-provision.py"),
                                  str(self.repo), str(self.wt), "."], capture_output=True, text=True)
         self.assertEqual(result.returncode, 1)
         self.assertEqual(result.stderr, "dependency-provision-rejected\n")

--- a/.agents/scripts/tests/test-worktree-dependency-provision.py
+++ b/.agents/scripts/tests/test-worktree-dependency-provision.py
@@ -78,7 +78,7 @@ _dlw_restore_worktree_deps "$2" "$3"
                        env=env, check=True, capture_output=True, text=True, timeout=20)
 
     def test_bounded_read_and_repeat_preserve_checkpoint(self):
-        self.assertEqual(self.validate(), self.modules)
+        self.assertEqual(self.validate()[0], self.modules)
         head = self.git(self.wt, "rev-parse", "HEAD")
         (self.wt / "checkpoint.txt").write_text("PR fixture #42; pending request perm-fixture")
         self.run_restore()
@@ -179,20 +179,75 @@ _dlw_restore_worktree_deps "$2" "$3"
         self.run_restore()
         self.assertFalse((self.wt / "node_modules").exists())
 
-    def test_pnpm_contained_links(self):
+    def make_pnpm(self):
+        lock_text = "lockfileVersion: '9.0'\npackages:\n  example@1.0.0:\n    resolution: {integrity: fixture}\n"
         for parent in (self.repo, self.wt):
             (parent / "package-lock.json").unlink()
-            (parent / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n")
+            (parent / "pnpm-lock.yaml").write_text(lock_text)
         (self.modules / ".package-lock.json").unlink()
         store = self.modules / ".pnpm" / "example@1.0.0" / "node_modules"
         store.mkdir(parents=True)
         (self.modules / "example").rename(store / "example")
         (self.modules / "example").symlink_to(".pnpm/example@1.0.0/node_modules/example")
-        (self.modules / ".pnpm" / "lock.yaml").write_text("lockfileVersion: '9.0'\n")
+        (self.modules / ".pnpm" / "lock.yaml").write_text(lock_text)
+
+    def test_pnpm_contained_links(self):
+        self.make_pnpm()
         self.run_restore()
         copied = self.wt / "node_modules" / "example" / "index.js"
         self.assertTrue(copied.resolve().is_relative_to(self.wt))
         self.assertEqual(copied.read_text(), "export const fixture = 1;\n")
+
+    def test_extra_unrecorded_package(self):
+        self.write(self.modules / "extra" / "package.json", {"name": "extra", "version": "1.0.0"})
+        self.run_restore()
+        self.assertFalse((self.wt / "node_modules").exists())
+
+    def test_manifestless_package_roots_and_files(self):
+        for manager in ("npm", "pnpm"):
+            if manager == "pnpm":
+                self.make_pnpm()
+            for extra in ("extra/index.js", "extra.js", "@extra.js", ".extra.js"):
+                with self.subTest(manager=manager, extra=extra):
+                    payload = self.modules / extra
+                    payload.parent.mkdir(parents=True, exist_ok=True)
+                    payload.write_text("fixture only")
+                    self.run_restore()
+                    self.assertFalse((self.wt / "node_modules").exists())
+                    payload.unlink()
+                    if payload.parent != self.modules:
+                        payload.parent.rmdir()
+
+    def test_missing_expected_installed_package(self):
+        self.lock["packages"]["node_modules/missing"] = {"version": "1.0.0"}
+        for parent in (self.repo, self.wt):
+            self.write(parent / "package-lock.json", self.lock)
+        with self.assertRaises(provision.Rejected):
+            self.validate()
+
+    def test_shared_worktree_root_rejected(self):
+        self.wt.chmod(0o777)
+        with self.assertRaises(provision.Rejected):
+            self.validate()
+
+    def test_malformed_lock_is_redacted(self):
+        for parent in (self.repo, self.wt):
+            self.write(parent / "package-lock.json", [])
+        result = subprocess.run(["python3", str(SCRIPTS / "worktree-dependency-provision.py"),
+                                 str(self.repo), str(self.wt), "."], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stderr, "dependency-provision-rejected\n")
+
+    def test_atomic_promotion_does_not_replace_existing_directory(self):
+        stage = self.wt / ".aidevops-deps-fixture" / "node_modules"
+        stage.mkdir(parents=True, mode=0o700)
+        stage.parent.chmod(0o700)
+        destination = self.wt / "node_modules"
+        destination.mkdir()
+        with self.assertRaises(provision.Rejected):
+            provision.publish(stage, self.wt, Path("."))
+        self.assertTrue(stage.is_dir())
+        self.assertTrue(destination.is_dir())
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/tests/test-worktree-dependency-provision.py
+++ b/.agents/scripts/tests/test-worktree-dependency-provision.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Fixture-only dependency provisioning and ownership regression tests."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("provision", SCRIPTS / "worktree-dependency-provision.py")
+provision = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(provision)
+
+
+class ProvisionTests(unittest.TestCase):
+    def setUp(self):
+        previous_umask = os.umask(0o022)
+        self.addCleanup(os.umask, previous_umask)
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve()
+        self.repo = self.root / "repo"
+        self.wt = self.root / "worktree"
+        self.repo.mkdir()
+        self.git(self.repo, "init", "-q")
+        self.package = {"name": "fixture", "version": "1.0.0", "dependencies": {"example": "1.0.0"}}
+        self.metadata = {"version": "1.0.0", "resolved": "fixture:example"}
+        self.lock = {"lockfileVersion": 3, "packages": {"": self.package, "node_modules/example": self.metadata}}
+        self.write(self.repo / "package.json", self.package)
+        self.write(self.repo / "package-lock.json", self.lock)
+        (self.repo / ".gitignore").write_text("node_modules/\n")
+        self.git(self.repo, "add", ".")
+        self.git(self.repo, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "-qm", "fixture")
+        self.git(self.repo, "worktree", "add", "-qb", "fixture-work", str(self.wt))
+        self.modules = self.repo / "node_modules"
+        self.write(self.modules / "example" / "package.json", {"name": "example", "version": "1.0.0"})
+        (self.modules / "example" / "index.js").write_text("export const fixture = 1;\n")
+        self.write(self.modules / ".package-lock.json", {"packages": {"node_modules/example": self.metadata}})
+
+    @staticmethod
+    def git(path, *args):
+        return subprocess.check_output(["git", "-C", str(path), *args], stderr=subprocess.DEVNULL, text=True).strip()
+
+    @staticmethod
+    def write(path, value):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value))
+
+    def validate(self):
+        return provision.identity(self.repo, self.wt, Path("."))
+
+    def run_restore(self, owner="current", exact="true", root="auto", budget="67108864"):
+        # All ownership and controller inputs are fixtures; never use the live registry.
+        script = r'''
+source "$1/worktree-helper-add.sh"
+source "$1/pulse-dispatch-worker-launch.sh"
+check_worktree_owner_snapshot() {
+    if [[ "$OWNER" == current ]]; then printf '%s|fixture-session||31372|fixture-created|fixture-start\n' "$$";
+    else printf '999999|foreign-session||31372|fixture-created|fixture-start\n'; fi
+}
+worktree_has_exact_owner_contract() { [[ "$EXACT" == true ]]; }
+_dlw_node_modules_restore_acquire_lock() { return 0; }
+_dlw_node_modules_restore_release_lock() { return 0; }
+_dlw_restore_worktree_deps "$2" "$3"
+'''
+        env = {**os.environ, "OWNER": owner, "EXACT": exact,
+               "LOGFILE": str(self.root / "restore.log"), "AIDEVOPS_WORKSPACE_DIR": str(self.root),
+               "WORKTREE_NODE_MODULES_RESTORE_ROOT_ENABLED": root,
+               "WORKTREE_NODE_MODULES_RESTORE_ENABLED": "1",
+               "WORKTREE_NODE_MODULES_RESTORE_MAX_BYTES": budget}
+        subprocess.run(["bash", "-c", script, "fixture", str(SCRIPTS), str(self.wt), str(self.repo)],
+                       env=env, check=True, capture_output=True, text=True, timeout=20)
+
+    def test_bounded_read_and_repeat_preserve_checkpoint(self):
+        self.assertEqual(self.validate(), self.modules)
+        head = self.git(self.wt, "rev-parse", "HEAD")
+        (self.wt / "checkpoint.txt").write_text("PR fixture #42; pending request perm-fixture")
+        self.run_restore()
+        copied = self.wt / "node_modules" / "example" / "index.js"
+        self.assertEqual(copied.read_text(), "export const fixture = 1;\n")
+        before = copied.stat().st_mtime_ns
+        self.run_restore()
+        self.assertEqual(copied.stat().st_mtime_ns, before)
+        self.assertEqual(self.git(self.wt, "rev-parse", "HEAD"), head)
+        self.assertIn("perm-fixture", (self.wt / "checkpoint.txt").read_text())
+        self.assertFalse(list(self.wt.glob(".aidevops-deps-*")))
+
+    def test_root_disabled(self):
+        self.run_restore(root="0")
+        self.assertFalse((self.wt / "node_modules").exists())
+
+    def test_foreign_live_or_dead_owner(self):
+        self.run_restore(owner="foreign")
+        self.assertFalse((self.wt / "node_modules").exists())
+
+    def test_recycled_owner_generation(self):
+        self.run_restore(exact="false")
+        self.assertFalse((self.wt / "node_modules").exists())
+
+    def test_byte_budget(self):
+        self.run_restore(budget="10")
+        self.assertFalse((self.wt / "node_modules").exists())
+
+    def test_copy_enforces_budget_without_preflight(self):
+        stage = self.wt / "stage"
+        stage.mkdir(mode=0o700)
+        with self.assertRaises(provision.Rejected):
+            provision.snapshot(self.modules, 10, 20000, stage)
+        self.assertLessEqual(sum(p.stat().st_size for p in stage.rglob("*") if p.is_file()), 10)
+
+    def test_entry_budget(self):
+        with self.assertRaises(provision.Rejected):
+            provision.snapshot(self.modules, 67108864, 1)
+
+    def test_stale_package(self):
+        self.write(self.wt / "package.json", {"name": "different"})
+        with self.assertRaises(provision.Rejected):
+            self.validate()
+
+    def test_missing_package_identity(self):
+        for parent in (self.repo, self.wt):
+            self.write(parent / "package.json", {})
+        with self.assertRaises(provision.Rejected):
+            self.validate()
+
+    def test_stale_lock(self):
+        self.write(self.wt / "package-lock.json", {})
+        with self.assertRaises(provision.Rejected):
+            self.validate()
+
+    def test_stale_installed_package(self):
+        self.write(self.modules / "example" / "package.json", {"name": "example", "version": "2.0.0"})
+        with self.assertRaises(provision.Rejected):
+            self.validate()
+
+    def test_missing_dependencies(self):
+        shutil.rmtree(self.modules)
+        self.run_restore()
+        self.assertFalse((self.wt / "node_modules").exists())
+
+    def test_missing_installed_lock(self):
+        (self.modules / ".package-lock.json").unlink()
+        with self.assertRaises(OSError):
+            self.validate()
+
+    def test_symlinked_manifest(self):
+        (self.repo / "package.json").unlink()
+        (self.repo / "package.json").symlink_to(self.wt / "package.json")
+        with self.assertRaises(OSError):
+            self.validate()
+
+    def test_escaping_link_and_credentials(self):
+        (self.modules / "escape").symlink_to(self.repo)
+        self.run_restore()
+        self.assertFalse((self.wt / "node_modules").exists())
+        (self.modules / "escape").unlink()
+        (self.modules / ".npmrc").write_text("fixture only")
+        self.run_restore()
+        self.assertFalse((self.wt / "node_modules").exists())
+
+    def test_destination_symlink(self):
+        (self.wt / "node_modules").symlink_to(self.modules)
+        self.run_restore()
+        self.assertTrue((self.wt / "node_modules").is_symlink())
+
+    def test_source_not_shared_writable(self):
+        (self.modules / "example" / "index.js").chmod(0o666)
+        self.run_restore()
+        self.assertFalse((self.wt / "node_modules").exists())
+
+    def test_special_file(self):
+        os.mkfifo(self.modules / "fifo")
+        self.run_restore()
+        self.assertFalse((self.wt / "node_modules").exists())
+
+    def test_pnpm_contained_links(self):
+        for parent in (self.repo, self.wt):
+            (parent / "package-lock.json").unlink()
+            (parent / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n")
+        (self.modules / ".package-lock.json").unlink()
+        store = self.modules / ".pnpm" / "example@1.0.0" / "node_modules"
+        store.mkdir(parents=True)
+        (self.modules / "example").rename(store / "example")
+        (self.modules / "example").symlink_to(".pnpm/example@1.0.0/node_modules/example")
+        (self.modules / ".pnpm" / "lock.yaml").write_text("lockfileVersion: '9.0'\n")
+        self.run_restore()
+        copied = self.wt / "node_modules" / "example" / "index.js"
+        self.assertTrue(copied.resolve().is_relative_to(self.wt))
+        self.assertEqual(copied.read_text(), "export const fixture = 1;\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/worker-permission-helper.sh
+++ b/.agents/scripts/worker-permission-helper.sh
@@ -221,6 +221,10 @@ permission_render_capabilities() {
 		+ "\n  - Reason: " + (if .intent == "" then "No additional model rationale was available." else (.intent | safe) end)
 		+ "\n  - Risk: **" + .risk.level + "** — " + (.risk.reason | safe)
 		+ (if avoidable_tool_bin_read then "\n  - Recovery: Routine tool discovery should use `command -v TOOL`, `TOOL --version`, or a repository wrapper instead of reading the install directory." else "" end)
+		+ (if .permission == "external_directory" and .tool == "read"
+			and (.patterns | length > 0) and all(.patterns[]; contains("/node_modules/"))
+			then "\n  - Owned recovery: The AI controller should evaluate bounded in-worktree dependency provisioning (`reference/dispatch-blockers.md`). This is a candidate, not permission to read or copy the requested external path. Preserve this request, branch, PR and session; prove the original process terminal or transfer ownership before provisioning. The current signed permission-history contract has no unsigned supersession path: retain the hold and route this exact checkpoint to the existing AI brief owner/coordinator. Never retry the denied tool, clear the hold, or launch a replacement worker under an implied grant."
+			else "" end)
 		+ (if .risk.grantable then "" else "\n  - **Not grantable:** sensitive scope requires an alternative approach." end)' \
 		"$envelope_file"
 	return $?

--- a/.agents/scripts/worktree-dependency-provision.py
+++ b/.agents/scripts/worktree-dependency-provision.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Validate bounded dependency snapshots for the controller's fast_cp path.
+
+No installation, permissions, registry ownership transfer, or worker resume occurs
+here. Callers must hold their existing restore lock and own the destination.
+Only npm and pnpm installations with verifiable installed lock metadata qualify.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+
+
+class Rejected(ValueError):
+    """A dependency snapshot cannot safely be provisioned."""
+
+
+def regular_bytes(path, limit=8 * 1024 * 1024):
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    with os.fdopen(fd, "rb") as source:
+        info = os.fstat(source.fileno())
+        if not stat.S_ISREG(info.st_mode) or info.st_size > limit:
+            raise Rejected("invalid-or-oversized-file")
+        data = source.read(limit + 1)
+        if len(data) > limit:
+            raise Rejected("byte-budget-exceeded")
+        return data
+
+
+def contained_path(path):
+    """Reject symlink components, including dangling links, before any read."""
+    path = Path(os.path.abspath(path))
+    for parent in [*reversed(path.parents), path]:
+        if parent.is_symlink():
+            raise Rejected("symlink-component")
+    return path
+
+
+def git(path, *args):
+    return subprocess.check_output(
+        ["git", "-C", str(path), *args], stderr=subprocess.DEVNULL,
+        timeout=10, text=True,
+    ).strip()
+
+
+def identity(repo, worktree, relative):
+    repo, worktree = contained_path(repo), contained_path(worktree)
+    if repo == worktree or git(worktree, "rev-parse", "--show-toplevel") != str(worktree):
+        raise Rejected("not-linked-worktree")
+    if git(repo, "rev-parse", "--show-toplevel") != str(repo):
+        raise Rejected("not-repository-root")
+    common = [git(p, "rev-parse", "--path-format=absolute", "--git-common-dir")
+              for p in (repo, worktree)]
+    if common[0] != common[1] or not (worktree / ".git").is_file():
+        raise Rejected("foreign-repository")
+    if relative.is_absolute() or ".." in relative.parts:
+        raise Rejected("invalid-package-path")
+    source, dest = [contained_path(p / relative) for p in (repo, worktree)]
+    if dest.stat().st_uid != os.getuid() or dest.stat().st_mode & 0o022:
+        raise Rejected("foreign-or-shared-destination")
+    package = regular_bytes(source / "package.json")
+    if package != regular_bytes(dest / "package.json"):
+        raise Rejected("stale-package-identity")
+    parsed = json.loads(package)
+    if not isinstance(parsed, dict) or not parsed.get("name"):
+        raise Rejected("missing-package-identity")
+    locks = [name for name in ("package-lock.json", "pnpm-lock.yaml")
+             if (source / name).exists() or (dest / name).exists()]
+    if len(locks) != 1:
+        raise Rejected("missing-or-ambiguous-supported-lock")
+    name = locks[0]
+    lock = regular_bytes(source / name)
+    if lock != regular_bytes(dest / name):
+        raise Rejected("stale-lock-identity")
+    modules = contained_path(source / "node_modules")
+    if name == "pnpm-lock.yaml":
+        installed = contained_path(modules / ".pnpm" / "lock.yaml")
+        if regular_bytes(installed) != lock:
+            raise Rejected("stale-installed-lock")
+    else:
+        expected = json.loads(lock).get("packages")
+        installed = json.loads(regular_bytes(modules / ".package-lock.json")).get("packages")
+        if not expected or not installed:
+            raise Rejected("missing-installed-identity")
+        for location, metadata in installed.items():
+            if location not in expected or metadata != expected[location]:
+                raise Rejected("stale-installed-lock")
+            if not location.startswith("node_modules/") or ".." in Path(location).parts:
+                raise Rejected("invalid-installed-path")
+            manifest = json.loads(regular_bytes(contained_path(source / location / "package.json")))
+            if not manifest.get("name") or not manifest.get("version") or manifest["version"] != metadata.get("version"):
+                raise Rejected("stale-installed-package")
+    return modules
+
+
+def snapshot(root, max_bytes, max_entries):
+    root = contained_path(root)
+    digest = hashlib.sha256()
+    total = 0
+    count = 0
+    for directory, dirs, files in os.walk(root, followlinks=False):
+        for name in sorted(dirs + files):
+            count += 1
+            if count > max_entries:
+                raise Rejected("entry-budget-exceeded")
+            lower = name.lower()
+            if (lower in {".git", ".ssh", ".aws", ".npmrc", ".netrc", ".pypirc", "credentials.json"}
+                    or lower.startswith(".env") or lower.endswith((".pem", ".key", ".p12", ".pfx"))):
+                raise Rejected("credential-bearing-path")
+            path = Path(directory) / name
+            info = path.lstat()
+            digest.update(str(path.relative_to(root)).encode() + b"\0")
+            if stat.S_ISLNK(info.st_mode):
+                target = os.readlink(path)
+                if os.path.isabs(target) or not path.resolve(strict=True).is_relative_to(root):
+                    raise Rejected("escaping-dependency-link")
+                digest.update(b"link\0" + target.encode())
+            elif stat.S_ISDIR(info.st_mode):
+                digest.update(b"dir\0")
+            elif stat.S_ISREG(info.st_mode):
+                if info.st_size > max_bytes - total:
+                    raise Rejected("byte-budget-exceeded")
+                data = regular_bytes(path, max_bytes - total)
+                total += len(data)
+                digest.update(b"file\0" + hashlib.sha256(data).digest())
+            else:
+                raise Rejected("special-file")
+    if not root.is_dir() or count == 0:
+        raise Rejected("missing-dependencies")
+    return f"{digest.hexdigest()} {total} {count}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo")
+    parser.add_argument("worktree")
+    parser.add_argument("relative")
+    parser.add_argument("--snapshot", help="Validate a private staged copy instead of the source")
+    parser.add_argument("--max-bytes", type=int, default=64 * 1024 * 1024)
+    parser.add_argument("--max-entries", type=int, default=20000)
+    args = parser.parse_args()
+    try:
+        if not 0 < args.max_bytes <= 64 * 1024 * 1024 or not 0 < args.max_entries <= 20000:
+            raise Rejected("invalid-budget")
+        modules = identity(args.repo, args.worktree, Path(args.relative))
+        root = contained_path(args.snapshot) if args.snapshot else modules
+        if args.snapshot and not root.is_relative_to(contained_path(args.worktree)):
+            raise Rejected("foreign-staging-directory")
+        print(snapshot(root, args.max_bytes, args.max_entries))
+        return 0
+    except (OSError, ValueError, subprocess.SubprocessError):
+        # Never copy raw paths, package contents or subprocess stderr into logs.
+        print("dependency-provision-rejected", file=__import__("sys").stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/worktree-dependency-provision.py
+++ b/.agents/scripts/worktree-dependency-provision.py
@@ -9,10 +9,12 @@ Only npm and pnpm installations with verifiable installed lock metadata qualify.
 """
 
 import argparse
+import ctypes
 import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import stat
 import subprocess
 import sys
@@ -40,6 +42,36 @@ def open_directory(path):
 def trusted(info):
     if info.st_uid != os.getuid() or info.st_mode & 0o022:
         raise Rejected("foreign-or-shared-source")
+
+
+def object_json(data):
+    result = json.loads(data)
+    if not isinstance(result, dict):
+        raise Rejected("invalid-object-metadata")
+    return result
+
+
+def pnpm_inventory(lock):
+    """Accept only pnpm's simple v9 packages map, not arbitrary YAML features."""
+    text = lock.decode("utf-8")
+    if not re.search(r"(?m)^lockfileVersion: ['\"]?9\.0['\"]?$", text):
+        raise Rejected("unsupported-pnpm-lock")
+    section = False
+    packages = set()
+    for line in text.splitlines():
+        if line == "packages:":
+            section = True
+            continue
+        if section and line and not line.startswith(" "):
+            break
+        if section and line.startswith("  ") and not line.startswith("   "):
+            match = re.fullmatch(r"  ['\"]?(@?[a-zA-Z0-9_./-]+@[0-9][a-zA-Z0-9.+_-]*)['\"]?:", line)
+            if not match:
+                raise Rejected("unsupported-pnpm-package-key")
+            packages.add(match[1])
+    if not packages:
+        raise Rejected("missing-pnpm-inventory")
+    return packages
 
 
 def regular_bytes(path, limit=8 * 1024 * 1024):
@@ -85,16 +117,21 @@ def identity(repo, worktree, relative):
             or not (repo / ".git").is_dir()):
         raise Rejected("foreign-repository")
     trusted(repo.stat())
+    trusted(worktree.parent.stat())
+    trusted(worktree.stat())
     if relative.is_absolute() or ".." in relative.parts:
         raise Rejected("invalid-package-path")
     source, dest = [contained_path(p / relative) for p in (repo, worktree)]
-    if dest.stat().st_uid != os.getuid() or dest.stat().st_mode & 0o022:
-        raise Rejected("foreign-or-shared-destination")
+    for base in (repo, worktree):
+        current = base
+        for part in relative.parts:
+            current /= part
+            trusted(current.stat())
     package = regular_bytes(source / "package.json")
     if package != regular_bytes(dest / "package.json"):
         raise Rejected("stale-package-identity")
-    parsed = json.loads(package)
-    if not isinstance(parsed, dict) or not parsed.get("name"):
+    parsed = object_json(package)
+    if not parsed.get("name"):
         raise Rejected("missing-package-identity")
     locks = [name for name in ("package-lock.json", "pnpm-lock.yaml")
              if (source / name).exists() or (dest / name).exists()]
@@ -109,27 +146,38 @@ def identity(repo, worktree, relative):
         installed = contained_path(modules / ".pnpm" / "lock.yaml")
         if regular_bytes(installed) != lock:
             raise Rejected("stale-installed-lock")
+        inventory = ("pnpm", pnpm_inventory(lock))
     else:
-        expected = json.loads(lock).get("packages")
-        installed = json.loads(regular_bytes(modules / ".package-lock.json")).get("packages")
-        if not expected or not installed:
+        expected = object_json(lock).get("packages")
+        installed = object_json(regular_bytes(modules / ".package-lock.json")).get("packages")
+        if not isinstance(expected, dict) or not isinstance(installed, dict) or not installed:
             raise Rejected("missing-installed-identity")
+        root_package = expected.get("")
+        if not isinstance(root_package, dict) or any(
+            parsed.get(key) != root_package.get(key)
+            for key in ("name", "version", "dependencies", "devDependencies", "optionalDependencies")
+        ):
+            raise Rejected("stale-root-lock-identity")
+        if set(expected) - {""} != set(installed):
+            raise Rejected("incomplete-installed-inventory")
         for location, metadata in installed.items():
-            if location not in expected or metadata != expected[location]:
+            if not isinstance(metadata, dict) or metadata != expected[location]:
                 raise Rejected("stale-installed-lock")
             if not location.startswith("node_modules/") or ".." in Path(location).parts:
                 raise Rejected("invalid-installed-path")
-            manifest = json.loads(regular_bytes(contained_path(source / location / "package.json")))
+            manifest = object_json(regular_bytes(contained_path(source / location / "package.json")))
             if not manifest.get("name") or not manifest.get("version") or manifest["version"] != metadata.get("version"):
                 raise Rejected("stale-installed-package")
-    return modules
+        inventory = ("npm", set(installed))
+    return modules, inventory
 
 
-def snapshot(root, max_bytes, max_entries, copy_to=None):
+def snapshot(root, max_bytes, max_entries, copy_to=None, inventory=None):
     root = contained_path(root)
     total = 0
     count = 0
     records = {}
+    seen_packages = set()
 
     def walk(fd, relative, output, depth=0):
         nonlocal total, count
@@ -148,23 +196,48 @@ def snapshot(root, max_bytes, max_entries, copy_to=None):
                     raise Rejected("credential-bearing-path")
                 rel = relative / name
                 info = entry.stat(follow_symlinks=False)
+                package_root = Path("node_modules") / rel
+                namespace = name.startswith("@") and stat.S_ISDIR(info.st_mode)
+                metadata_entry = (
+                    name in {".bin", ".pnpm"} and stat.S_ISDIR(info.st_mode)
+                    or name in {".package-lock.json", ".modules.yaml", ".pnpm-workspace-state-v1.json"}
+                    and stat.S_ISREG(info.st_mode)
+                )
+                resolution_root = (
+                    package_root.parent.name == "node_modules" and not (namespace or metadata_entry)
+                    or package_root.parent.name.startswith("@") and package_root.parent.parent.name == "node_modules"
+                )
+                if inventory and resolution_root:
+                    if not (stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode)):
+                        raise Rejected("unrecorded-module-file")
+                    resolved = (root / rel).resolve(strict=True)
+                    if not resolved.is_relative_to(root):
+                        raise Rejected("escaping-package-root")
+                    manifest = object_json(regular_bytes(resolved / "package.json"))
+                    package_key = (str(package_root) if inventory[0] == "npm" else
+                                   f"{manifest.get('name')}@{manifest.get('version')}")
+                    if package_key not in inventory[1]:
+                        raise Rejected("unrecorded-package-root")
                 if stat.S_ISLNK(info.st_mode):
                     target = os.readlink(name, dir_fd=fd)
                     if os.path.isabs(target) or not (root / rel).resolve(strict=True).is_relative_to(root):
                         raise Rejected("escaping-dependency-link")
                     records[str(rel)] = b"link\0" + target.encode()
                     if output is not None:
-                        os.symlink(target, output / name)
+                        os.symlink(target, name, dir_fd=output)
                 elif stat.S_ISDIR(info.st_mode):
                     child = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd)
+                    target_dir = None
                     try:
-                        target_dir = output / name if output is not None else None
-                        if target_dir is not None:
-                            target_dir.mkdir(mode=0o755)
+                        if output is not None:
+                            os.mkdir(name, mode=0o755, dir_fd=output)
+                            target_dir = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=output)
                         records[str(rel)] = b"dir\0"
                         walk(child, rel, target_dir, depth + 1)
                     finally:
                         os.close(child)
+                        if target_dir is not None:
+                            os.close(target_dir)
                 elif stat.S_ISREG(info.st_mode):
                     source_fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=fd)
                     with os.fdopen(source_fd, "rb") as source:
@@ -177,22 +250,64 @@ def snapshot(root, max_bytes, max_entries, copy_to=None):
                         after = os.fstat(source_fd)
                         if total > max_bytes or (before.st_size, before.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
                             raise Rejected("changed-or-oversized-source")
-                    records[str(rel)] = b"file\0" + hashlib.sha256(data).digest()
+                    package_path = Path("node_modules") / rel.parent
+                    is_package = (package_path.parent.name == "node_modules" or
+                                  (package_path.parent.name.startswith("@") and package_path.parent.parent.name == "node_modules"))
+                    if inventory and name == "package.json" and is_package:
+                        manifest = object_json(data)
+                        key = (str(package_path) if inventory[0] == "npm" else
+                               f"{manifest.get('name')}@{manifest.get('version')}")
+                        if key not in inventory[1]:
+                            raise Rejected("unrecorded-package")
+                        seen_packages.add(key)
+                    records[str(rel)] = b"file\0" + str(before.st_mode & 0o755).encode() + hashlib.sha256(data).digest()
                     if output is not None:
-                        with (output / name).open("xb") as destination:
+                        destination_fd = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                                                 0o600, dir_fd=output)
+                        with os.fdopen(destination_fd, "wb") as destination:
                             destination.write(data)
-                        (output / name).chmod(before.st_mode & 0o755)
+                            os.fchmod(destination_fd, before.st_mode & 0o755)
                 else:
                     raise Rejected("special-file")
 
     with open_directory(root) as fd:
-        walk(fd, Path(), copy_to)
+        if copy_to is None:
+            walk(fd, Path(), None)
+        else:
+            with open_directory(copy_to) as output_fd:
+                trusted(os.fstat(output_fd))
+                walk(fd, Path(), output_fd)
     if count == 0:
         raise Rejected("missing-dependencies")
+    if inventory and seen_packages != inventory[1]:
+        raise Rejected("incomplete-package-inventory")
     digest = hashlib.sha256()
     for name, value in sorted(records.items()):
         digest.update(name.encode() + b"\0" + value)
     return f"{digest.hexdigest()} {total} {count}"
+
+
+def publish(stage, worktree, relative):
+    """Atomic no-replace promotion using pinned directories; no BSD mv fallback."""
+    stage, worktree = contained_path(stage), contained_path(worktree)
+    if (stage.name != "node_modules" or stage.parent.parent != worktree
+            or not stage.parent.name.startswith(".aidevops-deps-")):
+        raise Rejected("invalid-promotion-source")
+    trusted(stage.parent.stat())
+    if stage.parent.stat().st_mode & 0o077:
+        raise Rejected("non-private-stage")
+    libc = ctypes.CDLL(None, use_errno=True)
+    name, flag = ("renameatx_np", 4) if sys.platform == "darwin" else ("renameat2", 1)
+    rename = getattr(libc, name, None)
+    if rename is None:
+        raise Rejected("atomic-no-replace-unavailable")
+    rename.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+    rename.restype = ctypes.c_int
+    with open_directory(stage.parent) as source, open_directory(worktree / relative) as destination:
+        trusted(os.fstat(source))
+        trusted(os.fstat(destination))
+        if rename(source, b"node_modules", destination, b"node_modules", flag) != 0:
+            raise Rejected("atomic-promotion-refused")
 
 
 def main():
@@ -202,15 +317,17 @@ def main():
     parser.add_argument("relative")
     parser.add_argument("--snapshot", help="Validate a private staged copy instead of the source")
     parser.add_argument("--copy-to", help="Copy with enforced byte/entry limits into an empty private staging directory")
+    parser.add_argument("--publish", help="Validate and atomically promote a private staged copy without replacing a destination")
     parser.add_argument("--max-bytes", type=int, default=64 * 1024 * 1024)
     parser.add_argument("--max-entries", type=int, default=20000)
     args = parser.parse_args()
     try:
         if not 0 < args.max_bytes <= 64 * 1024 * 1024 or not 0 < args.max_entries <= 20000:
             raise Rejected("invalid-budget")
-        modules = identity(args.repo, args.worktree, Path(args.relative))
-        root = contained_path(args.snapshot) if args.snapshot else modules
-        if args.snapshot and not root.is_relative_to(contained_path(args.worktree)):
+        modules, inventory = identity(args.repo, args.worktree, Path(args.relative))
+        staging = args.snapshot or args.publish
+        root = contained_path(staging) if staging else modules
+        if staging and not root.is_relative_to(contained_path(args.worktree)):
             raise Rejected("foreign-staging-directory")
         output = contained_path(args.copy_to) if args.copy_to else None
         if output is not None:
@@ -218,7 +335,10 @@ def main():
                     or output.stat().st_mode & 0o077 or any(output.iterdir())):
                 raise Rejected("invalid-private-staging")
             trusted(output.stat())
-        print(snapshot(root, args.max_bytes, args.max_entries, output))
+        result = snapshot(root, args.max_bytes, args.max_entries, output, inventory)
+        if args.publish:
+            publish(root, Path(args.worktree), Path(args.relative))
+        print(result)
         return 0
     except (OSError, ValueError, RuntimeError, subprocess.SubprocessError):
         # Never copy raw paths, package contents or subprocess stderr into logs.

--- a/.agents/scripts/worktree-dependency-provision.py
+++ b/.agents/scripts/worktree-dependency-provision.py
@@ -3,299 +3,25 @@
 # SPDX-FileCopyrightText: 2026 Marcus Quinn
 """Validate and copy bounded dependency snapshots for the controller restore path.
 
-No installation, permissions, registry ownership transfer, or worker resume occurs
-here. Callers must hold their existing restore lock and own the destination.
-Only npm and pnpm installations with verifiable installed lock metadata qualify.
+No installs, permission changes, ownership transfers or worker resumes occur here.
+Callers must hold their existing restore lock and own the destination.
 """
 
 import argparse
 import ctypes
-import hashlib
-import json
 import os
 from pathlib import Path
-import re
-import stat
-import subprocess
+from subprocess import SubprocessError  # nosec B404 -- exception type only, no process execution.
 import sys
-from contextlib import contextmanager
 
-
-class Rejected(ValueError):
-    """A dependency snapshot cannot safely be provisioned."""
-
-
-@contextmanager
-def open_directory(path):
-    """Pin every directory component without following a racing symlink."""
-    fd = os.open("/", os.O_RDONLY | os.O_DIRECTORY)
-    try:
-        for part in Path(os.path.abspath(path)).parts[1:]:
-            child = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd)
-            os.close(fd)
-            fd = child
-        yield fd
-    finally:
-        os.close(fd)
-
-
-def trusted(info):
-    if info.st_uid != os.getuid() or info.st_mode & 0o022:
-        raise Rejected("foreign-or-shared-source")
-
-
-def object_json(data):
-    result = json.loads(data)
-    if not isinstance(result, dict):
-        raise Rejected("invalid-object-metadata")
-    return result
-
-
-def pnpm_inventory(lock):
-    """Accept only pnpm's simple v9 packages map, not arbitrary YAML features."""
-    text = lock.decode("utf-8")
-    if not re.search(r"(?m)^lockfileVersion: ['\"]?9\.0['\"]?$", text):
-        raise Rejected("unsupported-pnpm-lock")
-    section = False
-    packages = set()
-    for line in text.splitlines():
-        if line == "packages:":
-            section = True
-            continue
-        if section and line and not line.startswith(" "):
-            break
-        if section and line.startswith("  ") and not line.startswith("   "):
-            match = re.fullmatch(r"  ['\"]?(@?[a-zA-Z0-9_./-]+@[0-9][a-zA-Z0-9.+_-]*)['\"]?:", line)
-            if not match:
-                raise Rejected("unsupported-pnpm-package-key")
-            packages.add(match[1])
-    if not packages:
-        raise Rejected("missing-pnpm-inventory")
-    return packages
-
-
-def regular_bytes(path, limit=8 * 1024 * 1024):
-    path = Path(path)
-    with open_directory(path.parent) as parent:
-        fd = os.open(path.name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=parent)
-    with os.fdopen(fd, "rb") as source:
-        info = os.fstat(source.fileno())
-        trusted(info)
-        if not stat.S_ISREG(info.st_mode) or info.st_size > limit:
-            raise Rejected("invalid-or-oversized-file")
-        data = source.read(limit + 1)
-        if len(data) > limit:
-            raise Rejected("byte-budget-exceeded")
-        return data
-
-
-def contained_path(path):
-    """Reject symlink components, including dangling links, before any read."""
-    path = Path(os.path.abspath(path))
-    for parent in [*reversed(path.parents), path]:
-        if parent.is_symlink():
-            raise Rejected("symlink-component")
-    return path
-
-
-def git(path, *args):
-    return subprocess.check_output(
-        ["git", "-C", str(path), *args], stderr=subprocess.DEVNULL,
-        timeout=10, text=True,
-    ).strip()
-
-
-def identity(repo, worktree, relative):
-    repo, worktree = contained_path(repo), contained_path(worktree)
-    if repo == worktree or git(worktree, "rev-parse", "--show-toplevel") != str(worktree):
-        raise Rejected("not-linked-worktree")
-    if git(repo, "rev-parse", "--show-toplevel") != str(repo):
-        raise Rejected("not-repository-root")
-    common = [git(p, "rev-parse", "--path-format=absolute", "--git-common-dir")
-              for p in (repo, worktree)]
-    if (common[0] != common[1] or not (worktree / ".git").is_file()
-            or not (repo / ".git").is_dir()):
-        raise Rejected("foreign-repository")
-    trusted(repo.stat())
-    trusted(worktree.parent.stat())
-    trusted(worktree.stat())
-    if relative.is_absolute() or ".." in relative.parts:
-        raise Rejected("invalid-package-path")
-    source, dest = [contained_path(p / relative) for p in (repo, worktree)]
-    for base in (repo, worktree):
-        current = base
-        for part in relative.parts:
-            current /= part
-            trusted(current.stat())
-    package = regular_bytes(source / "package.json")
-    if package != regular_bytes(dest / "package.json"):
-        raise Rejected("stale-package-identity")
-    parsed = object_json(package)
-    if not parsed.get("name"):
-        raise Rejected("missing-package-identity")
-    locks = [name for name in ("package-lock.json", "pnpm-lock.yaml")
-             if (source / name).exists() or (dest / name).exists()]
-    if len(locks) != 1:
-        raise Rejected("missing-or-ambiguous-supported-lock")
-    name = locks[0]
-    lock = regular_bytes(source / name)
-    if lock != regular_bytes(dest / name):
-        raise Rejected("stale-lock-identity")
-    modules = contained_path(source / "node_modules")
-    if name == "pnpm-lock.yaml":
-        installed = contained_path(modules / ".pnpm" / "lock.yaml")
-        if regular_bytes(installed) != lock:
-            raise Rejected("stale-installed-lock")
-        inventory = ("pnpm", pnpm_inventory(lock))
-    else:
-        expected = object_json(lock).get("packages")
-        installed = object_json(regular_bytes(modules / ".package-lock.json")).get("packages")
-        if not isinstance(expected, dict) or not isinstance(installed, dict) or not installed:
-            raise Rejected("missing-installed-identity")
-        root_package = expected.get("")
-        if not isinstance(root_package, dict) or any(
-            parsed.get(key) != root_package.get(key)
-            for key in ("name", "version", "dependencies", "devDependencies", "optionalDependencies")
-        ):
-            raise Rejected("stale-root-lock-identity")
-        if set(expected) - {""} != set(installed):
-            raise Rejected("incomplete-installed-inventory")
-        for location, metadata in installed.items():
-            if not isinstance(metadata, dict) or metadata != expected[location]:
-                raise Rejected("stale-installed-lock")
-            if not location.startswith("node_modules/") or ".." in Path(location).parts:
-                raise Rejected("invalid-installed-path")
-            manifest = object_json(regular_bytes(contained_path(source / location / "package.json")))
-            if not manifest.get("name") or not manifest.get("version") or manifest["version"] != metadata.get("version"):
-                raise Rejected("stale-installed-package")
-        inventory = ("npm", set(installed))
-    return modules, inventory
-
-
-def snapshot(root, max_bytes, max_entries, copy_to=None, inventory=None):
-    root = contained_path(root)
-    total = 0
-    count = 0
-    records = {}
-    seen_packages = set()
-
-    def walk(fd, relative, output, depth=0):
-        nonlocal total, count
-        trusted(os.fstat(fd))
-        if depth > 64:
-            raise Rejected("depth-budget-exceeded")
-        with os.scandir(fd) as entries:
-            for entry in entries:
-                count += 1
-                if count > max_entries:
-                    raise Rejected("entry-budget-exceeded")
-                name = entry.name
-                lower = name.lower()
-                if (lower in {".git", ".ssh", ".aws", ".npmrc", ".netrc", ".pypirc", "credentials.json"}
-                        or lower.startswith(".env") or lower.endswith((".pem", ".key", ".p12", ".pfx"))):
-                    raise Rejected("credential-bearing-path")
-                rel = relative / name
-                info = entry.stat(follow_symlinks=False)
-                package_root = Path("node_modules") / rel
-                namespace = name.startswith("@") and stat.S_ISDIR(info.st_mode)
-                metadata_entry = (
-                    name in {".bin", ".pnpm"} and stat.S_ISDIR(info.st_mode)
-                    or name in {".package-lock.json", ".modules.yaml", ".pnpm-workspace-state-v1.json"}
-                    and stat.S_ISREG(info.st_mode)
-                )
-                resolution_root = (
-                    package_root.parent.name == "node_modules" and not (namespace or metadata_entry)
-                    or package_root.parent.name.startswith("@") and package_root.parent.parent.name == "node_modules"
-                )
-                if inventory and resolution_root:
-                    if not (stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode)):
-                        raise Rejected("unrecorded-module-file")
-                    resolved = (root / rel).resolve(strict=True)
-                    if not resolved.is_relative_to(root):
-                        raise Rejected("escaping-package-root")
-                    manifest = object_json(regular_bytes(resolved / "package.json"))
-                    package_key = (str(package_root) if inventory[0] == "npm" else
-                                   f"{manifest.get('name')}@{manifest.get('version')}")
-                    if package_key not in inventory[1]:
-                        raise Rejected("unrecorded-package-root")
-                if stat.S_ISLNK(info.st_mode):
-                    target = os.readlink(name, dir_fd=fd)
-                    if os.path.isabs(target) or not (root / rel).resolve(strict=True).is_relative_to(root):
-                        raise Rejected("escaping-dependency-link")
-                    records[str(rel)] = b"link\0" + target.encode()
-                    if output is not None:
-                        os.symlink(target, name, dir_fd=output)
-                elif stat.S_ISDIR(info.st_mode):
-                    child = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd)
-                    target_dir = None
-                    try:
-                        if output is not None:
-                            os.mkdir(name, mode=0o755, dir_fd=output)
-                            target_dir = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=output)
-                        records[str(rel)] = b"dir\0"
-                        walk(child, rel, target_dir, depth + 1)
-                    finally:
-                        os.close(child)
-                        if target_dir is not None:
-                            os.close(target_dir)
-                elif stat.S_ISREG(info.st_mode):
-                    source_fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=fd)
-                    with os.fdopen(source_fd, "rb") as source:
-                        before = os.fstat(source_fd)
-                        trusted(before)
-                        if not stat.S_ISREG(before.st_mode) or before.st_size > max_bytes - total:
-                            raise Rejected("byte-budget-exceeded")
-                        data = source.read(max_bytes - total + 1)
-                        total += len(data)
-                        after = os.fstat(source_fd)
-                        if total > max_bytes or (before.st_size, before.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
-                            raise Rejected("changed-or-oversized-source")
-                    package_path = Path("node_modules") / rel.parent
-                    is_package = (package_path.parent.name == "node_modules" or
-                                  (package_path.parent.name.startswith("@") and package_path.parent.parent.name == "node_modules"))
-                    if inventory and name == "package.json" and is_package:
-                        manifest = object_json(data)
-                        key = (str(package_path) if inventory[0] == "npm" else
-                               f"{manifest.get('name')}@{manifest.get('version')}")
-                        if key not in inventory[1]:
-                            raise Rejected("unrecorded-package")
-                        seen_packages.add(key)
-                    records[str(rel)] = b"file\0" + str(before.st_mode & 0o755).encode() + hashlib.sha256(data).digest()
-                    if output is not None:
-                        destination_fd = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
-                                                 0o600, dir_fd=output)
-                        with os.fdopen(destination_fd, "wb") as destination:
-                            destination.write(data)
-                            os.fchmod(destination_fd, before.st_mode & 0o755)
-                else:
-                    raise Rejected("special-file")
-
-    with open_directory(root) as fd:
-        if copy_to is None:
-            walk(fd, Path(), None)
-        else:
-            with open_directory(copy_to) as output_fd:
-                trusted(os.fstat(output_fd))
-                walk(fd, Path(), output_fd)
-    if count == 0:
-        raise Rejected("missing-dependencies")
-    if inventory and seen_packages != inventory[1]:
-        raise Rejected("incomplete-package-inventory")
-    digest = hashlib.sha256()
-    for name, value in sorted(records.items()):
-        digest.update(name.encode() + b"\0" + value)
-    return f"{digest.hexdigest()} {total} {count}"
+from _worktree_dependency_identity import Rejected, contained_path, identity, open_directory, trusted
+from _worktree_dependency_snapshot import snapshot
 
 
 def publish(stage, worktree, relative):
     """Atomic no-replace promotion using pinned directories; no BSD mv fallback."""
     stage, worktree = contained_path(stage), contained_path(worktree)
-    if (stage.name != "node_modules" or stage.parent.parent != worktree
-            or not stage.parent.name.startswith(".aidevops-deps-")):
-        raise Rejected("invalid-promotion-source")
-    trusted(stage.parent.stat())
-    if stage.parent.stat().st_mode & 0o077:
-        raise Rejected("non-private-stage")
+    validate_promotion_source(stage, worktree)
     libc = ctypes.CDLL(None, use_errno=True)
     name, flag = ("renameatx_np", 4) if sys.platform == "darwin" else ("renameat2", 1)
     rename = getattr(libc, name, None)
@@ -310,37 +36,64 @@ def publish(stage, worktree, relative):
             raise Rejected("atomic-promotion-refused")
 
 
-def main():
+def validate_promotion_source(stage, worktree):
+    if (stage.name != "node_modules" or stage.parent.parent != worktree
+            or not stage.parent.name.startswith(".aidevops-deps-")):
+        raise Rejected("invalid-promotion-source")
+    trusted(stage.parent.stat())
+    if stage.parent.stat().st_mode & 0o077:
+        raise Rejected("non-private-stage")
+
+
+def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("repo")
     parser.add_argument("worktree")
     parser.add_argument("relative")
     parser.add_argument("--snapshot", help="Validate a private staged copy instead of the source")
-    parser.add_argument("--copy-to", help="Copy with enforced byte/entry limits into an empty private staging directory")
-    parser.add_argument("--publish", help="Validate and atomically promote a private staged copy without replacing a destination")
+    parser.add_argument("--copy-to", help="Copy with enforced limits into an empty private staging directory")
+    parser.add_argument("--publish", help="Validate and atomically promote a private staged copy without replacement")
     parser.add_argument("--max-bytes", type=int, default=64 * 1024 * 1024)
     parser.add_argument("--max-entries", type=int, default=20000)
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def staging_root(args, modules):
+    staging = args.snapshot or args.publish
+    root = contained_path(staging) if staging else modules
+    if staging and not root.is_relative_to(contained_path(args.worktree)):
+        raise Rejected("foreign-staging-directory")
+    return root
+
+
+def copy_destination(args):
+    if not args.copy_to:
+        return None
+    output = contained_path(args.copy_to)
+    if (not output.is_relative_to(contained_path(args.worktree))
+            or output.stat().st_mode & 0o077 or any(output.iterdir())):
+        raise Rejected("invalid-private-staging")
+    trusted(output.stat())
+    return output
+
+
+def run(args):
+    if not 0 < args.max_bytes <= 64 * 1024 * 1024 or not 0 < args.max_entries <= 20000:
+        raise Rejected("invalid-budget")
+    modules, inventory = identity(args.repo, args.worktree, Path(args.relative))
+    root = staging_root(args, modules)
+    result = snapshot(root, args.max_bytes, args.max_entries, copy_destination(args), inventory)
+    if args.publish:
+        publish(root, Path(args.worktree), Path(args.relative))
+    return result
+
+
+def main():
+    args = parse_args()
     try:
-        if not 0 < args.max_bytes <= 64 * 1024 * 1024 or not 0 < args.max_entries <= 20000:
-            raise Rejected("invalid-budget")
-        modules, inventory = identity(args.repo, args.worktree, Path(args.relative))
-        staging = args.snapshot or args.publish
-        root = contained_path(staging) if staging else modules
-        if staging and not root.is_relative_to(contained_path(args.worktree)):
-            raise Rejected("foreign-staging-directory")
-        output = contained_path(args.copy_to) if args.copy_to else None
-        if output is not None:
-            if (not output.is_relative_to(contained_path(args.worktree))
-                    or output.stat().st_mode & 0o077 or any(output.iterdir())):
-                raise Rejected("invalid-private-staging")
-            trusted(output.stat())
-        result = snapshot(root, args.max_bytes, args.max_entries, output, inventory)
-        if args.publish:
-            publish(root, Path(args.worktree), Path(args.relative))
-        print(result)
+        print(run(args))
         return 0
-    except (OSError, ValueError, RuntimeError, subprocess.SubprocessError):
+    except (OSError, ValueError, RuntimeError, SubprocessError):
         # Never copy raw paths, package contents or subprocess stderr into logs.
         print("dependency-provision-rejected", file=sys.stderr)
         return 1

--- a/.agents/scripts/worktree-dependency-provision.py
+++ b/.agents/scripts/worktree-dependency-provision.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 Marcus Quinn
-"""Validate bounded dependency snapshots for the controller's fast_cp path.
+"""Validate and copy bounded dependency snapshots for the controller restore path.
 
 No installation, permissions, registry ownership transfer, or worker resume occurs
 here. Callers must hold their existing restore lock and own the destination.
@@ -15,16 +15,40 @@ import os
 from pathlib import Path
 import stat
 import subprocess
+import sys
+from contextlib import contextmanager
 
 
 class Rejected(ValueError):
     """A dependency snapshot cannot safely be provisioned."""
 
 
+@contextmanager
+def open_directory(path):
+    """Pin every directory component without following a racing symlink."""
+    fd = os.open("/", os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        for part in Path(os.path.abspath(path)).parts[1:]:
+            child = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd)
+            os.close(fd)
+            fd = child
+        yield fd
+    finally:
+        os.close(fd)
+
+
+def trusted(info):
+    if info.st_uid != os.getuid() or info.st_mode & 0o022:
+        raise Rejected("foreign-or-shared-source")
+
+
 def regular_bytes(path, limit=8 * 1024 * 1024):
-    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    path = Path(path)
+    with open_directory(path.parent) as parent:
+        fd = os.open(path.name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=parent)
     with os.fdopen(fd, "rb") as source:
         info = os.fstat(source.fileno())
+        trusted(info)
         if not stat.S_ISREG(info.st_mode) or info.st_size > limit:
             raise Rejected("invalid-or-oversized-file")
         data = source.read(limit + 1)
@@ -57,8 +81,10 @@ def identity(repo, worktree, relative):
         raise Rejected("not-repository-root")
     common = [git(p, "rev-parse", "--path-format=absolute", "--git-common-dir")
               for p in (repo, worktree)]
-    if common[0] != common[1] or not (worktree / ".git").is_file():
+    if (common[0] != common[1] or not (worktree / ".git").is_file()
+            or not (repo / ".git").is_dir()):
         raise Rejected("foreign-repository")
+    trusted(repo.stat())
     if relative.is_absolute() or ".." in relative.parts:
         raise Rejected("invalid-package-path")
     source, dest = [contained_path(p / relative) for p in (repo, worktree)]
@@ -99,40 +125,73 @@ def identity(repo, worktree, relative):
     return modules
 
 
-def snapshot(root, max_bytes, max_entries):
+def snapshot(root, max_bytes, max_entries, copy_to=None):
     root = contained_path(root)
-    digest = hashlib.sha256()
     total = 0
     count = 0
-    for directory, dirs, files in os.walk(root, followlinks=False):
-        for name in sorted(dirs + files):
-            count += 1
-            if count > max_entries:
-                raise Rejected("entry-budget-exceeded")
-            lower = name.lower()
-            if (lower in {".git", ".ssh", ".aws", ".npmrc", ".netrc", ".pypirc", "credentials.json"}
-                    or lower.startswith(".env") or lower.endswith((".pem", ".key", ".p12", ".pfx"))):
-                raise Rejected("credential-bearing-path")
-            path = Path(directory) / name
-            info = path.lstat()
-            digest.update(str(path.relative_to(root)).encode() + b"\0")
-            if stat.S_ISLNK(info.st_mode):
-                target = os.readlink(path)
-                if os.path.isabs(target) or not path.resolve(strict=True).is_relative_to(root):
-                    raise Rejected("escaping-dependency-link")
-                digest.update(b"link\0" + target.encode())
-            elif stat.S_ISDIR(info.st_mode):
-                digest.update(b"dir\0")
-            elif stat.S_ISREG(info.st_mode):
-                if info.st_size > max_bytes - total:
-                    raise Rejected("byte-budget-exceeded")
-                data = regular_bytes(path, max_bytes - total)
-                total += len(data)
-                digest.update(b"file\0" + hashlib.sha256(data).digest())
-            else:
-                raise Rejected("special-file")
-    if not root.is_dir() or count == 0:
+    records = {}
+
+    def walk(fd, relative, output, depth=0):
+        nonlocal total, count
+        trusted(os.fstat(fd))
+        if depth > 64:
+            raise Rejected("depth-budget-exceeded")
+        with os.scandir(fd) as entries:
+            for entry in entries:
+                count += 1
+                if count > max_entries:
+                    raise Rejected("entry-budget-exceeded")
+                name = entry.name
+                lower = name.lower()
+                if (lower in {".git", ".ssh", ".aws", ".npmrc", ".netrc", ".pypirc", "credentials.json"}
+                        or lower.startswith(".env") or lower.endswith((".pem", ".key", ".p12", ".pfx"))):
+                    raise Rejected("credential-bearing-path")
+                rel = relative / name
+                info = entry.stat(follow_symlinks=False)
+                if stat.S_ISLNK(info.st_mode):
+                    target = os.readlink(name, dir_fd=fd)
+                    if os.path.isabs(target) or not (root / rel).resolve(strict=True).is_relative_to(root):
+                        raise Rejected("escaping-dependency-link")
+                    records[str(rel)] = b"link\0" + target.encode()
+                    if output is not None:
+                        os.symlink(target, output / name)
+                elif stat.S_ISDIR(info.st_mode):
+                    child = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd)
+                    try:
+                        target_dir = output / name if output is not None else None
+                        if target_dir is not None:
+                            target_dir.mkdir(mode=0o755)
+                        records[str(rel)] = b"dir\0"
+                        walk(child, rel, target_dir, depth + 1)
+                    finally:
+                        os.close(child)
+                elif stat.S_ISREG(info.st_mode):
+                    source_fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=fd)
+                    with os.fdopen(source_fd, "rb") as source:
+                        before = os.fstat(source_fd)
+                        trusted(before)
+                        if not stat.S_ISREG(before.st_mode) or before.st_size > max_bytes - total:
+                            raise Rejected("byte-budget-exceeded")
+                        data = source.read(max_bytes - total + 1)
+                        total += len(data)
+                        after = os.fstat(source_fd)
+                        if total > max_bytes or (before.st_size, before.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
+                            raise Rejected("changed-or-oversized-source")
+                    records[str(rel)] = b"file\0" + hashlib.sha256(data).digest()
+                    if output is not None:
+                        with (output / name).open("xb") as destination:
+                            destination.write(data)
+                        (output / name).chmod(before.st_mode & 0o755)
+                else:
+                    raise Rejected("special-file")
+
+    with open_directory(root) as fd:
+        walk(fd, Path(), copy_to)
+    if count == 0:
         raise Rejected("missing-dependencies")
+    digest = hashlib.sha256()
+    for name, value in sorted(records.items()):
+        digest.update(name.encode() + b"\0" + value)
     return f"{digest.hexdigest()} {total} {count}"
 
 
@@ -142,6 +201,7 @@ def main():
     parser.add_argument("worktree")
     parser.add_argument("relative")
     parser.add_argument("--snapshot", help="Validate a private staged copy instead of the source")
+    parser.add_argument("--copy-to", help="Copy with enforced byte/entry limits into an empty private staging directory")
     parser.add_argument("--max-bytes", type=int, default=64 * 1024 * 1024)
     parser.add_argument("--max-entries", type=int, default=20000)
     args = parser.parse_args()
@@ -152,11 +212,17 @@ def main():
         root = contained_path(args.snapshot) if args.snapshot else modules
         if args.snapshot and not root.is_relative_to(contained_path(args.worktree)):
             raise Rejected("foreign-staging-directory")
-        print(snapshot(root, args.max_bytes, args.max_entries))
+        output = contained_path(args.copy_to) if args.copy_to else None
+        if output is not None:
+            if (not output.is_relative_to(contained_path(args.worktree))
+                    or output.stat().st_mode & 0o077 or any(output.iterdir())):
+                raise Rejected("invalid-private-staging")
+            trusted(output.stat())
+        print(snapshot(root, args.max_bytes, args.max_entries, output))
         return 0
-    except (OSError, ValueError, subprocess.SubprocessError):
+    except (OSError, ValueError, RuntimeError, subprocess.SubprocessError):
         # Never copy raw paths, package contents or subprocess stderr into logs.
-        print("dependency-provision-rejected", file=__import__("sys").stderr)
+        print("dependency-provision-rejected", file=sys.stderr)
         return 1
 
 

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -410,11 +410,7 @@ _provision_worktree_node_modules() (
 	[[ "$(check_worktree_owner_snapshot "$wt_path")" == "$owner" ]] || return 1
 	worktree_has_exact_owner_contract "$wt_path" "$$" "$owner_session" "$owner_task" || return 1
 	[[ ! -e "$destination" && ! -L "$destination" ]] || return 1
-	mv -T "${stage}/node_modules" "$destination" 2>/dev/null || {
-		# BSD mv has no -T; the destination must still be absent.
-		[[ ! -e "$destination" && ! -L "$destination" ]] || return 1
-		mv "${stage}/node_modules" "$destination" || return 1
-	}
+	python3 "$validator" "$repo_root" "$wt_path" "$relative" --publish "${stage}/node_modules" --max-bytes "$max_bytes" >/dev/null || return 1
 	printf 'Dependency snapshot provisioned (sha256 bytes entries): %s\n' "$after"
 	return 0
 )

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -377,6 +377,48 @@ _restore_worktree_node_modules_release_lock() {
 	return 0
 }
 
+# Controller-only copy into a newly owned worktree. No resume or permission
+# mutation: a continuation owned by another process (even dead) is left intact.
+_provision_worktree_node_modules() (
+	local wt_path="$1"
+	local repo_root="$2"
+	local relative="${3:-.}"
+	local owner="" validator="" before="" after="" stage=""
+	local owner_pid="" owner_session="" owner_batch="" owner_task="" owner_created="" owner_start=""
+	local destination="${wt_path}/${relative}/node_modules"
+	local max_bytes="${WORKTREE_NODE_MODULES_RESTORE_MAX_BYTES:-67108864}"
+	# aidevops:trust-boundary -- only the registered current controller may write;
+	# a live/foreign/continuation owner requires the existing ownership handoff.
+	declare -F check_worktree_owner_snapshot >/dev/null 2>&1 || return 1
+	declare -F worktree_has_exact_owner_contract >/dev/null 2>&1 || return 1
+	owner=$(check_worktree_owner_snapshot "$wt_path") || return 1
+	IFS='|' read -r owner_pid owner_session owner_batch owner_task owner_created owner_start <<<"$owner"
+	[[ "$owner_pid" == "$$" && -n "$owner_start" && -n "$owner_created" ]] || return 1
+	worktree_has_exact_owner_contract "$wt_path" "$$" "$owner_session" "$owner_task" || return 1
+	[[ ! -e "$destination" && ! -L "$destination" ]] || return 1
+	validator="$(dirname "${BASH_SOURCE[0]}")/worktree-dependency-provision.py"
+	before=$(python3 "$validator" "$repo_root" "$wt_path" "$relative" --max-bytes "$max_bytes") || return 1
+	stage=$(mktemp -d "${wt_path}/.aidevops-deps-XXXXXXXX") || return 1
+	trap 'rm -rf -- "$stage"' EXIT
+	mkdir -m 700 "${stage}/node_modules" || return 1
+	# Keep the existing restore lifecycle/locks, but enforce limits during copying:
+	# whole-directory fast_cp can exceed the budget if the source changes mid-copy.
+	after=$(python3 "$validator" "$repo_root" "$wt_path" "$relative" --copy-to "${stage}/node_modules" --max-bytes "$max_bytes") || return 1
+	[[ "$before" == "$after" ]] || return 1
+	after=$(python3 "$validator" "$repo_root" "$wt_path" "$relative" --snapshot "${stage}/node_modules" --max-bytes "$max_bytes") || return 1
+	[[ "$before" == "$after" ]] || return 1
+	[[ "$(check_worktree_owner_snapshot "$wt_path")" == "$owner" ]] || return 1
+	worktree_has_exact_owner_contract "$wt_path" "$$" "$owner_session" "$owner_task" || return 1
+	[[ ! -e "$destination" && ! -L "$destination" ]] || return 1
+	mv -T "${stage}/node_modules" "$destination" 2>/dev/null || {
+		# BSD mv has no -T; the destination must still be absent.
+		[[ ! -e "$destination" && ! -L "$destination" ]] || return 1
+		mv "${stage}/node_modules" "$destination" || return 1
+	}
+	printf 'Dependency snapshot provisioned (sha256 bytes entries): %s\n' "$after"
+	return 0
+)
+
 _restore_worktree_node_modules() {
 	local wt_path="$1"
 	local repo_root="$2"
@@ -405,10 +447,9 @@ _restore_worktree_node_modules() {
 		local _src="${repo_root}${_rel}/node_modules"
 		local _dst="${wt_path}${_rel}/node_modules"
 		if [[ -d "$_src" && ! -d "$_dst" ]]; then
-			# t2889: fast_cp uses APFS clonefile / btrfs reflink CoW where
-			# available — sub-second copy on macOS, near-zero disk delta.
-			fast_cp "$_src" "$_dst" 2>/dev/null || true
-			_restored=$((_restored + 1))
+			if _provision_worktree_node_modules "$wt_path" "$repo_root" "${_rel#/}"; then
+				_restored=$((_restored + 1))
+			fi
 		fi
 	done < <(find "$wt_path" -maxdepth 3 -name "package.json" -not -path "*/node_modules/*" 2>/dev/null)
 	_restore_worktree_node_modules_release_lock "$_lock_dir"


### PR DESCRIPTION
## Summary

- Provision supported npm/pnpm dependency sources inside the registered controller-owned worktree before worker launch, capped at 64 MiB and 20,000 entries per snapshot. Explicit root-disable remains respected.
- Verify canonical repository, package/lock/installed inventory, current owner process generation, trusted directory modes and link containment. Use bounded no-follow copying and atomic no-replace promotion.
- Add dependency-read remediation to the existing deduplicated permission dossier without modifying signed requests, permission labels, grants, dispatch gates or checkpoints.

## Files Changed

- `.agents/scripts/worktree-dependency-provision.py`
- `.agents/scripts/_worktree_dependency_identity.py`
- `.agents/scripts/_worktree_dependency_snapshot.py`
- `.agents/scripts/worktree-helper-add.sh`
- `.agents/scripts/pulse-dispatch-worker-launch.sh`
- `.agents/scripts/worker-permission-helper.sh`
- `.agents/scripts/tests/test-worktree-dependency-provision.py`
- `.agents/scripts/tests/test-worker-permission-helper.sh`
- `.agents/reference/dispatch-blockers.md`

Reference patterns: existing restore lifecycle/ownership registry and request-specific permission dossier. Canonical issue scope was corrected before adding the shared helper and exact fixture path.

## Runtime Testing

- **Risk level:** high
- **Verification:** runtime-verified — fixture-only repositories and fake permission/GitHub envelopes; no live grants or installs.
- `python3 .agents/scripts/tests/test-worktree-dependency-provision.py -v`: 25 tests passed, including npm/pnpm manifest-less payload subcases, bounded reads/copy, explicit root disable, stale/missing identity, containment, foreign/recycled owner, preserved checkpoint, repeat deduplication and no-replace promotion.
- `bash .agents/scripts/tests/test-worker-permission-helper.sh`: passed; broad external bash does not receive dependency recovery treatment, and unchanged request evidence does not create another comment.
- `node .agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs`: 10 passed.
- Existing `test-pulse-dispatch-worker-launch-lock.sh`, `test-worktree-js-dependency-bootstrap.sh`, `test-pulse-dispatch-permission-gate.sh`, `test-dispatch-dedup-maintainer-permission-block.sh`, `test-precreation-failure-skip.sh` (48 checks), and `test-dispatch-single-issue-helper.sh`: passed.
- ShellCheck on all changed shell files, Ruff on all four Python files (also enforcing C901 max complexity 8), `git diff --check`, pre-commit gates, and pre-push `bun run typecheck`: passed.
- Local Qlty 0.636.0 reports zero smells across all four Python files after decomposing identity and snapshot logic. This repairs the terminal new-file/regression/threshold failures reported on 2fbec0e47; CI uses pinned Qlty 0.643.0.
- Terminal CodeFactor/Codacy feedback: resolved executable paths replace partial executable names, complex functions are decomposed, and fixed-argv offline fixture subprocess false positives are narrowly documented using the established repository audit-annotation pattern. No scanner configuration or gate is relaxed.
- Runtime versions: Python 3.12.3, Node 22.23.1, Git 2.43.0, ShellCheck 0.9.0.

## Security review and decisions

Independent read-only security review identified unbounded copy-on-source-change, PID-generation, source trust, installed-inventory, output-path and malformed-JSON issues. The implementation repairs those findings; regressions cover inventory omissions including manifest-less, scoped-looking and hidden root files. Output creation uses pinned descriptors; promotion requires Linux renameat2 or macOS renameatx_np and fails closed elsewhere. Linux fixture behavior is verified; macOS syscall behavior was source-reviewed, not executed here.

The restore controller/locks are reused, but whole-directory fast_cp is deliberately replaced: preflight size cannot bound a concurrently changing copy. Supported trees need complete installed inventories; partial/platform-filtered installations, unsupported pnpm v9 serialization, and Bun/Yarn-only trees skip safely.

Existing stale-lock age-only reclamation in `pulse-dispatch-worker-launch.sh` predates this PR and is not changed. Its separate concurrency concern was reported during review; byte limits are enforced independently during copying rather than relying on that lock.

The current signed permission-history contract has no unsigned supersession path. Already-paused work remains held and routed through its existing AI coordinator/request dossier; provisioning is not permission to retry a denied tool, clear a hold or start a replacement worker. No permission/ownership boundary is widened, no packages are installed, and no publication is authorized.

Resolves #31372

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.321 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-6-astra spent 56m and 458,125 tokens on this as a headless worker.