### PR TITLE
GH#31378: fix blocked-worker redispatch comment storms

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -68,7 +68,35 @@ claim loops:
 | `Dispatching worker ...` with no later terminal marker | Active worker ownership. It blocks re-dispatch for the normal dispatch TTL, then for the extended non-terminal worker window (`DISPATCH_ACTIVE_WORKER_MAX_AGE`, default 7200s). | Worker log growth, PR creation, `MERGE_SUMMARY`, `CLAIM_RELEASED`, `Worker failed`, or watchdog output. |
 | Draft/open PR or recent issue/PR timeline event after dispatch | Natural liveness signal. Prefer these durable events over synthetic heartbeat comments. | Continue from the referenced branch/PR if the worker later goes silent. Stale recovery uses the latest visible issue activity and targeted open-PR activity before reclaiming. |
 | `DISPATCH_CLAIM ... reason=stale_worker_takeover prior_dispatch_age_s=<n> no_terminal=true` | A later runner is deliberately taking over after the extended non-terminal worker window expired. This is not a bare duplicate claim. | A fresh `Dispatching worker` comment or a deterministic skip/failure reason. |
-| `CLAIM_RELEASED ...` / `MERGE_SUMMARY` / `Worker failed` / `Worker Watchdog Kill` / `BLOCKED` | Terminal ownership marker. Prior dispatch comments no longer block. | Re-dispatch is safe if the issue remains open and eligible. |
+| `CLAIM_RELEASED ...` / `MERGE_SUMMARY` / `Worker failed` / `Worker Watchdog Kill` / `BLOCKED` | Terminal ownership marker. Prior dispatch ownership ends, not the underlying blocker. | Re-dispatch requires eligibility plus the terminal-blocker circuit/backoff checks. |
+
+### Blocked-release storms (GH#31378)
+
+The incident produced 66 launches and 65 blocked releases across three runners;
+each attempt added claim, lease, launch and release comments without a PR. The
+worker correctly preserved a protected-source denial, but continuations emitted
+generic `BLOCKED` without a new permission event. Unknown blockers had no durable
+circuit, and comment-bloat clean-room mode bypassed the zero-output hold.
+
+`terminal-blocker-circuit.sh` now throttles authenticated bare blocked-release
+history independently of local counters and task revisions: two failures cause
+a 15-minute delay, further failures double it up to 24 hours. The read-only gate
+adds no comments or labels. Only OWNER/MEMBER releases with matching API author
+and runner count; malformed, future and ambiguous collaborator evidence does not.
+Expiry or a standalone trusted `terminal-blocker-circuit:retry` directive permits
+another attempt. Unknown causes remain retryable, not permanent global holds.
+
+An evidenced unresolved permission boundary uses the explicit final-message
+`TERMINAL_BLOCKER_REASON=permission_required` contract, including continuations
+without a new denied tool call. Its known-blocker circuit is bound to the issue,
+not unrelated code/brief edits or dependency API availability. Resolve the
+human-owned prerequisite before explicitly retrying; scheduling consent never
+grants source access, and the original guard must verify the exact context.
+
+Clean-room mode changes prompt content only; it cannot bypass the zero-output
+retry budget. Verify with `test-terminal-blocker-circuit.sh`,
+`test-pulse-dispatch-worker-launch-comment-metrics.sh`, and
+`test-zero-output-url-fallback.sh` under `scripts/tests/`.
 
 Headless workers should emit the smallest append-only GitHub-visible signal that
 helps watchdogs and recovery. Do not post routine "still working" comments when

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1021,8 +1021,16 @@ the authorized scope, use this alternative reason line:
 TERMINAL_BLOCKER_REASON=target_code_blocker
 Target-code blockers may re-arm when the brief, dependencies, or target revision
 changes. Never use that class for permissions, credentials, provider failures,
-capability limits, missing/excluded scope, or ambiguous evidence. If no class is
-established, omit the reason line: unknown evidence stays retryable, not held.
+capability limits, missing/excluded scope, or ambiguous evidence.
+For an evidenced unresolved permission boundary, including a continued session
+whose prior protected-source denial has no changed exact-context grant, use:
+TERMINAL_BLOCKER_REASON=permission_required
+Preserve the protected blocker dossier and human-owned recovery action. Do not
+retry the denied read or regenerate a request to produce another permission event.
+Brief edits and unrelated merges cannot resolve this class; an explicit trusted
+retry only schedules verification and never grants source or secret access.
+If no class is established, omit the reason line: unknown evidence stays retryable
+with bounded cross-runner backoff, not a permanent hold.
 Do not invent classes or emit multiple reason lines. Keep raw stderr, private paths, secrets,
 and sensitive evidence in protected telemetry; public recovery messages are
 runtime-generated from allowlisted reason/action text, never copied model prose.

--- a/.agents/scripts/pulse-dispatch-worker-prompt.sh
+++ b/.agents/scripts/pulse-dispatch-worker-prompt.sh
@@ -479,11 +479,8 @@ _dlw_hold_repeated_zero_output() {
 
 	local hold_threshold="${ZERO_OUTPUT_BRIEF_REWRITE_HOLD_THRESHOLD:-4}"
 	[[ "$hold_threshold" =~ ^[0-9]+$ ]] || hold_threshold=4
-	if [[ "$zero_attempt_count" -lt "$hold_threshold" ]] &&
-		_dlw_comment_bloat_requires_clean_room "$issue_number" "$repo_slug" "$comment_metrics"; then
-		echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: bypassing repeated zero-output brief-rewrite hold for clean-room brief mode" >>"$LOGFILE"
-		return 1
-	fi
+	# Clean-room mode changes prompt content, never the retry budget. Otherwise
+	# failures create enough comments to disable the very fuse bounding them.
 
 	local zero_count=""
 	zero_count=$(_dlw_zero_output_evidence_count "$issue_number" "$repo_slug" "$precomputed_zero_count")

--- a/.agents/scripts/terminal-blocker-circuit.sh
+++ b/.agents/scripts/terminal-blocker-circuit.sh
@@ -12,6 +12,7 @@ _TBC_CIRCUIT_MARKER='aidevops:terminal-blocker-circuit'
 _TBC_RETRY_MARKER='terminal-blocker-circuit:retry'
 _TBC_MISSING_SCOPE='missing_files_scope'
 _TBC_UNKNOWN='unknown'
+_TBC_AUTHORITATIVE_ASSOCIATIONS='["OWNER","MEMBER"]'
 
 _terminal_blocker_hash() {
 	local value="$1"
@@ -32,7 +33,7 @@ _terminal_blocker_hash() {
 _terminal_blocker_reason() {
 	local fingerprint="$1"
 	local reason=""
-	for reason in missing_files_scope files_scope_excluded target_code_blocker unknown; do
+	for reason in missing_files_scope files_scope_excluded target_code_blocker permission_required unknown; do
 		if [[ "$fingerprint" == "$(_terminal_blocker_hash "v2:${reason}")" ]]; then
 			printf '%s\n' "$reason"
 			return 0
@@ -80,14 +81,14 @@ if not marker.search(candidate):
     raise SystemExit(1)
 
 reasons = re.findall(r"^TERMINAL_BLOCKER_REASON=(.*)$", candidate, re.M)
-allowed = {'missing_files_scope', 'files_scope_excluded', 'target_code_blocker'}
+allowed = {'missing_files_scope', 'files_scope_excluded', 'target_code_blocker', 'permission_required'}
 print(reasons[0] if len(reasons) == 1 and reasons[0] in allowed else 'unknown')
 PY
 	) || normalized=""
 	[[ -n "$normalized" ]] || return 1
 	# Do not infer a missing heading from words such as "Files Scope excludes".
 	# Verify the structural condition independently against the issue itself.
-	if [[ "${WORKER_ISSUE_NUMBER:-}" =~ ^[0-9]+$ &&
+	if [[ "$normalized" != "permission_required" && "${WORKER_ISSUE_NUMBER:-}" =~ ^[0-9]+$ &&
 		"${DISPATCH_REPO_SLUG:-}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
 		issue_json=$(gh api "repos/${DISPATCH_REPO_SLUG}/issues/${WORKER_ISSUE_NUMBER}" 2>/dev/null) || issue_json=""
 		if printf '%s' "$issue_json" | jq -e '.body | type == "string"' >/dev/null 2>&1 &&
@@ -152,6 +153,13 @@ terminal_blocker_task_revision() {
 	local reason="${5:-}"
 	local task_json="" dependency_signature="" target_revision="" canonical=""
 	[[ -n "$reason" ]] || reason=$(_terminal_blocker_reason "${AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT:-}")
+	# A brief edit, unrelated merge or GraphQL outage cannot satisfy a permission
+	# prerequisite. Explicit retry only schedules a new check; it grants nothing.
+	if [[ "$reason" == "permission_required" ]]; then
+		[[ "$repo_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ && "$issue_number" =~ ^[0-9]+$ ]] || return 1
+		_terminal_blocker_hash "v2:${reason}:${repo_slug}:${issue_number}"
+		return $?
+	fi
 	task_json=$(printf '%s' "$issue_json" | jq -c '{title: (.title // ""), body: (.body // "")}' 2>/dev/null) || return 1
 	if [[ "$reason" == "$_TBC_MISSING_SCOPE" || "$reason" == "files_scope_excluded" ]]; then
 		_terminal_blocker_hash "v2:${reason}:${task_json}"
@@ -174,7 +182,7 @@ terminal_blocker_fetch_trusted_comments() {
 	printf '%s' "$raw" | jq -c '
 		def trusted: . == "OWNER" or . == "MEMBER" or . == "COLLABORATOR";
 		[(if type == "array" and ((.[0]? | type) == "array") then .[] else . end)[]
-		| {body: (.body // ""), created_at: .created_at,
+		| {id: .id, author: (.user.login // ""), body: (.body // ""), created_at: .created_at,
 		   author_association: (.author_association // "")}
 		| select(.author_association | trusted)]
 	' 2>/dev/null || return 1
@@ -184,8 +192,12 @@ terminal_blocker_fetch_trusted_comments() {
 _terminal_blocker_latest_marker() {
 	local comments_json="$1"
 	local marker="$2"
-	printf '%s' "$comments_json" | jq -c --arg marker "$marker" '
-		[.[] | select((.body // "") | contains($marker))]
+	# aidevops:trust-boundary — a deterministic marker is not a signature.
+	# The same authoritative actors must own both opening and clearing a hold.
+	printf '%s' "$comments_json" | jq -c --arg marker "$marker" \
+		--argjson authoritative "$_TBC_AUTHORITATIVE_ASSOCIATIONS" '
+		[.[] | select(.author_association as $a | $authoritative | index($a) != null)
+		| select((.body // "") | contains($marker))]
 		| sort_by(.created_at) | last // empty
 	' 2>/dev/null
 	return $?
@@ -193,10 +205,14 @@ _terminal_blocker_latest_marker() {
 
 _terminal_blocker_latest_retry_at() {
 	local comments_json="$1"
+	# aidevops:trust-boundary — retry affects scheduling, not source authority;
+	# ambiguous collaborators and quoted recovery prose cannot authorize it.
 	printf '%s' "$comments_json" | jq -r --arg marker "$_TBC_RETRY_MARKER" \
+		--argjson authoritative "$_TBC_AUTHORITATIVE_ASSOCIATIONS" \
 		--arg circuit_marker "$_TBC_CIRCUIT_MARKER" '
-		[.[] | select((.body // "") as $body
-		| ($body | contains($marker)) and (($body | contains($circuit_marker)) | not))
+		[.[] | select(.author_association as $a | $authoritative | index($a) != null)
+		| select((.body // "") as $body
+		| ($body | test("(?m)^" + $marker + "[ \\t]*\\r?$")) and (($body | contains($circuit_marker)) | not))
 		| .created_at]
 		| sort | last // ""
 	' 2>/dev/null
@@ -259,6 +275,10 @@ _terminal_blocker_recovery() {
 		owner="target-maintainer"
 		action='Review the protected blocker dossier and correct the target code or task dependencies before retrying.'
 		;;
+	permission_required)
+		owner="permission-maintainer"
+		action='Resolve the evidenced permission prerequisite through the human-owned approval flow, then post the explicit retry directive. Retry is scheduling consent only: the original permission guard must independently verify the exact context. Do not regenerate requests or bypass the guard.'
+		;;
 	*)
 		owner="worker-triage"
 		action='Interpret the protected dossier and record a known blocker class or repair the brief. No global dispatch hold is imposed.'
@@ -277,10 +297,50 @@ terminal_blocker_circuit_comment() {
 	local task_revision="$2"
 	local blocker_fingerprint="$3"
 	[[ "$(_terminal_blocker_reason "$blocker_fingerprint")" != "$_TBC_UNKNOWN" ]] || return 1
-	printf '<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\n%s\n<!-- %s revision=%s blocker=%s -->\nTERMINAL_BLOCKER_CIRCUIT active=true observations=2 task_revision=%s blocker=%s\n\nAutomatic redispatch is held for the repeated known blocker. See the preceding recovery observation.\n\nA maintainer can retry without deleting history by posting %s. A relevant revision change also re-arms dispatch; brief-only blockers ignore target commits and dependencies.\n<!-- ops:end -->\n' \
+	printf '<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\n%s\n<!-- %s revision=%s blocker=%s -->\nTERMINAL_BLOCKER_CIRCUIT active=true observations=2 task_revision=%s blocker=%s\n\nAutomatic redispatch is held for the repeated known blocker. See the preceding recovery observation.\n\nAn OWNER/MEMBER can retry without deleting history by posting %s as a standalone line. Relevant revisions re-arm code/brief blockers, but never permission blockers. Retry schedules verification only and grants no access.\n<!-- ops:end -->\n' \
 		"$machine_readable_release" "$_TBC_CIRCUIT_MARKER" "$task_revision" \
 		"$blocker_fingerprint" "$task_revision" "$blocker_fingerprint" \
 		"$_TBC_RETRY_MARKER"
+	return 0
+}
+
+# Unknown/legacy BLOCKED results remain retryable, but not on every pulse. Use
+# shared GitHub evidence, independent of local counters, model prose, target
+# revisions and comment-bloat mode. Expiry or an explicit trusted retry re-arms
+# dispatch; no labels or comments are written by this gate.
+terminal_blocker_backoff_active() {
+	local comments_json="$1"
+	local now_epoch="${TERMINAL_BLOCKER_NOW_EPOCH:-}"
+	local evidence="" count=0 last_epoch=0 delay=900 steps=0
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || now_epoch=$(date -u '+%s')
+	# aidevops:trust-boundary — bare COLLABORATOR is not proof of write access.
+	# Accept only OWNER/MEMBER releases whose runner matches the API author.
+	# A retry must be a standalone directive, not quoted recovery instructions.
+	evidence=$(printf '%s' "$comments_json" | jq -r --argjson now "$now_epoch" \
+		--argjson associations "$_TBC_AUTHORITATIVE_ASSOCIATIONS" '
+		def authoritative: .author_association as $a | $associations | index($a) != null;
+		def epoch: try (.created_at | fromdateiso8601) catch 0;
+		[.[] | select(authoritative) | select(epoch > 0 and epoch <= $now)] as $trusted
+		| ([$trusted[] | select((.body // "") | test("(?m)^terminal-blocker-circuit:retry[ \\t]*\\r?$")) | epoch] | max // 0) as $retry
+		| [$trusted[] | select(epoch > $retry)
+			| . as $comment
+			| ((.body // "") | try capture("(?m)^CLAIM_RELEASED reason=blocked runner=(?<runner>[A-Za-z0-9-]+) ") catch null) as $release
+			| select($release != null and $release.runner == ($comment.author // $comment.user.login // ""))
+			| epoch] | [length, (max // 0)] | @tsv
+	' 2>/dev/null) || return 1
+	IFS=$'\t' read -r count last_epoch <<<"$evidence"
+	[[ "$count" =~ ^[0-9]+$ && "$last_epoch" =~ ^[0-9]+$ && "$count" -ge 2 ]] || return 1
+	# Two failures: 15 minutes; each further failure doubles the delay, capped
+	# at 24 hours. Cap before arithmetic so even very long histories stay safe.
+	steps=$((count - 2))
+	[[ "$steps" -le 7 ]] || steps=7
+	while [[ "$steps" -gt 0 ]]; do
+		delay=$((delay * 2))
+		steps=$((steps - 1))
+	done
+	[[ "$delay" -le 86400 ]] || delay=86400
+	[[ "$((now_epoch - last_epoch))" -lt "$delay" ]] || return 1
+	printf 'TERMINAL_BLOCKER_BACKOFF failures=%s retry_after=%s\n' "$count" "$((last_epoch + delay))"
 	return 0
 }
 
@@ -291,6 +351,9 @@ terminal_blocker_circuit_active() {
 	local issue_number="$4"
 	local repo_path="$5"
 	local circuit="" circuit_at="" retry_at="" current_revision="" fingerprint="" reason=""
+	if terminal_blocker_backoff_active "$comments_json"; then
+		return 0
+	fi
 	circuit=$(_terminal_blocker_latest_marker "$comments_json" "$_TBC_CIRCUIT_MARKER revision=") || circuit=""
 	[[ -n "$circuit" ]] || return 1
 	fingerprint=$(printf '%s' "$circuit" | jq -r '.body | capture("<!-- aidevops:terminal-blocker-circuit revision=[a-f0-9]{24} blocker=(?<id>[a-f0-9]{24}) -->").id' 2>/dev/null) || return 1

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
@@ -106,11 +106,17 @@ if ! LOGFILE="${TEST_TMP}/pulse.log" \
 	_dlw_hold_repeated_zero_output "123" "owner/repo" $'12\t12\t4\t60000\t4'; then
 	fail "clean-room comment bloat bypassed a threshold of zero-attempt infrastructure failures"
 fi
-if LOGFILE="${TEST_TMP}/pulse.log" \
+if ! LOGFILE="${TEST_TMP}/pulse.log" \
 	CLEAN_ROOM_COMMENT_THRESHOLD=1 \
 	ZERO_OUTPUT_BRIEF_REWRITE_HOLD_THRESHOLD=4 \
 	_dlw_hold_repeated_zero_output "123" "owner/repo" $'12\t12\t4\t60000\t0'; then
-	fail "clean-room mode stopped bypassing a generic zero-output brief rewrite"
+	fail "clean-room mode bypassed the generic zero-output retry budget"
+fi
+if LOGFILE="${TEST_TMP}/pulse.log" \
+	CLEAN_ROOM_COMMENT_THRESHOLD=1 \
+	ZERO_OUTPUT_BRIEF_REWRITE_HOLD_THRESHOLD=4 \
+	_dlw_hold_repeated_zero_output "123" "owner/repo" $'400\t400\t3\t60000\t0'; then
+	fail "comment bloat alone consumed the remaining clean-room recovery attempt"
 fi
 
 cat >"$GH_COMMENTS_FIXTURE" <<'EOF'
@@ -170,9 +176,10 @@ fi
 completion_contract=$(_dlw_first_pass_completion_contract)
 # shellcheck disable=SC2016 # Markdown backticks are intentional literals.
 if [[ "$completion_contract" != *'terminal failing check caused by your current changes'* ]] \
-	|| [[ "$completion_contract" != *'canonical `### Files Scope` section'* ]] \
+	|| [[ "$completion_contract" != *'authorized outcome and explicit exclusions are binding'* ]] \
 	|| [[ "$completion_contract" != *'blocker dossier'* ]] \
-	|| [[ "$completion_contract" != *'revised brief or follow-up issue'* ]]; then
+	|| [[ "$completion_contract" != *'minimal corrected canonical issue/local brief'* ]] \
+	|| [[ "$completion_contract" != *'Never widen an explicit hard boundary'* ]]; then
 	fail "first-pass contract does not bound CI remediation to canonical files scope"
 fi
 completion_contract_call_sites=$(grep -cE '^[[:space:]]+_dlw_first_pass_completion_contract$' \

--- a/.agents/scripts/tests/test-terminal-blocker-circuit.sh
+++ b/.agents/scripts/tests/test-terminal-blocker-circuit.sh
@@ -136,7 +136,10 @@ test_release_modes_and_retry() {
 	local empty='[]'
 	local observed="[{\"body\":\"${observation}\",\"created_at\":\"2026-08-31T10:00:00Z\"}]"
 	local opened="[{\"body\":\"${observation}\",\"created_at\":\"2026-08-31T10:00:00Z\"},{\"body\":\"${circuit}\",\"created_at\":\"2026-08-31T10:05:00Z\"}]"
-	local retried="[{\"body\":\"${observation}\",\"created_at\":\"2026-08-31T10:00:00Z\"},{\"body\":\"${circuit}\",\"created_at\":\"2026-08-31T10:05:00Z\"},{\"body\":\"terminal-blocker-circuit:retry\",\"created_at\":\"2026-08-31T10:10:00Z\"}]"
+	local retried="[{\"body\":\"${observation}\",\"created_at\":\"2026-08-31T10:00:00Z\"},{\"body\":\"${circuit}\",\"created_at\":\"2026-08-31T10:05:00Z\"},{\"body\":\"terminal-blocker-circuit:retry\",\"created_at\":\"2026-08-31T10:10:00Z\",\"author_association\":\"OWNER\"}]"
+	observed=$(printf '%s' "$observed" | jq -c 'map(.author_association="OWNER")')
+	opened=$(printf '%s' "$opened" | jq -c 'map(.author_association="OWNER")')
+	retried=$(printf '%s' "$retried" | jq -c 'map(.author_association="OWNER")')
 	local status=1
 	if [[ "$(terminal_blocker_release_mode "$empty" "$revision" "$blocker")" == "first" &&
 	"$(terminal_blocker_release_mode "$observed" "$revision" "$blocker")" == "circuit" &&
@@ -154,7 +157,7 @@ test_dispatch_hold_revalidates_revision() {
 	revision=$(terminal_blocker_task_revision "$issue_json" "owner/repo" 42 "$TEST_ROOT")
 	local blocker=""
 	blocker=$(_terminal_blocker_hash 'v2:target_code_blocker')
-	local comments="[{\"body\":\"<!-- aidevops:terminal-blocker-circuit revision=${revision} blocker=${blocker} -->\",\"created_at\":\"2026-08-31T10:05:00Z\"}]"
+	local comments="[{\"body\":\"<!-- aidevops:terminal-blocker-circuit revision=${revision} blocker=${blocker} -->\",\"created_at\":\"2026-08-31T10:05:00Z\",\"author_association\":\"MEMBER\"}]"
 	local same_status=0 changed_status=0 ambiguous_status=0
 	terminal_blocker_circuit_active "$comments" "$issue_json" "owner/repo" 42 "$TEST_ROOT" >/dev/null || same_status=$?
 	terminal_blocker_circuit_active "$comments" '{"title":"Fix scope","body":"Files Scope: b.sh"}' \
@@ -284,7 +287,7 @@ test_unknown_and_redaction() {
 	fragment=$(WORKER_SESSION_KEY='/private/runner/private-token' terminal_blocker_observation_fragment 111111111111111111111111 "$fingerprint")
 	[[ "$fragment" == *'reason=unknown owner=worker-triage'* && "$fragment" == *'Next action:'* &&
 		"$fragment" != *'private-token'* && "$fragment" != *'/private/'* ]] || status=1
-	comments=$(jq -nc --arg body "$fragment" '[{body:$body,created_at:"2026-08-31T10:00:00Z"}]')
+	comments=$(jq -nc --arg body "$fragment" '[{body:$body,created_at:"2026-08-31T10:00:00Z",author_association:"MEMBER"}]')
 	[[ "$(terminal_blocker_release_mode "$comments" 111111111111111111111111 "$fingerprint")" == normal ]] || status=1
 	terminal_blocker_circuit_comment release 111111111111111111111111 "$fingerprint" >/dev/null && status=1
 	terminal_blocker_circuit_active "$comments" '{}' owner/repo 42 "$TEST_ROOT" >/dev/null && status=1
@@ -337,6 +340,86 @@ test_final_dossier_and_structural_precedence() {
 	return 0
 }
 
+test_legacy_blocked_backoff() {
+	local comments="" changed="" result="" status=0
+	# No local metrics, fingerprints or task revision: reproduce legacy releases
+	# by two runners, as seen on GH#31378. Exercise the actual dispatch gate.
+	comments=$(jq -nc '[range(2) | {id:(. + 1), body:("<!-- ops:start -->\nCLAIM_RELEASED reason=blocked runner=runner-" + tostring + " ts=ignored\n<!-- ops:end -->"), author:("runner-" + tostring), author_association:"MEMBER", created_at:"2026-09-06T12:00:00Z"}]')
+	result=$(TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_circuit_active "$comments" '{}' owner/repo 42 '') || status=1
+	[[ "$result" == 'TERMINAL_BLOCKER_BACKOFF failures=2 retry_after=1788696900' ]] || status=1
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696900 terminal_blocker_backoff_active "$comments" >/dev/null && status=1
+	changed=$(printf '%s' "$comments" | jq -c '.[0:1]')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null && status=1
+	changed=$(printf '%s' "$comments" | jq -c '. + [{body:"terminal-blocker-circuit:retry",author_association:"OWNER",created_at:"2026-09-06T12:00:01Z"}]')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696002 terminal_blocker_backoff_active "$changed" >/dev/null && status=1
+	changed=$(jq -nc '[range(400) | {body:"CLAIM_RELEASED reason=blocked runner=runner ts=ignored",author:"runner",author_association:"OWNER",created_at:"2026-09-06T12:00:00Z"}]')
+	result=$(TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed") || status=1
+	[[ "$result" == 'TERMINAL_BLOCKER_BACKOFF failures=400 retry_after=1788782400' ]] || status=1
+	TERMINAL_BLOCKER_NOW_EPOCH=1788782400 terminal_blocker_backoff_active "$changed" >/dev/null && status=1
+	print_result "legacy blocked releases impose cross-runner exponential backoff with expiry, cap and trusted retry" "$status"
+	return 0
+}
+
+test_blocked_backoff_trust() {
+	local comments="" changed="" association="" status=0
+	comments=$(jq -nc '[range(2) | {body:"CLAIM_RELEASED reason=blocked runner=runner ts=ignored",author:"runner",author_association:"OWNER",created_at:"2026-09-06T12:00:00Z"}]')
+	for association in COLLABORATOR CONTRIBUTOR NONE; do
+		changed=$(printf '%s' "$comments" | jq -c --arg association "$association" 'map(.author_association=$association)')
+		TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null && status=1
+	done
+	changed=$(printf '%s' "$comments" | jq -c 'map(.author="impostor")')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null && status=1
+	changed=$(printf '%s' "$comments" | jq -c 'map(.body="> " + .body)')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null && status=1
+	TERMINAL_BLOCKER_NOW_EPOCH=1788695999 terminal_blocker_backoff_active "$comments" >/dev/null && status=1
+	changed=$(printf '%s' "$comments" | jq -c 'map(.created_at="invalid")')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null && status=1
+	changed=$(printf '%s' "$comments" | jq -c '. + [{body:"terminal-blocker-circuit:retry",author_association:"COLLABORATOR",created_at:"2026-09-06T12:00:01Z"}]')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696002 terminal_blocker_backoff_active "$changed" >/dev/null || status=1
+	changed=$(printf '%s' "$comments" | jq -c '. + [{body:"A maintainer can post terminal-blocker-circuit:retry",author_association:"OWNER",created_at:"2026-09-06T12:00:01Z"}]')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696002 terminal_blocker_backoff_active "$changed" >/dev/null || status=1
+	print_result "backoff rejects untrusted, forged, quoted, invalid and future evidence; recovery prose cannot reset it" "$status"
+	return 0
+}
+
+test_permission_blocker_continuation() {
+	local output="${TEST_ROOT}/permission.ndjson" status=0 fingerprint="" revision="" changed="" comments="" contract=""
+	contract=$(
+		# shellcheck source=../headless-runtime-lib.sh
+		source "${SCRIPT_DIR}/headless-runtime-lib.sh"
+		append_worker_headless_contract '/full-loop Resume after source denial'
+	) || status=1
+	[[ "$contract" == *'TERMINAL_BLOCKER_REASON=permission_required'* ]] || status=1
+	printf '%s\n' '{"type":"text","part":{"text":"BLOCKED: prior protected-source denial has no changed exact-context grant\nTERMINAL_BLOCKER_REASON=permission_required"}}' >"$output"
+	terminal_blocker_capture_output "$output" || status=1
+	fingerprint="$AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT"
+	[[ "$(_terminal_blocker_reason "$fingerprint")" == permission_required ]] || status=1
+	revision=$(terminal_blocker_task_revision '{}' owner/repo 42 '') || status=1
+	TEST_DEPENDENCIES=unavailable
+	TEST_TARGET_REVISION=unavailable
+	changed=$(terminal_blocker_task_revision '{"body":"changed brief"}' owner/repo 42 '') || status=1
+	[[ "$revision" == "$changed" ]] || status=1
+	comments=$(jq -nc --arg body "<!-- aidevops:terminal-blocker-circuit revision=${revision} blocker=${fingerprint} -->" '[{body:$body,created_at:"2026-09-06T12:00:00Z",author_association:"OWNER"}]')
+	terminal_blocker_circuit_active "$comments" '{}' owner/repo 42 '' >/dev/null || status=1
+	terminal_blocker_circuit_active "$comments" '{}' owner/repo 43 '' >/dev/null && status=1
+	changed=$(printf '%s' "$comments" | jq -c 'map(.author_association="COLLABORATOR")')
+	terminal_blocker_circuit_active "$changed" '{}' owner/repo 42 '' >/dev/null && status=1
+	changed=$(printf '%s' "$comments" | jq -c '. + [.[0] | .author_association="COLLABORATOR" | .created_at="2026-09-06T12:00:30Z" | .body |= sub("revision=[a-f0-9]+"; "revision=aaaaaaaaaaaaaaaaaaaaaaaa")]')
+	terminal_blocker_circuit_active "$changed" '{}' owner/repo 42 '' >/dev/null || status=1
+	changed=$(printf '%s' "$comments" | jq -c '. + [{body:"terminal-blocker-circuit:retry",created_at:"2026-09-06T12:01:00Z",author_association:"COLLABORATOR"}]')
+	terminal_blocker_circuit_active "$changed" '{}' owner/repo 42 '' >/dev/null || status=1
+	changed=$(printf '%s' "$comments" | jq -c '. + [{body:"Please post terminal-blocker-circuit:retry",created_at:"2026-09-06T12:01:00Z",author_association:"OWNER"}]')
+	terminal_blocker_circuit_active "$changed" '{}' owner/repo 42 '' >/dev/null || status=1
+	comments=$(printf '%s' "$comments" | jq -c '. + [{body:"terminal-blocker-circuit:retry",created_at:"2026-09-06T12:01:00Z",author_association:"OWNER"}]')
+	terminal_blocker_circuit_active "$comments" '{}' owner/repo 42 '' >/dev/null && status=1
+	[[ "$(_terminal_blocker_recovery "$fingerprint")" == *'Retry is scheduling consent only'* ]] || status=1
+	TEST_DEPENDENCIES='{"nodes":[],"truncated":false}'
+	TEST_TARGET_REVISION='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+	unset AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT
+	print_result "continued permission denial has a stable class; edits and API outages do not re-arm; retry grants nothing" "$status"
+	return 0
+}
+
 main() {
 	test_normalized_blocker_fingerprint
 	test_worker_contract_reason_protocol
@@ -348,6 +431,9 @@ main() {
 	test_unknown_and_redaction
 	test_final_dossier_and_structural_precedence
 	test_release_integration_bounds_comments
+	test_legacy_blocked_backoff
+	test_blocked_backoff_trust
+	test_permission_blocker_continuation
 	printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 }

--- a/.agents/scripts/tests/test-terminal-blocker-circuit.sh
+++ b/.agents/scripts/tests/test-terminal-blocker-circuit.sh
@@ -420,6 +420,22 @@ test_permission_blocker_continuation() {
 	return 0
 }
 
+test_blocked_backoff_cli() {
+	local result="" status=0
+	result=$(
+		gh() {
+			[[ "$1" == api && "$2" == 'repos/owner/repo/issues/42/comments?per_page=100' ]] || return 1
+			jq -nc '[[range(2) | {id:(. + 1),body:"CLAIM_RELEASED reason=blocked runner=runner ts=ignored",user:{login:"runner"},author_association:"OWNER",created_at:"2026-09-06T12:00:00Z"}]]'
+			return 0
+		}
+		export -f gh
+		TERMINAL_BLOCKER_NOW_EPOCH=1788696001 bash "${SCRIPT_DIR}/dispatch-dedup-helper.sh" has-dispatch-comment 42 owner/repo runner
+	) || status=1
+	[[ "$result" == 'TERMINAL_BLOCKER_BACKOFF failures=2 retry_after=1788696900' ]] || status=1
+	print_result "production dispatch CLI preserves paginated API authors and blocks legacy repeated releases" "$status"
+	return 0
+}
+
 main() {
 	test_normalized_blocker_fingerprint
 	test_worker_contract_reason_protocol
@@ -434,6 +450,7 @@ main() {
 	test_legacy_blocked_backoff
 	test_blocked_backoff_trust
 	test_permission_blocker_continuation
+	test_blocked_backoff_cli
 	printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 }

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -38,8 +38,15 @@ gh() {
 	if [[ "$command_name" == "api" ]]; then
 		printf '%s\n' "$command_name $*" >>"${TMP}/gh-api-calls.log"
 	fi
-	if [[ "$command_name" == "api" && -n "${GH_COMMENT_METRICS:-}" ]]; then
-		printf '%s\n' "$GH_COMMENT_METRICS"
+	if [[ "$command_name" == "api" && "$*" == *"--slurp"* ]]; then
+		# The real API returns comment pages, not precomputed TSV metrics.
+		local comments=0 ops=0 zero=0 chars=0
+		IFS=$'\t' read -r comments ops zero chars <<<"${GH_COMMENT_METRICS:-$'0\t0\t0\t0'}"
+		jq -nc --argjson comments "$comments" --argjson ops "$ops" --argjson zero "$zero" '
+			[[range([$comments, $ops, $zero] | max) | . as $index |
+			{body: ((if $index < $ops then "<!-- ops:start --> " else "" end) +
+			(if $index < $zero then "worker_noop_zero_output" else "status" end)),
+			author_association:"OWNER", user:{login:"runner"}}]]'
 		return 0
 	fi
 	if [[ "$command_name" == "api" && "${GH_COMMENT_ZERO_COUNT:-0}" =~ ^[0-9]+$ ]]; then
@@ -233,11 +240,12 @@ GH_COMMENT_METRICS=$'275\t260\t87\t81500'
 _dlw_hold_repeated_zero_output 123 owner/repo
 clean_room_hold_rc=$?
 clean_room_gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
-if [[ "$clean_room_hold_rc" -eq 1 ]] \
+if [[ "$clean_room_hold_rc" -eq 0 ]] \
+	&& printf '%s' "$clean_room_gh_calls" | grep -q 'set_issue_status 123 owner/repo blocked' \
 	&& ! printf '%s' "$clean_room_gh_calls" | grep -q 'needs-brief-rewrite'; then
-	pass "comment-bloated issues bypass repeated zero-output hold"
+	pass "comment-bloated issues retain the repeated zero-output hold"
 else
-	fail "comment-bloated issues bypass repeated zero-output hold" \
+	fail "comment-bloated issues retain the repeated zero-output hold" \
 		"rc=${clean_room_hold_rc}; gh_calls=${clean_room_gh_calls}"
 fi
 


### PR DESCRIPTION
## Summary

Fix the dispatch/comment storm observed on #31378. Ref #31378 — this PR does **not** implement or close its original bundled source-access feature.

- Bound legacy/unclassified `CLAIM_RELEASED reason=blocked` redispatch across runners using authenticated GitHub history: 15 minutes after two failures, doubling to a 24-hour cap. The read-only gate posts no additional comments and does not permanently hold unknown causes.
- Give continued, evidenced permission denials an explicit `permission_required` terminal class. Its circuit survives unrelated brief/code changes and dependency API outages; a retry schedules verification, never grants source access.
- Require OWNER/MEMBER authority for circuit/observation markers and standalone retry directives. Ambiguous collaborator markers cannot create, shadow, or clear a circuit.
- Remove the clean-room prompt exemption from the zero-output retry budget. Preserve clean-room recovery below the limit.

## Root cause and evidence

The inspected thread contained 66 worker launches, 65 blocked releases and 69 claims across three runners, with no implementation PR. A substantive worker checkpoint reported an incompatible protected-source broker, and a later preserved worker result explicitly refused to repeat a denied read without an exact-context grant. That safe refusal became generic `blocked`; claim release made the issue eligible again. Unknown terminal evidence had no cross-runner backoff. Local diagnostics also repeatedly logged the unconditional clean-room hold exemption once the issue accumulated operational comments.

## Files and reference patterns

- `.agents/scripts/terminal-blocker-circuit.sh`: existing shared release/dispatch circuit, new bounded fallback and permission identity.
- `.agents/scripts/headless-runtime-lib.sh`: producer contract for the new reason.
- `.agents/scripts/pulse-dispatch-worker-prompt.sh`: prompt selection no longer overrides failure limits.
- Existing terminal-circuit, comment-metrics and URL-fallback tests: fake-clock, multi-runner, trust and recovery coverage. Updated two stale fixture contracts to match the current API page shape and integration-scope guidance rather than weakening production checks.
- `.agents/reference/worker-diagnostics.md`: incident evidence, scheduling semantics and recovery instructions.

## Runtime Testing

**runtime-verified** using the real shell functions with fake GitHub identities, comments, clocks and mutation capture; no live worker launch or privileged/source-access operation.

Passed:

```bash
/bin/bash .agents/scripts/tests/test-terminal-blocker-circuit.sh
bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
bash .agents/scripts/tests/test-zero-output-url-fallback.sh
bash .agents/scripts/tests/test-dispatch-lifecycle-comms.sh
.agents/scripts/linters-local.sh
```

Terminal-circuit coverage: 15 checks, including the production dispatch CLI with paginated fake GitHub responses; URL fallback: 12 checks; lifecycle communication: 21 checks; comment-metrics suite passes. Local gates include ShellCheck on all six changed shell files, secretlint, Markdown lint, whitespace, literal/complexity/portability ratchets. Existing formatting and historical-debt advisories remain advisory.

## Review and decisions

Independent review findings were inspected and addressed: retained author/id projections, standalone authoritative retries, and authoritative circuit markers with forged/shadow-marker regressions. The claimed unreachable production backoff was falsified by the actual caller: `dispatch-dedup-helper.sh::_dd_fetch_trusted_issue_comments` already preserves `author` before `has_dispatch_comment` invokes the circuit. Existing same-second timestamp ordering is separate follow-up work.

Final locally reviewed evidence bundle: `a884131f4cc8664f8fd232e63b799ca67d45d9e8d201f591c55e4b0269d84060`, head `7822a8a88effa088b345d212590a4d64948f9963`; prompt-injection scan clean.

No source capability, credential permission, publication, or deployed broker mutation is introduced. #31378 remains open behind its original human-owned prerequisite. No release requested.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.323 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 41m and 256,431 tokens on this with the user in an interactive session.