### PR TITLE
GH#31409: validate untracked whitespace before staging

### DIFF
--- a/.agents/scripts/linters-local-validators.sh
+++ b/.agents/scripts/linters-local-validators.sh
@@ -47,6 +47,40 @@ fi
 
 # --- Functions ---
 
+# Git's normal diff inventory omits untracked files until they are staged.
+# Keep this read-only and bounded; Git owns whitespace rules and binary detection.
+_linters_check_untracked_whitespace() {
+	local inventory="" file="" size="" quoted=""
+	local exit_code=0
+	local diff_rc=0
+	local max_bytes=1048576
+	inventory=$(mktemp) || return 1
+	if ! git ls-files --others --exclude-standard -z >"$inventory"; then
+		rm -f "$inventory"
+		return 1
+	fi
+	while IFS= read -r -d '' file; do
+		[[ -f "$file" && ! -L "$file" ]] || continue
+		printf -v quoted '%q' "$file"
+		if ! size=$(wc -c <"$file"); then
+			print_error "Untracked whitespace check: cannot read $quoted"
+			exit_code=1
+			continue
+		fi
+		if [[ "$size" -gt "$max_bytes" ]]; then
+			print_warning "Untracked whitespace check: skipped $quoted (over ${max_bytes} bytes); stage it for Git's cached check"
+			continue
+		fi
+		# --no-index implies --exit-code: 1 is an ordinary addition (including
+		# binary files), while --check reports whitespace errors with bit 2.
+		diff_rc=0
+		git diff --no-index --no-ext-diff --no-textconv --check -- /dev/null "$file" || diff_rc=$?
+		[[ "$diff_rc" -le 1 ]] || exit_code=1
+	done <"$inventory"
+	rm -f "$inventory"
+	return "$exit_code"
+}
+
 check_git_diff_whitespace() {
 	echo -e "${BLUE}Checking Git Diff Whitespace...${NC}"
 
@@ -64,9 +98,10 @@ check_git_diff_whitespace() {
 	fi
 	git diff --check || exit_code=1
 	git diff --cached --check || exit_code=1
+	_linters_check_untracked_whitespace || exit_code=1
 
 	if [[ "$exit_code" -eq 0 ]]; then
-		print_success "git diff --check: no whitespace errors"
+		print_success "git diff --check: no whitespace errors in checked files"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-linters-local-untracked-mode.sh
+++ b/.agents/scripts/tests/test-linters-local-untracked-mode.sh
@@ -14,6 +14,25 @@ TESTS_FAILED=0
 # shellcheck source=../lint-file-discovery.sh
 source "$DISCOVERY_HELPER"
 
+# shellcheck source=../linters-local-validators.sh
+source "${TEST_SCRIPT_DIR}/../linters-local-validators.sh"
+print_warning() {
+	printf '%s\n' "$*"
+	return 0
+}
+print_success() {
+	printf '%s\n' "$*"
+	return 0
+}
+print_error() {
+	printf '%s\n' "$*"
+	return 0
+}
+_linters_local_base_ref() {
+	git rev-parse HEAD
+	return $?
+}
+
 print_result() {
 	local test_name="$1"
 	local passed="$2"
@@ -119,12 +138,49 @@ test_full_shell_inventory_has_no_setup_module_duplicates() {
 	return 0
 }
 
+test_untracked_whitespace() {
+	local original_dir="$PWD" output="" rc=0
+	local unusual_name=$'space and\nnewline.md'
+	cd "$TEST_ROOT" || return 1
+	printf 'bad   \n' >"$unusual_name"
+	output=$(BLUE='' NC='' check_git_diff_whitespace 2>&1) || rc=$?
+	if [[ "$rc" -ne 0 && "$output" == *"trailing whitespace"* ]]; then
+		print_result "production whitespace gate rejects untracked text with unusual filename" 0
+	else
+		print_result "production whitespace gate rejects untracked text with unusual filename" 1 "$output"
+	fi
+	printf 'clean\n' >"$unusual_name"
+	printf 'ignored   \n' >ignored/whitespace.md
+	printf '\000binary   \n' >binary.dat
+	ln -s ignored/whitespace.md linked.md
+	output=$(BLUE='' NC='' check_git_diff_whitespace 2>&1) && rc=0 || rc=$?
+	print_result "clean text, binary, ignored files and symlinks pass" "$rc" "$output"
+	# Git config remains authoritative (intentional Markdown-style trailing spaces).
+	printf 'allowed   \n' >"$unusual_name"
+	git config core.whitespace -blank-at-eol
+	output=$(BLUE='' NC='' check_git_diff_whitespace 2>&1) && rc=0 || rc=$?
+	print_result "untracked check honors repository whitespace configuration" "$rc" "$output"
+	git config --unset core.whitespace
+	printf 'clean\n' >"$unusual_name"
+	# Sparse fixture avoids generating large content merely to exercise the bound.
+	python3 -c 'with open("large.md", "wb") as f: f.truncate(1048577)'
+	output=$(BLUE='' NC='' check_git_diff_whitespace 2>&1) && rc=0 || rc=$?
+	if [[ "$rc" -eq 0 && "$output" == *"skipped large.md"* ]]; then
+		print_result "oversized untracked file is explicitly reported as skipped" 0
+	else
+		print_result "oversized untracked file is explicitly reported as skipped" 1 "$output"
+	fi
+	cd "$original_dir" || return 1
+	return 0
+}
+
 main() {
 	setup_fixture
 	trap teardown_fixture EXIT
 	test_changed_inventory_coverage
 	test_untracked_content_changes_fingerprint
 	test_full_shell_inventory_has_no_setup_module_duplicates
+	test_untracked_whitespace
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 }


### PR DESCRIPTION
## Summary

Add bounded NUL-safe untracked whitespace validation while preserving Git whitespace configuration, binary handling, ignored files and symlink exclusions.

## Files Changed

.agents/scripts/linters-local-validators.sh, .agents/scripts/tests/test-linters-local-untracked-mode.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified production whitespace gate fixtures; 7 untracked tests and 10 changed-mode tests pass; ShellCheck, shfmt, git diff --check and linters-local.sh --changed pass.

Resolves #31409


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.323 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 1h 42m and 263,136 tokens on this with the user in an interactive session.