### PR TITLE
GH#31382: fix: scope legacy task mappings by repository identity

### DIFF
--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -317,6 +317,21 @@ resolve_repository_node_id() {
 	return 1
 }
 
+# A successful child exit is not evidence that the coordinator persisted a bind.
+# Re-read and compare every immutable field before exposing an issue write target.
+_verify_persisted_issue_mapping() {
+	local coordinator="$1" task_id="$2" repository_id="$3" repo="$4"
+	local role="$5" issue_id="$6" issue_number="$7" mapping=""
+	mapping=$(node "$coordinator" resolve-issue --task-id "$task_id" --forge github \
+		--repository-id "$repository_id" 2>/dev/null) || return 1
+	jq -e --arg task "$task_id" --arg repository "$repository_id" --arg repo "$repo" \
+		--arg role "$role" --arg issue "$issue_id" --arg number "$issue_number" \
+		'.taskId == $task and .forge == "github" and .repositoryId == $repository
+		and .repositorySlug == $repo and .role == $role and .issueId == $issue
+		and (.displayNumber | tostring) == $number' <<<"$mapping" >/dev/null || return 1
+	return 0
+}
+
 # Resolve a task ID to a repository-validated GitHub issue mapping. The
 # coordinator is authoritative; ref:GH remains a migration projection that is
 # backfilled only after both repository and issue node identities are fetched.
@@ -352,6 +367,8 @@ resolve_task_gh_number() {
 					--repository-id "$repository_id" --repository-slug "$repo" --role "$mapped_role" \
 					--issue-id "$mapped_issue_id" --display-number "$mapped_number" \
 					"${refresh_args[@]}" --sync-metadata "$mapped_metadata" >/dev/null 2>&1 || return 1
+				_verify_persisted_issue_mapping "$coordinator" "$task_id" "$repository_id" "$repo" \
+					"$mapped_role" "$mapped_issue_id" "$mapped_number" || return 1
 			fi
 			_cache_issue_sync_node_id "$mapped_number" "$mapped_issue_id"
 			printf '%s\n' "$mapped_number"
@@ -381,6 +398,8 @@ resolve_task_gh_number() {
 			--issue-id "$issue_id" --display-number "$issue_number" \
 			"${bind_args[@]}" \
 			--sync-metadata "$(jq -cn --arg state "$issue_state" --arg source ref-gh-backfill '{state:$state,source:$source}')" >/dev/null 2>&1 || return 1
+		_verify_persisted_issue_mapping "$coordinator" "$task_id" "$repository_id" "$repo" \
+			home "$issue_id" "$issue_number" || return 1
 	fi
 	_cache_issue_sync_node_id "$issue_number" "$issue_id"
 	printf '%s\n' "$issue_number"

--- a/.agents/scripts/task-coordinator.mjs
+++ b/.agents/scripts/task-coordinator.mjs
@@ -4,12 +4,13 @@
 
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { canonicalizeSqliteDbPath, sqlEscape } from "./sqlite-process.mjs";
 
-const SCHEMA_VERSION = 7;
+const SCHEMA_VERSION = 8;
 const PAYLOAD_MAX_BYTES = 64 * 1024;
 const EVIDENCE_MAX_BYTES = 64 * 1024;
 const CROCKFORD = "0123456789abcdefghjkmnpqrstvwxyz";
@@ -97,6 +98,11 @@ CREATE TABLE IF NOT EXISTS issue_mappings (
 CREATE TABLE IF NOT EXISTS legacy_task_adoptions (
   task_id TEXT PRIMARY KEY REFERENCES tasks(task_id), repository_id TEXT NOT NULL,
   adopted_operation_id TEXT NOT NULL REFERENCES operations(operation_id), adopted_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS repository_task_aliases (
+  local_task_id TEXT NOT NULL, forge TEXT NOT NULL, repository_id TEXT NOT NULL, task_id TEXT NOT NULL,
+  PRIMARY KEY(local_task_id,forge,repository_id), UNIQUE(task_id,forge,repository_id),
+  FOREIGN KEY(task_id,forge,repository_id) REFERENCES issue_mappings(task_id,forge,repository_id)
 );
 CREATE TABLE IF NOT EXISTS forge_event_cursors (
   forge TEXT NOT NULL, repository_id TEXT NOT NULL, subject_kind TEXT NOT NULL, subject_id TEXT NOT NULL,
@@ -237,6 +243,17 @@ INSERT INTO migration_history(version,applied_at,backup_path,integrity_result) V
 COMMIT;`);
   if (sqlite(path, "PRAGMA integrity_check;\n") !== "ok") throw new Error("migration integrity verification failed");
 }
+function migrateV7ToV8(path) {
+  const copy = backup(path, "pre-migrate-v8");
+  sqlite(path, `PRAGMA foreign_keys=ON; BEGIN IMMEDIATE;
+${SCHEMA}
+INSERT OR IGNORE INTO repository_task_aliases(local_task_id,forge,repository_id,task_id)
+SELECT task_id,forge,repository_id,task_id FROM issue_mappings WHERE task_id GLOB 't[0-9]*';
+UPDATE coordinator_meta SET value='8' WHERE key='schema_version';
+INSERT INTO migration_history(version,applied_at,backup_path,integrity_result) VALUES (8,${sqlEscape(now())},${sqlEscape(copy)},'ok');
+COMMIT;`);
+  if (sqlite(path, "PRAGMA integrity_check;\n") !== "ok" || rows(path, "PRAGMA foreign_key_check;").length) throw new Error("migration integrity verification failed");
+}
 function migrate(path, version) {
   if (version === 1) {
     migrateV1ToV2(path);
@@ -264,7 +281,8 @@ function migrate(path, version) {
     migrateV5ToV6(path);
     migrateV6ToV7(path);
   } else if (version === 6) migrateV6ToV7(path);
-  else if (version !== SCHEMA_VERSION) throw new Error(`unsupported coordinator schema ${version}`);
+  else if (version !== 7 && version !== SCHEMA_VERSION) throw new Error(`unsupported coordinator schema ${version}`);
+  if (version < 8) migrateV7ToV8(path);
 }
 function bootstrap(path) {
   const origin = originId();
@@ -431,31 +449,44 @@ function adoptLegacyTask(input = {}, path = initialise()) {
   const timestamp = now();
   try {
     sqlite(path, `PRAGMA foreign_keys=ON; BEGIN IMMEDIATE;
+CREATE TEMP TABLE adoption_identity(task_id TEXT NOT NULL);
+INSERT INTO adoption_identity SELECT COALESCE(
+  (SELECT task_id FROM repository_task_aliases WHERE local_task_id=${sqlEscape(taskId)} AND forge=${sqlEscape(value.forge)} AND repository_id=${sqlEscape(value.repositoryId)}),
+  CASE WHEN EXISTS (SELECT 1 FROM legacy_task_adoptions WHERE task_id=${sqlEscape(taskId)} AND repository_id<>${sqlEscape(value.repositoryId)})
+    OR EXISTS (SELECT 1 FROM issue_mappings WHERE task_id=${sqlEscape(taskId)} AND role='home' AND repository_id<>${sqlEscape(value.repositoryId)})
+  THEN (SELECT 't'||origin_id||'-'||(sequence+1) FROM origins WHERE state='active' ORDER BY created_at DESC LIMIT 1)
+  ELSE ${sqlEscape(taskId)} END);
 CREATE TEMP TABLE adoption_decision(status TEXT NOT NULL CHECK(status IN ('accepted','conflict')));
 INSERT INTO adoption_decision SELECT CASE
-  WHEN EXISTS (SELECT 1 FROM legacy_task_adoptions WHERE task_id=${sqlEscape(taskId)} AND repository_id<>${sqlEscape(value.repositoryId)}) THEN 'conflict'
-  WHEN EXISTS (SELECT 1 FROM issue_mappings WHERE task_id=${sqlEscape(taskId)} AND role='home'
+  WHEN EXISTS (SELECT 1 FROM legacy_task_adoptions WHERE task_id=(SELECT task_id FROM adoption_identity) AND repository_id<>${sqlEscape(value.repositoryId)}) THEN 'conflict'
+  WHEN EXISTS (SELECT 1 FROM issue_mappings WHERE task_id=(SELECT task_id FROM adoption_identity) AND role='home'
     AND (forge<>${sqlEscape(value.forge)} OR repository_id<>${sqlEscape(value.repositoryId)} OR issue_id<>${sqlEscape(value.issueId)} OR display_number<>${value.displayNumber})) THEN 'conflict'
+  WHEN EXISTS (SELECT 1 FROM issue_mappings WHERE task_id=(SELECT task_id FROM adoption_identity) AND forge=${sqlEscape(value.forge)} AND repository_id=${sqlEscape(value.repositoryId)}
+    AND (role<>'home' OR issue_id<>${sqlEscape(value.issueId)} OR display_number<>${value.displayNumber})) THEN 'conflict'
   WHEN EXISTS (SELECT 1 FROM issue_mappings WHERE forge=${sqlEscape(value.forge)} AND repository_id=${sqlEscape(value.repositoryId)}
-    AND (issue_id=${sqlEscape(value.issueId)} OR display_number=${value.displayNumber}) AND task_id<>${sqlEscape(taskId)}) THEN 'conflict'
+    AND (issue_id=${sqlEscape(value.issueId)} OR display_number=${value.displayNumber}) AND task_id<>(SELECT task_id FROM adoption_identity)) THEN 'conflict'
   ELSE 'accepted' END;
 INSERT INTO operations(operation_id,kind,task_id,payload_hash,payload_json,status,result_json,created_at,updated_at)
-SELECT ${sqlEscape(operationId)},'task.adopt',${sqlEscape(taskId)},${sqlEscape(payloadHash)},${sqlEscape(payloadText)},CASE WHEN status='accepted' THEN 'terminal' ELSE 'conflict' END,'null',${sqlEscape(timestamp)},${sqlEscape(timestamp)} FROM adoption_decision;
+SELECT ${sqlEscape(operationId)},'task.adopt',(SELECT task_id FROM adoption_identity),${sqlEscape(payloadHash)},${sqlEscape(payloadText)},CASE WHEN status='accepted' THEN 'terminal' ELSE 'conflict' END,'null',${sqlEscape(timestamp)},${sqlEscape(timestamp)} FROM adoption_decision;
 UPDATE origins SET sequence=sequence+1 WHERE origin_id=(SELECT origin_id FROM origins WHERE state='active' ORDER BY created_at DESC LIMIT 1)
-AND NOT EXISTS (SELECT 1 FROM tasks WHERE task_id=${sqlEscape(taskId)}) AND (SELECT status FROM adoption_decision)='accepted';
+AND NOT EXISTS (SELECT 1 FROM tasks WHERE task_id=(SELECT task_id FROM adoption_identity)) AND (SELECT status FROM adoption_decision)='accepted';
 INSERT INTO tasks(task_id,origin_id,sequence,parent_task_id,created_operation_id,payload_hash,payload_json,created_at)
-SELECT ${sqlEscape(taskId)},origin_id,sequence,NULL,${sqlEscape(operationId)},${sqlEscape(payloadHash)},${sqlEscape(payloadText)},${sqlEscape(timestamp)}
-FROM origins WHERE state='active' AND NOT EXISTS (SELECT 1 FROM tasks WHERE task_id=${sqlEscape(taskId)})
+SELECT (SELECT task_id FROM adoption_identity),origin_id,sequence,NULL,${sqlEscape(operationId)},${sqlEscape(payloadHash)},${sqlEscape(payloadText)},${sqlEscape(timestamp)}
+FROM origins WHERE state='active' AND NOT EXISTS (SELECT 1 FROM tasks WHERE task_id=(SELECT task_id FROM adoption_identity))
 AND (SELECT status FROM adoption_decision)='accepted' ORDER BY created_at DESC LIMIT 1;
 INSERT INTO legacy_task_adoptions(task_id,repository_id,adopted_operation_id,adopted_at)
-SELECT ${sqlEscape(taskId)},${sqlEscape(value.repositoryId)},${sqlEscape(operationId)},${sqlEscape(timestamp)} FROM adoption_decision WHERE status='accepted' ON CONFLICT(task_id) DO NOTHING;
+SELECT (SELECT task_id FROM adoption_identity),${sqlEscape(value.repositoryId)},${sqlEscape(operationId)},${sqlEscape(timestamp)} FROM adoption_decision WHERE status='accepted' ON CONFLICT(task_id) DO NOTHING;
 INSERT INTO issue_mappings(task_id,forge,repository_id,repository_slug,role,issue_id,project_id,display_number,state_cursor,sync_metadata_json,created_at,updated_at)
-SELECT ${sqlEscape(taskId)},${sqlEscape(value.forge)},${sqlEscape(value.repositoryId)},${sqlEscape(value.repositorySlug)},'home',${sqlEscape(value.issueId)},${sqlEscape(value.projectId)},${value.displayNumber},${sqlEscape(value.stateCursor)},${sqlEscape(value.syncMetadataText)},${sqlEscape(timestamp)},${sqlEscape(timestamp)}
+SELECT (SELECT task_id FROM adoption_identity),${sqlEscape(value.forge)},${sqlEscape(value.repositoryId)},${sqlEscape(value.repositorySlug)},'home',${sqlEscape(value.issueId)},${sqlEscape(value.projectId)},${value.displayNumber},${sqlEscape(value.stateCursor)},${sqlEscape(value.syncMetadataText)},${sqlEscape(timestamp)},${sqlEscape(timestamp)}
 FROM adoption_decision WHERE status='accepted' ON CONFLICT(task_id,forge,repository_id) DO NOTHING;
-UPDATE operations SET result_json=(SELECT json_object('adopted',status='accepted','operationId',${sqlEscape(operationId)},'repositoryId',${sqlEscape(value.repositoryId)},'status',status,'taskId',${sqlEscape(taskId)}) FROM adoption_decision) WHERE operation_id=${sqlEscape(operationId)};
+INSERT INTO repository_task_aliases(local_task_id,forge,repository_id,task_id)
+SELECT ${sqlEscape(taskId)},${sqlEscape(value.forge)},${sqlEscape(value.repositoryId)},(SELECT task_id FROM adoption_identity) FROM adoption_decision WHERE status='accepted'
+ON CONFLICT(local_task_id,forge,repository_id) DO NOTHING;
+UPDATE coordinator_meta SET value='1' WHERE key='namespaced_emitted' AND (SELECT task_id FROM adoption_identity) LIKE 'to%' AND (SELECT status FROM adoption_decision)='accepted';
+UPDATE operations SET result_json=(SELECT json_object('adopted',status='accepted','operationId',${sqlEscape(operationId)},'repositoryId',${sqlEscape(value.repositoryId)},'status',status,'taskId',${sqlEscape(taskId)},'coordinatorTaskId',(SELECT task_id FROM adoption_identity)) FROM adoption_decision) WHERE operation_id=${sqlEscape(operationId)};
 INSERT INTO terminal_evidence(operation_id,result_state,evidence_json,occurred_at)
 SELECT ${sqlEscape(operationId)},CASE WHEN status='accepted' THEN 'terminal' ELSE 'conflict' END,json_object('adoption',status,'issueId',${sqlEscape(value.issueId)},'repositoryId',${sqlEscape(value.repositoryId)}),${sqlEscape(timestamp)} FROM adoption_decision;
-DROP TABLE adoption_decision; COMMIT;`);
+DROP TABLE adoption_decision; DROP TABLE adoption_identity; COMMIT;`);
   } catch (error) {
     const raced = durableAdoptionResult(path, operationId, payloadHash);
     if (!raced) throw new Error("legacy task adoption conflict", { cause: error });
@@ -476,6 +507,10 @@ function publication({ operationId, taskId, repositoryId, repositoryPath, remote
   const payloadHash = hashText(payloadText);
   const prior = operationResult(path, operationId, payloadHash);
   if (prior) return prior;
+  if (LEGACY_TASK_ID.test(taskId)) {
+    if (!repositoryId) throw new Error("legacy publication requires verified repository context");
+    taskId = resolveIssue({ taskId, repositoryId }, path).coordinatorTaskId;
+  }
   const intentId = randomUUID();
   const timestamp = now();
   const result = { intentId, operationId, status: "retryable", taskId };
@@ -619,6 +654,14 @@ function issueMappingInput(input) {
 }
 function bindIssue(input, path = initialise()) {
   const value = issueMappingInput(input);
+  if (LEGACY_TASK_ID.test(value.taskId) && value.role === "home") {
+    const adopted = adoptLegacyTask(input, path);
+    if (!adopted.ok) throw new Error("legacy home mapping conflict");
+    value.taskId = adopted.coordinatorTaskId || adopted.taskId;
+  } else if (LEGACY_TASK_ID.test(value.taskId)) {
+    const identities = rows(path, `SELECT DISTINCT task_id FROM repository_task_aliases WHERE local_task_id=${sqlEscape(value.taskId)};`);
+    if (identities.some((identity) => identity.task_id !== value.taskId)) throw new Error("ambiguous legacy non-home mapping; use an internal task identity");
+  }
   const timestamp = now();
   try {
     sqlite(path, `BEGIN IMMEDIATE;
@@ -645,14 +688,14 @@ COMMIT;`);
 function resolveIssue({ taskId, forge = "github", repositoryId }, path = initialise()) {
   if (!TASK_ID.test(taskId)) throw new TypeError("task_id is not canonical");
   validId(repositoryId, "repository_id");
-  const matches = rows(path, `SELECT task_id AS taskId,forge,repository_id AS repositoryId,repository_slug AS repositorySlug,role,issue_id AS issueId,project_id AS projectId,display_number AS displayNumber,state_cursor AS stateCursor,sync_metadata_json AS syncMetadataJson FROM issue_mappings WHERE task_id=${sqlEscape(taskId)} AND forge=${sqlEscape(forge)} AND repository_id=${sqlEscape(repositoryId)};`);
+  const matches = rows(path, `SELECT COALESCE(a.local_task_id,m.task_id) AS taskId,m.task_id AS coordinatorTaskId,m.forge,m.repository_id AS repositoryId,m.repository_slug AS repositorySlug,m.role,m.issue_id AS issueId,m.project_id AS projectId,m.display_number AS displayNumber,m.state_cursor AS stateCursor,m.sync_metadata_json AS syncMetadataJson FROM issue_mappings m LEFT JOIN repository_task_aliases a USING(task_id,forge,repository_id) WHERE (m.task_id=${sqlEscape(taskId)} OR a.local_task_id=${sqlEscape(taskId)}) AND m.forge=${sqlEscape(forge)} AND m.repository_id=${sqlEscape(repositoryId)};`);
   if (matches.length !== 1) throw new Error("issue mapping not found");
   return { ...matches[0], syncMetadata: JSON.parse(matches[0].syncMetadataJson) };
 }
 function reconciliationTargets({ repositoryId, limit = 100 }, path = initialise()) {
   validId(repositoryId, "repository_id");
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 500) throw new TypeError("limit must be 1..500");
-  const targets = rows(path, `SELECT m.task_id AS taskId,m.issue_id AS subjectId,m.display_number AS displayNumber,m.state_cursor AS stateCursor FROM issue_mappings m JOIN tasks t ON t.task_id=m.task_id WHERE m.forge='github' AND m.repository_id=${sqlEscape(repositoryId)} ORDER BY COALESCE(m.state_cursor,'') ASC,m.display_number ASC LIMIT ${limit};`);
+  const targets = rows(path, `SELECT COALESCE(a.local_task_id,m.task_id) AS taskId,m.task_id AS coordinatorTaskId,m.issue_id AS subjectId,m.display_number AS displayNumber,m.state_cursor AS stateCursor FROM issue_mappings m JOIN tasks t ON t.task_id=m.task_id LEFT JOIN repository_task_aliases a USING(task_id,forge,repository_id) WHERE m.forge='github' AND m.repository_id=${sqlEscape(repositoryId)} ORDER BY COALESCE(m.state_cursor,'') ASC,m.display_number ASC LIMIT ${limit};`);
   return { bounded: true, repositoryId, targets };
 }
 function forgeEventInput(input) {
@@ -690,8 +733,10 @@ function transitionForEvent(eventKind, action) {
 }
 function forgeEventMapping(path, value) {
   if (value.eventKind === "push") return null;
-  const selector = value.taskId ? `m.task_id=${sqlEscape(value.taskId)}` : `m.issue_id=${sqlEscape(value.subjectId)}`;
-  return rows(path, `SELECT m.task_id AS taskId FROM issue_mappings m JOIN tasks t ON t.task_id=m.task_id WHERE m.forge='github' AND m.repository_id=${sqlEscape(value.repositoryId)} AND ${selector};`)[0];
+  const selector = value.taskId ? `(m.task_id=${sqlEscape(value.taskId)} OR a.local_task_id=${sqlEscape(value.taskId)})` : `m.issue_id=${sqlEscape(value.subjectId)}`;
+  const matches = rows(path, `SELECT m.task_id AS taskId,COALESCE(a.local_task_id,m.task_id) AS localTaskId FROM issue_mappings m JOIN tasks t ON t.task_id=m.task_id LEFT JOIN repository_task_aliases a USING(task_id,forge,repository_id) WHERE m.forge='github' AND m.repository_id=${sqlEscape(value.repositoryId)} AND ${selector};`);
+  if (matches.length > 1) throw new Error("ambiguous event task mapping");
+  return matches[0];
 }
 function forgeEventCursor(path, value) {
   return rows(path, `SELECT cursor_timestamp AS cursorTimestamp,cursor_tiebreaker AS cursorTiebreaker,payload_hash AS payloadHash FROM forge_event_cursors WHERE forge='github' AND repository_id=${sqlEscape(value.repositoryId)} AND subject_kind=${sqlEscape(value.eventKind)} AND subject_id=${sqlEscape(value.subjectId)};`)[0];
@@ -709,7 +754,7 @@ function prepareForgeEvent(value, path, transitionKind, payloadText, payloadHash
   const intentId = shouldPublish ? randomUUID() : null;
   const result = { action: value.action, deliveryId: value.deliveryId, eventKind: value.eventKind, mappingMode: repositoryOnly ? "trusted-repository" : value.taskId ? "explicit-task" : "immutable-subject", operationId: value.operationId, repositoryId: value.repositoryId, status, taskId: mapping?.taskId || null, transitionKind };
   const resultText = JSON.stringify(result);
-  const projection = shouldPublish ? jsonText({ branchName: "main", coalesceKey: "forge-event", maxAttempts: 5, payload: { paths: ["TODO.md"], projection: "forge-event", transition: { kind: transitionKind, taskId: mapping.taskId } }, remoteName: "origin", repositoryId: value.repositoryId, repositoryPath: value.repositoryPath, taskId: mapping.taskId }, "projection") : null;
+  const projection = shouldPublish ? jsonText({ branchName: "main", coalesceKey: "forge-event", maxAttempts: 5, payload: { paths: ["TODO.md"], projection: "forge-event", transition: { kind: transitionKind, taskId: mapping.localTaskId } }, remoteName: "origin", repositoryId: value.repositoryId, repositoryPath: value.repositoryPath, taskId: mapping.taskId }, "projection") : null;
   return { conflict, intentId, mapping, payloadHash, payloadText, projection, result, resultText, shouldPublish, status, timestamp, transitionKind, value };
 }
 function forgeEventTransactionSql(event) {
@@ -827,7 +872,7 @@ export function run(args = process.argv.slice(2)) {
   return result.ok === false ? 1 : 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && existsSync(process.argv[1]) && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1])) {
   try { process.exitCode = run(); } catch (error) { process.stderr.write(`task-coordinator: ${error.message}\n`); process.exitCode = 1; }
 }
 

--- a/.agents/scripts/task-coordinator.mjs
+++ b/.agents/scripts/task-coordinator.mjs
@@ -494,6 +494,11 @@ DROP TABLE adoption_decision; DROP TABLE adoption_identity; COMMIT;`);
   }
   return durableAdoptionResult(path, operationId, payloadHash);
 }
+function publicationTaskIdentity(taskId, repositoryId, path) {
+  if (!LEGACY_TASK_ID.test(taskId)) return taskId;
+  if (!repositoryId) throw new Error("legacy publication requires verified repository context");
+  return resolveIssue({ taskId, repositoryId }, path).coordinatorTaskId;
+}
 function publication({ operationId, taskId, repositoryId, repositoryPath, remoteName = "origin", branchName = "main", coalesceKey = "planning", maxAttempts = 5, payload = {} }, path = initialise()) {
   validId(operationId, "operation_id");
   if (!TASK_ID.test(taskId)) throw new TypeError("task_id is not canonical");
@@ -507,10 +512,7 @@ function publication({ operationId, taskId, repositoryId, repositoryPath, remote
   const payloadHash = hashText(payloadText);
   const prior = operationResult(path, operationId, payloadHash);
   if (prior) return prior;
-  if (LEGACY_TASK_ID.test(taskId)) {
-    if (!repositoryId) throw new Error("legacy publication requires verified repository context");
-    taskId = resolveIssue({ taskId, repositoryId }, path).coordinatorTaskId;
-  }
+  taskId = publicationTaskIdentity(taskId, repositoryId, path);
   const intentId = randomUUID();
   const timestamp = now();
   const result = { intentId, operationId, status: "retryable", taskId };

--- a/.agents/scripts/tests/test-issue-mapping-isolation.sh
+++ b/.agents/scripts/tests/test-issue-mapping-isolation.sh
@@ -87,12 +87,14 @@ gh() {
 	return 1
 }
 
+# shellcheck source=../issue-sync-lib-parse.sh
+source "${SCRIPT_DIR}/issue-sync-lib-parse.sh"
 # shellcheck source=../issue-sync-lib-ref.sh
 source "${SCRIPT_DIR}/issue-sync-lib-ref.sh"
 
 : >"$JQ_CALL_LOG"
 [[ "$(resolve_task_gh_number t101 "$TODO_FILE" owner/one)" == "42" ]]
-if [[ "$(wc -l <"$JQ_CALL_LOG" | tr -d ' ')" != "3" ]]; then
+if [[ "$(wc -l <"$JQ_CALL_LOG" | tr -d ' ')" != "4" ]]; then
 	printf 'FAIL repository identity and issue backfill did not use bounded jq parsing\n' >&2
 	exit 1
 fi
@@ -147,5 +149,15 @@ if AIDEVOPS_TASK_COORDINATOR_DB="${TEST_ROOT}/conflict.db" resolve_task_gh_numbe
 	printf 'FAIL unresolved issue projection was accepted\n' >&2
 	exit 1
 fi
+
+# A child that exits successfully without persisting anything cannot validate a
+# backfill, even when GitHub returned a valid existing issue. No creation occurs.
+printf '%s\n' '- [ ] t101 first repository task ref:GH#42' >"$TODO_FILE"
+node() { return 0; }
+if resolve_task_gh_number t101 "$TODO_FILE" owner/one >/dev/null 2>&1; then
+	printf 'FAIL empty-success coordinator validated an unpersisted mapping\n' >&2
+	exit 1
+fi
+unset -f node
 
 printf 'PASS repository-scoped issue mapping isolation and fail-closed backfill\n'

--- a/.agents/scripts/tests/test-task-coordinator.sh
+++ b/.agents/scripts/tests/test-task-coordinator.sh
@@ -11,6 +11,18 @@ TEST_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 export AIDEVOPS_TASK_COORDINATOR_DB="${TEST_ROOT}/coordinator.db"
 
+# Direct and symlink CLI entry execute; importing never runs the CLI.
+ln -s "$COORDINATOR" "${TEST_ROOT}/coordinator link.mjs"
+node "$COORDINATOR" --help >"${TEST_ROOT}/direct-help"
+node "${TEST_ROOT}/coordinator link.mjs" --help >"${TEST_ROOT}/linked-help"
+[[ -s "${TEST_ROOT}/direct-help" ]]
+cmp "${TEST_ROOT}/direct-help" "${TEST_ROOT}/linked-help"
+COORDINATOR_PATH="$COORDINATOR" node --input-type=module \
+	-e 'import { pathToFileURL } from "node:url"; await import(pathToFileURL(process.env.COORDINATOR_PATH))' \
+	>"${TEST_ROOT}/import-output"
+[[ ! -s "${TEST_ROOT}/import-output" ]]
+[[ ! -e "$AIDEVOPS_TASK_COORDINATOR_DB" ]]
+
 # Multiprocess WAL allocation and offline uniqueness.
 for i in $(seq 1 24); do
 	node "$COORDINATOR" allocate --operation-id "parallel-${i}" --payload "{\"worker\":${i}}" >"${TEST_ROOT}/parallel-${i}.json" &
@@ -97,19 +109,61 @@ if node "$COORDINATOR" adopt-legacy-task --operation-id adopt-28465 --task-id t2
 	printf 'FAIL changed legacy adoption reused an operation ID\n' >&2
 	exit 1
 fi
-if node "$COORDINATOR" adopt-legacy-task --operation-id adopt-cross-repo --task-id t28465 --repository-id R_other \
-	--repository-slug owner/other --issue-id I_other --display-number 28465 >/dev/null 2>&1; then
-	printf 'FAIL legacy task adoption crossed repository identities\n' >&2
-	exit 1
-fi
+other_adoption=$(node "$COORDINATOR" adopt-legacy-task --operation-id adopt-cross-repo --task-id t28465 --repository-id R_other \
+	--repository-slug owner/other --issue-id I_other --display-number 28465)
+other_identity=$(jq -r '.coordinatorTaskId' <<<"$other_adoption")
+[[ "$other_identity" == to* ]]
+[[ "$(node "$COORDINATOR" resolve-issue --task-id t28465 --repository-id R_other | jq -r '.issueId')" == "I_other" ]]
+[[ "$(node "$COORDINATOR" resolve-issue --task-id t28465 --repository-id R_adopt | jq -r '.issueId')" == "I_adopt" ]]
+for i in $(seq 1 8); do
+	node "$COORDINATOR" adopt-legacy-task --operation-id adopt-cross-repo --task-id t28465 --repository-id R_other \
+		--repository-slug owner/other --issue-id I_other --display-number 28465 >"${TEST_ROOT}/adopt-${i}.json" &
+done
+wait
+for i in $(seq 1 8); do
+	[[ "$(jq -r '.coordinatorTaskId' "${TEST_ROOT}/adopt-${i}.json")" == "$other_identity" ]]
+done
 if node "$COORDINATOR" adopt-legacy-task --operation-id adopt-issue-conflict --task-id t28465 --repository-id R_adopt \
 	--repository-slug owner/adopt --issue-id I_other --display-number 28466 >/dev/null 2>&1; then
 	printf 'FAIL legacy task adoption replaced immutable issue identity\n' >&2
 	exit 1
 fi
 [[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(*) FROM tasks WHERE task_id='t28465';")" == "1" ]]
-[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT status FROM operations WHERE operation_id='adopt-cross-repo';")" == "conflict" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT status FROM operations WHERE operation_id='adopt-cross-repo';")" == "terminal" ]]
 [[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT status FROM operations WHERE operation_id='adopt-issue-conflict';")" == "conflict" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(DISTINCT task_id) FROM repository_task_aliases WHERE local_task_id='t28465';")" == "2" ]]
+node "$COORDINATOR" verify | jq -e '.ok' >/dev/null
+
+# Simultaneous first adoption allocates one internal identity in the third repo.
+for i in $(seq 1 8); do
+	node "$COORDINATOR" adopt-legacy-task --operation-id "third-${i}" --task-id t28465 --repository-id R_third \
+		--repository-slug owner/third --issue-id I_third --display-number 9 >"${TEST_ROOT}/third-${i}.json" &
+done
+wait
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(DISTINCT task_id) FROM operations WHERE operation_id GLOB 'third-*';")" == "1" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(*) FROM tasks WHERE created_operation_id GLOB 'third-*';")" == "1" ]]
+if node "$COORDINATOR" bind-issue --task-id t28465 --repository-id R_impl_ambiguous --repository-slug owner/ambiguous \
+	--role implementation --issue-id I_ambiguous --display-number 1 >/dev/null 2>&1; then
+	printf 'FAIL ambiguous legacy non-home binding accepted\n' >&2
+	exit 1
+fi
+
+# New publications use repository-scoped internal identity, not the global token.
+node "$COORDINATOR" publication-intent --operation-id scoped-publication --task-id t28465 \
+	--repository-id R_other --repository-path "$TEST_ROOT" >/dev/null
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT task_id FROM publication_intents WHERE operation_id='scoped-publication';")" == "$other_identity" ]]
+
+# A v7 fixture migrates aliases without rewriting historical operation evidence.
+v7_db="${TEST_ROOT}/v7.db"
+AIDEVOPS_TASK_COORDINATOR_DB="$v7_db" node "$COORDINATOR" adopt-legacy-task --operation-id historical --task-id t100 \
+	--repository-id R_old --repository-slug owner/old --issue-id I_old --display-number 1 >/dev/null
+sqlite3 "$v7_db" "DROP TABLE repository_task_aliases; UPDATE coordinator_meta SET value='7' WHERE key='schema_version'; DELETE FROM migration_history; INSERT INTO migration_history VALUES(7,'2026-01-01',NULL,'ok'); UPDATE operations SET result_json=json_remove(result_json,'$.coordinatorTaskId');"
+historical_result=$(sqlite3 "$v7_db" "SELECT result_json FROM operations WHERE operation_id='historical';")
+AIDEVOPS_TASK_COORDINATOR_DB="$v7_db" node "$COORDINATOR" verify | jq -e '.ok and .schemaVersion == 8' >/dev/null
+[[ "$(sqlite3 "$v7_db" "SELECT result_json FROM operations WHERE operation_id='historical';")" == "$historical_result" ]]
+[[ "$(sqlite3 "$v7_db" "SELECT task_id FROM repository_task_aliases WHERE local_task_id='t100';")" == "t100" ]]
+AIDEVOPS_TASK_COORDINATOR_DB="$v7_db" node "$COORDINATOR" bind-issue --task-id t100 \
+	--repository-id R_old --repository-slug owner/old --issue-id I_old --display-number 1 >/dev/null
 
 # Independent reinstall/clone state creates a new CSPRNG origin at the same sequence.
 origin_one=$(node "$COORDINATOR" status | jq -r '.origin_id')
@@ -151,7 +205,7 @@ migration_db="${TEST_ROOT}/migration.db"
 AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/null
 sqlite3 "$migration_db" "DROP TABLE legacy_task_adoptions; DROP TABLE issue_mappings; DROP TABLE forge_event_cursors; ALTER TABLE restore_controls DROP COLUMN backup_high_water; UPDATE coordinator_meta SET value='1' WHERE key='schema_version'; DELETE FROM migration_history; INSERT INTO migration_history VALUES(1,'2026-01-01T00:00:00Z',NULL,'ok');"
 AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/null
-[[ "$(sqlite3 "$migration_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "7" ]]
+[[ "$(sqlite3 "$migration_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "8" ]]
 [[ "$(sqlite3 "$migration_db" "SELECT COUNT(*) FROM pragma_table_info('operations') WHERE name='result_hash';")" == "0" ]]
 [[ -n "$(ls "${TEST_ROOT}"/migration.db-backup-*-pre-migrate-v2.db)" ]]
 [[ -n "$(ls "${TEST_ROOT}"/migration.db-backup-*-pre-migrate-v3.db)" ]]
@@ -163,7 +217,7 @@ sqlite3 "$v2_db" "DROP TABLE legacy_task_adoptions; DROP TABLE issue_mappings; D
 AIDEVOPS_TASK_COORDINATOR_DB="$v2_db" node "$COORDINATOR" status >/dev/null
 v2_backup=$(ls "${TEST_ROOT}"/v2.db-backup-*-pre-migrate-v3.db)
 [[ "$(sqlite3 "$v2_backup" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='issue_mappings';")" == "0" ]]
-[[ "$(sqlite3 "$v2_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "7" ]]
+[[ "$(sqlite3 "$v2_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "8" ]]
 
 # Immutable task/repository identities isolate equal display numbers and allow
 # one task to retain home, implementation, and upstream issue projections.

--- a/todo/gh31382-continuation.md
+++ b/todo/gh31382-continuation.md
@@ -1,0 +1,65 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2026 Marcus Quinn -->
+
+# GH#31382 continuation — approved maintainer batch
+
+## Goal and authority
+
+Continue the approved interactive full-loop batch through verified PR merges and
+the explicitly requested release. Primary-session implementation ownership stays
+local. This checkpoint is partial progress, not issue completion or a live worker.
+
+## Verified local progress
+
+- `.agents/scripts/task-coordinator.mjs`: compare real paths for direct CLI entry;
+  symlink paths (including spaces) now execute, imports remain side-effect free.
+- `.agents/scripts/issue-sync-lib-ref.sh`: read back exact persisted mappings after
+  backfill and repository-slug refresh, rejecting empty-success child execution.
+- Existing coordinator and isolation fixtures cover these behaviors. The isolation
+  fixture now loads its existing parser dependency rather than failing because
+  `_first_todo_task_line_or_empty` is undefined.
+- `bash .agents/scripts/tests/test-task-coordinator.sh`: PASS.
+- `bash .agents/scripts/tests/test-issue-mapping-isolation.sh`: PASS.
+- ShellCheck, Node syntax, `git diff --check`: PASS.
+- `.agents/scripts/linters-local.sh --changed`: exit 0; shfmt advisory remains.
+- Schema 8 introduces repository-local aliases without rewriting historical task
+  rows or operation results. Foreign-home collisions allocate namespaced internal
+  identities under the adoption transaction. Resolver output includes local
+  `taskId` plus internal `coordinatorTaskId`.
+- Publication references use internal identity; TODO event transitions use local
+  tokens. Bare new legacy publications require verified repository context.
+- Added passing fixtures for three repositories sharing one token, concurrent
+  first adoption, replay, ambiguous non-home rejection, v7 migration preserving
+  historical result JSON, and scoped publication references.
+
+## Required review before merge
+
+The migration is implemented but independent closeout is not complete. Inference
+review calls failed at both standard and thinking tiers; a read-only reviewer
+could not access the allowed worktree source and returned blocked. Do not treat
+passing tests as a substitute for independent review of this migration.
+
+Review atomic allocation, exact home binding, migration/replay, old non-home role
+conflicts, and local projection versus durable internal identity. Existing durable
+conflicts retain their outcome; a changed adoption attempt requires a new explicit
+operation ID rather than mutating historical evidence. Resolve any in-scope review
+findings and reverify the final rebased head before readiness/merge.
+
+## Batch gates and remaining work
+
+- PR #31426 merged through the canonical gate at
+  `fa71e61608090616b1ee29b9191364fa6e06f648`.
+- GH#31408 implemented and tested in PR #31431, merged through the canonical gate
+  at `83b82f37f59c4ed143995b3ccf4b43d023c1777c`.
+- GH#31405 bounded cleanup progress is still pending implementation.
+- Reconcile existing PR #31416 without duplicating its executor's work.
+- GH#31407 diagnostic repair is shipped; safe reclamation still requires
+  producer-bound terminal/publication evidence and must not be claimed complete.
+- v3.32.327 was already published; do not repeat it. Recompute latest release and
+  exact merged-source inventory only after the remaining merge gates pass.
+
+## Resume
+
+Revalidate the current worktree and PR state. Obtain independent review of the
+implemented migration, rerun affected tests after any rebase, and complete the PR
+gates. Continue the remaining approved batch without duplicating other executors.


### PR DESCRIPTION
## Summary

- Add schema 8 repository-local aliases so identical legacy task tokens can identify distinct tasks in different verified repositories without rewriting historical task rows.
- Allocate internal namespaced identities atomically on foreign-home collisions; preserve one home per internal task, durable replay, immutable issue binding, and cursor protections.
- Separate local TODO projection tokens from internal publication references; reject ambiguous legacy non-home bindings.
- Fix symlink CLI entry and verify exact persisted issue mappings after backfill or slug refresh.

## Files and reference pattern

- `.agents/scripts/task-coordinator.mjs`: existing backed-up schema migrations, `BEGIN IMMEDIATE` adoption, immutable home guards, resolver and event/publication boundaries.
- `.agents/scripts/issue-sync-lib-ref.sh`: exact repository/issue identity read-back.
- Existing `test-task-coordinator.sh` and `test-issue-mapping-isolation.sh` fixtures under `.agents/scripts/tests/`.
- `todo/gh31382-continuation.md`: implementation evidence, remaining review and batch state.

## Runtime Testing

- **Risk level:** High — identity/schema migration and publication state.
- **Verification:** runtime-verified; exact-head independent approval received.
- Coordinator tests PASS: WAL concurrency, operation replay, restore, v1/v2 migration, v7 result-preserving migration, same-token isolation across three repositories, concurrent first adoption, ambiguity rejection, and scoped publication.
- Mapping-isolation tests PASS: exact repository identities, renamed slugs, dotted IDs, and empty-success child rejection.
- Both suites rerun after the publication-complexity repair at head `672cc411833b59b26f813734e63ef1dc7f1e115d` and passed.
- Node syntax, ShellCheck, changed-file lint and helper Node typecheck passed. Existing shfmt advisory remains.

## Review status

CodeRabbit approved exact head `672cc411833b59b26f813734e63ef1dc7f1e115d`; no inline review findings are present. Required CI and the review-bot gate pass. The earlier local-review tooling blocker recorded in the continuation checkpoint is superseded by this remote review. Durable historical conflicts retain their result; a new request uses a new explicit operation ID.

Resolves #31382

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.328 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 9h 5m and 892,637 tokens on this with the user in an interactive session.