### PR TITLE
GH#31377: fix: fence merges from release reservation

### DIFF
--- a/.agents/reference/release-lane-coordination.md
+++ b/.agents/reference/release-lane-coordination.md
@@ -1,0 +1,77 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2026 Marcus Quinn -->
+
+# Release-lane merge coordination
+
+## Proven defect and ownership
+
+GH#31377 independently reproduced ordinary TODO merge admission during an active
+`reserved`, `preparing`, or `reconcile-required` lane. The shared
+`release_lane_merge_guard` in `scripts/release-lane-helper.sh` owns the correction;
+Full-loop and Pulse already consume it. The historical initiating caller of
+PR #31362 remains unknown. Fixture evidence is not historical attribution.
+
+Active ownership now fences ordinary main merges from reservation until the
+lane is explicitly inactive. An unknown active phase or inconsistent terminal
+label fails closed. Source, provenance, and metadata-only aggregation exceptions
+retain their existing phase restrictions and downstream authorization checks.
+Other repositories and non-main bases are not fenced by this guard.
+
+## Previously admitted work and remaining race
+
+Before creating a new reservation, `_release_lane_queue_preflight` enumerates
+open main PRs using GitHub's `autoMergeRequest` and `mergeQueueEntry` fields with
+pagination. Queued work, partial enumeration, missing fields, or API uncertainty
+returns 75 **before reservation writes**. The helper does not cancel or mutate
+queued work. Existing owners can still adopt/resume their lane during an API
+outage; competing sources cannot displace them.
+
+This is not an atomic GitHub lock. A queue entry admitted after the snapshot,
+an already-running merge, direct REST/GraphQL writes, an unwrapped CLI, or a
+manual host action can still advance main. Neither this guard nor the PATH shim
+can revoke those actions. Do not claim that an enqueue-time check proves main
+will remain stable. Do not install a blanket repository freeze or weaken branch
+protection to compensate.
+
+## Bounded recovery owner
+
+The existing release reconciliation and authorized aggregation helpers remain
+the recovery owner, not the TODO producer or an ordinary implementation worker.
+Keep exact-tree/provenance checks ahead of tag/package publication. A mismatch
+must stop publication, retain the lane, and require reviewed immutable source
+evidence; queued work is not itself publication authorization.
+
+For a stale, open, reviewed aggregation, the existing
+`aidevops release refresh-aggregate STALE_AGGREGATION_PR` operation performs one
+bounded successor transaction in `scripts/full-loop-release-aggregate-recovery.sh`:
+
+1. Verify the reviewed manifest against reserved intent and the current main tip.
+2. Allocate/reuse one lane-CAS successor slot and deterministic exact-tip branch.
+3. Create/reuse one draft metadata-only PR with immutable source trailers.
+4. Stop for independent review and guarded merge. It neither publishes nor
+   recursively creates successors. A changed tip or competing transaction must
+   be reconciled, not overwritten or retried in an unbounded loop.
+
+The already-authorized release owner uses `recover-aggregate` only with validated
+source evidence and its existing publication authority. An implementation brief
+does not grant that authority. Never mutate an already published immutable tag
+to repair drift. A terminal receipt releases ordinary work through the existing
+lane finalization contract.
+
+## Verification
+
+Run from the repository root:
+
+```bash
+bash .agents/scripts/tests/test-release-lane-reservation.sh
+bash .agents/scripts/tests/test-release-lane.sh
+bash .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+bash .agents/scripts/tests/test-full-loop-release-reconcile.sh
+shellcheck .agents/scripts/release-lane-helper.sh .agents/scripts/tests/test-release-lane-reservation.sh
+```
+
+Reservation fixtures exercise both queue mechanisms, later pages, partial/API
+failure, competing actors, same-source resume, and terminal recovery. Existing
+lane/aggregation fixtures cover permitted provenance and metadata-only recovery,
+CAS ownership, exact-tip/source-manifest rejection, and successor convergence.
+No live release or package writes are needed to verify these contracts.

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -183,6 +183,45 @@ _release_lane_reclaim_same_source() {
 	return 0
 }
 
+#aidevops:trust-boundary
+# Check already-admitted host work before reserving a new lane. This snapshot
+# does not atomically fence GitHub; publication must still verify the exact tree.
+_release_lane_queue_preflight() {
+	local repo="$1"
+	local coordinated_repo="${AIDEVOPS_RELEASE_LANE_COORDINATED_REPO:-marcusquinn/aidevops}"
+	local pages=""
+	# shellcheck disable=SC2016 # GraphQL variables, not shell interpolation.
+	local query='query($owner:String!,$name:String!,$endCursor:String) {
+		repository(owner:$owner,name:$name) {
+			pullRequests(first:100,after:$endCursor,states:OPEN,baseRefName:"main") {
+				nodes { number autoMergeRequest { enabledAt } mergeQueueEntry { id } }
+				pageInfo { hasNextPage endCursor }
+			}
+		}
+	}'
+	[[ "$repo" == "$coordinated_repo" ]] || return 0
+	pages=$(gh api graphql --paginate --slurp -f query="$query" \
+		-f owner="${repo%%/*}" -f name="${repo#*/}" 2>/dev/null) || {
+		printf 'Cannot verify admitted GitHub merge work; release reservation deferred\n' >&2
+		return 75
+	}
+	if ! jq -e '
+		type == "array" and length > 0
+		and all(.[]; (.errors // [] | length) == 0
+			and (.data.repository.pullRequests.nodes | type) == "array"
+			and (.data.repository.pullRequests.pageInfo.hasNextPage | type) == "boolean"
+			and all(.data.repository.pullRequests.nodes[];
+				(.number | type) == "number" and has("autoMergeRequest") and has("mergeQueueEntry")))
+		and .[-1].data.repository.pullRequests.pageInfo.hasNextPage == false
+		and all(.[] | .data.repository.pullRequests.nodes[];
+			.autoMergeRequest == null and .mergeQueueEntry == null)
+	' <<<"$pages" >/dev/null; then
+		printf 'Queued or unverifiable GitHub merge work; release reservation deferred (no queue mutation)\n' >&2
+		return 75
+	fi
+	return 0
+}
+
 release_lane_acquire() {
 	local repo="$1"
 	local source_pr="$2"
@@ -219,6 +258,7 @@ release_lane_acquire() {
 	2) _AIDEVOPS_RELEASE_LANE_HEAD="" ;;
 	*) return 1 ;;
 	esac
+	_release_lane_queue_preflight "$repo" || return $?
 	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(date +%s)-$$-${RANDOM:-0}"
 	state_json=$(jq -cn --arg repo "$repo" --argjson source_pr "$source_pr" --arg expected_sources "$expected_sources" \

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -894,7 +894,6 @@ release_lane_merge_guard() {
 	local phase=""
 	local source_pr=""
 	local tag_name=""
-	local terminal_receipt=""
 
 	[[ "$repo" == "$coordinated_repo" && "$base_ref" == "main" ]] || return 0
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
@@ -909,14 +908,21 @@ release_lane_merge_guard() {
 	esac
 	active=$(jq -r '.active' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	phase=$(jq -r '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
-	terminal_receipt=$(jq -r 'if .terminal_receipt == null then "" elif (.terminal_receipt | type) == "string" then .terminal_receipt else .terminal_receipt.status // "" end' \
-		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
-	if [[ "$active" == "false" || "$phase" == "terminal" || "$terminal_receipt" == "published" || "$terminal_receipt" == "superseded" || "$terminal_receipt" == "recovered" ]]; then
+	#aidevops:trust-boundary
+	# Ownership, not a stale receipt or phase label, releases the merge fence.
+	# Fence from reservation onwards, including preparation and reconciliation.
+	# This is an admission check, not a host-side lock: pre-existing native queues
+	# still require exact-tree publication checks and authorized aggregation recovery.
+	# See reference/release-lane-coordination.md for the bounded recovery contract.
+	if [[ "$active" == "false" ]]; then
 		return 0
 	fi
 	case "$phase" in
-	remote-publication | exact-tag-deployment | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" | "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" | "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING") ;;
-	*) return 0 ;;
+	reserved | preparing | reconcile-required | remote-publication | exact-tag-deployment | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_RECOVERY" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT" | "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH" | "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING") ;;
+	*)
+		printf 'Cannot authorize merge for active release lane phase=%s\n' "$phase" >&2
+		return 75
+		;;
 	esac
 	source_pr=$(jq -r '.source_pr' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	tag_name=$(jq -r '.tag // ""' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1

--- a/.agents/scripts/tests/test-maintenance-selector-contract.sh
+++ b/.agents/scripts/tests/test-maintenance-selector-contract.sh
@@ -78,7 +78,7 @@ required_functions = {
         "_compute_worker_success_rates",
         "_refresh_person_stats_cache",
     ],
-    ".agents/scripts/stats-health-dashboard.sh": ["update_health_issues"],
+    ".agents/scripts/stats-health-dashboard.sh": ["_health_routine_repo_entries"],
     ".agents/scripts/stats-quality-sweep.sh": ["run_daily_quality_sweep"],
     ".agents/scripts/repo-aidevops-health-helper.sh": ["_check_version_bumps"],
 }

--- a/.agents/scripts/tests/test-release-lane-reservation.sh
+++ b/.agents/scripts/tests/test-release-lane-reservation.sh
@@ -54,4 +54,68 @@ release_lane_read() { return 1; }
 expect_guard 'API uncertainty defers merge' 75 test/repo 202 main feature/work
 release_lane_read() { return 2; }
 expect_guard 'absent lane retains legacy behavior' 0 test/repo 202 main feature/work
+
+# Production acquisition must not reserve while host work is already admitted.
+empty_pages='[{"data":{"repository":{"pullRequests":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}]'
+queue_response="$empty_pages"
+api_rc=0
+writes=0
+gh() {
+	[[ "$1 $2" == 'api graphql' && "$*" == *'--paginate --slurp'* &&
+		"$*" == *'mergeQueueEntry'* && "$*" == *'autoMergeRequest'* ]] || return 1
+	printf '%s\n' "$queue_response"
+	return "$api_rc"
+}
+_release_lane_write() {
+	writes=$((writes + 1))
+	_AIDEVOPS_RELEASE_LANE_JSON="$2"
+	return 0
+}
+expect_acquire() {
+	local name="$1"
+	local expected="$2"
+	local expected_writes="$3"
+	local rc=0
+	writes=0
+	release_lane_acquire test/repo 101 101 >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -eq "$expected" && "$writes" -eq "$expected_writes" ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s: rc=%s writes=%s\n' "$name" "$rc" "$writes"
+		failures=$((failures + 1))
+	fi
+	return 0
+}
+expect_acquire 'empty host queue allows one reservation' 0 1
+queue_response=$(jq \
+	'.[0].data.repository.pullRequests.nodes=[{number:202,autoMergeRequest:null,mergeQueueEntry:null}]
+	 | . + . | .[0].data.repository.pullRequests.pageInfo={hasNextPage:true,endCursor:"page-one"}' <<<"$empty_pages")
+expect_acquire 'two clean pages with unqueued PRs allow reservation' 0 1
+for field in autoMergeRequest mergeQueueEntry; do
+	queue_response=$(jq --arg field "$field" \
+		'.[0].data.repository.pullRequests.nodes=[{number:202,autoMergeRequest:null,mergeQueueEntry:null} | .[$field]={id:"queued"}]' <<<"$empty_pages")
+	expect_acquire "pre-existing $field prevents reservation writes" 75 0
+done
+queue_response=$(jq --argjson queued "$queue_response" \
+	'.[0].data.repository.pullRequests.pageInfo={hasNextPage:true,endCursor:"page-one"} | . + $queued' <<<"$empty_pages")
+expect_acquire 'queued entry on second page prevents reservation' 75 0
+queue_response=$(jq '.[0].data.repository.pullRequests.pageInfo.hasNextPage=true' <<<"$empty_pages")
+expect_acquire 'incomplete pagination prevents reservation' 75 0
+queue_response='[{"errors":[{"message":"unavailable"}],"data":{"repository":null}}]'
+expect_acquire 'GraphQL uncertainty prevents reservation' 75 0
+queue_response=$(jq '.[0].data.repository.pullRequests.nodes=[{number:202}]' <<<"$empty_pages")
+expect_acquire 'missing queue fields fail closed' 75 0
+queue_response="$empty_pages"
+api_rc=1
+expect_acquire 'transport failure prevents reservation' 75 0
+
+# Queue API failure must not displace or strand an existing release owner.
+state='{"active":true,"source_pr":101,"phase":"remote-publication","tag":"v1.2.3","operation_token":"fixture-owner"}'
+release_lane_read() {
+	_AIDEVOPS_RELEASE_LANE_JSON="$state"
+	return 0
+}
+expect_acquire 'same-source resume does not require fresh queue admission' 0 0
+state='{"active":true,"source_pr":303,"phase":"remote-publication","tag":"v1.2.3"}'
+expect_acquire 'competing actor cannot displace reservation' 75 0
 [[ "$failures" -eq 0 ]]

--- a/.agents/scripts/tests/test-release-lane-reservation.sh
+++ b/.agents/scripts/tests/test-release-lane-reservation.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# GH#31377: a reservation must fence ordinary merges before publication starts.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../release-lane-helper.sh
+source "$SCRIPT_DIR/release-lane-helper.sh"
+
+state='{"active":false,"source_pr":101,"phase":"terminal","terminal_receipt":"published"}'
+export AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo
+release_lane_read() {
+	_AIDEVOPS_RELEASE_LANE_JSON="$state"
+	return 0
+}
+# No real API or publication commands are permitted in this fixture.
+gh() { return 1; }
+
+failures=0
+expect_guard() {
+	local name="$1"
+	local expected="$2"
+	local rc=0
+	shift 2
+	release_lane_merge_guard "$@" >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -eq "$expected" ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s: expected=%s actual=%s\n' "$name" "$expected" "$rc"
+		failures=$((failures + 1))
+	fi
+	return 0
+}
+
+expect_guard 'admission before reservation' 0 test/repo 202 main aidevops/issue-sync-todo
+for phase in reserved preparing reconcile-required remote-publication exact-tag-deployment future-phase; do
+	state=$(jq -cn --arg phase "$phase" \
+		'{active:true,source_pr:101,phase:$phase,tag:null,terminal_receipt:null}')
+	expect_guard "ordinary TODO deferred in $phase" 75 test/repo 202 main aidevops/issue-sync-todo
+	expect_guard "other repository unaffected in $phase" 0 other/repo 202 main feature/work
+	expect_guard "other base unaffected in $phase" 0 test/repo 202 develop feature/work
+done
+
+# A stale phase/receipt must not reopen an active lane to concurrent actors.
+state='{"active":true,"source_pr":101,"phase":"terminal","terminal_receipt":null}'
+expect_guard 'inconsistent terminal phase stays closed' 75 test/repo 202 main feature/work
+state='{"active":true,"source_pr":101,"phase":"reserved","terminal_receipt":"published"}'
+expect_guard 'stale receipt cannot override active ownership' 75 test/repo 202 main feature/work
+state='{"active":false,"source_pr":101,"phase":"terminal","terminal_receipt":"published"}'
+expect_guard 'ordinary work resumes after terminal receipt' 0 test/repo 202 main aidevops/issue-sync-todo
+
+release_lane_read() { return 1; }
+expect_guard 'API uncertainty defers merge' 75 test/repo 202 main feature/work
+release_lane_read() { return 2; }
+expect_guard 'absent lane retains legacy behavior' 0 test/repo 202 main feature/work
+[[ "$failures" -eq 0 ]]


### PR DESCRIPTION
## Summary

Resolves #31377

- Reproduced ordinary TODO merge admission during active reservation, preparation, and reconciliation in the shared release-lane guard used by Full-loop and Pulse.
- Fence those phases and fail closed on unknown active phases and inconsistent terminal metadata.
- Before new reservation writes, check all open main PR pages for GitHub auto-merge and merge-queue membership. Defer on queued work or API uncertainty without mutating queues; retain same-source resume.
- Historical incident caller remains unknown. This change is not a host-side exclusion lock for pre-existing native queues or manual/API merges.

## Files and reference pattern

`.agents/scripts/release-lane-helper.sh`, `.agents/scripts/tests/test-release-lane-reservation.sh`, `.agents/reference/release-lane-coordination.md`; existing permitted provenance and aggregation cases are covered by `test-release-lane.sh`.

## Runtime Testing

- Risk: high (merge authorization state machine).
- Testing: runtime-verified using fake GitHub responses; no live publication experiment.
- ShellCheck passes for changed shell files.
- Reservation fixture reproduced six failures before the fix and passes after it.
- Existing release-lane suite: 16 passing cases.
- Passing suites: `test-release-lane-reservation.sh`, `test-release-lane.sh`, `test-full-loop-release-aggregate-recovery.sh`, `test-full-loop-release-reconcile.sh`, `test-full-loop-merge.sh`, `test-gh-shim-transport-cases.sh`, `test-pulse-merge-native-auto.sh`, `test-version-manager-protected-publication.sh`.
- Protected-publication fixtures verify changed main trees stop before immutable tag publication. No live release/tag/package writes were performed.
- Markdownlint and `git diff --check` pass.
- Installed gh 2.100.0; a read-only GitHub schema query confirmed both queue fields.

## Review and recovery boundary

Independent thinking-tier review found no confirmed actionable defects in changed production code. Added its suggested positive two-page clean-queue fixture; all checks pass. Reviewed bundle: `42cab402eca1e971df9cba375644bb3c153a159c2ca7a0aef331cc6fccd0ccaf` (head `90fdcdf1e0558cc1ed997ec1a4cebfbce2d6df3d`).

The queue preflight is a snapshot, not an atomic GitHub lock. Concurrent enqueueing or direct/manual host writes remain possible. Existing exact-tree publication checks remain fail-closed; reuse the existing authorized aggregation helper's single CAS-bound draft-successor transaction rather than adding a second recovery publisher. Documentation identifies this bounded owner, immutable source checks, explicit review/merge boundary, and no recursive successor loop. This PR neither grants publication authority nor mutates the completed v3.32.321 release.

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.322 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra
