### PR TITLE
GH#31383: admit unchanged dispatch targets from lagging mirrors

### DIFF
--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -344,14 +344,45 @@ _large_file_gate_remote_default_line_count() {
 }
 
 #######################################
-# Verify that a local repository is currently at the remote default-branch
-# commit. Large-file measurements are unsafe when this check fails because a
-# just-merged split may not exist in the runner's canonical checkout yet.
-# Arguments: repo_path
-# Returns: 0 when exact, 1 when stale or unverifiable
+# Prove that measurements from a lagging mirror use the exact target bytes
+# from the pinned remote commit. This reads existing objects only: it neither
+# fetches per candidate nor modifies a checkout to recover dispatch capacity.
+#######################################
+_large_file_gate_targets_match_remote_default() {
+	local repo_path="$1"
+	local remote_sha="$2"
+	local targets="$3"
+	local target="" full_path="" relative_path="" entry=""
+	local mode="" object_type="" object_sha="" entry_path="" working_sha=""
+	[[ -n "$targets" ]] || return 1
+	git -C "$repo_path" cat-file -e "${remote_sha}^{commit}" 2>/dev/null || return 1
+	while IFS= read -r target; do
+		[[ -n "$target" ]] || continue
+		if [[ "$target" =~ ^(.+):([0-9]+(-[0-9]+)?)$ ]]; then
+			target="${BASH_REMATCH[1]}"
+		fi
+		full_path=$(_large_file_gate_resolve_full_path "$target" "$repo_path") || return 1
+		relative_path="${full_path#"${repo_path}/"}"
+		entry=$(git -C "$repo_path" --literal-pathspecs ls-tree "$remote_sha" -- "$relative_path" 2>/dev/null) || return 1
+		[[ -n "$entry" && "$entry" != *$'\n'* ]] || return 1
+		read -r mode object_type object_sha entry_path <<<"$entry"
+		[[ "$mode" == "100644" || "$mode" == "100755" ]] || return 1
+		[[ "$object_type" == "blob" && -n "$object_sha" ]] || return 1
+		working_sha=$(git -C "$repo_path" hash-object --no-filters -- "$full_path" 2>/dev/null) || return 1
+		[[ "$working_sha" == "$object_sha" ]] || return 1
+	done <<<"$targets"
+	return 0
+}
+
+#######################################
+# Verify the remote default commit or, for a lagging mirror, every target's
+# exact bytes. Unrelated merged files must not strand otherwise eligible work.
+# Arguments: repo_path, optional newline-separated targets
+# Returns: 0 when measurements are current, 1 when stale or unverifiable
 #######################################
 _large_file_gate_repo_matches_remote_default() {
 	local repo_path="$1"
+	local targets="${2:-}"
 	local default_branch=""
 	local current_branch=""
 	local local_sha=""
@@ -368,7 +399,9 @@ _large_file_gate_repo_matches_remote_default() {
 	remote_line=$(git -C "$repo_path" ls-remote --heads origin "refs/heads/${default_branch}" 2>/dev/null) || return 1
 	[[ -n "$remote_line" && "$remote_line" != *$'\n'* ]] || return 1
 	remote_sha="${remote_line%%[[:space:]]*}"
-	[[ "$remote_sha" =~ ^[0-9a-fA-F]{40}$ && "$local_sha" == "$remote_sha" ]]
+	[[ "$remote_sha" =~ ^[0-9a-fA-F]{40}$ ]] || return 1
+	[[ "$local_sha" == "$remote_sha" ]] && return 0
+	_large_file_gate_targets_match_remote_default "$repo_path" "$remote_sha" "$targets"
 	return $?
 }
 
@@ -1125,11 +1158,11 @@ _issue_targets_large_files() {
 
 	# `_pulse_refresh_repo` is best-effort and canonical recovery may be delayed
 	# or unavailable on a contributor runner. When the pulse orchestration is
-	# loaded, require exact remote-default freshness before any local wc -l.
-	# A stale/unverifiable checkout blocks this candidate for one cycle without
-	# mutating issue labels or reopening debt issues.
+	# loaded, require remote-default target freshness before any local wc -l.
+	# A lagging mirror is sufficient only when the target bytes provably match.
+	# Unverifiable measurements defer without labels or debt-issue mutations.
 	if declare -F _pulse_refresh_repo >/dev/null 2>&1 \
-		&& ! _large_file_gate_repo_matches_remote_default "$repo_path"; then
+		&& ! _large_file_gate_repo_matches_remote_default "$repo_path" "$all_paths"; then
 		echo "[pulse-wrapper] Large-file gate: deferring #${issue_number} (${repo_slug}); ${repo_path} is not at the verified remote default-branch commit" >>"$LOGFILE"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
+++ b/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
@@ -404,9 +404,67 @@ assert_eq \
 	"#55555 (existing)" \
 	"$out"
 
+# ---- Target freshness uses real Git objects without requiring mirror sync ----
+fixture_repo="${TMP}/objects.git"
+command git init --bare --quiet "$fixture_repo" || exit 1
+cp "$UNDER_FILE" "${TMP}/target.sh"
+fixture_blob=$(command git -C "$fixture_repo" hash-object -w "${TMP}/target.sh") || exit 1
+fixture_tree=$(printf '100644 blob %s\ttarget.sh\n' "$fixture_blob" | command git -C "$fixture_repo" mktree) || exit 1
+fixture_remote=$(printf 'target freshness fixture\n' | env \
+	GIT_AUTHOR_NAME=Test GIT_AUTHOR_EMAIL=test@example.invalid \
+	GIT_COMMITTER_NAME=Test GIT_COMMITTER_EMAIL=test@example.invalid \
+	git -C "$fixture_repo" commit-tree "$fixture_tree") || exit 1
+fixture_local=1111111111111111111111111111111111111111
+fixture_branch=main
+git() {
+	shift 2 # production calls supply -C repo_path
+	case "$1" in
+	symbolic-ref)
+		if [[ "$*" == *refs/remotes/origin/HEAD* ]]; then
+			printf 'origin/main\n'
+		else
+			printf '%s\n' "$fixture_branch"
+		fi
+		;;
+	rev-parse) printf '%s\n' "$fixture_local" ;;
+	ls-remote) printf '%s\trefs/heads/main\n' "$fixture_remote" ;;
+	*) command git -C "$fixture_repo" "$@" ;;
+	esac
+}
+rc=0
+_large_file_gate_repo_matches_remote_default "$TMP" "target.sh:1-3000" || rc=$?
+assert_eq "lagging mirror with exact target bytes is usable" "0" "$rc"
+rc=0
+_large_file_gate_repo_matches_remote_default "$TMP" $'target.sh\nmissing.sh' || rc=$?
+assert_eq "all targets must verify, including missing targets" "1" "$rc"
+printf 'changed target\n' >>"${TMP}/target.sh"
+rc=0
+_large_file_gate_repo_matches_remote_default "$TMP" "target.sh" || rc=$?
+assert_eq "changed target bytes still defer" "1" "$rc"
+cp "$UNDER_FILE" "${TMP}/target.sh"
+saved_remote="$fixture_remote"
+fixture_remote=2222222222222222222222222222222222222222
+rc=0
+_large_file_gate_repo_matches_remote_default "$TMP" "target.sh" || rc=$?
+assert_eq "unavailable pinned remote object still defers" "1" "$rc"
+fixture_remote="$saved_remote"
+fixture_branch=feature
+rc=0
+_large_file_gate_repo_matches_remote_default "$TMP" "target.sh" || rc=$?
+assert_eq "non-default checkout still defers" "1" "$rc"
+fixture_branch=main
+fixture_local="$fixture_remote"
+rc=0
+_large_file_gate_repo_matches_remote_default "$TMP" || rc=$?
+assert_eq "exact default commit preserves legacy admission" "0" "$rc"
+unset -f git
+
 # ---- Test 9 — stale pulse checkout → defer before local measurement ----
 _pulse_refresh_repo() { return 0; }
-_large_file_gate_repo_matches_remote_default() { return 1; }
+_large_file_gate_repo_matches_remote_default() {
+	assert_eq "gate passes extracted target paths for freshness proof" "over.sh" "${2:-}"
+	return 1
+}
 GH_OPEN_RESPONSE=""
 GH_CLOSED_RESPONSE="18706"
 GH_REMOTE_CONTENT_RESPONSE=$(_remote_content_json "$UNDER_FILE")


### PR DESCRIPTION
## Summary

In pulse-dispatch-large-file-gate.sh, verify target bytes against pinned remote blobs when canonical HEAD lags. Reuse existing path resolution and local objects; literal pathspecs and regular blob modes preserve proof. Extend existing continuation verification fixtures. No thresholds or authority gates change.

## Files Changed

.agents/scripts/pulse-dispatch-large-file-gate.sh, .agents/scripts/tests/test-large-file-gate-continuation-verify.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified using production gate functions and real local Git objects: continuation suite30, body35, dedup12, extraction8, surgical11 assertions all pass (96 total). ShellCheck and git diff --check pass. Independent standard-tier review of source excerpts found no blocking integrity defect. Exact review bundle53d01684875eb78f8993352f843c7063819265e4819247102c616c99babc1f38.

Resolves #31383


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.322 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 2h 14m and 600,704 tokens on this with the user in an interactive session.