### PR TITLE
GH#31411: handle Playwriter blank bootstrap safely

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
@@ -48,6 +48,11 @@ test("registers only the explicit MCP activation profiles", () => {
   assert.match(config.agent.playwriter.prompt, /no browser tab is approved/i);
   assert.match(config.agent.playwriter.prompt, /before requesting authentication/i);
   assert.match(config.agent.playwriter.prompt, /enumerate.*context\.pages\(\)/i);
+  assert.match(config.agent.playwriter.prompt, /exactly one `about:blank` bootstrap page/i);
+  assert.match(config.agent.playwriter.prompt, /already approved the exact HTTPS destination/i);
+  assert.match(config.agent.playwriter.prompt, /unmatched non-blank or multiple pages/i);
+  assert.match(config.agent.playwriter.prompt, /prior attachment was invalidated/i);
+  assert.match(config.agent.playwriter.prompt, /not consent to inspect another page/i);
   assert.match(config.agent.playwriter.prompt, /never silently substitute.*playwright/i);
   assert.match(config.agent.playwriter.prompt, /never close\s+user-owned[\s\S]*browser windows/i);
   assert.match(config.agent.playwriter.prompt, /# Playwriter - Legacy Browser Extension MCP/);

--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -108,14 +108,26 @@ only a relay process it started. A conflicting or unverifiable relay fails
 closed without `--replace` or port-owner termination.
 
 1. Connect Playwriter and enumerate the accessible pages with `context.pages()`.
-2. Match only the intended target by its expected URL and title. Confirm that the
-   controlled tab and expected Chrome profile/session are visible; do not expose
-   unrelated approved-tab details.
-3. If the bridge, approved tab, or target profile is absent or ambiguous, fail
-   closed and relay the consent/target diagnostic. Do not ask the user to log in.
-4. Never silently substitute isolated-profile Playwright. Explain the storage
+   Inspect only the URL and title needed to classify the intended target; do not
+   expose unrelated approved-tab details.
+2. Match the intended target by its exact approved HTTPS URL and expected title.
+   Confirm that the controlled tab and expected Chrome profile/session are
+   visible before authenticated work.
+3. Classify a result with no exact match as one of: no controlled pages; exactly
+   one `about:blank` bootstrap page; unmatched non-blank or multiple pages; or a
+   target lost after MCP reconnection. Do not collapse these states into a generic
+   request to reactivate the extension.
+4. For exactly one `about:blank` bootstrap page, navigate that page only when the
+   user already approved the exact HTTPS destination. Revalidate the resulting
+   URL and expected profile/session before continuing. This bounded bootstrap is
+   not consent to inspect another page or navigate to a broader origin.
+5. For no pages, unmatched non-blank or multiple pages, or any target/profile
+   ambiguity, fail closed with the classified diagnostic. After reconnection,
+   repeat the preflight and report when the prior attachment was invalidated. Do
+   not ask the user to log in.
+6. Never silently substitute isolated-profile Playwright. Explain the storage
    boundary and obtain explicit user consent before any fallback.
-5. On completion or cancellation, disconnect the Playwriter MCP. Never close
+7. On completion or cancellation, disconnect the Playwriter MCP. Never close
    user-owned pages, contexts, profiles, or browser windows.
 
 ### Extension-page QA Preflight
@@ -226,6 +238,7 @@ approved-tab, privacy, and mutation boundaries.
 - **Extension not connecting**: Installed and pinned? Click icon on tab (should turn green). Red badge = error. Reload tab.
 - **MCP not finding tabs**: Green icon? Restart MCP client. Verify WebSocket on port 19988.
 - **No approved tab**: Click the Playwriter extension on the intended tab and wait for the icon to turn green; this consent requirement is distinct from missing MCP tools.
+- **Blank bootstrap only**: If the sole accessible page is `about:blank`, use the bounded exact-HTTPS bootstrap above instead of repeatedly requesting extension reactivation.
 - **Terminal OpenCode activation failure**: After the one bounded reset, treat Playwriter as unavailable for the session and use the documented secure CLI diagnostic path only to isolate the cause. Do not retry through another child or treat direct CLI initialization as successful OpenCode activation.
 - **Automation detection**: Disconnect (click icon → gray) → complete manual action (login, captcha) → reconnect (click → green) → resume.
 


### PR DESCRIPTION
## Summary

Classify Playwriter tab handoff states and permit only an exact-HTTPS, user-approved about:blank bootstrap fallback while preserving fail-closed browser consent boundaries.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs, .agents/tools/browser/playwriter.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Self-assessed: 27 focused MCP activation tests pass; changed-file linters pass; closeout review found no P0/P1 findings; local review bundle d09a49a9d496a2d3dcadc0db1712e2ae05a4d0cc724c7a705b494d34c0a49b75.

Resolves #31411


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.325 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 12m and 163,562 tokens on this with the user in an interactive session.