### PR TITLE
GH#31291: deduplicate Claude proxy framework context

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy-context.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-context.mjs
@@ -326,6 +326,31 @@ export function resolveEffortLevel(incoming) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Combine proxy-owned and incoming system guidance without repeating the
+ * canonical deployed framework document. Only an exact body from the exact
+ * deployed source is compacted: unknown wrappers and distinct authorities are
+ * retained so the proxy never turns untrusted text into framework policy.
+ */
+export function assembleClaudeSystemPrompt(frameworkPrompt, agentPrompt, systemPrompt, frameworkPath) {
+  const canonicalDocument = frameworkPrompt && frameworkPath
+    ? `Instructions from: ${frameworkPath}\n${frameworkPrompt}`
+    : "";
+  const frameworkReference = frameworkPath
+    ? `Instructions from: ${frameworkPath}\nThe complete framework body is already supplied by the Claude proxy.`
+    : "";
+  const incomingPrompt = typeof systemPrompt === "string" ? systemPrompt : "";
+  const escapedDocument = canonicalDocument.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const compactedIncoming = canonicalDocument
+    ? incomingPrompt.replace(
+      new RegExp(`(^|\\n\\n)${escapedDocument}(?=\\n\\nInstructions from:|$)`, "g"),
+      `$1${frameworkReference}`,
+    )
+    : incomingPrompt;
+
+  return [frameworkPrompt, agentPrompt, compactedIncoming].filter(Boolean).join("\n\n");
+}
+
+/**
  * Build the argv list to pass to `claude` for a given request body.
  * The body must contain `model`, `agentName`, `prompt`, optional `effortLevel`.
  */
@@ -352,11 +377,16 @@ export function buildClaudeArgs(body, systemPrompt, streaming) {
     args.push("--mcp-config", mcpConfig);
   }
 
-  // Combine: framework base (build.txt + AGENTS.md) + agent prompt + request system prompt.
-  // Framework and agent go first (static), OpenCode's context-specific prompt last.
+  // Combine proxy-owned guidance with context-specific input. The exact canonical
+  // framework document may already be in OpenCode's system context.
   const frameworkPrompt = getFrameworkPrompt();
   const agentPrompt = getAgentPrompt(agentName);
-  const combinedPrompt = [frameworkPrompt, agentPrompt, systemPrompt].filter(Boolean).join("\n\n");
+  const combinedPrompt = assembleClaudeSystemPrompt(
+    frameworkPrompt,
+    agentPrompt,
+    systemPrompt,
+    join(agentsDir, "AGENTS.md"),
+  );
   if (combinedPrompt) {
     args.push("--append-system-prompt", combinedPrompt);
   }

--- a/.agents/plugins/opencode-aidevops/tests/test-claude-proxy-context.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-claude-proxy-context.mjs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Marcus Quinn
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { assembleClaudeSystemPrompt, buildClaudeArgs } from "../claude-proxy-context.mjs";
+
+const framework = "Keep safeguards intact.\nNever omit verification.";
+const agent = "Selected domain knowledge remains available.";
+const frameworkPath = "/home/test/.aidevops/agents/AGENTS.md";
+const frameworkDocument = `Instructions from: ${frameworkPath}\n${framework}`;
+
+function occurrences(text, value) {
+  return text.split(value).length - 1;
+}
+
+test("Claude proxy compacts only an exact canonical framework document", () => {
+  const incoming = `${frameworkDocument}\n\nInstructions from: /repo/AGENTS.md\nRequest context.`;
+  const result = assembleClaudeSystemPrompt(framework, agent, incoming, frameworkPath);
+
+  assert.equal(occurrences(result, framework), 1);
+  assert.match(result, /already supplied by the Claude proxy/);
+  assert.match(result, /Selected domain knowledge remains available/);
+  assert.match(result, /Request context/);
+  assert.equal(result, assembleClaudeSystemPrompt(framework, agent, incoming, frameworkPath));
+});
+
+test("Claude proxy preserves absent, unknown, similar, and different-authority input", () => {
+  const cases = [
+    "Request context.",
+    `<framework>${framework}</framework>`,
+    `Instructions from: ${frameworkPath}\n${framework}\nAn additional instruction.`,
+    `Instructions from: /repo/AGENTS.md\n${framework}`,
+  ];
+
+  for (const incoming of cases) {
+    const result = assembleClaudeSystemPrompt(framework, agent, incoming, frameworkPath);
+    assert.match(result, /Selected domain knowledge remains available/);
+    assert.ok(result.endsWith(incoming));
+    assert.equal(occurrences(result, framework), incoming.includes(framework) ? 2 : 1);
+  }
+});
+
+test("Claude proxy builder retains the expected Claude argv shape", () => {
+  const args = buildClaudeArgs({ model: "claude-sonnet-4-6", agentName: "legal", prompt: "Continue." }, "", false);
+
+  assert.deepEqual(args.slice(0, 3), ["-p", "--model", "claude-sonnet-4-6"]);
+  assert.ok(args.includes("--permission-mode"));
+  assert.ok(args.includes("--append-system-prompt"));
+  assert.deepEqual(args.slice(-3), ["--output-format", "json", "Continue."]);
+});


### PR DESCRIPTION
## Summary

Deduplicate only exact canonical framework documents at the Claude proxy boundary while preserving selected-agent and unknown or distinct-authority input.

## Files Changed

.agents/plugins/opencode-aidevops/claude-proxy-context.mjs, .agents/plugins/opencode-aidevops/tests/test-claude-proxy-context.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --test .agents/plugins/opencode-aidevops/tests/test-context-catalogue.mjs .agents/plugins/opencode-aidevops/tests/test-claude-proxy-context.mjs; node --check .agents/plugins/opencode-aidevops/claude-proxy-context.mjs; .agents/scripts/linters-local.sh --changed

Resolves #31291


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.323 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 4m and 88,830 tokens on this as a headless worker.