### PR TITLE
GH#31425: verify bounded operation supervisor execution

### DIFF
--- a/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
@@ -24,6 +24,7 @@ import {
 
 const MAX_OPERATIONS = 24;
 const SUPERVISOR_PATH = fileURLToPath(new URL("./bounded-operation-supervisor.mjs", import.meta.url));
+const SUPERVISOR_RUNTIME = "node";
 
 export class BoundedInteractiveOperationManager {
   constructor(options = {}) {
@@ -36,6 +37,7 @@ export class BoundedInteractiveOperationManager {
     this.killGraceMs = options.killGraceMs ?? 500;
     this.setTimer = options.setTimer || setTimeout;
     this.clearTimer = options.clearTimer || clearTimeout;
+    this.supervisorRuntime = options.supervisorRuntime || SUPERVISOR_RUNTIME;
     this.operations = new Map();
   }
 
@@ -58,13 +60,23 @@ export class BoundedInteractiveOperationManager {
     }
   }
 
-  spawnOwned(operation, command) {
+  spawnOwned(operation, command, stage) {
     const childBudgetMs = command === operation.command ? operation.budgetMs : operation.restorationBudgetMs;
-    const child = this.spawn(process.execPath, [SUPERVISOR_PATH], {
+    const child = this.spawn(this.supervisorRuntime, [SUPERVISOR_PATH], {
       cwd: operation.cwd,
       detached: true,
       env: process.env,
       stdio: ["pipe", "pipe", "pipe", "ipc"],
+    });
+    child.on("message", (message) => {
+      if (message?.type !== "aidevops.operation" || message.event !== "command_started"
+        || message.operationID !== operation.id) return;
+      if (stage === "main") {
+        operation.commandStarted = true;
+        operation.supervisorRuntime = scalar(message.runtime);
+      } else {
+        operation.restorationCommandStarted = true;
+      }
     });
     child.stdin.end(JSON.stringify({
       budgetMs: childBudgetMs,
@@ -98,8 +110,11 @@ export class BoundedInteractiveOperationManager {
       disposition: "running",
       processExit: null,
       processSignal: "",
+      commandStarted: false,
+      supervisorRuntime: "",
       restorationState: args.restorationCommand ? "pending" : "not_required",
       restorationExit: null,
+      restorationCommandStarted: false,
       lastMeaningfulProgressAt: null,
       progressEvents: 0,
       progressRemainder: "",
@@ -119,7 +134,7 @@ export class BoundedInteractiveOperationManager {
     this.operations.set(operation.id, operation);
 
     await new Promise((resolve) => {
-      const child = this.spawnOwned(operation, operation.command);
+      const child = this.spawnOwned(operation, operation.command, "main");
       operation.child = child;
       child.once("exit", () => { operation.childExited = true; });
       child.once("spawn", () => {
@@ -157,7 +172,9 @@ export class BoundedInteractiveOperationManager {
     operation.child = null;
     operation.processExit = Number.isInteger(code) ? code : null;
     operation.processSignal = scalar(signal);
-    if (operation.disposition === "running") operation.disposition = code === 0 ? "succeeded" : "failed";
+    if (operation.disposition === "running") {
+      operation.disposition = code === 0 && operation.commandStarted ? "succeeded" : "failed";
+    }
     if (operation.restorationCommand) await this.runRestoration(operation);
     await this.finalize(operation);
   }
@@ -176,7 +193,7 @@ export class BoundedInteractiveOperationManager {
         operation.restorationState = state;
         resolve();
       };
-      const child = this.spawnOwned(operation, operation.restorationCommand);
+      const child = this.spawnOwned(operation, operation.restorationCommand, "restoration");
       operation.restorationChild = child;
       operation.restorationChildExited = false;
       child.once("exit", () => { operation.restorationChildExited = true; });
@@ -189,7 +206,7 @@ export class BoundedInteractiveOperationManager {
       child.once("error", () => finish("failed"));
       child.once("close", (code, signal) => {
         const timedOut = operation.restorationState === "timing_out";
-        finish(timedOut ? "timed_out" : (code === 0 ? "succeeded" : "failed"), code);
+        finish(timedOut ? "timed_out" : (code === 0 && operation.restorationCommandStarted ? "succeeded" : "failed"), code);
       });
     });
   }

--- a/.agents/plugins/opencode-aidevops/bounded-operation-runtime.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-operation-runtime.mjs
@@ -71,6 +71,10 @@ export function operationReceipt(operation, now) {
       && (lastProgressAgeMs === null || lastProgressAgeMs >= operation.progressIntervalMs),
     process_exit: operation.processExit,
     process_signal: operation.processSignal || null,
+    command_execution: operation.state === "starting" || operation.state === "running"
+      ? "pending"
+      : (operation.commandStarted ? "observed" : "missing"),
+    supervisor_runtime: operation.supervisorRuntime || null,
     restoration_state: operation.restorationState,
     restoration_exit: operation.restorationExit,
     output_id: operation.outputID || null,

--- a/.agents/plugins/opencode-aidevops/bounded-operation-supervisor.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-operation-supervisor.mjs
@@ -39,6 +39,23 @@ function groupMemberCount(groupID) {
   return count;
 }
 
+function reportCommandStarted(operationID) {
+  if (typeof process.send !== "function") return Promise.resolve();
+  return new Promise((resolve) => {
+    try {
+      process.send({
+        type: "aidevops.operation",
+        event: "command_started",
+        operationID: String(operationID || ""),
+        runtime: `node ${process.version}`,
+      }, resolve);
+    } catch {
+      // The parent closes IPC during cancellation or an abnormal launcher exit.
+      resolve();
+    }
+  });
+}
+
 export async function runSupervisor() {
   const config = await readPrivateConfig();
   const command = config?.command;
@@ -50,6 +67,7 @@ export async function runSupervisor() {
   let terminating = false;
   let childFinished = false;
   let childExit = 1;
+  let commandStarted = Promise.resolve();
 
   const terminateOwnedGroup = () => {
     if (terminating) return;
@@ -81,6 +99,7 @@ export async function runSupervisor() {
     stdio: ["ignore", "inherit", "inherit"],
   });
 
+  child.once("spawn", () => { commandStarted = reportCommandStarted(config.operationID); });
   child.once("error", () => {
     childFinished = true;
     childExit = 127;
@@ -97,7 +116,7 @@ export async function runSupervisor() {
       if (members !== 1) return;
       clearInterval(drainTimer);
       clearTimeout(budgetTimer);
-      resolve(childExit);
+      commandStarted.finally(() => resolve(childExit));
     }, 25);
   });
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Marcus Quinn
 
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -31,6 +32,34 @@ function manager(options = {}) {
   });
   managers.push(instance);
   return instance;
+}
+
+function launcher({ started = false } = {}) {
+  return (runtime) => {
+    const child = new EventEmitter();
+    child.stdin = { end() {} };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.connected = false;
+    child.exitCode = null;
+    child.signalCode = null;
+    queueMicrotask(() => {
+      child.emit("spawn");
+      if (started) {
+        child.emit("message", {
+          type: "aidevops.operation",
+          event: "command_started",
+          operationID: "op_fixture",
+          runtime: "node v22.23.1",
+        });
+      }
+      child.exitCode = 0;
+      child.emit("exit", 0, null);
+      child.emit("close", 0, null);
+    });
+    assert.equal(runtime, "node");
+    return child;
+  };
 }
 
 async function terminal(instance, operationID, context = owner, timeoutMs = 2000) {
@@ -64,6 +93,8 @@ describe("bounded interactive operations", () => {
     assert.equal(result.output_id, "out_fixture_1");
     assert.equal(result.evidence_state, "recorded");
     assert.equal(result.restoration_state, "not_required");
+    assert.equal(result.command_execution, "observed");
+    assert.match(result.supervisor_runtime, /^node v\d+\./);
     assert.equal(JSON.stringify(result).includes("phase-one"), false);
   });
 
@@ -111,6 +142,34 @@ describe("bounded interactive operations", () => {
     const spawnFailureResult = await terminal(instance, spawnFailure.operation_id);
     assert.equal(spawnFailureResult.state, "failed");
     assert.equal(spawnFailureResult.restoration_state, "succeeded");
+  });
+
+  test("a launcher cannot report success without supervisor command evidence", async () => {
+    const missingEvidence = manager({
+      makeID: () => "op_fixture",
+      spawn: launcher(),
+    });
+    const missingStarted = await missingEvidence.start({
+      command: ["git", "--version"],
+      budgetMs: 1000,
+    }, owner);
+    const missingResult = await terminal(missingEvidence, missingStarted.operation_id);
+    assert.equal(missingResult.state, "failed");
+    assert.equal(missingResult.process_exit, 0);
+    assert.equal(missingResult.command_execution, "missing");
+
+    const verifiedEvidence = manager({
+      makeID: () => "op_fixture",
+      spawn: launcher({ started: true }),
+    });
+    const verifiedStarted = await verifiedEvidence.start({
+      command: ["git", "--version"],
+      budgetMs: 1000,
+    }, owner);
+    const verifiedResult = await terminal(verifiedEvidence, verifiedStarted.operation_id);
+    assert.equal(verifiedResult.state, "succeeded");
+    assert.equal(verifiedResult.command_execution, "observed");
+    assert.equal(verifiedResult.supervisor_runtime, "node v22.23.1");
   });
 
   test("restoration runs after success and remains visible when it fails", async () => {


### PR DESCRIPTION
## Summary

Launch the bounded-operation supervisor through the Node runtime and require matching IPC command-start evidence before terminal success.

## Files Changed

.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs, .agents/plugins/opencode-aidevops/bounded-operation-runtime.mjs, .agents/plugins/opencode-aidevops/bounded-operation-supervisor.mjs, .agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified: node --test tests/test-bounded-interactive-operation.mjs; node syntax checks; changed-file local linters passed. Full plugin test suite has two unrelated terminal failures: observability routing expectation mismatch and missing @opencode-ai/plugin dependency.

Resolves #31425


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.325 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 13m and 156,510 tokens on this as a headless worker.