### PR TITLE
GH#31406: bound binary review evidence

### DIFF
--- a/.agents/scripts/review-evidence-helper.sh
+++ b/.agents/scripts/review-evidence-helper.sh
@@ -10,11 +10,15 @@ TEMP_ROOT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
 REVIEW_BODY_FILE=""
 REVIEW_PATHS_FILE=""
 REVIEW_AUX_FILE=""
+REVIEW_BINARY_PATHS_FILE=""
+REVIEW_BINARY_METADATA_FILE=""
 
 _review_cleanup() {
 	[[ -z "$REVIEW_BODY_FILE" ]] || rm -f "$REVIEW_BODY_FILE"
 	[[ -z "$REVIEW_PATHS_FILE" ]] || rm -f "$REVIEW_PATHS_FILE"
 	[[ -z "$REVIEW_AUX_FILE" ]] || rm -f "$REVIEW_AUX_FILE"
+	[[ -z "$REVIEW_BINARY_PATHS_FILE" ]] || rm -f "$REVIEW_BINARY_PATHS_FILE"
+	[[ -z "$REVIEW_BINARY_METADATA_FILE" ]] || rm -f "$REVIEW_BINARY_METADATA_FILE"
 	return 0
 }
 
@@ -108,7 +112,7 @@ _review_sensitive_path() {
 _review_check_paths() {
 	local paths_file="$1"
 	local path=""
-	while IFS= read -r path; do
+	while IFS= read -r -d '' path; do
 		[[ -z "$path" ]] && continue
 		if _review_sensitive_path "$path"; then
 			_review_die "refusing security-sensitive path in review bundle: ${path}"
@@ -148,12 +152,23 @@ _review_scan_status() {
 	return 0
 }
 
+_review_git_diff() {
+	local repo_root="$1" range="$2"
+	shift 2
+	if [[ "$range" == commit:* ]]; then
+		git -C "$repo_root" show --format= --root "${range#commit:}" "$@"
+	else
+		git -C "$repo_root" diff "$range" "$@"
+	fi
+	return $?
+}
+
 _review_is_binary_diff() {
 	local repo_root="$1"
 	local range="$2"
 	local path="$3"
 	local numstat=""
-	numstat=$(git -C "$repo_root" diff --numstat --no-renames "$range" -- "$path") || return 1
+	numstat=$(_review_git_diff "$repo_root" "$range" --numstat --no-renames -- ":(literal)$path") || return 1
 	[[ "$numstat" == $'-\t-\t'* ]]
 }
 
@@ -169,7 +184,7 @@ _review_diff_status() {
 	local repo_root="$1"
 	local range="$2"
 	local path="$3"
-	git -C "$repo_root" diff --name-status --no-renames "$range" -- "$path" | cut -f1
+	_review_git_diff "$repo_root" "$range" --name-status --no-renames -- ":(literal)$path" | cut -f1
 	return 0
 }
 
@@ -203,7 +218,7 @@ _review_binary_metadata() {
 	byte_size=$(wc -c <"$artifact_file" | tr -d '[:space:]') || return 1
 	mime_type=$(file --brief --mime-type -- "$artifact_file") || return 1
 	digest=$(_review_sha256 "$artifact_file") || return 1
-	printf '%s\t%s\t%s\t%s\t%s\n' "$status" "$path" "$byte_size" "$mime_type" "$digest"
+	printf '%s\t%q\t%s\t%s\t%s\n' "$status" "$path" "$byte_size" "$mime_type" "$digest"
 	return 0
 }
 
@@ -212,42 +227,53 @@ _review_collect_diff_binaries() {
 	local range="$2"
 	local preferred_ref="$3"
 	local fallback_ref="$4"
+	local use_worktree="${5:-false}" current_file=""
 	local path=""
 	local status=""
-	while IFS= read -r path; do
+	while IFS= read -r -d '' path; do
 		[[ -z "$path" ]] && continue
 		if _review_is_binary_diff "$repo_root" "$range" "$path"; then
 			status=$(_review_diff_status "$repo_root" "$range" "$path") || return 1
-			printf '%s\n' "$path" >>"$REVIEW_BINARY_PATHS_FILE"
-			_review_binary_metadata "$repo_root" "$path" "$status" "$repo_root/$path" "$preferred_ref" "$fallback_ref" >>"$REVIEW_BINARY_METADATA_FILE" || return 1
+			printf '%s\0' "$path" >>"$REVIEW_BINARY_PATHS_FILE"
+			current_file=""
+			[[ "$use_worktree" != true ]] || current_file="$repo_root/$path"
+			_review_binary_metadata "$repo_root" "$path" "$status" "$current_file" "$preferred_ref" "$fallback_ref" >>"$REVIEW_BINARY_METADATA_FILE" || return 1
 		fi
-	done < <(git -C "$repo_root" diff --name-only --no-renames "$range")
+	done < <(_review_git_diff "$repo_root" "$range" --name-only --no-renames -z)
 	return 0
 }
 
 _review_collect_untracked_binaries() {
 	local repo_root="$1"
 	local path=""
-	while IFS= read -r path; do
+	while IFS= read -r -d '' path; do
 		[[ -z "$path" ]] && continue
 		if _review_is_binary_untracked "$repo_root" "$path"; then
-			printf '%s\n' "$path" >>"$REVIEW_BINARY_PATHS_FILE"
+			printf '%s\0' "$path" >>"$REVIEW_BINARY_PATHS_FILE"
 			_review_binary_metadata "$repo_root" "$path" 'A' "$repo_root/$path" '' '' >>"$REVIEW_BINARY_METADATA_FILE" || return 1
 		fi
-	done < <(git -C "$repo_root" ls-files --others --exclude-standard)
+	done < <(git -C "$repo_root" ls-files --others --exclude-standard -z)
 	return 0
+}
+
+_review_binary_path_recorded() {
+	local wanted="$1" path=""
+	while IFS= read -r -d '' path; do
+		[[ "$path" != "$wanted" ]] || return 0
+	done <"$REVIEW_BINARY_PATHS_FILE"
+	return 1
 }
 
 _review_write_text_diff() {
 	local repo_root="$1"
 	local range="$2"
-	local -a diff_args=(--no-ext-diff "$range" -- .)
+	local -a diff_args=(--no-ext-diff -- .)
 	local path=""
-	while IFS= read -r path; do
+	while IFS= read -r -d '' path; do
 		[[ -z "$path" ]] && continue
-		diff_args+=(":(exclude)$path")
+		diff_args+=(":(top,literal,exclude)$path")
 	done <"$REVIEW_BINARY_PATHS_FILE"
-	git -C "$repo_root" diff "${diff_args[@]}"
+	_review_git_diff "$repo_root" "$range" "${diff_args[@]}"
 	return 0
 }
 
@@ -266,10 +292,10 @@ _review_write_local() {
 	local repo_root=""
 	repo_root=$(_review_repo_root) || return 1
 	_review_require file || return 1
-	git -C "$repo_root" diff --name-only HEAD >"$paths_file"
-	git -C "$repo_root" ls-files --others --exclude-standard >>"$paths_file"
+	git -C "$repo_root" diff --name-only -z HEAD >"$paths_file"
+	git -C "$repo_root" ls-files --others --exclude-standard -z >>"$paths_file"
 	_review_check_paths "$paths_file" || return 1
-	_review_collect_diff_binaries "$repo_root" 'HEAD' 'HEAD' 'HEAD' || return 1
+	_review_collect_diff_binaries "$repo_root" 'HEAD' 'HEAD' 'HEAD' true || return 1
 	_review_collect_untracked_binaries "$repo_root" || return 1
 	{
 		printf 'target: local\n'
@@ -279,12 +305,12 @@ _review_write_local() {
 		printf '%s\n\n## Patch\n\n%s\n' '```' '```diff'
 		_review_write_text_diff "$repo_root" 'HEAD'
 		local untracked_file=""
-		while IFS= read -r untracked_file; do
+		while IFS= read -r -d '' untracked_file; do
 			[[ -z "$untracked_file" ]] && continue
-			if ! grep -Fqx -- "$untracked_file" "$REVIEW_BINARY_PATHS_FILE"; then
+			if ! _review_binary_path_recorded "$untracked_file"; then
 				git -C "$repo_root" diff --no-index --no-ext-diff -- /dev/null "$repo_root/$untracked_file" || true
 			fi
-		done < <(git -C "$repo_root" ls-files --others --exclude-standard)
+		done < <(git -C "$repo_root" ls-files --others --exclude-standard -z)
 		printf '```\n'
 		_review_write_binary_metadata
 	} >"$body_file"
@@ -300,9 +326,11 @@ _review_write_branch() {
 	_review_require file || return 1
 	[[ -n "$base" ]] || base=$(_review_default_base) || return 1
 	_review_validate_ref "$base" || return 1
-	git -C "$repo_root" diff --name-only "${base}...HEAD" >"$paths_file"
+	local merge_base=""
+	merge_base=$(git -C "$repo_root" merge-base "$base" HEAD) || return 1
+	git -C "$repo_root" diff --name-only -z "${base}...HEAD" >"$paths_file"
 	_review_check_paths "$paths_file" || return 1
-	_review_collect_diff_binaries "$repo_root" "${base}...HEAD" 'HEAD' "$base" || return 1
+	_review_collect_diff_binaries "$repo_root" "${base}...HEAD" 'HEAD' "$merge_base" || return 1
 	{
 		printf 'target: branch\n'
 		printf 'base: %s\n' "$base"
@@ -329,16 +357,16 @@ _review_write_commit() {
 		return 1
 	}
 	_review_validate_ref "$commit_ref" || return 1
-	git -C "$repo_root" diff-tree --root --no-commit-id --name-only -r "$commit_ref" >"$paths_file"
+	git -C "$repo_root" diff-tree --root --no-commit-id --name-only -z -r "$commit_ref" >"$paths_file"
 	_review_check_paths "$paths_file" || return 1
-	_review_collect_diff_binaries "$repo_root" "${commit_ref}^!" "$commit_ref" "${commit_ref}^" || return 1
+	_review_collect_diff_binaries "$repo_root" "commit:${commit_ref}" "$commit_ref" "${commit_ref}^" || return 1
 	{
 		printf 'target: commit\n'
 		printf 'commit: %s\n' "$(git -C "$repo_root" rev-parse "$commit_ref")"
 		printf '\n## Commit metadata and patch\n\n```text\n'
 		git -C "$repo_root" show --format=fuller --no-patch "$commit_ref"
 		printf '%s\n\n%s\n' '```' '```diff'
-		_review_write_text_diff "$repo_root" "${commit_ref}^!"
+		_review_write_text_diff "$repo_root" "commit:${commit_ref}"
 		printf '```\n'
 		_review_write_binary_metadata
 	} >"$body_file"
@@ -378,7 +406,7 @@ _review_write_pr() {
 	gh pr view "$number" "${repo_args[@]}" \
 		--json number,title,body,author,createdAt,state,baseRefName,headRefName,files,comments \
 		>"$REVIEW_AUX_FILE"
-	jq -r '.files[]?.path // empty' "$REVIEW_AUX_FILE" >"$paths_file"
+	jq -j '.files[]?.path // empty | ., "\u0000"' "$REVIEW_AUX_FILE" >"$paths_file"
 	_review_check_paths "$paths_file" || {
 		rm -f "$REVIEW_AUX_FILE"
 		REVIEW_AUX_FILE=""

--- a/.agents/scripts/review-evidence-helper.sh
+++ b/.agents/scripts/review-evidence-helper.sh
@@ -27,9 +27,10 @@ Usage:
   review-evidence-helper.sh bundle issue NUMBER [--repo OWNER/REPO] [--output FILE]
   review-evidence-helper.sh bundle pr NUMBER [--repo OWNER/REPO] [--output FILE]
 
-The emitted Markdown bundle uses schema aidevops.review-evidence/v1. It contains
-the selected metadata and complete patch, a prompt-injection scan status, and a
-SHA-256 digest. It never fetches, changes refs, or invokes a reviewer.
+The emitted Markdown bundle uses schema aidevops.review-evidence/v1. Git targets
+contain complete text patches and SHA-256-bound metadata for binary changes, plus
+a prompt-injection scan status and bundle digest. It never fetches, changes refs,
+or invokes a reviewer.
 EOF
 	return 0
 }
@@ -147,26 +148,145 @@ _review_scan_status() {
 	return 0
 }
 
+_review_is_binary_diff() {
+	local repo_root="$1"
+	local range="$2"
+	local path="$3"
+	local numstat=""
+	numstat=$(git -C "$repo_root" diff --numstat --no-renames "$range" -- "$path") || return 1
+	[[ "$numstat" == $'-\t-\t'* ]]
+}
+
+_review_is_binary_untracked() {
+	local repo_root="$1"
+	local path="$2"
+	local numstat=""
+	numstat=$(git -C "$repo_root" diff --no-index --numstat -- /dev/null "$repo_root/$path" 2>/dev/null || true)
+	[[ "$numstat" == $'-\t-\t'* ]]
+}
+
+_review_diff_status() {
+	local repo_root="$1"
+	local range="$2"
+	local path="$3"
+	git -C "$repo_root" diff --name-status --no-renames "$range" -- "$path" | cut -f1
+	return 0
+}
+
+_review_binary_metadata() {
+	local repo_root="$1"
+	local path="$2"
+	local status="$3"
+	local current_file="$4"
+	local preferred_ref="$5"
+	local fallback_ref="$6"
+	local artifact_file="$current_file"
+	local ref=""
+	local byte_size=""
+	local mime_type=""
+	local digest=""
+	if [[ ! -f "$artifact_file" ]]; then
+		for ref in "$preferred_ref" "$fallback_ref"; do
+			[[ -n "$ref" ]] || continue
+			if git -C "$repo_root" cat-file -e "${ref}:${path}" 2>/dev/null; then
+				[[ -n "$REVIEW_AUX_FILE" ]] || REVIEW_AUX_FILE=$(mktemp "${TEMP_ROOT}/review-evidence-binary.XXXXXX")
+				git -C "$repo_root" show "${ref}:${path}" >"$REVIEW_AUX_FILE" || return 1
+				artifact_file="$REVIEW_AUX_FILE"
+				break
+			fi
+		done
+	fi
+	[[ -f "$artifact_file" ]] || {
+		_review_die "cannot materialize binary artifact for review: ${path}"
+		return 1
+	}
+	byte_size=$(wc -c <"$artifact_file" | tr -d '[:space:]') || return 1
+	mime_type=$(file --brief --mime-type -- "$artifact_file") || return 1
+	digest=$(_review_sha256 "$artifact_file") || return 1
+	printf '%s\t%s\t%s\t%s\t%s\n' "$status" "$path" "$byte_size" "$mime_type" "$digest"
+	return 0
+}
+
+_review_collect_diff_binaries() {
+	local repo_root="$1"
+	local range="$2"
+	local preferred_ref="$3"
+	local fallback_ref="$4"
+	local path=""
+	local status=""
+	while IFS= read -r path; do
+		[[ -z "$path" ]] && continue
+		if _review_is_binary_diff "$repo_root" "$range" "$path"; then
+			status=$(_review_diff_status "$repo_root" "$range" "$path") || return 1
+			printf '%s\n' "$path" >>"$REVIEW_BINARY_PATHS_FILE"
+			_review_binary_metadata "$repo_root" "$path" "$status" "$repo_root/$path" "$preferred_ref" "$fallback_ref" >>"$REVIEW_BINARY_METADATA_FILE" || return 1
+		fi
+	done < <(git -C "$repo_root" diff --name-only --no-renames "$range")
+	return 0
+}
+
+_review_collect_untracked_binaries() {
+	local repo_root="$1"
+	local path=""
+	while IFS= read -r path; do
+		[[ -z "$path" ]] && continue
+		if _review_is_binary_untracked "$repo_root" "$path"; then
+			printf '%s\n' "$path" >>"$REVIEW_BINARY_PATHS_FILE"
+			_review_binary_metadata "$repo_root" "$path" 'A' "$repo_root/$path" '' '' >>"$REVIEW_BINARY_METADATA_FILE" || return 1
+		fi
+	done < <(git -C "$repo_root" ls-files --others --exclude-standard)
+	return 0
+}
+
+_review_write_text_diff() {
+	local repo_root="$1"
+	local range="$2"
+	local -a diff_args=(--no-ext-diff "$range" -- .)
+	local path=""
+	while IFS= read -r path; do
+		[[ -z "$path" ]] && continue
+		diff_args+=(":(exclude)$path")
+	done <"$REVIEW_BINARY_PATHS_FILE"
+	git -C "$repo_root" diff "${diff_args[@]}"
+	return 0
+}
+
+_review_write_binary_metadata() {
+	[[ -s "$REVIEW_BINARY_METADATA_FILE" ]] || return 0
+	printf '\n## Binary artifacts\n\nThe following binary changes are represented by status, repository-relative path, byte size, MIME type, and SHA-256.\n\n```text\n'
+	printf 'status\tpath\tbytes\tmime_type\tsha256\n'
+	cat "$REVIEW_BINARY_METADATA_FILE"
+	printf '```\n'
+	return 0
+}
+
 _review_write_local() {
 	local body_file="$1"
 	local paths_file="$2"
 	local repo_root=""
 	repo_root=$(_review_repo_root) || return 1
+	_review_require file || return 1
 	git -C "$repo_root" diff --name-only HEAD >"$paths_file"
 	git -C "$repo_root" ls-files --others --exclude-standard >>"$paths_file"
 	_review_check_paths "$paths_file" || return 1
+	_review_collect_diff_binaries "$repo_root" 'HEAD' 'HEAD' 'HEAD' || return 1
+	_review_collect_untracked_binaries "$repo_root" || return 1
 	{
 		printf 'target: local\n'
 		printf 'head: %s\n' "$(git -C "$repo_root" rev-parse HEAD)"
 		printf '\n## Changed files\n\n```text\n'
 		git -C "$repo_root" status --short
 		printf '%s\n\n## Patch\n\n%s\n' '```' '```diff'
-		git -C "$repo_root" diff --binary --no-ext-diff HEAD
+		_review_write_text_diff "$repo_root" 'HEAD'
 		local untracked_file=""
-		while IFS= read -r -d '' untracked_file; do
-			git -C "$repo_root" diff --no-index --binary -- /dev/null "$untracked_file" || true
-		done < <(git -C "$repo_root" ls-files --others --exclude-standard -z)
+		while IFS= read -r untracked_file; do
+			[[ -z "$untracked_file" ]] && continue
+			if ! grep -Fqx -- "$untracked_file" "$REVIEW_BINARY_PATHS_FILE"; then
+				git -C "$repo_root" diff --no-index --no-ext-diff -- /dev/null "$repo_root/$untracked_file" || true
+			fi
+		done < <(git -C "$repo_root" ls-files --others --exclude-standard)
 		printf '```\n'
+		_review_write_binary_metadata
 	} >"$body_file"
 	return 0
 }
@@ -177,10 +297,12 @@ _review_write_branch() {
 	local base="$3"
 	local repo_root=""
 	repo_root=$(_review_repo_root) || return 1
+	_review_require file || return 1
 	[[ -n "$base" ]] || base=$(_review_default_base) || return 1
 	_review_validate_ref "$base" || return 1
 	git -C "$repo_root" diff --name-only "${base}...HEAD" >"$paths_file"
 	_review_check_paths "$paths_file" || return 1
+	_review_collect_diff_binaries "$repo_root" "${base}...HEAD" 'HEAD' "$base" || return 1
 	{
 		printf 'target: branch\n'
 		printf 'base: %s\n' "$base"
@@ -188,8 +310,9 @@ _review_write_branch() {
 		printf '\n## Changed files\n\n```text\n'
 		git -C "$repo_root" diff --name-status "${base}...HEAD"
 		printf '%s\n\n## Patch\n\n%s\n' '```' '```diff'
-		git -C "$repo_root" diff --binary --no-ext-diff "${base}...HEAD"
+		_review_write_text_diff "$repo_root" "${base}...HEAD"
 		printf '```\n'
+		_review_write_binary_metadata
 	} >"$body_file"
 	return 0
 }
@@ -200,6 +323,7 @@ _review_write_commit() {
 	local commit_ref="$3"
 	local repo_root=""
 	repo_root=$(_review_repo_root) || return 1
+	_review_require file || return 1
 	[[ -n "$commit_ref" ]] || {
 		_review_die "commit target requires --commit REF"
 		return 1
@@ -207,12 +331,16 @@ _review_write_commit() {
 	_review_validate_ref "$commit_ref" || return 1
 	git -C "$repo_root" diff-tree --root --no-commit-id --name-only -r "$commit_ref" >"$paths_file"
 	_review_check_paths "$paths_file" || return 1
+	_review_collect_diff_binaries "$repo_root" "${commit_ref}^!" "$commit_ref" "${commit_ref}^" || return 1
 	{
 		printf 'target: commit\n'
 		printf 'commit: %s\n' "$(git -C "$repo_root" rev-parse "$commit_ref")"
-		printf '\n## Commit metadata and patch\n\n```diff\n'
-		git -C "$repo_root" show --format=fuller --binary --no-ext-diff "$commit_ref"
+		printf '\n## Commit metadata and patch\n\n```text\n'
+		git -C "$repo_root" show --format=fuller --no-patch "$commit_ref"
+		printf '%s\n\n%s\n' '```' '```diff'
+		_review_write_text_diff "$repo_root" "${commit_ref}^!"
 		printf '```\n'
+		_review_write_binary_metadata
 	} >"$body_file"
 	return 0
 }
@@ -357,6 +485,8 @@ main() {
 	mkdir -p "$TEMP_ROOT"
 	REVIEW_BODY_FILE=$(mktemp "${TEMP_ROOT}/review-evidence-body.XXXXXX")
 	REVIEW_PATHS_FILE=$(mktemp "${TEMP_ROOT}/review-evidence-paths.XXXXXX")
+	REVIEW_BINARY_PATHS_FILE=$(mktemp "${TEMP_ROOT}/review-evidence-binary-paths.XXXXXX")
+	REVIEW_BINARY_METADATA_FILE=$(mktemp "${TEMP_ROOT}/review-evidence-binary-metadata.XXXXXX")
 	trap _review_cleanup EXIT
 	case "$target" in
 	local) _review_write_local "$REVIEW_BODY_FILE" "$REVIEW_PATHS_FILE" ;;

--- a/.agents/scripts/review-evidence-helper.sh
+++ b/.agents/scripts/review-evidence-helper.sh
@@ -125,11 +125,11 @@ _review_check_paths() {
 _review_sha256() {
 	local file="$1"
 	if command -v shasum >/dev/null 2>&1; then
-		shasum -a 256 "$file" | cut -d' ' -f1
+		shasum -a 256 <"$file" | cut -d' ' -f1
 		return 0
 	fi
 	if command -v sha256sum >/dev/null 2>&1; then
-		sha256sum "$file" | cut -d' ' -f1
+		sha256sum <"$file" | cut -d' ' -f1
 		return 0
 	fi
 	_review_die "neither shasum nor sha256sum is available"

--- a/.agents/scripts/review-evidence-helper.sh
+++ b/.agents/scripts/review-evidence-helper.sh
@@ -156,7 +156,9 @@ _review_git_diff() {
 	local repo_root="$1" range="$2"
 	shift 2
 	if [[ "$range" == commit:* ]]; then
-		git -C "$repo_root" show --format= --root "${range#commit:}" "$@"
+		# One first-parent policy binds sensitive-path inventory, binary metadata
+		# and text patches to the same tree comparison, including merge commits.
+		git -C "$repo_root" show --format= --root --diff-merges=first-parent "${range#commit:}" "$@"
 	else
 		git -C "$repo_root" diff "$range" "$@"
 	fi
@@ -357,7 +359,7 @@ _review_write_commit() {
 		return 1
 	}
 	_review_validate_ref "$commit_ref" || return 1
-	git -C "$repo_root" diff-tree --root --no-commit-id --name-only -z -r "$commit_ref" >"$paths_file"
+	_review_git_diff "$repo_root" "commit:${commit_ref}" --name-only --no-renames -z >"$paths_file" || return 1
 	_review_check_paths "$paths_file" || return 1
 	_review_collect_diff_binaries "$repo_root" "commit:${commit_ref}" "$commit_ref" "${commit_ref}^" || return 1
 	{

--- a/.agents/scripts/tests/test-review-evidence-helper.sh
+++ b/.agents/scripts/tests/test-review-evidence-helper.sh
@@ -132,7 +132,7 @@ ODD_BUNDLE="${TEST_ROOT}/odd-paths.md"
 assert_contains "$ODD_BUNDLE" '+literal-neighbor-text' 'literal binary exclusion'
 [[ "$(grep -c '^+unusual-file-content' "$ODD_BUNDLE")" == 3 ]] || fail 'unusual text paths omitted'
 ODD_DIGEST=$(printf '\000odd-binary\n' | shasum -a 256 | cut -d' ' -f1)
-assert_contains "$ODD_BUNDLE" "$ODD_DIGEST" 'unusual binary path digest'
+awk -F '\t' -v digest="$ODD_DIGEST" '$1 == "A" && $5 == digest { found=1 } END { exit !found }' "$ODD_BUNDLE" || fail 'unusual binary path has noncanonical digest'
 assert_not_contains "$ODD_BUNDLE" 'GIT binary patch' 'unusual binary payload bounded'
 
 gh() {

--- a/.agents/scripts/tests/test-review-evidence-helper.sh
+++ b/.agents/scripts/tests/test-review-evidence-helper.sh
@@ -48,6 +48,19 @@ assert_not_contains() {
 	return 0
 }
 
+sha256() {
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 | cut -d' ' -f1
+		return 0
+	fi
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum | cut -d' ' -f1
+		return 0
+	fi
+	fail 'neither shasum nor sha256sum is available'
+	return 1
+}
+
 REPO="${TEST_ROOT}/repo"
 mkdir -p "$REPO"
 git -C "$REPO" init -q
@@ -106,7 +119,8 @@ printf '\000dirty-not-selected\n' >"${REPO}/tracked.bin"
 printf 'dirty-text-not-selected\n' >"${REPO}/tracked.txt"
 ROOT_BUNDLE="${TEST_ROOT}/root.md"
 (cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle commit --commit "$INITIAL_SHA" --output "$ROOT_BUNDLE" >/dev/null)
-ROOT_DIGEST=$(git -C "$REPO" show "${INITIAL_SHA}:tracked.bin" | shasum -a 256 | cut -d' ' -f1)
+ROOT_DIGEST=$(git -C "$REPO" show "${INITIAL_SHA}:tracked.bin" | sha256)
+[[ -n "$ROOT_DIGEST" ]] || fail 'historical root digest was empty'
 assert_contains "$ROOT_BUNDLE" "$ROOT_DIGEST" 'historical root binary digest'
 assert_contains "$ROOT_BUNDLE" '+one' 'root addition patch'
 assert_not_contains "$ROOT_BUNDLE" '+two' 'later checkout absent from root patch'
@@ -131,7 +145,8 @@ ODD_BUNDLE="${TEST_ROOT}/odd-paths.md"
 (cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle local --output "$ODD_BUNDLE" >/dev/null)
 assert_contains "$ODD_BUNDLE" '+literal-neighbor-text' 'literal binary exclusion'
 [[ "$(grep -c '^+unusual-file-content' "$ODD_BUNDLE")" == 3 ]] || fail 'unusual text paths omitted'
-ODD_DIGEST=$(printf '\000odd-binary\n' | shasum -a 256 | cut -d' ' -f1)
+ODD_DIGEST=$(printf '\000odd-binary\n' | sha256)
+[[ -n "$ODD_DIGEST" ]] || fail 'unusual binary digest was empty'
 awk -F '\t' -v digest="$ODD_DIGEST" '$1 == "A" && $5 == digest { found=1 } END { exit !found }' "$ODD_BUNDLE" || fail 'unusual binary path has noncanonical digest'
 assert_not_contains "$ODD_BUNDLE" 'GIT binary patch' 'unusual binary payload bounded'
 

--- a/.agents/scripts/tests/test-review-evidence-helper.sh
+++ b/.agents/scripts/tests/test-review-evidence-helper.sh
@@ -38,37 +38,68 @@ assert_contains() {
 	return 0
 }
 
+assert_not_contains() {
+	local file="$1"
+	local unexpected="$2"
+	local label="$3"
+	if grep -Fq -- "$unexpected" "$file"; then
+		fail "${label}: unexpectedly contained ${unexpected}"
+	fi
+	return 0
+}
+
 REPO="${TEST_ROOT}/repo"
 mkdir -p "$REPO"
 git -C "$REPO" init -q
 printf 'one\n' >"${REPO}/tracked.txt"
+printf '\000initial\n' >"${REPO}/tracked.bin"
 git -C "$REPO" add tracked.txt
+git -C "$REPO" add tracked.bin
 git -C "$REPO" -c user.name='Review Test' -c user.email='review@example.invalid' commit -qm 'initial'
 INITIAL_SHA=$(git -C "$REPO" rev-parse HEAD)
 
 printf 'one\ntwo\n' >"${REPO}/tracked.txt"
 printf 'new\n' >"${REPO}/untracked.txt"
+printf '\000changed\n' >"${REPO}/tracked.bin"
+printf '\000untracked\n' >"${REPO}/untracked.bin"
 LOCAL_BUNDLE="${TEST_ROOT}/local.md"
 (cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle local --output "$LOCAL_BUNDLE" >/dev/null)
 assert_contains "$LOCAL_BUNDLE" 'schema: aidevops.review-evidence/v1' 'local schema'
 assert_contains "$LOCAL_BUNDLE" 'target: local' 'local target'
 assert_contains "$LOCAL_BUNDLE" '+two' 'tracked patch'
 assert_contains "$LOCAL_BUNDLE" 'untracked.txt' 'untracked patch'
+assert_contains "$LOCAL_BUNDLE" '## Binary artifacts' 'local binary metadata heading'
+assert_contains "$LOCAL_BUNDLE" $'M\ttracked.bin\t' 'tracked binary metadata'
+assert_contains "$LOCAL_BUNDLE" $'A\tuntracked.bin\t' 'untracked binary metadata'
+assert_not_contains "$LOCAL_BUNDLE" 'GIT binary patch' 'local binary payload'
+LOCAL_DIGEST=$(grep '^bundle_sha256:' "$LOCAL_BUNDLE" | cut -d' ' -f2)
+printf '\000changed-again\n' >"${REPO}/tracked.bin"
+LOCAL_CHANGED_BUNDLE="${TEST_ROOT}/local-changed.md"
+(cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle local --output "$LOCAL_CHANGED_BUNDLE" >/dev/null)
+LOCAL_CHANGED_DIGEST=$(grep '^bundle_sha256:' "$LOCAL_CHANGED_BUNDLE" | cut -d' ' -f2)
+if [[ "$LOCAL_DIGEST" == "$LOCAL_CHANGED_DIGEST" ]]; then
+	fail 'binary content did not change local bundle digest'
+fi
 if grep -Fq "$TEST_ROOT" "$LOCAL_BUNDLE"; then
 	fail 'bundle exposed host test path'
 fi
 
 git -C "$REPO" add tracked.txt untracked.txt
+git -C "$REPO" add tracked.bin untracked.bin
 git -C "$REPO" -c user.name='Review Test' -c user.email='review@example.invalid' commit -qm 'change'
 BRANCH_BUNDLE="${TEST_ROOT}/branch.md"
 (cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle branch --base "$INITIAL_SHA" --output "$BRANCH_BUNDLE" >/dev/null)
 assert_contains "$BRANCH_BUNDLE" 'target: branch' 'branch target'
 assert_contains "$BRANCH_BUNDLE" 'A' 'branch name-status'
+assert_contains "$BRANCH_BUNDLE" '## Binary artifacts' 'branch binary metadata heading'
+assert_not_contains "$BRANCH_BUNDLE" 'GIT binary patch' 'branch binary payload'
 
 COMMIT_BUNDLE="${TEST_ROOT}/commit.md"
 (cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle commit --commit HEAD --output "$COMMIT_BUNDLE" >/dev/null)
 assert_contains "$COMMIT_BUNDLE" 'target: commit' 'commit target'
 assert_contains "$COMMIT_BUNDLE" 'Commit:' 'commit metadata'
+assert_contains "$COMMIT_BUNDLE" '## Binary artifacts' 'commit binary metadata heading'
+assert_not_contains "$COMMIT_BUNDLE" 'GIT binary patch' 'commit binary payload'
 
 gh() {
 	local resource="$1"

--- a/.agents/scripts/tests/test-review-evidence-helper.sh
+++ b/.agents/scripts/tests/test-review-evidence-helper.sh
@@ -101,6 +101,40 @@ assert_contains "$COMMIT_BUNDLE" 'Commit:' 'commit metadata'
 assert_contains "$COMMIT_BUNDLE" '## Binary artifacts' 'commit binary metadata heading'
 assert_not_contains "$COMMIT_BUNDLE" 'GIT binary patch' 'commit binary payload'
 
+# A historical root commit must not read later or dirty working-tree content.
+printf '\000dirty-not-selected\n' >"${REPO}/tracked.bin"
+printf 'dirty-text-not-selected\n' >"${REPO}/tracked.txt"
+ROOT_BUNDLE="${TEST_ROOT}/root.md"
+(cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle commit --commit "$INITIAL_SHA" --output "$ROOT_BUNDLE" >/dev/null)
+ROOT_DIGEST=$(git -C "$REPO" show "${INITIAL_SHA}:tracked.bin" | shasum -a 256 | cut -d' ' -f1)
+assert_contains "$ROOT_BUNDLE" "$ROOT_DIGEST" 'historical root binary digest'
+assert_contains "$ROOT_BUNDLE" '+one' 'root addition patch'
+assert_not_contains "$ROOT_BUNDLE" '+two' 'later checkout absent from root patch'
+assert_not_contains "$ROOT_BUNDLE" 'dirty-text-not-selected' 'dirty text absent from root patch'
+DIRTY_BRANCH_BUNDLE="${TEST_ROOT}/dirty-branch.md"
+(cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle branch --base "$INITIAL_SHA" --output "$DIRTY_BRANCH_BUNDLE" >/dev/null)
+[[ "$(grep '^bundle_sha256:' "$BRANCH_BUNDLE")" == "$(grep '^bundle_sha256:' "$DIRTY_BRANCH_BUNDLE")" ]] || fail 'dirty checkout changed selected branch evidence'
+
+# Literal exclusions must not drop neighboring text that matches a glob-shaped
+# binary filename; newline/tab/backslash filenames remain complete evidence.
+printf '\000before\n' >"${REPO}/wild[ab].bin"
+printf 'before-text\n' >"${REPO}/wilda.bin"
+git -C "$REPO" add -- ':(literal)wild[ab].bin' wilda.bin
+git -C "$REPO" -c user.name='Review Test' -c user.email='review@example.invalid' commit -qm 'path fixtures'
+printf '\000after\n' >"${REPO}/wild[ab].bin"
+printf 'literal-neighbor-text\n' >"${REPO}/wilda.bin"
+for filename in $'line\nbreak.txt' $'tab\tname.txt' 'slash\name.txt'; do
+	printf 'unusual-file-content\n' >"${REPO}/${filename}"
+done
+printf '\000odd-binary\n' >"${REPO}/"$'binary\nname.bin'
+ODD_BUNDLE="${TEST_ROOT}/odd-paths.md"
+(cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle local --output "$ODD_BUNDLE" >/dev/null)
+assert_contains "$ODD_BUNDLE" '+literal-neighbor-text' 'literal binary exclusion'
+[[ "$(grep -c '^+unusual-file-content' "$ODD_BUNDLE")" == 3 ]] || fail 'unusual text paths omitted'
+ODD_DIGEST=$(printf '\000odd-binary\n' | shasum -a 256 | cut -d' ' -f1)
+assert_contains "$ODD_BUNDLE" "$ODD_DIGEST" 'unusual binary path digest'
+assert_not_contains "$ODD_BUNDLE" 'GIT binary patch' 'unusual binary payload bounded'
+
 gh() {
 	local resource="$1"
 	local action="$2"
@@ -136,5 +170,14 @@ printf 'unsafe\n' >"${REPO}/config/.env"
 if (cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle local >/dev/null 2>&1); then
 	fail 'security-sensitive untracked path was bundled'
 fi
+rm -f "${REPO}/config/.env"
+mkdir -p "${REPO}/"$'odd\ndirectory'
+printf 'fixture-only\n' >"${REPO}/"$'odd\ndirectory/.env'
+if (cd "$REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle local >/dev/null 2>&1); then
+	fail 'newline-bearing sensitive path bypassed the guard'
+fi
+for leftover in "${TEST_ROOT}/tmp"/review-evidence-binary-*; do
+	[[ ! -e "$leftover" ]] || fail 'binary evidence temporary file leaked'
+done
 
 printf 'PASS review evidence helper builds bounded target bundles\n'

--- a/.agents/scripts/tests/test-review-evidence-helper.sh
+++ b/.agents/scripts/tests/test-review-evidence-helper.sh
@@ -180,4 +180,34 @@ for leftover in "${TEST_ROOT}/tmp"/review-evidence-binary-*; do
 	[[ ! -e "$leftover" ]] || fail 'binary evidence temporary file leaked'
 done
 
+# A conflict-resolution merge must not hide sensitive paths from the inventory
+# while emitting them in its patch. All three commit stages use first-parent.
+MERGE_REPO="${TEST_ROOT}/merge-repo"
+mkdir -p "${MERGE_REPO}/config"
+MERGE_SENSITIVE_PATH="${MERGE_REPO}/config/.env"
+fixture_git() {
+	git -C "$MERGE_REPO" -c user.name='Review Test' -c user.email='review@example.invalid' "$@"
+	return $?
+}
+fixture_git init -q -b main
+printf 'base-fixture\n' >"$MERGE_SENSITIVE_PATH"
+fixture_git add -A
+fixture_git commit -qm base
+fixture_git checkout -qb side
+printf 'side-fixture\n' >"$MERGE_SENSITIVE_PATH"
+fixture_git add -A
+fixture_git commit -qm side
+fixture_git checkout -q main
+printf 'main-fixture\n' >"$MERGE_SENSITIVE_PATH"
+fixture_git add -A
+fixture_git commit -qm main
+fixture_git merge side --no-commit >/dev/null 2>&1 || true
+printf 'merged-fixture-only\n' >"$MERGE_SENSITIVE_PATH"
+fixture_git add -A
+fixture_git commit -qm merge
+[[ "$(fixture_git rev-list --parents -n 1 HEAD | wc -w | tr -d ' ')" == 3 ]] || fail 'fixture is not a merge commit'
+if (cd "$MERGE_REPO" && AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp" "$HELPER" bundle commit --commit HEAD >/dev/null 2>&1); then
+	fail 'merge commit sensitive path was bundled'
+fi
+
 printf 'PASS review evidence helper builds bounded target bundles\n'


### PR DESCRIPTION
## Summary

Replaced local, branch, and commit binary patch payloads with path, status, byte size, MIME type, and SHA-256 metadata while retaining text patches.

## Files Changed

.agents/scripts/review-evidence-helper.sh, .agents/scripts/tests/test-review-evidence-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck, test-review-evidence-helper.sh, and changed-file local linters passed; binary fixtures verify metadata, content-bound digest changes, and omitted binary payloads.

Resolves #31406


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.323 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 10m and 108,218 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Binary file changes are now included as summarized metadata, including path, status, size, file type, and integrity digest.
  * Review evidence separates binary artifacts from text-based diffs for clearer output.

* **Bug Fixes**
  * Improved handling of unusual filenames, binary changes, exclusions, and working-tree state.
  * Prevented sensitive files from appearing in review evidence, including in merge-commit scenarios.
  * Ensured temporary binary data is cleaned up after generating review evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->