### PR TITLE
GH#31407: report detached recovery claims accurately

### DIFF
--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -456,6 +456,31 @@ test_claim_state_uses_archive_repository() {
 	return 0
 }
 
+test_detached_claim_does_not_invent_active_owner() {
+	local identity='' claim='' evidence='' result=''
+	local branch='' rc=0
+	identity='{"archive_path":"/unused-fixture","source_removal_outcome":"removed","branch":"detached"}'
+	claim=$(_worktree_recovery_plan_claim_state "$identity") || rc=1
+	[[ "$claim" == 'not-applicable' ]] || rc=1
+	evidence=$(_worktree_recovery_plan_partial_evidence_json clear clear clear "$claim") || rc=1
+	result=$(_worktree_recovery_plan_classification_json "$identity" "$evidence" true) || rc=1
+	[[ "$(printf '%s\n' "$result" | jq -r '.disposition')" == protected ]] || rc=1
+	[[ "$(printf '%s\n' "$result" | jq -r '.reasons[0]')" == detached-or-unresolved-branch ]] || rc=1
+	# Even a hypothetical all-clear claim cannot turn detached identity into a
+	# deletion candidate. Exact commit/task evidence never overrides this gate.
+	evidence='{"git":"clear","worktree":"clear","registry":"clear","claim":"clear","process":"clear","external":{"commit":"merged","open_pr":"clear","task":"closed"}}'
+	result=$(_worktree_recovery_plan_classification_json "$identity" "$evidence" true) || rc=1
+	[[ "$(printf '%s\n' "$result" | jq -r '.disposition')" == protected ]] || rc=1
+	for branch in '' unknown refs/tags/v1; do
+		identity=$(jq -cn --arg branch "$branch" '{archive_path:"/unused-fixture",branch:$branch}') || rc=1
+		claim=$(_worktree_recovery_plan_claim_state "$identity") || rc=1
+		[[ "$claim" == "$WORKTREE_RECOVERY_UNAVAILABLE" ]] || rc=1
+	done
+	print_result "detached_claim_does_not_invent_active_owner" "$rc" \
+		"Expected truthful detached claim evidence while retaining deletion protection and unknown-identity failure"
+	return 0
+}
+
 test_plan_output_refuses_unsafe_targets() {
 	local existing_path="${TEST_DIR}/existing-plan.json"
 	local symlink_path="${TEST_DIR}/symlink-plan.json"
@@ -2405,6 +2430,7 @@ run_all_tests() {
 	test_archive_prunes_only_regenerable_ignored_caches
 	test_archive_pruning_preserves_tracked_codegraph_root
 	test_claim_state_uses_archive_repository
+	test_detached_claim_does_not_invent_active_owner
 	test_recovery_issue_attribution_uses_archived_source_path
 	test_unlinked_merged_pr_is_terminal_task_evidence
 	test_dirty_recovery_short_circuits_expensive_probes

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -590,8 +590,14 @@ _worktree_recovery_plan_claim_state() {
 
 	archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
 	branch=$(printf '%s\n' "$identity_json" | jq -r '.branch') || return 1
+	# Detached archives have no branch-keyed claim. Do not invent a live owner
+	# or report clear evidence: the classifier still protects detached identity.
+	if [[ "$branch" == "detached" ]]; then
+		printf '%s\n' 'not-applicable'
+		return 0
+	fi
 	[[ "$branch" == refs/heads/* ]] || {
-		printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE"
+		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
 		return 0
 	}
 	if ! _worktree_recovery_plan_repo_slug "$archive_path" >/dev/null; then


### PR DESCRIPTION
## Summary

For #31407 — complete the diagnostic repair without silently authorizing archive deletion.

- Return `not-applicable` for a producer-recorded detached identity rather than inventing an active branch claim.
- Return unavailable evidence for other non-head identities.
- Preserve the evidence short-circuit and the independent detached retention guard; no archive becomes a deletion candidate.

## Implementation

`.agents/scripts/worktree-recovery-lifecycle-helper.sh` owns claim evidence. Its sole production consumer treats every non-clear value conservatively. Regression coverage in `.agents/scripts/tests/test-worktree-recovery-lifecycle.sh` exercises the actual claim/classification chain, malformed identity and hypothetical all-clear detached evidence.

## Runtime Testing

**Risk:** high (recovery evidence). **Testing level:** runtime-verified.

- Complete recovery lifecycle suite: **49 tests passed**, including archive apply/replay, ownership protection, cache retrofit, deadline/cursor and the new detached fixture.
- `linters-local.sh --changed`: passed, including changed-file ShellCheck and Secretlint.
- `git diff --check`: passed.
- Existing unrelated one-line test stubs produce an advisory shfmt difference; unchanged by this patch.
- Independent bounded source review found no introduced correctness/deletion regression. Closeout bundle SHA-256: `590553f755196776da68045118dc0b604c453bba5093d05ab78c90d5eff60a71`, injection scan clean.

## Remaining issue scope

This does not reclaim the reported backlog. Safe detached archive reclamation requires producer-bound exact publication/terminal evidence rather than removal of the retention guard. Keep #31407 open for that separately verified phase; do not claim a disk-capacity recovery from this PR.

## Release intent

The maintainer explicitly requested full-loop through release in the interactive session. This PR is eligible for the final verified release aggregate.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.323 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 1h 55m and 289,147 tokens on this with the user in an interactive session.