### PR TITLE
GH#31297: fix FrontierHarness context calibration (t18411)

### DIFF
--- a/.agents/plugins/frontier-harness/index.mjs
+++ b/.agents/plugins/frontier-harness/index.mjs
@@ -41,11 +41,14 @@ async function FrontierObserver(input, options = {}) {
       || !(limit?.input > 0) || !(limit?.output > 0)) return null;
     const reserve = reserved ?? Math.min(20000, limit.output, 32000);
     return { formula: "opencode-1.18.29-explicit-input-v1", reserve,
+      reserve_source: reserved === undefined ? "runtime-default" : "compaction.reserved",
       usable_input: Math.max(0, limit.input - reserve) };
   };
   const initialUsage = (message) => {
     const state = stateFor(message.sessionID);
-    if (state.initial || message.summary || !message.time?.completed) return;
+    if (state.confirmed || message.summary || !message.time?.completed
+      || (state.initial && state.created <= message.time.created)) return;
+    state.created = message.time.created;
     const fields = [message.tokens?.input, message.tokens?.cache?.read, message.tokens?.cache?.write];
     const inputTokens = !message.error && fields.every((value) => number(value) !== null)
       ? fields.reduce((a, b) => a + b, 0) : null;
@@ -97,15 +100,19 @@ async function FrontierObserver(input, options = {}) {
       const state = stateFor(event.sessionID);
       // Bus delivery can lag the next turn. Read the completed first response
       // from this session only, never a global or previous-trial measurement.
-      if (options.experimental && state.capacity && !state.initial && input.client?.session?.messages) {
+      if (options.experimental && state.capacity && !state.confirmed && input.client?.session?.messages) {
         const result = await input.client.session.messages({ path: { id: event.sessionID } })
           .catch(() => ({ data: [] }));
         const first = result.data?.filter((row) => row.info?.role === "assistant"
-          && row.info.sessionID === event.sessionID && !row.info.summary && row.info.time?.completed)
+          && row.info.sessionID === event.sessionID && !row.info.summary)
           .sort((a, b) => a.info.time.created - b.info.time.created)[0];
-        if (first?.info.sessionID === event.sessionID) initialUsage(first.info);
+        if (first?.info.time?.completed) {
+          state.initial = null;
+          initialUsage(first.info);
+          state.confirmed = true;
+        }
       }
-      if (options.experimental && state.capacity && state.initial?.input_tokens_including_cache != null
+      if (options.experimental && state.confirmed && state.capacity && state.initial?.input_tokens_including_cache != null
         && state.initial.input_tokens_including_cache >= state.capacity.usable_input) {
         emit({ type: "calibration.stopped", session: opaque(event.sessionID),
           reason: "initial_input_exceeds_usable", capacity: state.capacity, ...state.initial });

--- a/.agents/plugins/frontier-harness/index.mjs
+++ b/.agents/plugins/frontier-harness/index.mjs
@@ -7,6 +7,60 @@ import { createHash } from "node:crypto";
 import { closeSync, openSync, writeSync } from "node:fs";
 import { isAbsolute } from "node:path";
 
+const opaque = (value) => createHash("sha256").update(String(value)).digest("hex").slice(0, 24);
+const number = (value) => Number.isFinite(value) && value >= 0 ? value : null;
+
+// overflow.ts / provider/transform.ts at OpenCode v1.18.29 (16747470).
+// Only the pinned adapter route is calibrated; other versions stay unknown.
+function capacityFor(model, runtimeVersion, reserved) {
+  const limit = model?.limit;
+  if (runtimeVersion !== "1.18.29" || !limit?.context
+    || !(limit?.input > 0) || !(limit?.output > 0)) return null;
+  const reserve = reserved ?? Math.min(20000, limit.output, 32000);
+  return { formula: "opencode-1.18.29-explicit-input-v1", reserve,
+    reserve_source: reserved === undefined ? "runtime-default" : "compaction.reserved",
+    usable_input: Math.max(0, limit.input - reserve) };
+}
+
+function recordInitialUsage(state, message, emit) {
+  if (state.confirmed || message.summary) return;
+  const earlier = state.initial && state.created <= message.time?.created;
+  if (!message.time?.completed || earlier) return;
+  state.created = message.time.created;
+  const fields = [message.tokens?.input, message.tokens?.cache?.read, message.tokens?.cache?.write];
+  const inputTokens = !message.error && fields.every((value) => number(value) !== null)
+    ? fields.reduce((a, b) => a + b, 0) : null;
+  state.initial = { input_tokens_including_cache: inputTokens };
+  emit({ type: "calibration.initial", session: opaque(message.sessionID),
+    ...state.initial, capacity: state.capacity ?? null,
+    status: inputTokens === null || !state.capacity ? "unknown"
+      : inputTokens >= state.capacity.usable_input ? "initial_input_exceeds_usable" : "initial_input_fits" });
+}
+
+async function checkInitialBudget(state, { client, sessionID, emit }) {
+  // Bus delivery can lag the next turn. Read the completed first response
+  // from this session only, never a global or previous-trial measurement.
+  if (state.capacity && !state.confirmed && client?.session?.messages) {
+    const result = await client.session.messages({ path: { id: sessionID } })
+      .catch(() => ({ data: [] }));
+    const first = result.data?.filter((row) => row.info?.role === "assistant"
+      && row.info.sessionID === sessionID && !row.info.summary)
+      .sort((a, b) => a.info.time.created - b.info.time.created)[0];
+    if (first?.info.time?.completed) {
+      state.initial = null;
+      recordInitialUsage(state, first.info, emit);
+      state.confirmed = true;
+    }
+  }
+  const inputTokens = state.initial?.input_tokens_including_cache;
+  const exceedsCapacity = state.capacity && inputTokens != null && inputTokens >= state.capacity.usable_input;
+  if (state.confirmed && exceedsCapacity) {
+    emit({ type: "calibration.stopped", session: opaque(sessionID),
+      reason: "initial_input_exceeds_usable", capacity: state.capacity, ...state.initial });
+    throw new Error("FrontierCalibrationInfeasible: initial input exceeds usable capacity; preserve this attempt");
+  }
+}
+
 async function FrontierObserver(input, options = {}) {
   const profile = options.profile;
   if (!["stock", "aidevops", "aidevops-native-compaction"].includes(profile)) {
@@ -25,39 +79,14 @@ async function FrontierObserver(input, options = {}) {
     if (++sequence > 100000) throw new Error("Benchmark telemetry limit reached");
     writeSync(fd, `${JSON.stringify({ schema: 1, sequence, time_ms: Date.now(), profile, ...data })}\n`);
   };
-  const opaque = (value) => createHash("sha256").update(String(value)).digest("hex").slice(0, 24);
-  const number = (value) => Number.isFinite(value) && value >= 0 ? value : null;
   const sessions = new Map();
   let reserved;
   const stateFor = (id) => {
     if (!sessions.has(id)) sessions.set(id, {});
     return sessions.get(id);
   };
-  // overflow.ts / provider/transform.ts at OpenCode v1.18.29 (16747470).
-  // Only the pinned adapter route is calibrated; other versions stay unknown.
-  const capacity = (model) => {
-    const limit = model?.limit;
-    if (options.runtimeVersion !== "1.18.29" || !limit?.context
-      || !(limit?.input > 0) || !(limit?.output > 0)) return null;
-    const reserve = reserved ?? Math.min(20000, limit.output, 32000);
-    return { formula: "opencode-1.18.29-explicit-input-v1", reserve,
-      reserve_source: reserved === undefined ? "runtime-default" : "compaction.reserved",
-      usable_input: Math.max(0, limit.input - reserve) };
-  };
-  const initialUsage = (message) => {
-    const state = stateFor(message.sessionID);
-    if (state.confirmed || message.summary || !message.time?.completed
-      || (state.initial && state.created <= message.time.created)) return;
-    state.created = message.time.created;
-    const fields = [message.tokens?.input, message.tokens?.cache?.read, message.tokens?.cache?.write];
-    const inputTokens = !message.error && fields.every((value) => number(value) !== null)
-      ? fields.reduce((a, b) => a + b, 0) : null;
-    state.initial = { input_tokens_including_cache: inputTokens };
-    emit({ type: "calibration.initial", session: opaque(message.sessionID),
-      ...state.initial, capacity: state.capacity ?? null,
-      status: inputTokens === null || !state.capacity ? "unknown"
-        : inputTokens >= state.capacity.usable_input ? "initial_input_exceeds_usable" : "initial_input_fits" });
-  };
+  const capacity = (model) => capacityFor(model, options.runtimeVersion, reserved);
+  const initialUsage = (message) => recordInitialUsage(stateFor(message.sessionID), message, emit);
   let hooks = {};
   if (profile !== "stock") {
     const { AidevopsPlugin } = await import("../opencode-aidevops/index.mjs");
@@ -97,26 +126,8 @@ async function FrontierObserver(input, options = {}) {
     },
     "experimental.session.compacting": async (event, output) => {
       emit({ type: "compaction.requested", session: opaque(event.sessionID) });
-      const state = stateFor(event.sessionID);
-      // Bus delivery can lag the next turn. Read the completed first response
-      // from this session only, never a global or previous-trial measurement.
-      if (options.experimental && state.capacity && !state.confirmed && input.client?.session?.messages) {
-        const result = await input.client.session.messages({ path: { id: event.sessionID } })
-          .catch(() => ({ data: [] }));
-        const first = result.data?.filter((row) => row.info?.role === "assistant"
-          && row.info.sessionID === event.sessionID && !row.info.summary)
-          .sort((a, b) => a.info.time.created - b.info.time.created)[0];
-        if (first?.info.time?.completed) {
-          state.initial = null;
-          initialUsage(first.info);
-          state.confirmed = true;
-        }
-      }
-      if (options.experimental && state.confirmed && state.capacity && state.initial?.input_tokens_including_cache != null
-        && state.initial.input_tokens_including_cache >= state.capacity.usable_input) {
-        emit({ type: "calibration.stopped", session: opaque(event.sessionID),
-          reason: "initial_input_exceeds_usable", capacity: state.capacity, ...state.initial });
-        throw new Error("FrontierCalibrationInfeasible: initial input exceeds usable capacity; preserve this attempt");
+      if (options.experimental) {
+        await checkInitialBudget(stateFor(event.sessionID), { client: input.client, sessionID: event.sessionID, emit });
       }
       // This ablates the entire custom context injection, including restored
       // operational state, NOT native compaction or the autocontinue hook.
@@ -131,8 +142,8 @@ async function FrontierObserver(input, options = {}) {
       if (event?.type === "session.compacted") {
         emit({ type: "compaction.completed", session: opaque(event.properties.sessionID) });
       }
-      if (event?.type !== "message.updated" || message?.role !== "assistant"
-        || !message.time?.completed || !message.id || seen.has(message.id)) return;
+      if (event?.type !== "message.updated" || message?.role !== "assistant") return;
+      if (!message.time?.completed || !message.id || seen.has(message.id)) return;
       seen.add(message.id);
       initialUsage(message);
       emit({

--- a/.agents/plugins/frontier-harness/index.mjs
+++ b/.agents/plugins/frontier-harness/index.mjs
@@ -45,9 +45,9 @@ async function FrontierObserver(input, options = {}) {
   };
   const initialUsage = (message) => {
     const state = stateFor(message.sessionID);
-    if (state.initial || message.summary || message.error || !message.time?.completed) return;
+    if (state.initial || message.summary || !message.time?.completed) return;
     const fields = [message.tokens?.input, message.tokens?.cache?.read, message.tokens?.cache?.write];
-    const inputTokens = fields.every((value) => number(value) !== null)
+    const inputTokens = !message.error && fields.every((value) => number(value) !== null)
       ? fields.reduce((a, b) => a + b, 0) : null;
     state.initial = { input_tokens_including_cache: inputTokens };
     emit({ type: "calibration.initial", session: opaque(message.sessionID),
@@ -97,10 +97,12 @@ async function FrontierObserver(input, options = {}) {
       const state = stateFor(event.sessionID);
       // Bus delivery can lag the next turn. Read the completed first response
       // from this session only, never a global or previous-trial measurement.
-      if (!state.initial && input.client?.session?.messages) {
-        const result = await input.client.session.messages({ path: { id: event.sessionID } });
-        const first = result.data?.find((row) => row.info?.role === "assistant"
-          && !row.info.summary && row.info.time?.completed);
+      if (options.experimental && state.capacity && !state.initial && input.client?.session?.messages) {
+        const result = await input.client.session.messages({ path: { id: event.sessionID } })
+          .catch(() => ({ data: [] }));
+        const first = result.data?.filter((row) => row.info?.role === "assistant"
+          && row.info.sessionID === event.sessionID && !row.info.summary && row.info.time?.completed)
+          .sort((a, b) => a.info.time.created - b.info.time.created)[0];
         if (first?.info.sessionID === event.sessionID) initialUsage(first.info);
       }
       if (options.experimental && state.capacity && state.initial?.input_tokens_including_cache != null

--- a/.agents/plugins/frontier-harness/index.mjs
+++ b/.agents/plugins/frontier-harness/index.mjs
@@ -27,6 +27,34 @@ async function FrontierObserver(input, options = {}) {
   };
   const opaque = (value) => createHash("sha256").update(String(value)).digest("hex").slice(0, 24);
   const number = (value) => Number.isFinite(value) && value >= 0 ? value : null;
+  const sessions = new Map();
+  let reserved;
+  const stateFor = (id) => {
+    if (!sessions.has(id)) sessions.set(id, {});
+    return sessions.get(id);
+  };
+  // overflow.ts / provider/transform.ts at OpenCode v1.18.29 (16747470).
+  // Only the pinned adapter route is calibrated; other versions stay unknown.
+  const capacity = (model) => {
+    const limit = model?.limit;
+    if (options.runtimeVersion !== "1.18.29" || !limit?.context
+      || !(limit?.input > 0) || !(limit?.output > 0)) return null;
+    const reserve = reserved ?? Math.min(20000, limit.output, 32000);
+    return { formula: "opencode-1.18.29-explicit-input-v1", reserve,
+      usable_input: Math.max(0, limit.input - reserve) };
+  };
+  const initialUsage = (message) => {
+    const state = stateFor(message.sessionID);
+    if (state.initial || message.summary || message.error || !message.time?.completed) return;
+    const fields = [message.tokens?.input, message.tokens?.cache?.read, message.tokens?.cache?.write];
+    const inputTokens = fields.every((value) => number(value) !== null)
+      ? fields.reduce((a, b) => a + b, 0) : null;
+    state.initial = { input_tokens_including_cache: inputTokens };
+    emit({ type: "calibration.initial", session: opaque(message.sessionID),
+      ...state.initial, capacity: state.capacity ?? null,
+      status: inputTokens === null || !state.capacity ? "unknown"
+        : inputTokens >= state.capacity.usable_input ? "initial_input_exceeds_usable" : "initial_input_fits" });
+  };
   let hooks = {};
   if (profile !== "stock") {
     const { AidevopsPlugin } = await import("../opencode-aidevops/index.mjs");
@@ -39,6 +67,7 @@ async function FrontierObserver(input, options = {}) {
     ...hooks,
     config: async (config) => {
       await hooks.config?.(config);
+      reserved = number(config.compaction?.reserved) ?? undefined;
       emit({ type: "config.applied" });
     },
     dispose: async () => {
@@ -47,15 +76,39 @@ async function FrontierObserver(input, options = {}) {
     },
     "chat.params": async (event, output) => {
       await hooks["chat.params"]?.(event, output);
+      const state = stateFor(event.sessionID);
+      if (!("capacity" in state)) state.capacity = capacity(event.model);
       emit({
         type: "request", session: opaque(event.sessionID),
         context_limit: number(event.model?.limit?.context),
         input_limit: number(event.model?.limit?.input),
         output_limit: number(event.model?.limit?.output),
+        capacity: capacity(event.model),
       });
+    },
+    "experimental.chat.system.transform": async (event, output) => {
+      await hooks["experimental.chat.system.transform"]?.(event, output);
+      emit({ type: "request.footprint", session: opaque(event.sessionID),
+        system_bytes: output.system.reduce((sum, text) => sum + Buffer.byteLength(text), 0),
+        system_entries: output.system.length });
     },
     "experimental.session.compacting": async (event, output) => {
       emit({ type: "compaction.requested", session: opaque(event.sessionID) });
+      const state = stateFor(event.sessionID);
+      // Bus delivery can lag the next turn. Read the completed first response
+      // from this session only, never a global or previous-trial measurement.
+      if (!state.initial && input.client?.session?.messages) {
+        const result = await input.client.session.messages({ path: { id: event.sessionID } });
+        const first = result.data?.find((row) => row.info?.role === "assistant"
+          && !row.info.summary && row.info.time?.completed);
+        if (first?.info.sessionID === event.sessionID) initialUsage(first.info);
+      }
+      if (options.experimental && state.capacity && state.initial?.input_tokens_including_cache != null
+        && state.initial.input_tokens_including_cache >= state.capacity.usable_input) {
+        emit({ type: "calibration.stopped", session: opaque(event.sessionID),
+          reason: "initial_input_exceeds_usable", capacity: state.capacity, ...state.initial });
+        throw new Error("FrontierCalibrationInfeasible: initial input exceeds usable capacity; preserve this attempt");
+      }
       // This ablates the entire custom context injection, including restored
       // operational state, NOT native compaction or the autocontinue hook.
       if (profile !== "aidevops-native-compaction") {
@@ -72,6 +125,7 @@ async function FrontierObserver(input, options = {}) {
       if (event?.type !== "message.updated" || message?.role !== "assistant"
         || !message.time?.completed || !message.id || seen.has(message.id)) return;
       seen.add(message.id);
+      initialUsage(message);
       emit({
         type: "completion", session: opaque(message.sessionID), message: opaque(message.id),
         summary: message.summary === true, error: Boolean(message.error),

--- a/.agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs
@@ -91,9 +91,17 @@ test("compaction injects only the active repository checkpoint", async () => {
       "UNRELATED_SIBLING_CHECKPOINT_STATE\n",
       "utf8",
     );
+    const protectedHandoff = [
+      "TARGET_REPO_CHECKPOINT_STATE",
+      "Aim: calibrate usable context without changing production defaults.",
+      "Decision: retain static fallback until route restoration is proven.",
+      "Accepted correction, not applied: preserve interrupted usage as unknown.",
+      "Progress: fixture checks passed; evidence: receipt-fixture.json.",
+      "Next action: verify the corrected report, then continue the open objective.",
+    ].join("\n");
     writeFileSync(
       scopedCheckpointPath(workspaceDir, targetRepo),
-      "TARGET_REPO_CHECKPOINT_STATE\n",
+      `${protectedHandoff}\n`,
       "utf8",
     );
     const targetCampaign = campaignCheckpointPath(workspaceDir, targetRepo);
@@ -131,11 +139,12 @@ test("compaction injects only the active repository checkpoint", async () => {
       "the non-instructional boundary must precede injected checkpoint data",
     );
     assert.match(payload, /TARGET_REPO_CHECKPOINT_STATE/);
+    assert.ok(payload.includes(protectedHandoff), "all protected fixture fields survive handoff injection verbatim");
     assert.match(payload, /Repository-scoped point-in-time data/);
     assert.doesNotMatch(payload, /Restore this operational state/);
     assert.match(
       payload,
-      /TARGET_REPO_CHECKPOINT_STATE\n\n## Repository Campaign Checkpoint/,
+      /continue the open objective\.\n\n## Repository Campaign Checkpoint/,
       "operational state sections must have a blank line between them",
     );
     assert.doesNotMatch(payload, /UNRELATED_LEGACY_CHECKPOINT_STATE/);

--- a/.agents/scripts/frontier-harness-report.mjs
+++ b/.agents/scripts/frontier-harness-report.mjs
@@ -113,6 +113,15 @@ export function summarizeRun(root) {
   };
   const reward = trial.verifier_result?.rewards?.reward;
   const stopped = telemetry.calibration.stopped.length > 0;
+  const initial = [...new Map(telemetry.calibration.initial.map((row) => [row.session, row])).values()];
+  const calibrated = manifest.opencode_version === "1.18.29" && initial.length > 0
+    && initial.every((row) => row.status === "initial_input_fits" && row.capacity?.usable_input > 0)
+    && telemetry.calibration.applied.length > 0
+    && telemetry.calibration.applied.every((row) => row.capacity?.formula === "opencode-1.18.29-explicit-input-v1"
+      && Number.isFinite(row.capacity.reserve) && row.capacity.reserve >= 0
+      && row.capacity.usable_input === Math.max(0, row.input - row.capacity.reserve));
+  const runnerFinished = manifest.status === "runner_finished" && manifest.runner_exit_code === 0
+    && manifest.completed_trials === 1 && manifest.errored_trials === 0 && !manifest.interrupted;
   const usageFieldsComplete = usage.length > 0 && usage.every((row) =>
     ["input_tokens", "output_tokens", "cached_tokens"].every((key) => Number.isFinite(row[key]) && row[key] >= 0));
   const digest = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
@@ -125,10 +134,12 @@ export function summarizeRun(root) {
     billing: manifest.inference_route, leaderboard_comparable: false,
     experimental_context_limit: manifest.experimental_context_limit ?? null,
     calibration_status: stopped ? "infeasible_configuration"
-      : telemetry.calibration.initial.length ? "observed" : "unobserved",
+      : calibrated ? "initial_input_fits" : "unknown",
     verifier_reward: Number.isFinite(reward) ? reward : null,
     task_passed: reward === 1 && !trial.exception_info,
-    comparison_valid: reward === 1 && !trial.exception_info && !stopped,
+    comparison_valid: reward === 1 && !trial.exception_info && !stopped && runnerFinished
+      && (manifest.experimental_context_limit == null || calibrated),
+    runner_finished: runnerFinished,
     trial_exception: /^[A-Za-z][A-Za-z0-9_]*$/.test(trial.exception_info?.exception_type || "")
       ? trial.exception_info.exception_type : null,
     agent_seconds: duration(trial.agent_execution), setup_seconds: duration(trial.agent_setup),

--- a/.agents/scripts/frontier-harness-report.mjs
+++ b/.agents/scripts/frontier-harness-report.mjs
@@ -80,6 +80,70 @@ export function summarize(records) {
   };
 }
 
+function validateRunEvidence(manifest, records, telemetry) {
+  if (telemetry.profile !== manifest.profile || !records.some((r) => r.type === "config.applied")
+    || (manifest.profile !== "stock" && !(records[0].framework_tool_count > 0))) {
+    throw new Error("Missing or mismatched plugin-loading evidence");
+  }
+  const limitsMatch = telemetry.calibration.applied.every((limit) => limit.context === manifest.experimental_context_limit
+    && limit.input === manifest.experimental_context_limit - manifest.experimental_output_reserve
+    && limit.output === manifest.experimental_output_reserve);
+  const limitsObserved = telemetry.observed_context_limits.length > 0;
+  if (manifest.experimental_context_limit != null && (!limitsObserved || !limitsMatch)) {
+    throw new Error("Experiment model limits were overridden or unobserved");
+  }
+}
+
+function transportUsage(manifest) {
+  const usage = manifest.relay?.upstream_usage || [];
+  const total = (key) => usage.length && usage.every((r) => Number.isFinite(r[key]) && r[key] >= 0)
+    ? usage.reduce((sum, r) => sum + r[key], 0) : null;
+  const usageFieldsComplete = usage.length > 0 && usage.every((row) =>
+    ["input_tokens", "output_tokens", "cached_tokens"].every((key) => Number.isFinite(row[key]) && row[key] >= 0));
+  return {
+    relay_requests: manifest.relay?.requests ?? null,
+    upstream_completed_responses: usage.length,
+    upstream_usage_scope: "completed responses only",
+    upstream_responses_without_usage: Number.isInteger(manifest.relay?.requests)
+      ? Math.max(0, manifest.relay.requests - usage.length) : null,
+    upstream_usage_complete: usageFieldsComplete && usage.length === manifest.relay?.requests
+      && manifest.relay?.stream_failures === 0,
+    upstream_input_tokens_including_cache: total("input_tokens"),
+    upstream_output_tokens: total("output_tokens"), upstream_cached_tokens: total("cached_tokens"),
+  };
+}
+
+function calibrationStatus(manifest, telemetry) {
+  if (telemetry.calibration.stopped.length > 0) return "infeasible_configuration";
+  const initial = [...new Map(telemetry.calibration.initial.map((row) => [row.session, row])).values()];
+  const initialFits = initial.every((row) => row.status === "initial_input_fits" && row.capacity?.usable_input > 0);
+  const capacityKnown = telemetry.calibration.applied.every((row) => {
+    const validReserve = Number.isFinite(row.capacity?.reserve) && row.capacity.reserve >= 0;
+    return validReserve && row.capacity?.formula === "opencode-1.18.29-explicit-input-v1"
+      && row.capacity.usable_input === Math.max(0, row.input - row.capacity.reserve);
+  });
+  const observed = initial.length > 0 && telemetry.calibration.applied.length > 0;
+  const calibrated = manifest.opencode_version === "1.18.29" && observed && initialFits && capacityKnown;
+  return calibrated ? "initial_input_fits" : "unknown";
+}
+
+function runVerdict(manifest, trial, status) {
+  const reward = trial.verifier_result?.rewards?.reward;
+  const successfulExit = manifest.status === "runner_finished" && manifest.runner_exit_code === 0 && !manifest.interrupted;
+  const runnerFinished = successfulExit && manifest.completed_trials === 1 && manifest.errored_trials === 0;
+  const taskPassed = reward === 1 && !trial.exception_info;
+  return {
+    calibration_status: status,
+    verifier_reward: Number.isFinite(reward) ? reward : null,
+    task_passed: taskPassed,
+    comparison_valid: taskPassed && status !== "infeasible_configuration" && runnerFinished
+      && (manifest.experimental_context_limit == null || status === "initial_input_fits"),
+    runner_finished: runnerFinished,
+    trial_exception: /^[A-Za-z][A-Za-z0-9_]*$/.test(trial.exception_info?.exception_type || "")
+      ? trial.exception_info.exception_type : null,
+  };
+}
+
 /** Join host-owned transport accounting with the runner's explicit verdict. */
 export function summarizeRun(root) {
   const json = (path) => JSON.parse(readFileSync(path, "utf8"));
@@ -93,37 +157,11 @@ export function summarizeRun(root) {
   const eventsPath = join(trialDir, "agent/frontier-events.jsonl");
   const records = readFileSync(eventsPath, "utf8").trim().split("\n").map(JSON.parse);
   const telemetry = summarize(records);
-  if (telemetry.profile !== manifest.profile || !records.some((r) => r.type === "config.applied")
-    || (manifest.profile !== "stock" && !(records[0].framework_tool_count > 0))) {
-    throw new Error("Missing or mismatched plugin-loading evidence");
-  }
-  if (manifest.experimental_context_limit != null
-    && (!telemetry.observed_context_limits.length
-      || !telemetry.calibration.applied.every((limit) => limit.context === manifest.experimental_context_limit
-        && limit.input === manifest.experimental_context_limit - manifest.experimental_output_reserve
-        && limit.output === manifest.experimental_output_reserve))) {
-    throw new Error("Experiment model limits were overridden or unobserved");
-  }
-  const usage = manifest.relay?.upstream_usage || [];
-  const total = (key) => usage.length && usage.every((r) => Number.isFinite(r[key]) && r[key] >= 0)
-    ? usage.reduce((sum, r) => sum + r[key], 0) : null;
+  validateRunEvidence(manifest, records, telemetry);
   const duration = (range) => {
     const ms = Date.parse(range?.finished_at) - Date.parse(range?.started_at);
     return Number.isFinite(ms) && ms >= 0 ? Math.round(ms) / 1000 : null;
   };
-  const reward = trial.verifier_result?.rewards?.reward;
-  const stopped = telemetry.calibration.stopped.length > 0;
-  const initial = [...new Map(telemetry.calibration.initial.map((row) => [row.session, row])).values()];
-  const calibrated = manifest.opencode_version === "1.18.29" && initial.length > 0
-    && initial.every((row) => row.status === "initial_input_fits" && row.capacity?.usable_input > 0)
-    && telemetry.calibration.applied.length > 0
-    && telemetry.calibration.applied.every((row) => row.capacity?.formula === "opencode-1.18.29-explicit-input-v1"
-      && Number.isFinite(row.capacity.reserve) && row.capacity.reserve >= 0
-      && row.capacity.usable_input === Math.max(0, row.input - row.capacity.reserve));
-  const runnerFinished = manifest.status === "runner_finished" && manifest.runner_exit_code === 0
-    && manifest.completed_trials === 1 && manifest.errored_trials === 0 && !manifest.interrupted;
-  const usageFieldsComplete = usage.length > 0 && usage.every((row) =>
-    ["input_tokens", "output_tokens", "cached_tokens"].every((key) => Number.isFinite(row[key]) && row[key] >= 0));
   const digest = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
   return {
     profile: manifest.profile, model: manifest.model,
@@ -133,25 +171,9 @@ export function summarizeRun(root) {
     source_manifest_sha256: digest(join(root, "manifest.json")),
     billing: manifest.inference_route, leaderboard_comparable: false,
     experimental_context_limit: manifest.experimental_context_limit ?? null,
-    calibration_status: stopped ? "infeasible_configuration"
-      : calibrated ? "initial_input_fits" : "unknown",
-    verifier_reward: Number.isFinite(reward) ? reward : null,
-    task_passed: reward === 1 && !trial.exception_info,
-    comparison_valid: reward === 1 && !trial.exception_info && !stopped && runnerFinished
-      && (manifest.experimental_context_limit == null || calibrated),
-    runner_finished: runnerFinished,
-    trial_exception: /^[A-Za-z][A-Za-z0-9_]*$/.test(trial.exception_info?.exception_type || "")
-      ? trial.exception_info.exception_type : null,
+    ...runVerdict(manifest, trial, calibrationStatus(manifest, telemetry)),
     agent_seconds: duration(trial.agent_execution), setup_seconds: duration(trial.agent_setup),
-    relay_requests: manifest.relay?.requests ?? null,
-    upstream_completed_responses: usage.length,
-    upstream_usage_scope: "completed responses only",
-    upstream_responses_without_usage: Number.isInteger(manifest.relay?.requests)
-      ? Math.max(0, manifest.relay.requests - usage.length) : null,
-    upstream_usage_complete: usageFieldsComplete && usage.length === manifest.relay?.requests
-      && manifest.relay?.stream_failures === 0,
-    upstream_input_tokens_including_cache: total("input_tokens"),
-    upstream_output_tokens: total("output_tokens"), upstream_cached_tokens: total("cached_tokens"),
+    ...transportUsage(manifest),
     telemetry,
   };
 }

--- a/.agents/scripts/frontier-harness-report.mjs
+++ b/.agents/scripts/frontier-harness-report.mjs
@@ -26,8 +26,13 @@ export function summarize(records) {
   const sum = (rows, field) => rows.length && rows.every((r) => Number.isFinite(r[field]) && r[field] >= 0)
     ? rows.reduce((total, r) => total + r[field], 0) : null;
   const tokens = {};
+  const usageCoverage = {};
   for (const field of ["input_tokens", "output_tokens", "reasoning_tokens", "cache_read_tokens", "cache_write_tokens"]) {
     tokens[field] = sum(completions, field);
+    const measured = completions.filter((r) => Number.isFinite(r[field]) && r[field] >= 0);
+    usageCoverage[field] = { measured_completions: measured.length,
+      missing_completions: completions.length - measured.length,
+      completed_subtotal: sum(measured, field) };
   }
   // Input + cache reads + cache writes is an occupancy PROXY, not a tokenizer
   // measurement of the actual live context. Never add cumulative session usage.
@@ -44,11 +49,22 @@ export function summarize(records) {
     requests: requests.length, completions: completions.length,
     errors: completions.filter((r) => r.error).length,
     ...tokens,
+    usage_coverage: usageCoverage,
+    calibration: {
+      initial: records.filter((r) => r.type === "calibration.initial"),
+      stopped: records.filter((r) => r.type === "calibration.stopped"),
+      applied: requests.map((r) => ({ session: r.session, context: r.context_limit,
+        input: r.input_limit, output: r.output_limit, capacity: r.capacity ?? null })),
+      footprints: records.filter((r) => r.type === "request.footprint"),
+    },
     peak_prompt_tokens_proxy: promptSizes.length && promptSizes.every((v) => v !== null)
       ? Math.max(...promptSizes) : null,
     observed_context_limits: [...new Set(requests.map((r) => r.context_limit).filter(Number.isFinite))],
     compactions_requested: requested.length, compactions_completed: completed.length,
     summary_completions: summaries.length,
+    summary_input_tokens: sum(summaries, "input_tokens"),
+    summary_cache_read_tokens: sum(summaries, "cache_read_tokens"),
+    summary_cache_write_tokens: sum(summaries, "cache_write_tokens"),
     summary_output_tokens: sum(summaries, "output_tokens"),
     completions_after_compaction: afterCompaction.length,
     errors_after_compaction: afterCompaction.filter((r) => r.error).length,
@@ -83,8 +99,10 @@ export function summarizeRun(root) {
   }
   if (manifest.experimental_context_limit != null
     && (!telemetry.observed_context_limits.length
-      || !telemetry.observed_context_limits.every((limit) => limit === manifest.experimental_context_limit))) {
-    throw new Error("Experiment context limit was overridden");
+      || !telemetry.calibration.applied.every((limit) => limit.context === manifest.experimental_context_limit
+        && limit.input === manifest.experimental_context_limit - manifest.experimental_output_reserve
+        && limit.output === manifest.experimental_output_reserve))) {
+    throw new Error("Experiment model limits were overridden or unobserved");
   }
   const usage = manifest.relay?.upstream_usage || [];
   const total = (key) => usage.length && usage.every((r) => Number.isFinite(r[key]) && r[key] >= 0)
@@ -94,6 +112,9 @@ export function summarizeRun(root) {
     return Number.isFinite(ms) && ms >= 0 ? Math.round(ms) / 1000 : null;
   };
   const reward = trial.verifier_result?.rewards?.reward;
+  const stopped = telemetry.calibration.stopped.length > 0;
+  const usageFieldsComplete = usage.length > 0 && usage.every((row) =>
+    ["input_tokens", "output_tokens", "cached_tokens"].every((key) => Number.isFinite(row[key]) && row[key] >= 0));
   const digest = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
   return {
     profile: manifest.profile, model: manifest.model,
@@ -103,15 +124,20 @@ export function summarizeRun(root) {
     source_manifest_sha256: digest(join(root, "manifest.json")),
     billing: manifest.inference_route, leaderboard_comparable: false,
     experimental_context_limit: manifest.experimental_context_limit ?? null,
+    calibration_status: stopped ? "infeasible_configuration"
+      : telemetry.calibration.initial.length ? "observed" : "unobserved",
     verifier_reward: Number.isFinite(reward) ? reward : null,
     task_passed: reward === 1 && !trial.exception_info,
+    comparison_valid: reward === 1 && !trial.exception_info && !stopped,
     trial_exception: /^[A-Za-z][A-Za-z0-9_]*$/.test(trial.exception_info?.exception_type || "")
       ? trial.exception_info.exception_type : null,
     agent_seconds: duration(trial.agent_execution), setup_seconds: duration(trial.agent_setup),
     relay_requests: manifest.relay?.requests ?? null,
     upstream_completed_responses: usage.length,
     upstream_usage_scope: "completed responses only",
-    upstream_usage_complete: usage.length === manifest.relay?.requests
+    upstream_responses_without_usage: Number.isInteger(manifest.relay?.requests)
+      ? Math.max(0, manifest.relay.requests - usage.length) : null,
+    upstream_usage_complete: usageFieldsComplete && usage.length === manifest.relay?.requests
       && manifest.relay?.stream_failures === 0,
     upstream_input_tokens_including_cache: total("input_tokens"),
     upstream_output_tokens: total("output_tokens"), upstream_cached_tokens: total("cached_tokens"),

--- a/.agents/scripts/frontier-harness-run.mjs
+++ b/.agents/scripts/frontier-harness-run.mjs
@@ -61,6 +61,10 @@ async function main() {
     max_requests: 64, concurrency: 1, retries: 0, install_only: values["install-only"],
     agent_setup_timeout_multiplier: 2,
     experimental_context_limit: contextLimit, experimental_output_reserve: outputLimit,
+    calibration_contract: values["opencode-version"] === "1.18.29"
+      ? "opencode-1.18.29-explicit-input-v1" : "unsupported-runtime",
+    requested_model_limits: contextLimit === null ? null
+      : { context: contextLimit, input: contextLimit - outputLimit, output: outputLimit },
     started_at: new Date().toISOString(),
   };
   const save = () => writeFileSync(join(values.out, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });

--- a/.agents/scripts/frontier_harness_agent.py
+++ b/.agents/scripts/frontier_harness_agent.py
@@ -49,6 +49,9 @@ class FrontierOpenCode(OpenCode):
             config["instructions"] = [f"{root}/AGENTS.md"]
         super().__init__(*args, opencode_config=config, **kwargs)
         self._opencode_config["small_model"] = self.model_name
+        observer_options = self._opencode_config["plugin"][0][1]
+        observer_options["runtimeVersion"] = self._version
+        observer_options["experimental"] = context_limit is not None
         if context_limit is not None or output_limit is not None:
             if not (isinstance(context_limit, int) and isinstance(output_limit, int)
                     and 4096 <= context_limit <= 1000000 and 1024 <= output_limit < context_limit):
@@ -83,7 +86,10 @@ class FrontierOpenCode(OpenCode):
             raise ValueError("An exact OpenCode version is required")
         await self.ensure_system_dependencies(environment, ("curl", "bash", "coreutils", "nodejs", "npm", "git", "tar"))
         package = shlex.quote(f"opencode-ai@{self._version}")
-        await self.exec_as_agent(environment, command=f"npm i -g {package} && opencode --version")
+        version = shlex.quote(self._version)
+        await self.exec_as_agent(environment, command=(
+            f'npm i -g {package} && test "$(opencode --version)" = {version}'
+        ))
         await environment.upload_file(self.archive, "/opt/frontier-framework.tar")
         # No setup.sh: its machine-wide setup/scheduling belongs outside trials.
         # The clean archive contains only pinned Git-tracked framework files.

--- a/.agents/scripts/tests/test-frontier-harness.mjs
+++ b/.agents/scripts/tests/test-frontier-harness.mjs
@@ -92,10 +92,17 @@ test("calibration stops measured infeasible input before summary, not feasible o
     { context: 16384, input: null, stop: false, usable: 12288 },
     { context: 16384, input: 13000, version: "1.18.22", stop: false, usable: null },
     { context: 16384, input: 13000, reserved: 0, stop: false, usable: 14336 },
+    { context: 16384, input: 13000, unavailable: true, stop: false, usable: 12288 },
   ]) {
     const dir = mkdtempSync(join(tmpdir(), "frontier-calibration-"));
     const events = join(dir, "events.jsonl");
-    const hooks = await observer({}, { profile: "stock", events,
+    const info = { id: "fixture-response", sessionID: "fixture-session", role: "assistant",
+      time: { created: 1, completed: 2 },
+      tokens: { input: scenario.input, output: 2048, cache: { read: 0, write: 0 } } };
+    const hooks = await observer({ client: { session: { messages: async () => {
+      if (scenario.unavailable) throw new Error("fixture unavailable");
+      return { data: [{ info }] };
+    } } } }, { profile: "stock", events,
       experimental: true, runtimeVersion: scenario.version ?? "1.18.29" });
     try {
       await hooks.config({ compaction: { reserved: scenario.reserved } });
@@ -104,11 +111,7 @@ test("calibration stops measured infeasible input before summary, not feasible o
       } } };
       await hooks["chat.params"](params, {});
       await hooks["experimental.chat.system.transform"](params, { system: ["private core"] });
-      await hooks.event({ event: { type: "message.updated", properties: { info: {
-        id: "fixture-response", sessionID: params.sessionID, role: "assistant",
-        time: { created: 1, completed: 2 },
-        tokens: { input: scenario.input, output: 2048, cache: { read: 0, write: 0 } },
-      } } } });
+      await hooks.event({ event: { type: "message.updated", properties: { info } } });
       const compact = () => hooks["experimental.session.compacting"](params, { context: [] });
       if (scenario.stop) await assert.rejects(compact(), /FrontierCalibrationInfeasible/);
       else await compact();
@@ -153,6 +156,9 @@ test("delayed bus usage is recovered from the first completed response in the sa
     await hooks["chat.params"]({ sessionID: "target", model: {
       limit: { context: 16384, input: 14336, output: 2048 },
     } }, {});
+    await hooks.event({ event: { type: "message.updated", properties: {
+      info: { ...message("target", 10, 1).info, id: "later-delivered-first" },
+    } } });
     await assert.rejects(hooks["experimental.session.compacting"]({ sessionID: "target" }, { context: [] }),
       /FrontierCalibrationInfeasible/);
   } finally { await hooks.dispose(); rmSync(dir, { recursive: true, force: true }); }
@@ -164,12 +170,14 @@ test("run report joins verifier evidence, detects overridden output and preserve
   mkdirSync(join(trialDir, "agent"), { recursive: true });
   const json = (path, data) => writeFileSync(path, JSON.stringify(data));
   const manifest = { profile: "stock", experimental_context_limit: 18432, experimental_output_reserve: 2048,
+    opencode_version: "1.18.29", status: "runner_finished", runner_exit_code: 0, completed_trials: 1, errored_trials: 0,
     relay: { requests: 2, stream_failures: 0, upstream_usage: [{ input_tokens: 13000, output_tokens: 2, cached_tokens: null }] } };
   const result = { verifier_result: { rewards: { reward: 1 } } };
   const rows = [{ type: "observer.started" }, { type: "config.applied" },
     { type: "request", session: "fixture", context_limit: 18432, input_limit: 16384, output_limit: 2048,
-      capacity: { usable_input: 14336, reserve: 2048 } },
-    { type: "calibration.initial", status: "initial_input_fits", input_tokens_including_cache: 13000 },
+      capacity: { formula: "opencode-1.18.29-explicit-input-v1", usable_input: 14336, reserve: 2048 } },
+    { type: "calibration.initial", status: "initial_input_fits", input_tokens_including_cache: 13000,
+      capacity: { usable_input: 14336 } },
     { type: "completion", input_tokens: 13000, output_tokens: 2 },
     { type: "completion", summary: true, input_tokens: 13000, output_tokens: 3 }];
   const saveEvents = () => writeFileSync(join(trialDir, "agent/frontier-events.jsonl"), rows.map((row, i) =>
@@ -185,6 +193,16 @@ test("run report joins verifier evidence, detects overridden output and preserve
     assert.equal(report.upstream_usage_complete, false);
     assert.equal(report.upstream_responses_without_usage, 1);
     assert.equal(report.source_result_sha256.length, 64);
+    manifest.interrupted = true;
+    json(join(root, "manifest.json"), manifest);
+    assert.equal(summarizeRun(root).comparison_valid, false);
+    manifest.interrupted = false;
+    manifest.opencode_version = "1.18.22";
+    json(join(root, "manifest.json"), manifest);
+    assert.equal(summarizeRun(root).comparison_valid, false);
+    assert.equal(summarizeRun(root).calibration_status, "unknown");
+    manifest.opencode_version = "1.18.29";
+    json(join(root, "manifest.json"), manifest);
     rows[2].output_limit = 4096;
     saveEvents();
     assert.throws(() => summarizeRun(root), /model limits/);

--- a/.agents/scripts/tests/test-frontier-harness.mjs
+++ b/.agents/scripts/tests/test-frontier-harness.mjs
@@ -3,12 +3,12 @@
 
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createRelay } from "../frontier-harness-oauth-relay.mjs";
 import observerPlugin from "../../plugins/frontier-harness/index.mjs";
-import { summarize } from "../frontier-harness-report.mjs";
+import { summarize, summarizeRun } from "../frontier-harness-report.mjs";
 
 const observer = observerPlugin.server;
 
@@ -82,4 +82,120 @@ test("observer deduplicates completed messages without recording content", async
     await assert.rejects(observer({}, { profile: "stock", events }));
     await hooks.dispose();
   } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("calibration stops measured infeasible input before summary, not feasible or unknown input", async () => {
+  for (const scenario of [
+    { context: 16384, input: 13000, stop: true, usable: 12288 },
+    { context: 18432, input: 13000, stop: false, usable: 14336 },
+    { context: 16384, input: 12288, stop: true, usable: 12288 },
+    { context: 16384, input: null, stop: false, usable: 12288 },
+    { context: 16384, input: 13000, version: "1.18.22", stop: false, usable: null },
+    { context: 16384, input: 13000, reserved: 0, stop: false, usable: 14336 },
+  ]) {
+    const dir = mkdtempSync(join(tmpdir(), "frontier-calibration-"));
+    const events = join(dir, "events.jsonl");
+    const hooks = await observer({}, { profile: "stock", events,
+      experimental: true, runtimeVersion: scenario.version ?? "1.18.29" });
+    try {
+      await hooks.config({ compaction: { reserved: scenario.reserved } });
+      const params = { sessionID: "fixture-session", model: { limit: {
+        context: scenario.context, input: scenario.context - 2048, output: 2048,
+      } } };
+      await hooks["chat.params"](params, {});
+      await hooks["experimental.chat.system.transform"](params, { system: ["private core"] });
+      await hooks.event({ event: { type: "message.updated", properties: { info: {
+        id: "fixture-response", sessionID: params.sessionID, role: "assistant",
+        time: { created: 1, completed: 2 },
+        tokens: { input: scenario.input, output: 2048, cache: { read: 0, write: 0 } },
+      } } } });
+      const compact = () => hooks["experimental.session.compacting"](params, { context: [] });
+      if (scenario.stop) await assert.rejects(compact(), /FrontierCalibrationInfeasible/);
+      else await compact();
+      // A shortfall in one trial/session never stops an unrelated session.
+      await hooks["experimental.session.compacting"]({ sessionID: "other-session" }, { context: [] });
+      const text = readFileSync(events, "utf8");
+      assert.equal(text.includes("private core"), false);
+      const report = summarize(text.trim().split("\n").map(JSON.parse));
+      assert.equal(report.calibration.applied[0].capacity?.usable_input ?? null, scenario.usable);
+      assert.equal(report.calibration.stopped.length, scenario.stop ? 1 : 0);
+      assert.equal(report.summary_completions, 0);
+      assert.equal(report.calibration.footprints[0].system_bytes, 12);
+    } finally { await hooks.dispose(); rmSync(dir, { recursive: true, force: true }); }
+  }
+});
+
+test("partial usage keeps known subtotals separate from unknown totals and summary overhead", () => {
+  const rows = [
+    { type: "observer.started" },
+    { type: "completion", input_tokens: 10, output_tokens: 2 },
+    { type: "completion", summary: true, input_tokens: null, output_tokens: 3 },
+  ].map((row, i) => ({ schema: 1, profile: "stock", sequence: i + 1, ...row }));
+  const report = summarize(rows);
+  assert.equal(report.input_tokens, null);
+  assert.deepEqual(report.usage_coverage.input_tokens, {
+    measured_completions: 1, missing_completions: 1, completed_subtotal: 10,
+  });
+  assert.equal(report.summary_input_tokens, null);
+  assert.equal(report.summary_output_tokens, 3);
+  assert.deepEqual(report.calibration.initial, []);
+});
+
+test("delayed bus usage is recovered from the first completed response in the same session", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "frontier-delayed-"));
+  const message = (sessionID, created, input) => ({ info: { sessionID, role: "assistant",
+    time: { created, completed: created + 1 }, tokens: { input, cache: { read: 0, write: 0 } } } });
+  const hooks = await observer({ client: { session: { messages: async ({ path }) => {
+    assert.equal(path.id, "target");
+    return { data: [message("target", 10, 1), message("other", 1, 1), message("target", 2, 13000)] };
+  } } } }, { profile: "stock", events: join(dir, "events.jsonl"), experimental: true, runtimeVersion: "1.18.29" });
+  try {
+    await hooks["chat.params"]({ sessionID: "target", model: {
+      limit: { context: 16384, input: 14336, output: 2048 },
+    } }, {});
+    await assert.rejects(hooks["experimental.session.compacting"]({ sessionID: "target" }, { context: [] }),
+      /FrontierCalibrationInfeasible/);
+  } finally { await hooks.dispose(); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("run report joins verifier evidence, detects overridden output and preserves failed attempts", () => {
+  const root = mkdtempSync(join(tmpdir(), "frontier-report-"));
+  const trialDir = join(root, "jobs/pilot/trial");
+  mkdirSync(join(trialDir, "agent"), { recursive: true });
+  const json = (path, data) => writeFileSync(path, JSON.stringify(data));
+  const manifest = { profile: "stock", experimental_context_limit: 18432, experimental_output_reserve: 2048,
+    relay: { requests: 2, stream_failures: 0, upstream_usage: [{ input_tokens: 13000, output_tokens: 2, cached_tokens: null }] } };
+  const result = { verifier_result: { rewards: { reward: 1 } } };
+  const rows = [{ type: "observer.started" }, { type: "config.applied" },
+    { type: "request", session: "fixture", context_limit: 18432, input_limit: 16384, output_limit: 2048,
+      capacity: { usable_input: 14336, reserve: 2048 } },
+    { type: "calibration.initial", status: "initial_input_fits", input_tokens_including_cache: 13000 },
+    { type: "completion", input_tokens: 13000, output_tokens: 2 },
+    { type: "completion", summary: true, input_tokens: 13000, output_tokens: 3 }];
+  const saveEvents = () => writeFileSync(join(trialDir, "agent/frontier-events.jsonl"), rows.map((row, i) =>
+    JSON.stringify({ schema: 1, sequence: i + 1, profile: "stock", ...row })).join("\n"));
+  try {
+    json(join(root, "manifest.json"), manifest);
+    json(join(trialDir, "result.json"), result);
+    saveEvents();
+    const report = summarizeRun(root);
+    assert.equal(report.comparison_valid, true);
+    assert.equal(report.telemetry.summary_output_tokens, 3);
+    assert.equal(report.telemetry.calibration.applied[0].capacity.usable_input, 14336);
+    assert.equal(report.upstream_usage_complete, false);
+    assert.equal(report.upstream_responses_without_usage, 1);
+    assert.equal(report.source_result_sha256.length, 64);
+    rows[2].output_limit = 4096;
+    saveEvents();
+    assert.throws(() => summarizeRun(root), /model limits/);
+    rows[2].output_limit = 2048;
+    rows.push({ type: "calibration.stopped", reason: "initial_input_exceeds_usable" });
+    saveEvents();
+    assert.equal(summarizeRun(root).comparison_valid, false);
+    assert.equal(summarizeRun(root).verifier_reward, 1, "never rewrite the verifier verdict");
+    result.exception_info = { exception_type: "AgentTimeoutError" };
+    json(join(trialDir, "result.json"), result);
+    assert.equal(summarizeRun(root).task_passed, false);
+    assert.equal(summarizeRun(root).trial_exception, "AgentTimeoutError");
+  } finally { rmSync(root, { recursive: true, force: true }); }
 });

--- a/.agents/tools/ai-assistants/frontier-harness-eval.md
+++ b/.agents/tools/ai-assistants/frontier-harness-eval.md
@@ -103,6 +103,54 @@ context 18,432. The first is below this pilot's initial aidevops request size an
 causes immediate repeated compaction. Do not run a full sweep at an infeasible
 budget or interpret that pathology as proof about summary quality.
 
+### Calibration contract v1
+
+Verified source: `anomalyco/opencode` v1.18.29,
+`16747470f976aca3d362ad730bcd3fe82ecc2c9a`, `session/overflow.ts` and
+`provider/transform.ts` under `packages/opencode/src`. For this adapter's explicit
+positive input/output limits and isolated environment (default output-token maximum
+32,000):
+
+```text
+effective_output = min(model.limit.output, 32000)
+reserved = config.compaction.reserved ?? min(20000, effective_output)
+usable_input = max(0, model.limit.input - reserved)
+```
+
+The native overflow decision compares **previous completed total occupancy**
+(including output) with `usable_input`, using `>=`. The pilot stop is narrower:
+at the first compaction it retrieves the earliest assistant response in that
+session and stops before summary generation only when its reported **input plus
+cache reads/writes alone** reaches that threshold. Output-only pressure is not
+called an infeasible initial input. This is an experimentally unusable initial
+budget, not a claim that the provider cannot accept the request. Missing/error
+usage or unavailable session history is unknown, never guessed from text size.
+Out-of-order event delivery is corroborated with session history before stopping.
+
+The adapter verifies the installed version; the observer records applied model
+limits, reserve source, initial reported input (including core/tools), system UTF-8
+bytes and framework tool count. Bytes/counts are footprint diagnostics, **not token
+estimates or a separately measured core/tool token breakdown**. Unknown runtime
+versions or unsupported limit shapes have null capacity and cannot qualify as a
+calibrated experimental comparison. No production model defaults change.
+
+Reports retain schema-1 compatibility and source digests. Known completion
+subtotals, missing per-field usage, host responses without final usage, and summary
+input/cache/output overhead are separate. An infeasibility stop never rewrites a
+verifier verdict or historical timeout; `comparison_valid` also requires successful
+host runner lifecycle evidence. `initial_input_fits` is not a task pass or a
+guarantee that later turns fit.
+
+Regression verification covers feasible/infeasible/equality/missing-usage cases,
+unknown versions, explicit reserves, delayed events, report joins and interrupted
+attempts. The protected handoff fixture retains aims, decisions, unapplied
+corrections, progress/evidence and next actions within the existing historical-data
+boundary; sibling/legacy checkpoints and stale campaign state stay excluded.
+These are hook/receipt tests, not proof that an LLM summary is lossless. Static
+summary policy remains unchanged: no route-specific restoration evidence here
+justifies removing its fallback. The live pilot observations below remain the
+original immutable attempts, not newly rerun or relabelled measurements.
+
 Telemetry records content-free request sizes, resolved limits, completed usage,
 summary usage, compaction requests/completions and post-compaction completions.
 It is contestant-writable diagnostic evidence, not tamper-proof proof; corroborate


### PR DESCRIPTION
## Summary

Resolves #31297 (t18411).

- Calibrate the opt-in FrontierHarness observer against verified OpenCode 1.18.29 source, with applied model limits, usable input, reserve source, initial usage and content-free footprint evidence.
- Corroborate the earliest assistant response against session history before stopping a measured initial-input shortfall, before repeated compaction. Unknown runtime/usage/history is not guessed; feasible settings continue.
- Separate known completion subtotals, missing usage, host responses without final usage, and summary overhead. Invalid calibration or failed/interrupted runner evidence cannot qualify an experimental comparison; raw verifier verdicts remain intact.
- Verify protected aims, decisions, unapplied corrections, progress/evidence and next actions survive checkpoint injection without sibling state or stale authority replay. No production context defaults, static handoff policy, OAuth transport, or historical pilot records change.

## Files and reference patterns

- `.agents/plugins/frontier-harness/index.mjs`: existing observer hooks and schema-1 telemetry; versioned calibration and session-history corroboration.
- `.agents/scripts/frontier_harness_agent.py`: existing pinned runtime setup, now version-checked and passed to the observer.
- `.agents/scripts/frontier-harness-run.mjs` and `.agents/scripts/frontier-harness-report.mjs`: additive manifest/report evidence and validity checks.
- `.agents/scripts/tests/test-frontier-harness.mjs` and `.agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs`: regression scenarios using existing test infrastructure.
- `.agents/tools/ai-assistants/frontier-harness-eval.md`: formula, observed calibration, limitations and retained evidence.

## Verification

Passed:

```bash
node --test .agents/scripts/tests/test-frontier-harness.mjs
node --test .agents/plugins/opencode-aidevops/tests/test-compaction-autocontinue.mjs
node --test .agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs
ruff check .agents/scripts/frontier_harness_agent.py
.agents/scripts/linters-local.sh --changed
git diff --check
```

## Runtime Testing

Risk: high (experimental compaction stop). Executed the actual observer hooks and report reader against bounded fixture events/immutable-attempt layouts: infeasible, feasible, equality, missing usage, explicit reserve, unknown version, delayed/out-of-order completion, unavailable history, overwritten metadata and interrupted runner cases. The existing continuation and repo-isolation hooks passed their regression suites. Independent read-only review found no remaining actionable defects after fixes.

Pinned runtime source inspected at `anomalyco/opencode@16747470f976aca3d362ad730bcd3fe82ecc2c9a`: overflow calculation, output maximum and compaction/plugin error propagation. Host OpenCode is 1.18.22 and is not assumed equivalent. The successful 18,432-context live pilot receipts and failed 16,384-context attempts remain the original committed observations; no fresh OAuth/Docker pilot is claimed here. Hook preservation is not a lossless LLM-summary guarantee. No paid fallback or publication.
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.323 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-6-astra spent 25m and 141,197 tokens on this as a headless worker.