### PR TITLE
GH#31378: fix approved manifest lookup across linked worktrees

### DIFF
--- a/.agents/plugins/opencode-aidevops/source-access-manifest-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/source-access-manifest-approval.mjs
@@ -4,7 +4,7 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync, realpathSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 
 const MANIFEST_RECEIPT_SCHEMA = "aidevops-source-access-receipt/v2";
 const MANIFEST_PAYLOAD_SCHEMA = "aidevops-source-access-approval/v2";
@@ -84,6 +84,22 @@ export function applyApprovedMutationPatch(state, mutation) {
 
 function repositoryId(repoRoot) {
   return createHash("sha256").update(repoRoot, "utf8").digest("hex");
+}
+
+function repositoryContextMatches(repositoryDir, requestedRoot, git, gitRun) {
+  const contextRoot = realpathSync(repositoryDir);
+  if (contextRoot === requestedRoot) return true;
+  const options = { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 15000 };
+  const commonDir = (root) => realpathSync(resolve(root, String(
+    gitRun(git, ["-C", root, "rev-parse", "--git-common-dir"], options),
+  ).trim()));
+  if (commonDir(contextRoot) !== commonDir(requestedRoot)) return false;
+  // The ambient app may remain in the canonical checkout. Require an actual
+  // registered worktree in that same repository, not an arbitrary directory.
+  // This proves context only: the signed payload still binds the exact root,
+  // paths, session, user, bytes and snapshots below. No grant is transferred.
+  const worktrees = String(gitRun(git, ["-C", contextRoot, "worktree", "list", "--porcelain", "-z"], options));
+  return worktrees.split("\0").includes(`worktree ${requestedRoot}`);
 }
 
 function manifestScopeId(sessionId, uid, repoRoot, reason, paths) {
@@ -229,7 +245,7 @@ export function validatedManifestReceipt(options, dependencies) {
   const canonicalPath = realpathSync(filePath);
   const requestedIdentity = dependencies.trackedFileIdentity(canonicalPath, git, gitRun);
   requireValidReceipt(requestedIdentity);
-  if (repositoryDir) requireValidReceipt(realpathSync(repositoryDir) === requestedIdentity.repoRoot);
+  if (repositoryDir) requireValidReceipt(repositoryContextMatches(repositoryDir, requestedIdentity.repoRoot, git, gitRun));
   const approvalsDir = join(stateDir, "approvals", String(uid));
   requireValidReceipt(dependencies.trustedDirectory(approvalsDir, trustUid));
   requireValidReceipt(dependencies.trustedDirectory(dirname(publicKeyPath), trustUid));

--- a/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
@@ -456,11 +456,12 @@ test("the loaded verifier accepts only the exact signed receipt", () => {
   }
 });
 
-test("one signed manifest authorizes only three exact repository-bound paths", () => {
+async function checkSignedManifest(inLinkedWorktree) {
   const tempParent = join(homedir(), ".aidevops", ".agent-workspace", "tmp");
   mkdirSync(tempParent, { recursive: true });
   const root = mkdtempSync(join(tempParent, "source-access-manifest-node-test-"));
   const repo = join(root, "repo");
+  const canonicalRepo = inLinkedWorktree ? join(root, "canonical") : repo;
   const otherRepo = join(root, "other-repo");
   const key = join(root, "source-access-key");
   const stateDir = join(root, "state");
@@ -469,9 +470,16 @@ test("one signed manifest authorizes only three exact repository-bound paths", (
   const now = 1_800_000_000;
 
   try {
-    mkdirSync(repo);
+    mkdirSync(canonicalRepo);
     mkdirSync(otherRepo);
-    execFileSync("git", ["-C", repo, "init", "--quiet"]);
+    execFileSync("/usr/bin/git", ["-C", canonicalRepo, "init", "--quiet"]);
+    if (inLinkedWorktree) {
+      execFileSync("/usr/bin/git", [
+        "-C", canonicalRepo, "-c", "commit.gpgsign=false", "-c", "user.name=Fixture",
+        "-c", "user.email=fixture@example.invalid", "commit", "--allow-empty", "-qm", "fixture",
+      ]);
+      execFileSync("/usr/bin/git", ["-C", canonicalRepo, "worktree", "add", "--detach", "--quiet", repo]);
+    }
     execFileSync("git", ["-C", otherRepo, "init", "--quiet"]);
     const relativePaths = ["secret-helper.sh", "secret-other.sh", "secret-third.sh"];
     const paths = relativePaths.map((name, index) => {
@@ -537,18 +545,56 @@ test("one signed manifest authorizes only three exact repository-bound paths", (
     const baseArgs = {
       sessionId,
       reason: SOURCE_ACCESS_REASON,
-      repositoryDir: repo,
+      repositoryDir: canonicalRepo,
       now: now + 1,
       uid,
       trustUid: uid,
       stateDir,
       publicKeyPath: `${key}.pub`,
     };
+    const scriptsDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "scripts");
+    const logsDir = join(root, "logs");
+    mkdirSync(logsDir);
+    const hooks = createQualityHooks({
+      scriptsDir,
+      logsDir,
+      repositoryDir: canonicalRepo,
+      verifySourceAccessReceipt: (options) => verifySourceAccessReceipt({ ...baseArgs, ...options }),
+      sourceAccessBrokerMatches: () => true,
+      sourceAccessRequestRun: () => {
+        throw new Error("an exact signed manifest must not generate a per-path request");
+      },
+    });
     for (const filePath of paths) {
       const approval = verifySourceAccessReceipt({ ...baseArgs, filePath });
       assert.ok(approval);
       assert.equal(readFileSync(approval.approvedPath, "utf8"), readFileSync(filePath, "utf8"));
+      const output = { args: { filePath } };
+      await hooks.toolExecuteBefore({ tool: "read", sessionID: sessionId, callID: filePath }, output);
+      assert.equal(output.args.filePath, approval.approvedPath);
     }
+    if (inLinkedWorktree) {
+      const sibling = join(root, "unapproved-sibling");
+      execFileSync("/usr/bin/git", ["-C", canonicalRepo, "worktree", "add", "--detach", "--quiet", sibling]);
+      const siblingPath = join(sibling, relativePaths[0]);
+      writeFileSync(siblingPath, "source-0\n");
+      execFileSync("/usr/bin/git", ["-C", sibling, "add", relativePaths[0]]);
+      assert.equal(verifySourceAccessReceipt({ ...baseArgs, filePath: siblingPath }), false);
+      assert.equal(verifySourceAccessReceipt({
+        ...baseArgs,
+        filePath: paths[0],
+        gitRun: () => { throw new Error("Git identity unavailable"); },
+      }), false);
+      assert.equal(verifySourceAccessReceipt({
+        ...baseArgs,
+        filePath: paths[0],
+        gitRun: (git, args, options) => args.includes("--porcelain")
+          ? `worktree ${canonicalRepo}\0\0`
+          : execFileSync(git, args, options),
+      }), false);
+    }
+    assert.equal(verifySourceAccessReceipt({ ...baseArgs, filePath: paths[0], repositoryDir: otherRepo }), false);
+    assert.equal(verifySourceAccessReceipt({ ...baseArgs, filePath: paths[0], sessionId: "ses_other_123456" }), false);
     assert.equal(verifySourceAccessReceipt({ ...baseArgs, filePath: extraPath }), false);
     assert.equal(
       verifySourceAccessReceipt({ ...baseArgs, filePath: foreignPath, repositoryDir: otherRepo }),
@@ -566,7 +612,10 @@ test("one signed manifest authorizes only three exact repository-bound paths", (
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
-});
+}
+
+test("one signed manifest authorizes only three exact repository-bound paths", () => checkSignedManifest(false));
+test("a canonical app context consumes its exact linked-worktree manifest without per-path requests", () => checkSignedManifest(true));
 
 test("one approval survives verified Write, Edit, and apply_patch cycles", () => {
   const fixture = mutationFixture();


### PR DESCRIPTION
## Summary

Fix the CLI-verified manifest / denied OpenCode Read mismatch reproduced during #31378. Ref #31378: this PR addresses the manifest-consumption defect only; durable proposals and the combined issue/source approval ceremony remain open.

OpenCode retains the canonical project directory when an interactive session creates a linked worktree. The manifest verifier incorrectly required that ambient project directory to equal the signed worktree root. The single-path verifier did not impose this extra equality, explaining why per-path approval could work while the manifest failed.

## Changes

- `.agents/plugins/opencode-aidevops/source-access-manifest-approval.mjs`: accept the ambient context only when it has the same canonical Git common directory and the requested root is a registered worktree. Preserve the exact-root fast path.
- Keep signed session, UID, repository root, paths, hashes, snapshots, TTL and signature validation unchanged. Context compatibility is not an authorization grant or cross-worktree capability transfer.
- `.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs`: exercise both ordinary and linked-worktree manifests through the real verifier and composed Read hook, with per-path request generation configured to fail the test.

## Runtime Testing

**runtime-verified** in synthetic repositories with genuine fixture signatures and Git linked worktrees. The new linked-worktree case failed before the fix and passed afterward. Foreign repositories, unapproved siblings with identical bytes, missing worktree registration, Git lookup failure, changed session, expiry, changed content and removed receipts remain denied.

Passed:

```bash
node --check .agents/plugins/opencode-aidevops/source-access-manifest-approval.mjs
node --check .agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
node --test .agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
.agents/scripts/linters-local.sh
```

All 20 plugin tests passed. The final added negative cases also passed in a focused rerun. Baseline Python and three shell source-approval suites passed before these JS-only edits.

## Security review and scope

Independent security review found no material introduced blocker. Exact signed scope remains authoritative even if local Git metadata changes; unknown contexts fail closed. No denied live source was read with an alternate reader, and no privileged broker or deployed runtime was modified.

Review bundle: `217c48a00ae85e05f19876f4974b99054dc2b86bf4efb509b78967e3ec7681c8`, head `f2c703dc9ecf2ea6e3928c4606bf83a663058992`, prompt-injection scan clean.

The already-loaded runtime still has its old verifier; the fixture result is not a claim that the live denial has disappeared. No release or deployment authority is included.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.323 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 2h 31m and 399,467 tokens on this with the user in an interactive session.