### PR TITLE
GH#31316: Deduplicate README inventory fixtures

### DIFF
--- a/.agents/scripts/tests/test-readme-inventory.py
+++ b/.agents/scripts/tests/test-readme-inventory.py
@@ -47,6 +47,10 @@ class InventoryTests(unittest.TestCase):
         target.write_text(text, encoding="utf-8")
         return target
 
+    def write_all(self, paths, text=PROFILE):
+        for path in paths:
+            self.write(path, text)
+
     def test_source_categories_and_exclusions(self):
         included = {
             "main_agents": [".agents/build-plus.md"],
@@ -83,8 +87,7 @@ class InventoryTests(unittest.TestCase):
             ".agents/tools/tests/example.md",
             ".agents/scripts/commands/README.md",
         ]
-        for name in excluded:
-            self.write(name)
+        self.write_all(excluded)
         self.git("add", ".agents")
         self.write(".agents/tools/untracked.md")
         data = inventory(self.root)
@@ -105,10 +108,9 @@ class InventoryTests(unittest.TestCase):
             ".agents/templates/example.md",
             ".agents/marketing-sales/example.md",
         ]
-        for name in modules:
-            self.write(
-                name, "# Independently callable instructions\nFollow this procedure.\n"
-            )
+        self.write_all(
+            modules, "# Independently callable instructions\nFollow this procedure.\n"
+        )
         self.git("add", ".agents")
         data = inventory(self.root)
         self.assertEqual(data["files"]["subagents"], sorted(modules))
@@ -129,8 +131,7 @@ class InventoryTests(unittest.TestCase):
                 ".jq",
             )
         ]
-        for name in names:
-            self.write(name, "# Production helper module\n")
+        self.write_all(names, "# Production helper module\n")
         self.write(".agents/scripts/gh", "#!/usr/bin/env bash\ntrue\n").chmod(0o755)
         self.write(".agents/scripts/NOTES", "Not an executable script.\n")
         self.git("add", ".agents")


### PR DESCRIPTION
## Summary

Consolidate repeated inventory fixture writes so the Linux Qlty similar-code finding is removed without suppressing findings or changing the threshold.

## Files Changed

.agents/scripts/tests/test-readme-inventory.py

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — python3 .agents/scripts/tests/test-readme-inventory.py; .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; bash .agents/scripts/tests/test-qlty-regression-helper.sh; ShellCheck on the Qlty helpers and their regression tests.

Resolves #31316


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.323 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 7m and 100,710 tokens on this as a headless worker.