### PR TITLE
GH#31369: Add opt-in Astra 240K compaction budget

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -28,6 +28,7 @@ import {
   registerManagedDirectoryPermissions,
 } from "./config-safety-guards.mjs";
 import {
+  ASTRA_COMPACTION_BUDGET_TARGET,
   ASTRA_COMPACTION_TARGET,
   ASTRA_OUTPUT_DEFAULT,
   CLAUDE_MODEL_LIMITS,
@@ -160,14 +161,18 @@ export function gpt56ContextCapEnabled() {
 }
 
 function contextCapEnabled(key) {
+  return readContextSettings()?.[key] !== false;
+}
+
+function readContextSettings() {
   const settingsPath = process.env.AIDEVOPS_SETTINGS_FILE ||
     join(homedir(), ".config", "aidevops", "settings.json");
   try {
-    if (!existsSync(settingsPath)) return true;
+    if (!existsSync(settingsPath)) return {};
     const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
-    return settings?.runtime?.opencode?.[key] !== false;
+    return settings?.runtime?.opencode ?? {};
   } catch {
-    return true;
+    return {};
   }
 }
 
@@ -199,9 +204,22 @@ export function registerGpt56ContextLimits(config) {
   return GPT56_MODEL_IDS.length;
 }
 
-/** Keep Astra at ~400K usable input without changing other models or global reserve. */
+// Receipts describe the settings actually consumed, not a later settings read.
+const astraContextHealth = new WeakMap();
+
+export function getAstraContextHealth(config) {
+  return astraContextHealth.get(config) ?? null;
+}
+
+/** Keep Astra at the selected usable input target without changing global reserve. */
 export function registerAstraContextLimits(config) {
-  if (!contextCapEnabled("astra_context_cap")) return 0;
+  const settings = readContextSettings();
+  const target = settings.astra_compaction_target === ASTRA_COMPACTION_BUDGET_TARGET
+    ? ASTRA_COMPACTION_BUDGET_TARGET : ASTRA_COMPACTION_TARGET;
+  const managed = settings.astra_context_cap !== false;
+  const health = { managed, target, auto: config.compaction?.auto !== false };
+  astraContextHealth.set(config, health);
+  if (!managed) return 0;
   config.provider ??= {};
   config.provider.openai ??= {};
   config.provider.openai.models ??= {};
@@ -209,11 +227,12 @@ export function registerAstraContextLimits(config) {
   const existing = models["gpt-6-astra"] || {};
   const output = existing.limit?.output ?? ASTRA_OUTPUT_DEFAULT;
   const reserve = config.compaction?.reserved ?? Math.min(20000, output);
-  const input = ASTRA_COMPACTION_TARGET + reserve;
+  const input = target + reserve;
   models["gpt-6-astra"] = {
     ...existing,
     limit: { ...existing.limit, context: input + output, input, output },
   };
+  Object.assign(health, { reserve, limits: { ...models["gpt-6-astra"].limit } });
   return 1;
 }
 

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -30,7 +30,7 @@ import { fileURLToPath } from "url";
 import { execSync } from "child_process";
 
 // Extracted modules
-import { createConfigHook } from "./config-hook.mjs";
+import { createConfigHook, getAstraContextHealth } from "./config-hook.mjs";
 import { adaptToolDefinition } from "./tool-definition.mjs";
 import { createMcpSessionRuntime, getOnDemandMcpAgents } from "./mcp-registry.mjs";
 import { enforceManagedMcpArtifactPath } from "./mcp-activation-tool.mjs";
@@ -352,6 +352,7 @@ export async function AidevopsPlugin({ directory, client }) {
         const result = await configHook(config);
         recordPluginHealthStage("config_applied", {
           gpt56_limits: config.provider?.openai?.models?.["gpt-5.6-sol"]?.limit || null,
+          astra_context: getAstraContextHealth(config),
           terminal_title_status: true,
         });
         return result;
@@ -601,6 +602,7 @@ export async function AidevopsPlugin({ directory, client }) {
       applyBoundedOperationPermission(config);
       recordPluginHealthStage("config_applied", {
         gpt56_limits: config.provider?.openai?.models?.["gpt-5.6-sol"]?.limit || null,
+        astra_context: getAstraContextHealth(config),
         terminal_title_status: true,
       });
       return result;

--- a/.agents/plugins/opencode-aidevops/model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/model-limits.mjs
@@ -43,6 +43,7 @@ export const GPT56_OUTPUT_DEFAULT = 128000;
 
 /** Managed Astra compaction target, not a claim about provider capacity. */
 export const ASTRA_COMPACTION_TARGET = 400000;
+export const ASTRA_COMPACTION_BUDGET_TARGET = 240000;
 export const ASTRA_OUTPUT_DEFAULT = 128000;
 
 /** GPT-5.6 model IDs currently exposed by the OpenAI provider. */

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
+  getAstraContextHealth,
   gpt56ContextCapEnabled,
   registerAstraContextLimits,
   registerGpt56ContextLimits,
@@ -108,4 +109,52 @@ test("Astra opt-out leaves metadata untouched", () => {
   const config = {};
   assert.equal(registerAstraContextLimits(config), 0);
   assert.deepEqual(config, {});
+});
+
+test("Astra lower budget honours reserves/output and preserves all other models", () => {
+  settingsFile({ runtime: { opencode: { astra_compaction_target: 240000 } } });
+  for (const reserved of [undefined, 0, 35000]) {
+    for (const output of [128000, 4000]) {
+      const config = { compaction: { reserved }, provider: { openai: { models: {
+        "gpt-6-astra": { name: "custom", limit: { context: 1000000, output } },
+        "gpt-5.6-sol": { name: "Sol" }, "unrelated": { limit: { input: 123 } },
+      } } } };
+      registerGpt56ContextLimits(config);
+      const before = structuredClone(config);
+      registerAstraContextLimits(config);
+      const reserve = reserved ?? Math.min(20000, output);
+      const limits = config.provider.openai.models["gpt-6-astra"].limit;
+      assert.equal(limits.input - reserve, 240000);
+      assert.equal(limits.context, limits.input + output);
+      assert.equal(config.provider.openai.models["gpt-6-astra"].name, "custom");
+      assert.deepEqual(getAstraContextHealth(config), { managed: true, target: 240000, auto: true, reserve, limits });
+      delete before.provider.openai.models["gpt-6-astra"];
+      delete config.provider.openai.models["gpt-6-astra"];
+      assert.deepEqual(config, before);
+    }
+  }
+});
+
+test("Astra invalid selections fall back to 400K without changing GPT-5.6", () => {
+  for (const target of [undefined, null, "240000", 0, -1, 300000, {}, true]) {
+    settingsFile({ runtime: { opencode: { astra_compaction_target: target } } });
+    const config = {};
+    registerAstraContextLimits(config);
+    assert.equal(getAstraContextHealth(config).target, 400000);
+  }
+  const file = settingsFile({});
+  writeFileSync(file, "not-json");
+  const config = {};
+  registerAstraContextLimits(config);
+  assert.equal(getAstraContextHealth(config).target, 400000);
+});
+
+test("Astra opt-out overrides a saved low target; receipts reflect the consumed settings", () => {
+  const file = settingsFile({ runtime: { opencode: { astra_context_cap: false, astra_compaction_target: 240000 } } });
+  const config = { compaction: { auto: false } };
+  assert.equal(getAstraContextHealth(config), null);
+  assert.equal(registerAstraContextLimits(config), 0);
+  writeFileSync(file, "{}");
+  assert.deepEqual(config, { compaction: { auto: false } });
+  assert.deepEqual(getAstraContextHealth(config), { managed: false, target: 240000, auto: false });
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-plugin-health.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-plugin-health.mjs
@@ -79,6 +79,7 @@ test("probe-only plugin factory registers config and terminal-title health", () 
       env: {
         ...process.env,
         AIDEVOPS_TEMP_DIR: root,
+        AIDEVOPS_SETTINGS_FILE: join(root, "absent-settings.json"),
         AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE: receipt,
         AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE: nonce,
         AIDEVOPS_PLUGIN_HEALTH_PROBE_ONLY: "1",
@@ -93,6 +94,10 @@ test("probe-only plugin factory registers config and terminal-title health", () 
     output: 128000,
     context: 300000,
     input: 260000,
+  });
+  assert.deepEqual(result.details.config_applied.astra_context, {
+    managed: true, target: 400000, auto: true, reserve: 20000,
+    limits: { context: 548000, input: 420000, output: 128000 },
   });
   rmSync(root, { recursive: true, force: true });
 });

--- a/.agents/reference/context-efficiency.md
+++ b/.agents/reference/context-efficiency.md
@@ -33,14 +33,25 @@ when their trigger applies; never remove them merely to meet a token target.
 
 ## Astra compaction
 
-`registerAstraContextLimits` targets 400,000 usable input tokens. With OpenCode's
-default 20,000-token reserve it advertises input 420,000; the managed context
-budget also accommodates output. An explicit `compaction.reserved` is honoured
-without changing the global setting. GPT-5.6 retains its separate ~240K target.
-These are operational budgets, not statements about provider maximum capacity.
+`registerAstraContextLimits` defaults to 400,000 usable input tokens. To opt into
+a lower budget, run `aidevops astra-context enable`: it persists a 240,000 target
+and enables the managed Astra cap. `aidevops astra-context disable` restores the
+400,000 target, preserving an existing native-metadata opt-out. `status` reports
+the selection and nonce-bound fresh-process plugin/config evidence; unavailable,
+old or failed probes are not reported as applied. If automatic compaction is
+disabled in OpenCode, status reports that separately.
+
+With OpenCode's default 20,000-token reserve, 240K advertises input 260,000;
+400K advertises input 420,000. Managed context also accommodates output.
+An explicit `compaction.reserved` (including zero) is honoured without changing
+the global setting. GPT-5.6 retains its separate ~240K target. These are operational
+budgets, not provider capacity claims or measured subscription savings. Earlier
+compaction may add summary overhead and lose information; judge total outcomes.
 
 Set `runtime.opencode.astra_context_cap` to `false` in aidevops settings to leave
-Astra metadata untouched. Restart OpenCode after deploying config-time changes.
+Astra metadata untouched; `enable` explicitly clears that opt-out. The target is
+stored separately as `runtime.opencode.astra_compaction_target` and survives normal
+updates. Restart OpenCode after changing the selection or deploying plugin changes.
 The running process retains its original loaded plugin/config. Custom upstream
 output-token ceilings can affect the default reserve; an explicit reserve makes
 the arithmetic unambiguous. Compaction can occur slightly beyond the target due

--- a/.agents/reference/settings.md
+++ b/.agents/reference/settings.md
@@ -64,6 +64,21 @@
 | `model_routing.budget_tracking_enabled` | boolean | `true` | -- | Track per-provider API spend. |
 | `model_routing.prefer_subscription` | boolean | `true` | -- | Prefer subscription over API billing when both available. |
 
+### runtime.opencode
+
+| Key | Type | Default | Env Var | Description |
+|-----|------|---------|---------|-------------|
+| `runtime.opencode.astra_context_cap` | boolean | `true` | -- | Manage Astra limits; `false` leaves provider/user metadata untouched. |
+| `runtime.opencode.astra_compaction_target` | number | `400000` | -- | Usable input target: `240000` opts into lower-budget compaction; other values fall back to `400000`. |
+
+Use `aidevops astra-context enable` to select 240K and enable the managed cap.
+`disable` restores the 400K target without clearing an existing native-metadata
+opt-out. `status` distinguishes the saved selection from fresh-process config
+evidence. Restart OpenCode after changes. These are file-only preferences, read
+at startup and retained by normal updates; no environment override is defined.
+The CLI/plugin support `AIDEVOPS_SETTINGS_FILE` for isolated probes and tests.
+Earlier compaction is not a guarantee of subscription savings.
+
 ### onboarding
 
 Tracks onboarding state. Written by `/onboarding`, readable by scripts.

--- a/.agents/scripts/astra-context-helper.sh
+++ b/.agents/scripts/astra-context-helper.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+SETTINGS_FILE="${AIDEVOPS_SETTINGS_FILE:-${HOME}/.config/aidevops/settings.json}"
+OPENCODE_BIN="${OPENCODE_BIN:-opencode}"
+PLUGIN_ENTRY="${AIDEVOPS_PLUGIN_ENTRY:-${HOME}/.aidevops/agents/plugins/opencode-aidevops/index.mjs}"
+
+usage() {
+	cat <<'EOF'
+Usage: aidevops astra-context [enable|disable|status]
+
+  enable   Select ~240,000 input tokens before compaction; enable the Astra cap.
+  disable  Restore the 400,000 target, preserving any native-metadata opt-out.
+  status   Show the selected target and a fresh-process effective-config probe.
+
+The default remains 400,000. GPT-5.6 and other models are unchanged.
+The existing runtime.opencode.astra_context_cap=false opt-out leaves metadata
+untouched; enable explicitly clears it. Preferences survive normal updates.
+Restart OpenCode after changes. A probe cannot update an already running session.
+Earlier compaction is a budget control, not guaranteed subscription savings.
+EOF
+	return 0
+}
+
+requested_state() {
+	local settings='{}'
+	if [[ -f "$SETTINGS_FILE" ]]; then
+		settings=$(jq -sc 'if length == 1 then .[0] else {} end' "$SETTINGS_FILE" 2>/dev/null) || settings='{}'
+	fi
+	jq -r '(try (.runtime.opencode // {}) catch {}) |
+		if type != "object" then {} else . end |
+		[(if .astra_compaction_target == 240000 then 240000 else 400000 end),
+		 (.astra_context_cap != false)] | @tsv' <<<"$settings"
+	return 0
+}
+
+report_probe() {
+	local receipt="$1" nonce="$2" target="$3" managed="$4"
+	if ! jq -e --arg nonce "$nonce" --argjson target "$target" --argjson managed "$managed" '
+		.schema == "aidevops.opencode-plugin-health/v1" and .nonce == $nonce and
+		(["imported","factory_initialized","config_applied"] - .stages | length == 0) and
+		(.details.config_applied.astra_context | .target == $target and .managed == $managed and
+		 (.auto | type == "boolean") and
+		 (if .managed then (.limits.input - .reserve == .target and
+		  .limits.context == .limits.input + .limits.output) else true end))' "$receipt" >/dev/null 2>&1; then
+		printf '%s\n' 'Effective Astra state: unavailable (missing, stale, or mismatched config evidence)'
+		return 0
+	fi
+	if [[ "$managed" == false ]]; then
+		printf '%s\n' 'Effective Astra state: native metadata opt-out confirmed (no managed target applied)'
+		return 0
+	fi
+	jq -r '.details.config_applied.astra_context |
+		"Effective Astra limits (new process): context=\(.limits.context), input=\(.limits.input), output=\(.limits.output), reserve=\(.reserve)",
+		(if .auto then "Effective Astra compaction target: \(.target) (applied)"
+		 else "Automatic compaction is disabled; selected limits are applied but no automatic threshold is active" end)' "$receipt"
+	return 0
+}
+
+show_status() (
+	local target managed probe_dir nonce
+	read -r target managed < <(requested_state)
+	printf 'Astra selected compaction target: %s input tokens; managed cap: %s\n' "$target" "$managed"
+	printf '%s\n' 'Restart OpenCode after changes; this probe checks a new process, not existing sessions.'
+	if ! command -v "$OPENCODE_BIN" >/dev/null 2>&1; then
+		printf '%s\n' 'Effective Astra state: unavailable (OpenCode is not installed)'
+		return 0
+	fi
+	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	mkdir -p "$temp_root"
+	probe_dir=$(mktemp -d "${temp_root}/astra-context.XXXXXX") || return 1
+	trap 'rm -rf "$probe_dir"' EXIT
+	nonce="astra-$$-$(date -u '+%Y%m%d%H%M%S')"
+	jq -cn --arg nonce "$nonce" '{nonce:$nonce,stages:[],details:{}}' >"$probe_dir/receipt.json"
+	chmod 600 "$probe_dir/receipt.json"
+	if ! "$OPENCODE_BIN" debug config >"$probe_dir/config.json" 2>"$probe_dir/error.txt" ||
+		! grep -Fq "$PLUGIN_ENTRY" "$probe_dir/config.json" ||
+		[[ ! -f "$PLUGIN_ENTRY" || -L "$PLUGIN_ENTRY" ]]; then
+		printf '%s\n' 'Effective Astra state: unavailable (managed plugin not discovered)'
+		return 0
+	fi
+	if ! AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE="$probe_dir/receipt.json" \
+		AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE="$nonce" AIDEVOPS_PLUGIN_HEALTH_PROBE_ONLY=1 \
+		"$OPENCODE_BIN" models openai --verbose >"$probe_dir/models.txt" 2>"$probe_dir/error.txt"; then
+		printf '%s\n' 'Effective Astra state: unavailable (OpenCode probe failed)'
+		return 0
+	fi
+	report_probe "$probe_dir/receipt.json" "$nonce" "$target" "$managed"
+	return 0
+)
+
+set_target() (
+	local target="$1" settings_dir source_file temp_file
+	settings_dir="${SETTINGS_FILE%/*}"
+	[[ "$settings_dir" != "$SETTINGS_FILE" ]] || settings_dir='.'
+	if [[ -L "$SETTINGS_FILE" || (-e "$SETTINGS_FILE" && ! -f "$SETTINGS_FILE") ]]; then
+		printf '%s\n' 'Error: settings must be a regular, non-symlink file' >&2
+		return 1
+	fi
+	mkdir -p "$settings_dir"
+	temp_file=$(mktemp "${settings_dir}/settings.json.XXXXXX") || return 1
+	trap 'rm -f "$temp_file"' EXIT
+	source_file="$SETTINGS_FILE"
+	[[ -f "$source_file" ]] || source_file=/dev/null
+	if ! jq -s --argjson target "$target" --arg source "$source_file" '
+		(if length == 0 and $source == "/dev/null" then {} elif length == 1 then .[0] else error("expected one settings document") end) |
+		if type != "object" then error("settings must be an object") else . end |
+		.runtime = (.runtime // {}) | .runtime.opencode = (.runtime.opencode // {}) |
+		.runtime.opencode.astra_compaction_target = $target |
+		if $target == 240000 then .runtime.opencode.astra_context_cap = true else . end' \
+		"$source_file" >"$temp_file"; then
+		printf '%s\n' 'Error: settings were not changed' >&2
+		return 1
+	fi
+	chmod 600 "$temp_file"
+	mv "$temp_file" "$SETTINGS_FILE"
+	show_status
+	return 0
+)
+
+main() {
+	local action="${1:-status}"
+	case "$action" in
+	help | --help | -h)
+		usage
+		return 0
+		;;
+	esac
+	if ! command -v jq >/dev/null 2>&1; then
+		printf '%s\n' 'Error: jq is required' >&2
+		return 1
+	fi
+	case "$action" in
+	enable | on) set_target 240000 ;;
+	disable | off) set_target 400000 ;;
+	status) show_status ;;
+	*)
+		usage >&2
+		return 2
+		;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/settings-helper.sh
+++ b/.agents/scripts/settings-helper.sh
@@ -86,6 +86,12 @@ _generate_defaults() {
     "budget_tracking_enabled": true,
     "prefer_subscription": true
   },
+  "runtime": {
+    "opencode": {
+      "astra_context_cap": true,
+      "astra_compaction_target": 400000
+    }
+  },
   "onboarding": {
     "completed": false,
     "work_type": "",
@@ -192,7 +198,7 @@ cmd_get() {
 		local jq_path
 		jq_path=$(_jq_path "$key")
 		local value
-		value=$(jq -r "$jq_path // empty" "$SETTINGS_FILE" 2>/dev/null || echo "")
+		value=$(jq -r "$jq_path | if . == null then empty else . end" "$SETTINGS_FILE" 2>/dev/null || echo "")
 		if [[ -n "$value" ]]; then
 			echo "$value"
 			return 0
@@ -201,7 +207,7 @@ cmd_get() {
 
 	# Precedence 3: Built-in default
 	local default_value
-	default_value=$(_generate_defaults | jq -r "$(_jq_path "$key") // empty" 2>/dev/null || echo "")
+	default_value=$(_generate_defaults | jq -r "$(_jq_path "$key") | if . == null then empty else . end" 2>/dev/null || echo "")
 	if [[ -n "$default_value" ]]; then
 		echo "$default_value"
 		return 0
@@ -238,7 +244,7 @@ cmd_set() {
 
 	# Validate the key exists in defaults (use getpath with key as data, not code)
 	local default_check
-	default_check=$(_generate_defaults | jq -r --arg k "$key" 'getpath($k | split(".")) // "__MISSING__"' 2>/dev/null || echo "__MISSING__")
+	default_check=$(_generate_defaults | jq -r --arg k "$key" 'getpath($k | split(".")) | if . == null then "__MISSING__" else . end' 2>/dev/null || echo "__MISSING__")
 	if [[ "$default_check" == "__MISSING__" ]]; then
 		print_error "Unknown setting: $key"
 		print_info "Run 'settings-helper.sh list' to see available settings"

--- a/.agents/scripts/tests/test-astra-context-helper.sh
+++ b/.agents/scripts/tests/test-astra-context-helper.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../shared-constants.sh
+source "${SCRIPT_DIR}/../shared-constants.sh"
+HELPER="${SCRIPT_DIR}/../astra-context-helper.sh"
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+export HOME="$TEST_HOME"
+export AIDEVOPS_TEMP_DIR="$TEST_HOME/tmp"
+export AIDEVOPS_SETTINGS_FILE="$HOME/.config/aidevops/settings.json"
+export AIDEVOPS_PLUGIN_ENTRY="$TEST_HOME/plugin.mjs"
+export TEST_CONFIG_HOOK="${SCRIPT_DIR}/../../plugins/opencode-aidevops/config-hook.mjs"
+export OPENCODE_BIN="$TEST_HOME/opencode"
+touch "$AIDEVOPS_PLUGIN_ENTRY"
+cat >"$OPENCODE_BIN" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == debug ]]; then
+  printf '{"plugin":["file://%s"]}\n' "$AIDEVOPS_PLUGIN_ENTRY"
+  exit 0
+fi
+[[ "$1 $2 $3" == 'models openai --verbose' ]]
+[[ "${PROBE_MODE:-}" != failed ]] || exit 1
+node --input-type=module <<'JS'
+import { writeFileSync } from 'node:fs';
+const { registerAstraContextLimits, getAstraContextHealth } = await import(process.env.TEST_CONFIG_HOOK);
+const config = {compaction: {reserved: 35000, auto: process.env.PROBE_MODE !== 'auto-off'}};
+registerAstraContextLimits(config);
+const receipt = {schema: 'aidevops.opencode-plugin-health/v1',
+  nonce: process.env.AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE,
+  stages: ['imported', 'factory_initialized', 'config_applied'],
+  details: {config_applied: {astra_context: getAstraContextHealth(config)}}};
+if (process.env.PROBE_MODE === 'old') delete receipt.details.config_applied.astra_context;
+if (process.env.PROBE_MODE === 'stale') receipt.nonce = 'wrong-nonce';
+if (process.env.PROBE_MODE === 'mismatch') receipt.details.config_applied.astra_context.target = 1;
+writeFileSync(process.env.AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE, JSON.stringify(receipt));
+JS
+MOCK
+chmod +x "$OPENCODE_BIN"
+
+assert_contains() {
+	local output="$1" expected="$2"
+	if [[ "$output" != *"$expected"* ]]; then
+		printf 'Expected: %s\nActual: %s\n' "$expected" "$output" >&2
+		return 1
+	fi
+	return 0
+}
+
+output=$(bash "$HELPER" status)
+assert_contains "$output" 'target: 400000 (applied)'
+output=$(bash "$HELPER" enable)
+assert_contains "$output" 'target: 240000 (applied)'
+assert_contains "$output" 'input=275000, output=128000, reserve=35000'
+assert_contains "$output" 'Restart OpenCode'
+jq -e '.runtime.opencode | .astra_compaction_target == 240000 and .astra_context_cap == true' "$AIDEVOPS_SETTINGS_FILE" >/dev/null
+output=$(bash "$HELPER" status)
+assert_contains "$output" 'target: 240000 (applied)'
+
+# Normal settings initialization (including update-time init) never replaces preferences.
+bash "${SCRIPT_DIR}/../settings-helper.sh" init >/dev/null
+[[ "$(bash "${SCRIPT_DIR}/../settings-helper.sh" get runtime.opencode.astra_compaction_target)" == 240000 ]]
+bash "${SCRIPT_DIR}/../settings-helper.sh" set runtime.opencode.astra_context_cap false >/dev/null
+[[ "$(bash "${SCRIPT_DIR}/../settings-helper.sh" get runtime.opencode.astra_context_cap)" == false ]]
+output=$(bash "$HELPER" disable)
+assert_contains "$output" 'native metadata opt-out confirmed'
+jq -e '.runtime.opencode | .astra_compaction_target == 400000 and .astra_context_cap == false' "$AIDEVOPS_SETTINGS_FILE" >/dev/null
+output=$(bash "$HELPER" enable)
+assert_contains "$output" 'target: 240000 (applied)'
+output=$(bash "$HELPER" disable)
+assert_contains "$output" 'target: 400000 (applied)'
+
+for mode in old stale mismatch failed; do
+	output=$(PROBE_MODE="$mode" bash "$HELPER" status)
+	assert_contains "$output" 'Effective Astra state: unavailable'
+done
+output=$(PROBE_MODE=auto-off bash "$HELPER" status)
+assert_contains "$output" 'Automatic compaction is disabled'
+output=$(OPENCODE_BIN="$TEST_HOME/missing" bash "$HELPER" status)
+assert_contains "$output" 'OpenCode is not installed'
+
+printf '%s\n' '{"other":{"keep":42},"runtime":{"opencode":{"gpt56_context_cap":false}}}' >"$AIDEVOPS_SETTINGS_FILE"
+bash "$HELPER" enable >/dev/null
+jq -e '.other.keep == 42 and .runtime.opencode.gpt56_context_cap == false' "$AIDEVOPS_SETTINGS_FILE" >/dev/null
+for invalid in '' '{} {}' 'broken-json' '[]' '{"runtime":"invalid"}'; do
+	printf '%s\n' "$invalid" >"$AIDEVOPS_SETTINGS_FILE"
+	if bash "$HELPER" enable >/dev/null 2>&1; then
+		printf '%s\n' 'Invalid settings unexpectedly overwritten' >&2
+		exit 1
+	fi
+	[[ "$(<"$AIDEVOPS_SETTINGS_FILE")" == "$invalid" ]]
+	output=$(bash "$HELPER" status)
+	assert_contains "$output" 'selected compaction target: 400000'
+done
+if bash "$HELPER" unknown >/dev/null 2>&1; then exit 1; fi
+printf '%s\n' 'PASS: Astra CLI settings, config consumer, persistence, opt-out and health evidence'

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ the required notices and preferred credit text.
 - `aidevops auto-update` - Automatic update polling (enable/disable/status)
 - `aidevops runtime-bundle list` - List retained validated runtime bundles; use `rollback --bundle-id <id> --reason <text>` for an explicit audited rollback
 - `aidevops gpt56-context [enable|disable|status]` - Keep GPT-5.6 at a 300K advertised context window in OpenCode (enabled by default), so 80% auto-compaction runs near 240K before long-context pricing; `status` verifies plugin discovery, initialization, hook registration, and effective limits
+- `aidevops astra-context [enable|disable|status]` - Opt into ~240K usable-input Astra compaction; `disable` restores the default 400K target while preserving native-metadata opt-out. Settings survive updates; `status` probes fresh-process configuration. Restart OpenCode after changes; subscription savings are not guaranteed
 - `aidevops buzz [status|apply|rollback]` - Inspect or manage Buzz Desktop OpenCode ACP compatibility
 - `~/.aidevops/agents/scripts/team-interface-helper.sh [providers|detect|status|doctor|plan]` - Inspect registered collaboration providers, persist read-only observations, or emit deterministic dry-run plans; no provider-write command is exposed
 - `aidevops opencode conversation --overlay FILE --dir PATH` - Launch fixed-argv OpenCode ACP with a schema-validated ephemeral team-interface overlay and a final read-only capability guard; see `.agents/reference/team-interface-opencode-overlays.md`

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1121,6 +1121,7 @@ _help_commands() {
 	echo "  cleanup <cmd>      Cleanup helpers (remote branch audit/delete)"
 	echo "  model-accounts-pool OAuth account pool (list/check/diagnose/add/rotate/reset-cooldowns)"
 	echo "  gpt56-context <cmd> Manage the 300K GPT-5.6 OpenCode context cap (enable/disable/status)"
+	echo "  astra-context <cmd> Opt into ~240K Astra compaction (enable/disable/status; default 400K)"
 	echo "  client-format      Client request format alignment (extract/check/canary/monitor)"
 	echo "  opencode-db <cmd>  OpenCode SQLite maintenance/session lookup (check/report/sessions/maintain/window/status/install)"
 	echo "  opencode [agent] [args]    Launch OpenCode with Build+ and per-session DB isolation"
@@ -1949,6 +1950,7 @@ main() {
 	ip-check | ip_check) _dispatch_helper "ip-reputation-helper.sh" "ip-reputation-helper.sh" "$@" ;;
 	model-accounts-pool | map) _dispatch_helper "oauth-pool-helper.sh" "oauth-pool-helper.sh" "$@" ;;
 	gpt56-context | gpt56_context) _dispatch_helper "gpt56-context-helper.sh" "gpt56-context-helper.sh" "$@" ;;
+	astra-context | astra_context) _dispatch_helper "astra-context-helper.sh" "astra-context-helper.sh" "$@" ;;
 	cleanup)
 		local _cleanup_sub="${1:-help}"
 		case "$_cleanup_sub" in


### PR DESCRIPTION
## Summary

Add astra-context enable/disable/status with durable settings, reserve-aware Astra target selection, nonce-bound effective-config health evidence, and documentation. Preserve default 400K, native-metadata opt-out, GPT-5.6 and other models.

## Files Changed

.agents/plugins/opencode-aidevops/config-hook.mjs, .agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/model-limits.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs, .agents/plugins/opencode-aidevops/tests/test-plugin-health.mjs, .agents/reference/context-efficiency.md, .agents/reference/settings.md, .agents/scripts/astra-context-helper.sh, .agents/scripts/settings-helper.sh, .agents/scripts/tests/test-astra-context-helper.sh, README.md, aidevops.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: OpenCode 1.18.29 isolated real CLI enable/status/disable passed at reserve 35000 with no inference requests. 13 Node context/health tests, Astra and GPT-5.6 shell suites, ShellCheck and linters-local.sh --changed passed. Direct closeout bundle 16676de1b20bf8f963f6bb43c81988a9ca1f550ba45805ba201c80323ca92cf0 clean; standard-tier advisory found no defects.

Resolves #31369


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.321 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 26m and 229,627 tokens on this with the user in an interactive session.