### PR TITLE
GH#31332: fix: make session handoffs actionable

### DIFF
--- a/.agents/reference/safety-stop-recovery.md
+++ b/.agents/reference/safety-stop-recovery.md
@@ -34,7 +34,11 @@ When a fuse trips:
 3. **Keep the objective open.** Use `recovering` or `blocked`, not `done`,
    `completed`, `skipped`, or `cancelled`.
 4. **Create the next safe action immediately.** Add it to the active todo list
-   and to the durable task/mission record before yielding the session.
+   and to the durable task/mission record before yielding the session. If a
+   human-only gate remains, name the owner, exact durable action, what it
+   unblocks, and the verification that will prove recovery; otherwise identify
+   the actual executor that owns the next action. A plan or expired command is
+   not an executor.
 5. **Change the conditions.** Select the first viable route in the recovery
    ladder below.
 6. **Resume and verify.** A recovery checkpoint is not completion evidence.
@@ -55,11 +59,16 @@ Record all fields; use `not yet known` rather than omitting one:
 - **Next safe route:** ...
 - **Resume condition:** ...
 - **Owner and status:** ... (`recovering` or `blocked`)
+- **Handoff action and verification:** ... (required for a human-only gate)
 ```
 
 Never place credentials, private paths, private repository identities, or raw
 sensitive diagnostics in a public checkpoint. Store private details only in the
 target-local private brief and publish aliases plus aggregate evidence.
+
+Do not claim that work continues in the background unless a named, live executor
+exists. When no executor exists, the durable record must instead say that the task
+is blocked or resumable and give its next executable action.
 
 ## Recovery Ladder
 

--- a/.agents/reference/session.md
+++ b/.agents/reference/session.md
@@ -17,6 +17,44 @@ Full PTY access: run any CLI (`vim`, `psql`, `ssh`, `htop`, dev servers). Long-r
 - Leave linked-worktree removal to the guarded post-exit routine. Do not attempt or report normal deferred cleanup; mention only failures requiring user action or putting unpublished work at risk.
 - Full docs: `workflows/session-manager.md`.
 
+## Execution Ownership and Truthful Stops
+
+State exactly one outcome before ending a response or session:
+
+1. **Delivered:** every promised acceptance criterion has verified evidence.
+2. **Externally blocked:** name the dependency, its durable action, its owner, what it unblocks, and the verification that will establish delivery.
+3. **Active:** identify an actually live executor or a verified durable checkpoint with its next executable action and resume condition. A plan, suggested next step, draft, or expired command is not an active executor.
+
+While authorized safe work remains, perform the next safe action instead of restating
+the plan, requesting approval for an already-authorized action, or calling the work
+complete. A safety or permission gate pauses only its unsafe path; continue
+independent safe work. Respect an explicit user stop and never bypass permissions.
+
+For a human-only gate, leave one durable handoff that states the exact action, where
+to take it, what it unblocks, and how delivery will be verified. Say that no user
+action is required only when a named live executor owns continuation; never imply
+background progress without that executor. Do not repeat short-lived approval or
+recovery commands after they expire.
+
+Before an unavoidable pause, save and verify a checkpoint containing the session
+aim, preserved directions, issue/PR/worktree identity, completed evidence, unmet
+criteria, blockers, next executable action, and resume conditions. A checkpoint
+preserves continuation; it does not make incomplete delivery complete.
+
+### Behavioral Examples
+
+| Situation | Required owner and truthful state |
+| --- | --- |
+| Authorized work remains and a safe edit or check is available | Execute it; the task is active, not complete or a plan handed back to the user. |
+| A permission must be granted by a human | Externally blocked; leave one durable action, what it unlocks, and its verification. |
+| A recoverable API call fails | Try a distinct safe recovery route; if pausing, checkpoint the next route rather than claim delivery. |
+| A human may not return soon | Preserve the durable handoff and resume condition; do not promise immediate attendance or repeat expired commands. |
+| Every accepted criterion has evidence | Delivered; summarize outcome and evidence without inventing remaining work. |
+| The user explicitly stops work | Stop execution, preserve the requested state, and do not represent the unfinished objective as delivered. |
+
+Review these examples against the task's actual evidence; literal policy checks do
+not prove a future model run complies with the contract.
+
 ## New Topic Hygiene
 
 Use only in interactive sessions; headless workers stay on their assigned task.

--- a/.agents/scripts/tests/test-session-completion-summary-policy.sh
+++ b/.agents/scripts/tests/test-session-completion-summary-policy.sh
@@ -8,7 +8,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
 AGENTS_DOC="${REPO_ROOT}/.agents/AGENTS.md"
 SESSION_DOC="${REPO_ROOT}/.agents/reference/session.md"
-FULL_LOOP_DOC="${REPO_ROOT}/.agents/workflows/full-loop.md"
+FULL_LOOP_COMMAND="${REPO_ROOT}/.agents/scripts/commands/full-loop.md"
+SAFETY_STOP_DOC="${REPO_ROOT}/.agents/reference/safety-stop-recovery.md"
 
 require_literal() {
 	local needle="$1"
@@ -32,9 +33,41 @@ main() {
 	require_literal 'Do not attempt or report normal deferred cleanup' \
 		"$SESSION_DOC" 'session lifecycle still asks the owning session to narrate cleanup' || return 1
 	require_literal "A valid routine-owned \`CLEANUP_DEFERRED\` handoff is silent operational bookkeeping" \
-		"$FULL_LOOP_DOC" 'full-loop guidance does not classify routine cleanup as silent' || return 1
+		"$FULL_LOOP_COMMAND" 'full-loop guidance does not classify routine cleanup as silent' || return 1
 	require_literal 'Do not copy lifecycle promise tokens' \
-		"$FULL_LOOP_DOC" 'machine lifecycle tokens may leak into the user-facing summary' || return 1
+		"$FULL_LOOP_COMMAND" 'machine lifecycle tokens may leak into the user-facing summary' || return 1
+	require_literal '**Delivered:** every promised acceptance criterion has verified evidence.' \
+		"$SESSION_DOC" 'session guidance does not define delivered evidence' || return 1
+	require_literal '**Externally blocked:** name the dependency, its durable action, its owner' \
+		"$SESSION_DOC" 'session guidance does not define an actionable external handoff' || return 1
+	require_literal '**Active:** identify an actually live executor or a verified durable checkpoint' \
+		"$SESSION_DOC" 'session guidance permits imaginary background continuation' || return 1
+	require_literal 'A plan, suggested next step, draft, or expired command is not an active executor.' \
+		"$SESSION_DOC" 'session guidance does not reject plans as execution' || return 1
+	require_literal 'While authorized safe work remains, perform the next safe action' \
+		"$SESSION_DOC" 'session guidance allows premature stops in authorized work' || return 1
+	require_literal '### Behavioral Examples' \
+		"$SESSION_DOC" 'session guidance lacks behavioral contract examples' || return 1
+	for behavior in \
+		'Authorized work remains and a safe edit or check is available' \
+		'A permission must be granted by a human' \
+		'A recoverable API call fails' \
+		'A human may not return soon' \
+		'Every accepted criterion has evidence' \
+		'The user explicitly stops work'; do
+		require_literal "$behavior" "$SESSION_DOC" \
+			"session guidance omits behavioral case: $behavior" || return 1
+	done
+	require_literal 'not prove a future model run complies with the contract.' \
+		"$SESSION_DOC" 'session guidance overstates literal policy coverage' || return 1
+	require_literal 'Handoff action and verification' \
+		"$SAFETY_STOP_DOC" 'safety-stop checkpoints omit human-only handoff evidence' || return 1
+	require_literal 'Do not claim that work continues in the background unless a named, live executor' \
+		"$SAFETY_STOP_DOC" 'safety-stop guidance allows unsupported background-progress claims' || return 1
+	require_literal '**Truthful execution state (MANDATORY):**' \
+		"$FULL_LOOP_COMMAND" 'full-loop command omits truthful execution states' || return 1
+	require_literal 'continuation; it never completes unfinished delivery.' \
+		"$FULL_LOOP_COMMAND" 'full-loop command treats checkpointing as completion' || return 1
 
 	if grep -Fq -- "Cleanup: commit or stash changes, then run \`wt merge\`" "$SESSION_DOC"; then
 		printf 'FAIL: session lifecycle still directs the owning session to clean its worktree\n' >&2

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -19,6 +19,19 @@ Fatal modes: **GH#5317** (exits without PR), **GH#5096** (exits after PR). Do NO
 
 **Interactive continuity (MANDATORY):** A user's full-loop instruction assigns the executor lifecycle to the primary conversation that received it. Keep the critical path in that session through either observed `FULL_LOOP_COMPLETE` or a durable `CLEANUP_DEFERRED` handoff; do not launch a background worker or delegate implementation, verification, review, or merge unless the user explicitly requests background execution. `CLEANUP_DEFERRED` is terminal for the interactive executor only: a guarded cleanup supervisor owns the remaining resource transition and `FULL_LOOP_COMPLETE` remains reserved for observed `CLEANED`. Continue autonomously from the current stage and do not stop after setup, implementation, PR creation, merge, or release merely to report progress. Pause only for a material blocker requiring user input. Progress reports must name the last verified stage and current action.
 
+**Truthful execution state (MANDATORY):** Before pausing, distinguish only
+`delivered` (all acceptance criteria have verified evidence), `externally blocked`
+(a named dependency has one durable human action, owner, unblock result, and
+verification), or `active` (a named live executor or verified checkpoint has a next
+executable action and resume condition). A plan, draft, suggested next step, or
+expired command is not an active executor. While authorized safe work remains,
+execute it rather than requesting approval for the same plan or describing an
+incomplete loop as complete. A safety or permission gate pauses only its unsafe
+path; continue independent safe work without bypassing the gate. Before an
+unavoidable pause, persist and verify the goal, directions, identity, evidence,
+unmet criteria, blockers, next action, and resume condition. Checkpointing preserves
+continuation; it never completes unfinished delivery.
+
 **Release-only exception:** After verified merge and explicit trusted publication intent, default to the local standard-tier handoff in `workflows/release.md` "Standard-tier release handoff" for release/postflight/deploy. The primary retains lifecycle ownership, validates terminal evidence once, and resumes exception handling or finalization. This does not delegate implementation, PR verification/review, merge, or cleanup and does not authorize remote/headless workers.
 
 **User-facing completion (MANDATORY):** A valid routine-owned `CLEANUP_DEFERRED` handoff is silent operational bookkeeping. Do not copy lifecycle promise tokens, cleanup-marker details, worktree-retention explanations, or expected owner-exit limitations into the final response. Summarize delivered changes, verification, and PR/issue/release outcomes. Mention cleanup only when human action is required or unpublished delivery is at risk; put that evidence and required action last.


### PR DESCRIPTION
## Summary

Defined truthful delivered, blocked, and active handoffs with durable continuation guidance.

## Files Changed

.agents/reference/safety-stop-recovery.md, .agents/reference/session.md, .agents/scripts/tests/test-session-completion-summary-policy.sh, .agents/workflows/full-loop.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — bash .agents/scripts/tests/test-session-completion-summary-policy.sh; shellcheck .agents/scripts/tests/test-session-completion-summary-policy.sh; bash .agents/scripts/linters-local.sh --changed; git diff --check

Resolves #31332


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.323 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 5h 9m and 247,757 tokens on this as a headless worker.
