### PR TITLE
GH#31413: fix: order terminal blocker retries by timestamp and comment ID

### DIFF
--- a/.agents/scripts/terminal-blocker-circuit.sh
+++ b/.agents/scripts/terminal-blocker-circuit.sh
@@ -14,6 +14,34 @@ _TBC_MISSING_SCOPE='missing_files_scope'
 _TBC_UNKNOWN='unknown'
 _TBC_AUTHORITATIVE_ASSOCIATIONS='["OWNER","MEMBER"]'
 
+# IDs break same-second ties only when both are positive, exact JSON integers.
+# Legacy/malformed IDs never let a tied retry clear evidence. For selection,
+# unknown marker IDs sort last (conservative hold), unknown retry IDs first.
+# shellcheck disable=SC2016 # Shared jq definitions, not shell expansions.
+_TBC_ORDER_JQ='
+def comment_id:
+  .id | if type == "number" then
+    if . > 0 and . <= 9007199254740991 and floor == . then . else null end
+  else null end;
+def valid_time: try (.created_at | fromdateiso8601 | . > 0) catch false;
+def retry_after($event):
+  . as $retry | ($retry.created_at // "") as $at
+  | ($event.created_at // "") as $before
+  | ($retry | valid_time) and ($event | valid_time) and
+    ($at > $before or ($at == $before and
+      ($retry | comment_id) != null and ($event | comment_id) != null and
+      ($retry | comment_id) > ($event | comment_id)));
+'
+
+_terminal_blocker_retry_after() {
+	local retry="$1"
+	local event="$2"
+	[[ -n "$retry" && -n "$event" ]] || return 1
+	printf '%s' "$retry" | jq -e --argjson event "$event" \
+		"${_TBC_ORDER_JQ}"'retry_after($event)' >/dev/null 2>&1
+	return $?
+}
+
 _terminal_blocker_hash() {
 	local value="$1"
 	local digest=""
@@ -195,26 +223,26 @@ _terminal_blocker_latest_marker() {
 	# aidevops:trust-boundary — a deterministic marker is not a signature.
 	# The same authoritative actors must own both opening and clearing a hold.
 	printf '%s' "$comments_json" | jq -c --arg marker "$marker" \
-		--argjson authoritative "$_TBC_AUTHORITATIVE_ASSOCIATIONS" '
+		--argjson authoritative "$_TBC_AUTHORITATIVE_ASSOCIATIONS" "${_TBC_ORDER_JQ}"'
 		[.[] | select(.author_association as $a | $authoritative | index($a) != null)
 		| select((.body // "") | contains($marker))]
-		| sort_by(.created_at) | last // empty
+		| sort_by(.created_at, (comment_id // 9007199254740992), .body) | last // empty
 	' 2>/dev/null
 	return $?
 }
 
-_terminal_blocker_latest_retry_at() {
+_terminal_blocker_latest_retry_comment() {
 	local comments_json="$1"
 	# aidevops:trust-boundary — retry affects scheduling, not source authority;
 	# ambiguous collaborators and quoted recovery prose cannot authorize it.
-	printf '%s' "$comments_json" | jq -r --arg marker "$_TBC_RETRY_MARKER" \
+	printf '%s' "$comments_json" | jq -c --arg marker "$_TBC_RETRY_MARKER" \
 		--argjson authoritative "$_TBC_AUTHORITATIVE_ASSOCIATIONS" \
-		--arg circuit_marker "$_TBC_CIRCUIT_MARKER" '
+		--arg circuit_marker "$_TBC_CIRCUIT_MARKER" "${_TBC_ORDER_JQ}"'
 		[.[] | select(.author_association as $a | $authoritative | index($a) != null)
 		| select((.body // "") as $body
 		| ($body | test("(?m)^" + $marker + "[ \\t]*\\r?$")) and (($body | contains($circuit_marker)) | not))
-		| .created_at]
-		| sort | last // ""
+		]
+		| sort_by(.created_at, (comment_id // 0), .body) | last // empty
 	' 2>/dev/null
 	return $?
 }
@@ -223,8 +251,8 @@ terminal_blocker_release_mode() {
 	local comments_json="$1"
 	local task_revision="$2"
 	local blocker_fingerprint="$3"
-	local retry_at="" circuit="" observation="" circuit_at="" observation_at=""
-	retry_at=$(_terminal_blocker_latest_retry_at "$comments_json") || retry_at=""
+	local retry="" circuit="" observation="" circuit_at="" observation_at=""
+	retry=$(_terminal_blocker_latest_retry_comment "$comments_json") || retry=""
 	circuit=$(_terminal_blocker_latest_marker "$comments_json" "$_TBC_CIRCUIT_MARKER revision=${task_revision} blocker=${blocker_fingerprint}") || circuit=""
 	observation=$(_terminal_blocker_latest_marker "$comments_json" "$_TBC_OBSERVATION_MARKER revision=${task_revision} blocker=${blocker_fingerprint}") || observation=""
 	circuit_at=$(printf '%s' "$circuit" | jq -r '.created_at // ""' 2>/dev/null) || circuit_at=""
@@ -232,16 +260,16 @@ terminal_blocker_release_mode() {
 	# Unknown dossiers can have one safe observation, never a durable circuit.
 	# Preserve each new CLAIM_RELEASED audit event, but omit repeated explanations.
 	if [[ "$(_terminal_blocker_reason "$blocker_fingerprint")" == "$_TBC_UNKNOWN" ]]; then
-		if [[ -n "$observation_at" && (-z "$retry_at" || "$observation_at" > "$retry_at") ]]; then
+		if [[ -n "$observation_at" ]] && ! _terminal_blocker_retry_after "$retry" "$observation"; then
 			printf 'normal\n'
 		else
 			printf 'first\n'
 		fi
 		return 0
 	fi
-	if [[ -n "$circuit_at" && (-z "$retry_at" || "$circuit_at" > "$retry_at") ]]; then
+	if [[ -n "$circuit_at" ]] && ! _terminal_blocker_retry_after "$retry" "$circuit"; then
 		printf 'open\n'
-	elif [[ -n "$observation_at" && (-z "$retry_at" || "$observation_at" > "$retry_at") ]]; then
+	elif [[ -n "$observation_at" ]] && ! _terminal_blocker_retry_after "$retry" "$observation"; then
 		printf 'circuit\n'
 	else
 		printf 'first\n'
@@ -317,12 +345,14 @@ terminal_blocker_backoff_active() {
 	# Accept only OWNER/MEMBER releases whose runner matches the API author.
 	# A retry must be a standalone directive, not quoted recovery instructions.
 	evidence=$(printf '%s' "$comments_json" | jq -r --argjson now "$now_epoch" \
-		--argjson associations "$_TBC_AUTHORITATIVE_ASSOCIATIONS" '
+		--argjson associations "$_TBC_AUTHORITATIVE_ASSOCIATIONS" "${_TBC_ORDER_JQ}"'
 		def authoritative: .author_association as $a | $associations | index($a) != null;
 		def epoch: try (.created_at | fromdateiso8601) catch 0;
 		[.[] | select(authoritative) | select(epoch > 0 and epoch <= $now)] as $trusted
-		| ([$trusted[] | select((.body // "") | test("(?m)^terminal-blocker-circuit:retry[ \\t]*\\r?$")) | epoch] | max // 0) as $retry
-		| [$trusted[] | select(epoch > $retry)
+		| ([$trusted[] | select((.body // "") | test("(?m)^terminal-blocker-circuit:retry[ \\t]*\\r?$"))
+			| select((.body // "") | contains("aidevops:terminal-blocker-circuit") | not)]
+			| sort_by(.created_at, (comment_id // 0), .body) | last) as $retry
+		| [$trusted[] | . as $event | select(($retry | retry_after($event)) | not)
 			| . as $comment
 			| ((.body // "") | try capture("(?m)^CLAIM_RELEASED reason=blocked runner=(?<runner>[A-Za-z0-9-]+) ") catch null) as $release
 			| select($release != null and $release.runner == ($comment.author // $comment.user.login // ""))
@@ -350,7 +380,7 @@ terminal_blocker_circuit_active() {
 	local repo_slug="$3"
 	local issue_number="$4"
 	local repo_path="$5"
-	local circuit="" circuit_at="" retry_at="" current_revision="" fingerprint="" reason=""
+	local circuit="" retry="" current_revision="" fingerprint="" reason=""
 	if terminal_blocker_backoff_active "$comments_json"; then
 		return 0
 	fi
@@ -362,9 +392,8 @@ terminal_blocker_circuit_active() {
 	current_revision=$(terminal_blocker_task_revision "$issue_json" "$repo_slug" "$issue_number" "$repo_path" "$reason") || return 1
 	circuit=$(_terminal_blocker_latest_marker "$comments_json" "$_TBC_CIRCUIT_MARKER revision=${current_revision} blocker=${fingerprint}") || circuit=""
 	[[ -n "$circuit" ]] || return 1
-	circuit_at=$(printf '%s' "$circuit" | jq -r '.created_at // ""' 2>/dev/null) || return 1
-	retry_at=$(_terminal_blocker_latest_retry_at "$comments_json") || retry_at=""
-	if [[ -n "$retry_at" && "$retry_at" > "$circuit_at" ]]; then
+	retry=$(_terminal_blocker_latest_retry_comment "$comments_json") || retry=""
+	if _terminal_blocker_retry_after "$retry" "$circuit"; then
 		return 1
 	fi
 	printf 'TERMINAL_BLOCKER_CIRCUIT task_revision=%s\n' "$current_revision"

--- a/.agents/scripts/terminal-blocker-circuit.sh
+++ b/.agents/scripts/terminal-blocker-circuit.sh
@@ -239,11 +239,21 @@ _terminal_blocker_latest_retry_comment() {
 		--argjson authoritative "$_TBC_AUTHORITATIVE_ASSOCIATIONS" \
 		--arg circuit_marker "$_TBC_CIRCUIT_MARKER" "${_TBC_ORDER_JQ}"'
 		[.[] | select(.author_association as $a | $authoritative | index($a) != null)
+		| select(valid_time)
 		| select((.body // "") as $body
 		| ($body | test("(?m)^" + $marker + "[ \\t]*\\r?$")) and (($body | contains($circuit_marker)) | not))
 		]
 		| sort_by(.created_at, (comment_id // 0), .body) | last // empty
 	' 2>/dev/null
+	return $?
+}
+
+# Compatibility for timestamp-only callers; scheduling uses the full comment.
+_terminal_blocker_latest_retry_at() {
+	local comments_json="$1"
+	local retry=""
+	retry=$(_terminal_blocker_latest_retry_comment "$comments_json") || return 1
+	printf '%s' "${retry:-null}" | jq -r '.created_at // ""'
 	return $?
 }
 

--- a/.agents/scripts/tests/test-terminal-blocker-circuit.sh
+++ b/.agents/scripts/tests/test-terminal-blocker-circuit.sh
@@ -410,6 +410,30 @@ test_permission_blocker_continuation() {
 	terminal_blocker_circuit_active "$changed" '{}' owner/repo 42 '' >/dev/null || status=1
 	changed=$(printf '%s' "$comments" | jq -c '. + [{body:"Please post terminal-blocker-circuit:retry",created_at:"2026-09-06T12:01:00Z",author_association:"OWNER"}]')
 	terminal_blocker_circuit_active "$changed" '{}' owner/repo 42 '' >/dev/null || status=1
+	local tied="" variant="" id=""
+	tied=$(printf '%s' "$comments" | jq -c '.[0].id=10 | . + [{id:11,body:"terminal-blocker-circuit:retry",created_at:.[0].created_at,author_association:"OWNER"}]')
+	terminal_blocker_circuit_active "$tied" '{}' owner/repo 42 '' >/dev/null && status=1
+	[[ "$(terminal_blocker_release_mode "$tied" "$revision" "$fingerprint")" == first ]] || status=1
+	variant=$(printf '%s' "$tied" | jq -c 'reverse')
+	terminal_blocker_circuit_active "$variant" '{}' owner/repo 42 '' >/dev/null && status=1
+	variant=$(printf '%s' "$tied" | jq -c '.[0].id=12')
+	terminal_blocker_circuit_active "$variant" '{}' owner/repo 42 '' >/dev/null || status=1
+	[[ "$(terminal_blocker_release_mode "$variant" "$revision" "$fingerprint")" == open ]] || status=1
+	# Missing, malformed and equal IDs cannot prove that a tied retry is later.
+	for id in null '"11"' -1 11.5 9007199254740992 10; do
+		variant=$(printf '%s' "$tied" | jq -c --argjson id "$id" '.[1].id=$id')
+		terminal_blocker_circuit_active "$variant" '{}' owner/repo 42 '' >/dev/null || status=1
+		[[ "$(terminal_blocker_release_mode "$variant" "$revision" "$fingerprint")" == open ]] || status=1
+	done
+	variant=$(printf '%s' "$tied" | jq -c 'del(.[0].id)')
+	terminal_blocker_circuit_active "$variant" '{}' owner/repo 42 '' >/dev/null || status=1
+	variant=$(printf '%s' "$tied" | jq -c '.[1].author_association="COLLABORATOR"')
+	terminal_blocker_circuit_active "$variant" '{}' owner/repo 42 '' >/dev/null || status=1
+	variant=$(printf '%s' "$tied" | jq -c '.[1].body="> terminal-blocker-circuit:retry"')
+	terminal_blocker_circuit_active "$variant" '{}' owner/repo 42 '' >/dev/null || status=1
+	variant=$(printf '%s' "$tied" | jq -c '.[1].created_at="invalid"')
+	terminal_blocker_circuit_active "$variant" '{}' owner/repo 42 '' >/dev/null || status=1
+	print_result "same-second permission retry ordering is conservative and independent of input order" "$status"
 	comments=$(printf '%s' "$comments" | jq -c '. + [{body:"terminal-blocker-circuit:retry",created_at:"2026-09-06T12:01:00Z",author_association:"OWNER"}]')
 	terminal_blocker_circuit_active "$comments" '{}' owner/repo 42 '' >/dev/null && status=1
 	[[ "$(_terminal_blocker_recovery "$fingerprint")" == *'Retry is scheduling consent only'* ]] || status=1
@@ -417,6 +441,28 @@ test_permission_blocker_continuation() {
 	TEST_TARGET_REVISION='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 	unset AIDEVOPS_TERMINAL_BLOCKER_FINGERPRINT
 	print_result "continued permission denial has a stable class; edits and API outages do not re-arm; retry grants nothing" "$status"
+	return 0
+}
+
+test_same_second_release_ordering() {
+	local comments="" changed="" marker="" selected="" fingerprint="" status=0
+	fingerprint=$(_terminal_blocker_hash 'v2:target_code_blocker')
+	marker="<!-- aidevops:terminal-blocker-observation revision=111111111111111111111111 blocker=${fingerprint} -->"
+	comments=$(jq -nc --arg body "$marker" '[{id:10,body:$body,created_at:"2026-09-06T12:00:00Z",author_association:"MEMBER"}, {id:11,body:"terminal-blocker-circuit:retry",created_at:"2026-09-06T12:00:00Z",author_association:"OWNER"}]')
+	[[ "$(terminal_blocker_release_mode "$comments" 111111111111111111111111 "$fingerprint")" == first ]] || status=1
+	changed=$(printf '%s' "$comments" | jq -c '. + [.[0] | .id=12] | reverse')
+	[[ "$(terminal_blocker_release_mode "$changed" 111111111111111111111111 "$fingerprint")" == circuit ]] || status=1
+	selected=$(_terminal_blocker_latest_marker "$changed" "$marker" | jq -r '.id')
+	[[ "$selected" == 12 ]] || status=1
+	comments=$(jq -nc '[range(10;12) | {id:.,body:"CLAIM_RELEASED reason=blocked runner=runner ts=ignored",author:"runner",author_association:"OWNER",created_at:"2026-09-06T12:00:00Z"}] + [{id:12,body:"terminal-blocker-circuit:retry",author_association:"OWNER",created_at:"2026-09-06T12:00:00Z"}]')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$comments" >/dev/null && status=1
+	changed=$(printf '%s' "$comments" | jq -c '. + [.[0] | .id=13] | reverse')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null && status=1
+	changed=$(printf '%s' "$comments" | jq -c '. + [.[0] | .id=13] + [.[1] | .id=14] | reverse')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null || status=1
+	changed=$(printf '%s' "$comments" | jq -c 'map(del(.id))')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null || status=1
+	print_result "same-second observations and post-retry releases survive reordered evidence; legacy ties retain bounded backoff" "$status"
 	return 0
 }
 
@@ -450,6 +496,7 @@ main() {
 	test_legacy_blocked_backoff
 	test_blocked_backoff_trust
 	test_permission_blocker_continuation
+	test_same_second_release_ordering
 	test_blocked_backoff_cli
 	printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-terminal-blocker-circuit.sh
+++ b/.agents/scripts/tests/test-terminal-blocker-circuit.sh
@@ -419,6 +419,11 @@ test_permission_blocker_continuation() {
 	variant=$(printf '%s' "$tied" | jq -c '.[0].id=12')
 	terminal_blocker_circuit_active "$variant" '{}' owner/repo 42 '' >/dev/null || status=1
 	[[ "$(terminal_blocker_release_mode "$variant" "$revision" "$fingerprint")" == open ]] || status=1
+	variant=$(printf '%s' "$tied" | jq -c '. + [.[0] | .id=12] | reverse')
+	terminal_blocker_circuit_active "$variant" '{}' owner/repo 42 '' >/dev/null || status=1
+	variant=$(printf '%s' "$tied" | jq -c '. + [.[1] | .id=9] | reverse')
+	terminal_blocker_circuit_active "$variant" '{}' owner/repo 42 '' >/dev/null && status=1
+	[[ "$(_terminal_blocker_latest_retry_at "$variant")" == '2026-09-06T12:00:00Z' ]] || status=1
 	# Missing, malformed and equal IDs cannot prove that a tied retry is later.
 	for id in null '"11"' -1 11.5 9007199254740992 10; do
 		variant=$(printf '%s' "$tied" | jq -c --argjson id "$id" '.[1].id=$id')
@@ -462,6 +467,8 @@ test_same_second_release_ordering() {
 	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null || status=1
 	changed=$(printf '%s' "$comments" | jq -c 'map(del(.id))')
 	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null || status=1
+	changed=$(printf '%s' "$comments" | jq -c '.[2].body += "\naidevops:terminal-blocker-circuit"')
+	TERMINAL_BLOCKER_NOW_EPOCH=1788696001 terminal_blocker_backoff_active "$changed" >/dev/null || status=1
 	print_result "same-second observations and post-retry releases survive reordered evidence; legacy ties retain bounded backoff" "$status"
 	return 0
 }
@@ -471,10 +478,18 @@ test_blocked_backoff_cli() {
 	result=$(
 		gh() {
 			[[ "$1" == api && "$2" == 'repos/owner/repo/issues/42/comments?per_page=100' ]] || return 1
-			jq -nc '[[range(2) | {id:(. + 1),body:"CLAIM_RELEASED reason=blocked runner=runner ts=ignored",user:{login:"runner"},author_association:"OWNER",created_at:"2026-09-06T12:00:00Z"}]]'
+			# Deliberately reverse pages: the retry is older by ID, not timestamp.
+			jq -nc '[[range(13;15) | {id:.,body:"CLAIM_RELEASED reason=blocked runner=runner ts=ignored",user:{login:"runner"},author_association:"OWNER",created_at:"2026-09-06T12:00:00Z"}], [{id:12,body:"terminal-blocker-circuit:retry",author_association:"OWNER",created_at:"2026-09-06T12:00:00Z"}]]'
 			return 0
 		}
 		export -f gh
+		local fetched=""
+		# Restore the real fetcher after the earlier release integration stub.
+		unset _TERMINAL_BLOCKER_CIRCUIT_LOADED
+		# shellcheck source=../terminal-blocker-circuit.sh
+		source "${SCRIPT_DIR}/terminal-blocker-circuit.sh"
+		fetched=$(terminal_blocker_fetch_trusted_comments 42 owner/repo) || exit 1
+		[[ "$(printf '%s' "$fetched" | jq -c 'map(.id)')" == '[13,14,12]' ]] || exit 1
 		TERMINAL_BLOCKER_NOW_EPOCH=1788696001 bash "${SCRIPT_DIR}/dispatch-dedup-helper.sh" has-dispatch-comment 42 owner/repo runner
 	) || status=1
 	[[ "$result" == 'TERMINAL_BLOCKER_BACKOFF failures=2 retry_after=1788696900' ]] || status=1


### PR DESCRIPTION
## Summary

Order circuit, observation and backoff scheduling by created_at and immutable comment ID. Preserve timestamp-only caller compatibility, OWNER/MEMBER trust, runner matching and permission fail-closed behavior. Cover same-second retries, newer circuits/releases, invalid IDs and reversed API pages.

## Files Changed

.agents/scripts/terminal-blocker-circuit.sh, .agents/scripts/tests/test-terminal-blocker-circuit.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Terminal-blocker circuit suite: 17 passed. Dispatch lifecycle communications suite: 21 passed. Changed-file ShellCheck and linters-local.sh --changed passed. shfmt advisory is pre-existing at test-terminal-blocker-circuit.sh lines 58 and 332 (unchanged one-line gh fixtures); no new formatting differences.

Resolves #31413


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.323 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-6-astra spent 11m and 88,594 tokens on this as a headless worker.
