### PR TITLE
GH#31401: report worker productivity without triage inflation

### DIFF
--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -458,7 +458,10 @@ if canonical_reconciliation_refusal_count:
         else 'upstream_or_default_branch_mismatch'
     )
 
-metric_class_counts = Counter(classify_metric(item) for item in metrics)
+# The runtime ledger also contains triage, research and supervisor events.
+# Keep their resource context, but never credit them as implementation workers.
+worker_metrics = [item for item in metrics if item.get('role') == 'worker']
+metric_class_counts = Counter(classify_metric(item) for item in worker_metrics)
 stage_counts = Counter(record['stage'] for record in stage_records)
 stage_timing = defaultdict(lambda: {'count': 0, 'sum_ms': 0, 'max_ms': 0})
 for record in stage_records:
@@ -623,7 +626,8 @@ result = {
     'dispatch_stage_events': len(stage_records),
     'dispatch_stage_counts': dict(stage_counts),
     'dispatch_stage_timing_ms': stage_timing_summary,
-    'worker_terminal_events': len(metrics),
+    'worker_terminal_events': len(worker_metrics),
+    'non_worker_terminal_events': len(metrics) - len(worker_metrics),
     'worker_result_counts': dict(metric_class_counts),
     'worker_successes': metric_class_counts.get('success', 0),
     'worker_failures_or_stalls': sum(count for key, count in metric_class_counts.items() if key != 'success'),

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -21,10 +21,14 @@ open(os.path.join(root, 'dispatch-stages.tsv'), 'w').write(
     f'{iso}\t#1\tmarcusquinn/aidevops\tceremony_total\t456\n'
 )
 open(os.path.join(root, 'headless-runtime-metrics.jsonl'), 'w').write(
-    json.dumps({'ts': now, 'result': 'success', 'exit_code': 0, 'duration_ms': 1000, 'load_1min': 1.5, 'load_per_cpu': 0.2}) + '\n' +
-    json.dumps({'ts': now, 'result': 'watchdog_stall_killed', 'exit_code': 79, 'duration_ms': 2000}) + '\n' +
-    json.dumps({'ts': now, 'result': 'rate_limit_fast', 'exit_code': 80, 'failure_reason': 'rate_limit_fast'}) + '\n' +
-    json.dumps({'ts': now, 'result': 'worker_noop', 'exit_code': 2}) + '\n'
+    json.dumps({'ts': now, 'role': 'worker', 'result': 'success', 'exit_code': 0, 'duration_ms': 1000, 'load_1min': 1.5, 'load_per_cpu': 0.2}) + '\n' +
+    json.dumps({'ts': now, 'role': 'worker', 'result': 'watchdog_stall_killed', 'exit_code': 79, 'duration_ms': 2000}) + '\n' +
+    json.dumps({'ts': now, 'role': 'worker', 'result': 'rate_limit_fast', 'exit_code': 80, 'failure_reason': 'rate_limit_fast'}) + '\n' +
+    json.dumps({'ts': now, 'role': 'worker', 'result': 'worker_noop', 'exit_code': 2}) + '\n' +
+    json.dumps({'ts': now, 'role': 'triage', 'result': 'success', 'exit_code': 0}) + '\n' +
+    json.dumps({'ts': now, 'role': 'triage', 'result': 'blocked', 'exit_code': 83}) + '\n' +
+    json.dumps({'ts': now, 'role': 'pulse', 'result': 'success', 'exit_code': 0, 'load_1min': 9.0}) + '\n' +
+    json.dumps({'ts': now, 'result': 'success', 'exit_code': 0}) + '\n'
 )
 json.dump({
     'counters': {
@@ -159,6 +163,9 @@ grep -q 'Oldest unverified assumption:' "$output"
 
 json_output="$TMP_DIR/out.json"
 "$HELPER" --log-dir "$TMP_DIR" --repo-path "$PWD" --window 15m --json >"$json_output"
+jq -e '.worker_terminal_events == 4 and .non_worker_terminal_events == 4' "$json_output" >/dev/null
+jq -e '.worker_successes == 1 and .worker_failures_or_stalls == 3' "$json_output" >/dev/null
+jq -e '.resource_context.load_1min_last == 9.0' "$json_output" >/dev/null
 jq -e '.worker_outcomes.spawned == 1' "$json_output" >/dev/null
 jq -e '.worker_outcomes.watchdog_killed == 1' "$json_output" >/dev/null
 jq -e '.worker_outcomes.rate_limited == 1' "$json_output" >/dev/null


### PR DESCRIPTION
## Summary

For #31401. Correct one evidenced obstacle to truthful productivity assessment: `pulse-current-state.py` reported all runtime roles as worker outcomes. The observed audit required manually separating implementation workers from successful triage/research/supervisor calls.

- Count worker terminal events, successes, failures and result-derived outcomes only for explicit `role=worker`, matching the canonical worker-activity summary's role boundary.
- Expose excluded non-worker/unattributed rows as `non_worker_terminal_events`; unknown legacy roles do not receive implementation credit.
- Preserve all-role host-load context and existing runtime liveness inputs. No admission, retry or permission policy changes.

## Files and verification

Only `.agents/scripts/pulse-current-state.py` and its existing `tests/test-pulse-current-state-helper.sh` change. The mixed-role fixture proves four worker events and four excluded events yield exactly one worker success and three non-success events, while retaining the supervisor's newer host-load sample.

## Runtime Testing

Medium-risk diagnostic projection; runtime-verified using the existing offline helper fixture. Current-state suite passed, all 23 existing current-state guardrail assertions passed, ShellCheck and changed-file local lint passed. Direct diff review verifies the role filter affects worker accounting without discarding resource evidence.

This is event accounting, not unique solved issues, merged delivery or a claim that concurrency recovered. Keep #31401 open for its wider deployed recovery assessment.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.325 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 14h 23m and 1,718,592 tokens on this with the user in an interactive session.