### PR TITLE
GH#31432: document Cloudflare crawler allow policy

### DIFF
--- a/.agents/services/hosting/cloudflare.md
+++ b/.agents/services/hosting/cloudflare.md
@@ -41,6 +41,7 @@ tools:
 - **Security**: IP filtering, expiration dates, minimal permissions
 - **Rotation**: Every 6-12 months or after team changes
 - **Code Mode MCP**: `.agents/tools/mcp/cloudflare-code-mode.md` (operations via 2,500+ endpoints)
+- **Crawler policy default**: Prefer allowing crawlers unless the user or site policy explicitly requires blocking; preserve search discovery by keeping mixed-purpose crawlers allowed
 
 <!-- AI-CONTEXT-END -->
 
@@ -152,6 +153,35 @@ Success returns `"success": true` with your zone list.
 ```
 
 Use cases: automated DNS for dev environments, dynamic subdomains for feature branches, SSL automation, traffic routing for A/B testing, security rule management for dev APIs.
+
+## AI Crawler Policy
+
+Cloudflare exposes the zone-level AI crawler control through Bot Management:
+
+- Read: `GET /zones/{zone_id}/bot_management`
+- Update: `PUT /zones/{zone_id}/bot_management`
+- Field: `ai_bots_protection`
+- Values: `disabled` (allow), `block`, or `only_on_ad_pages`
+- Token permissions: `Bot Management Read` for audits and `Bot Management Write` for changes
+
+Default to `disabled` so AI training crawlers and mixed-purpose crawlers used for
+search indexing remain allowed. Only select a blocking value when the user or an
+explicit site policy requires it. Do not infer crawler policy from Bot Fight Mode,
+robots.txt, or the legacy zone-settings API; read Bot Management directly.
+
+For a portfolio audit, enumerate every accessible zone with pagination, exclude
+non-active zones from mutation, read each active zone's Bot Management object, and
+compare `ai_bots_protection` with `disabled`. Update only non-compliant active zones,
+then re-read every active zone and report totals for compliant, changed, skipped,
+and failed zones. Never report success from the update response alone.
+
+Cloudflare may show a migration-specific dashboard preference for mixed-purpose
+crawlers separately from the older “Block AI bots” selector. The public Bot
+Management schema is the authoritative automation contract; do not guess an
+undocumented field from dashboard wording. If the public API does not expose the
+separate migration preference, inspect an authorized dashboard network request or
+use Cloudflare Code Mode OpenAPI search, then document the verified field before
+automating it.
 
 ## If a Token Is Compromised
 

--- a/.agents/tools/mcp/cloudflare-code-mode.md
+++ b/.agents/tools/mcp/cloudflare-code-mode.md
@@ -20,6 +20,14 @@ mcp_servers:
 - **Code Mode MCP** (`search` + `execute`): Manage DNS, zones, WAF, DDoS, firewall rules, R2 buckets, Workers deployments, Zero Trust, Access policies
 - **`cloudflare-platform-skill`**: Build Workers (SDK, bindings, patterns), configure wrangler.toml, local dev, debug runtime issues, understand product architecture
 
+For crawler controls, prefer allowing crawlers unless an explicit site policy says
+otherwise. Audit `GET /zones/{zone_id}/bot_management` and set
+`ai_bots_protection: "disabled"` with `PUT` to allow AI and mixed-purpose crawlers.
+Require `Bot Management Read`/`Bot Management Write`, paginate all zones, skip
+non-active zones, and re-read after updates. Do not substitute the legacy zone
+settings endpoint or invent an undocumented migration-preference field; search the
+live OpenAPI schema when Cloudflare's dashboard presents newer controls.
+
 ## Setup
 
 **Interactive (OAuth 2.1):** Add to MCP config — on first connection, Cloudflare prompts for authorization with downscoped permissions:
@@ -63,6 +71,45 @@ async () => {
   });
 }
 ```
+
+```javascript
+// Audit active zones and allow AI/mixed-purpose crawlers where needed.
+async () => {
+  const zones = await cloudflare.request({
+    method: "GET",
+    path: "/zones",
+    query: { per_page: 50, page: 1 },
+  });
+  const results = [];
+
+  for (const zone of zones.result.filter(({ status }) => status === "active")) {
+    const before = await cloudflare.request({
+      method: "GET",
+      path: `/zones/${zone.id}/bot_management`,
+    });
+    if (before.result.ai_bots_protection !== "disabled") {
+      await cloudflare.request({
+        method: "PUT",
+        path: `/zones/${zone.id}/bot_management`,
+        body: { ai_bots_protection: "disabled" },
+      });
+    }
+    const after = await cloudflare.request({
+      method: "GET",
+      path: `/zones/${zone.id}/bot_management`,
+    });
+    results.push({
+      zone: zone.name,
+      before: before.result.ai_bots_protection,
+      after: after.result.ai_bots_protection,
+    });
+  }
+  return results;
+}
+```
+
+The example shows one page for readability. Portfolio operations must follow
+`result_info.total_pages` until every page has been processed.
 
 ## References
 


### PR DESCRIPTION
## Summary

Document the Bot Management API contract and make crawler allowance the Cloudflare subagent default, including a paginated audit/update/re-read workflow.

## Files Changed

.agents/services/hosting/cloudflare.md, .agents/tools/mcp/cloudflare-code-mode.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Changed-file linters passed; git diff --check passed; branch review-evidence bundle inspected.

Resolves #31432


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.325 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 10m and 165,505 tokens on this with the user in an interactive session.