### PR TITLE
GH#31408: fix: keep missing-config secretlint scans read-only

### DIFF
--- a/.agents/scripts/secretlint-helper.sh
+++ b/.agents/scripts/secretlint-helper.sh
@@ -536,14 +536,14 @@ run_secretlint_scan() {
 		return 1
 	fi
 
+	# Scanning must not initialize configuration or select an installing runner.
+	if [[ ! -f "${SECRETLINT_CONFIG_FILE}" ]]; then
+		print_error "No configuration found. Run: $0 init"
+		return 2
+	fi
+
 	local cmd
 	cmd=$(get_secretlint_cmd)
-
-	# Check if configuration exists
-	if [[ ! -f "${SECRETLINT_CONFIG_FILE}" ]]; then
-		print_warning "No configuration found. Initializing..."
-		init_secretlint_config
-	fi
 
 	# Validate that required rules are installed
 	local rules_check=0

--- a/.agents/scripts/tests/test-scan-config-boundary.py
+++ b/.agents/scripts/tests/test-scan-config-boundary.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Exercise the scan configuration boundary without real scanners or network."""
+
+import concurrent.futures
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+HELPER = Path(__file__).resolve().parents[1] / "secretlint-helper.sh"
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="scan-config-boundary-") as temporary:
+        root = Path(temporary)
+        project = root / "project"
+        binaries = root / "bin"
+        project.mkdir()
+        binaries.mkdir()
+        calls = root / "calls"
+        for name in ("npm", "npx", "docker", "secretlint"):
+            stub = binaries / name
+            stub.write_text(
+                '#!/bin/sh\nprintf "%s\\n" "$0 $*" >> "$SCAN_CALL_LOG"\n'
+                'case "$0" in */secretlint) exit "${SCAN_EXIT:-0}";; esac\n'
+                'exit 0\n', encoding="utf-8"
+            )
+            stub.chmod(0o700)
+        environment = {
+            **os.environ,
+            "PATH": f"{binaries}:{os.environ['PATH']}",
+            "SCAN_CALL_LOG": str(calls),
+        }
+
+        def run(command, exit_code=0):
+            return subprocess.run(
+                ["bash", str(HELPER), command, "**/*", "json"],
+                cwd=project, env={**environment, "SCAN_EXIT": str(exit_code)},
+                stdin=subprocess.DEVNULL, capture_output=True, text=True,
+                timeout=30, check=False,
+            )
+
+        # Both aliases and overlapping scans must fail before any setup or runner.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            results = list(pool.map(run, ["scan", "lint", "scan", "lint"]))
+        for result in results:
+            assert result.returncode == 2, result
+            assert "init" in result.stdout + result.stderr, result
+            assert "No secrets detected" not in result.stdout, result
+        assert not list(project.iterdir()), "missing-config scans wrote project files"
+        assert not calls.exists(), "missing-config scans invoked a runner or installer"
+
+        # Explicit init remains the owner of configuration and ignore-file writes.
+        # A failing scanner --init exercises the helper's existing config fallback.
+        result = run("init", 1)
+        assert result.returncode == 0, result
+        config = project / ".secretlintrc.json"
+        ignore = project / ".secretlintignore"
+        assert config.is_file() and ignore.is_file(), result
+        before = {path.name: path.read_bytes() for path in project.iterdir() if path.is_file()}
+        if calls.exists():
+            calls.unlink()
+        for command, code in (("scan", 0), ("lint", 1), ("scan", 2)):
+            result = run(command, code)
+            assert result.returncode == code, result
+        after = {path.name: path.read_bytes() for path in project.iterdir() if path.is_file()}
+        assert before == after, "configured scans changed project files"
+        assert "secretlint **/* --format json" in calls.read_text(encoding="utf-8")
+    print("PASS scan/lint missing config, concurrency, explicit init, configured exit codes")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Make missing-config `scan` and `lint` return setup-error status 2 with explicit `init` guidance before scanner selection.
- Remove implicit configuration/ignore-file initialization from the scan path; leave configured scanning and explicit initialization unchanged.
- Add an isolated stdlib regression fixture with scanner/package-manager stubs; no real network or scanner dependency is required.

## Files and reference pattern

- `.agents/scripts/secretlint-helper.sh`: `run_secretlint_scan`, using the existing setup-error status 2 convention.
- `.agents/scripts/tests/test-scan-config-boundary.py`: exercise the actual CLI and both scan aliases.

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified
- `python3 .agents/scripts/tests/test-scan-config-boundary.py`: PASS, including rerun after the helper rebase at head `36d64b0727fe5d3ddbcc91d82943cf01e34d51bd`.
- Four overlapping missing-config scan/lint calls: status 2, no project writes, no scanner/package-manager calls, no false-clean message.
- Explicit init: existing fallback creates config and ignore files.
- Configured scanner statuses 0/1/2 propagate; config and ignore contents remain unchanged.
- ShellCheck, `git diff --check`, and `.agents/scripts/linters-local.sh --changed`: PASS before rebase; CLI fixture passes after rebase.
- Independent closeout review: no material in-scope defect identified. The configured npx fallback is intentionally unchanged.

Resolves #31408

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.325 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 4h 27m and 789,096 tokens on this with the user in an interactive session.