### PR TITLE
GH#31401: Reuse fresh REST evidence for Pulse admission

### DIFF
--- a/.agents/scripts/gh_transport_recovery.py
+++ b/.agents/scripts/gh_transport_recovery.py
@@ -88,6 +88,7 @@ def admission_status(directory: Path, scope: str) -> dict:
             state = "exhausted"
         return {"state": state, "source": "local_response_headers", "remaining": row[0],
                 "limit": row[4], "reserved": reserved, "floor": floor,
+                "blocked_until": row[3],
                 "reset": int(row[1]), "observation_age_seconds": max(0, int(now - row[2]))}
     finally:
         db.close()

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -60,6 +60,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 # shellcheck source=./shared-gh-budget-policy.sh
 source "${SCRIPT_DIR}/shared-gh-budget-policy.sh"
 
+# shellcheck source=./pulse-rest-observation.sh
+source "${SCRIPT_DIR}/pulse-rest-observation.sh"
+
 # shellcheck source=./shared-gh-request-state.sh
 if [[ -f "${SCRIPT_DIR}/shared-gh-request-state.sh" ]]; then
 	# shellcheck disable=SC1091
@@ -313,6 +316,12 @@ _cb_rest_core_observation() {
 	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=20
 	now=$(date +%s 2>/dev/null) || now=0
 	[[ "$now" =~ ^[0-9]+$ ]] || now=0
+
+	# Avoid spending a paced REST request just to rediscover recent headers.
+	# Request admission remains atomic in the transport; this is observation only.
+	if _cb_rest_core_local_observation "$ttl" "$now"; then
+		return 0
+	fi
 
 	if [[ -f "$_CB_REST_CORE_CACHE_FILE" ]]; then
 		read -r observed remaining limit reset resource < <(jq -r --arg unknown "$_CB_REST_CORE_UNKNOWN" '[.observed // 0, .remaining // $unknown, .limit // $unknown, .reset // 0, .resource // $unknown] | @tsv' "$_CB_REST_CORE_CACHE_FILE" 2>/dev/null) || true

--- a/.agents/scripts/pulse-rest-observation.sh
+++ b/.agents/scripts/pulse-rest-observation.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# Read-only transport evidence for Pulse; this never admits an HTTP request.
+
+_cb_rest_core_local_observation() {
+	local ttl="$1"
+	local now="$2"
+	local snapshot=""
+	local state_dir="${AIDEVOPS_GH_TRANSPORT_STATE_DIR:-${HOME}/.aidevops/state/gh-transport}"
+	[[ -f "${state_dir}/admission.sqlite3" ]] || return 2
+	# The transport status CLI currently resolves github.com only. Never reuse
+	# that principal's evidence for an explicitly selected enterprise host.
+	[[ "${GH_HOST:-github.com}" == "github.com" ]] || return 2
+	[[ -f "${SCRIPT_DIR}/gh_transport_budget.py" ]] || return 2
+	snapshot=$(python3 "${SCRIPT_DIR}/gh_transport_budget.py" status 2>/dev/null) || return 2
+	# The transport owns quota-owner alias resolution and conservative accounting.
+	# Reuse only fresh header evidence, subtracting all outstanding reservations.
+	# A recent server cooldown is zero usable headroom, never a positive grant.
+	printf '%s\n' "$snapshot" | jq -er --argjson ttl "$ttl" --argjson now "$now" '
+		select(.source == "local_response_headers") |
+		select(.state == "available" or .state == "exhausted" or .state == "cooldown") |
+		select(all((.remaining, .limit, .reserved, .reset, .observation_age_seconds);
+			type == "number" and . >= 0 and floor == .)) |
+		select(.limit > 0 and .remaining <= .limit) |
+		if .state == "cooldown" then
+			select(.blocked_until | type == "number" and . > $now) |
+			[0, .limit, ([.reset, (.blocked_until | ceil)] | max)]
+		else
+			select(.reset > $now and .observation_age_seconds <= $ttl) |
+			[([0, (.remaining - .reserved)] | max), .limit, .reset]
+		end | map(tostring) | join(" ")
+	' 2>/dev/null || return 2
+	return 0
+}

--- a/.agents/scripts/tests/test-pulse-rate-limit-circuit-breaker-timeout.sh
+++ b/.agents/scripts/tests/test-pulse-rate-limit-circuit-breaker-timeout.sh
@@ -76,4 +76,67 @@ if _cb_gh_read gh api rate_limit >/dev/null 2>&1; then
 fi
 PATH="$OLD_PATH"
 
+# A paced metadata probe must not hide fresh transport response-header evidence.
+# No real credentials, transport database, or network requests enter this fixture.
+export AIDEVOPS_GH_TRANSPORT_STATE_DIR="${TMP_DIR}/transport"
+mkdir -p "$AIDEVOPS_GH_TRANSPORT_STATE_DIR"
+touch "${AIDEVOPS_GH_TRANSPORT_STATE_DIR}/admission.sqlite3"
+python3() {
+	[[ "$*" == "${SCRIPT_DIR}/gh_transport_budget.py status" ]] || return 1
+	printf '%s\n' "$LOCAL_STATUS"
+	return 0
+}
+_cb_rest_core_probe() {
+	printf 'probe\n' >>"$TIMEOUT_CALL_LOG"
+	return 75
+}
+local_reset=$(($(date +%s) + 3600))
+LOCAL_STATUS="{\"state\":\"available\",\"source\":\"local_response_headers\",\"remaining\":100,\"limit\":5000,\"reserved\":3,\"reset\":${local_reset},\"observation_age_seconds\":0,\"blocked_until\":${local_reset}}"
+rm -f "$TIMEOUT_CALL_LOG"
+observation=$(_cb_rest_core_observation 2) || {
+	printf 'FAIL: paced probe hides fresh local response-header evidence\n' >&2
+	exit 1
+}
+[[ "$observation" == "97 5000 ${local_reset}" && ! -f "$TIMEOUT_CALL_LOG" ]] || {
+	printf 'FAIL: local observation must subtract reservations without probing\n' >&2
+	exit 1
+}
+
+valid_status="$LOCAL_STATUS"
+LOCAL_STATUS="${valid_status/\"available\"/\"cooldown\"}"
+[[ "$(_cb_rest_core_observation 2)" == "0 5000 ${local_reset}" ]] || exit 1
+# An active server cooldown outlives both the quota reset and header TTL.
+LOCAL_STATUS="${LOCAL_STATUS/\"reset\":${local_reset}/\"reset\":1}"
+LOCAL_STATUS="${LOCAL_STATUS/\"observation_age_seconds\":0/\"observation_age_seconds\":3600}"
+[[ "$(_cb_rest_core_observation 2)" == "0 5000 ${local_reset}" ]] || exit 1
+LOCAL_STATUS="${valid_status/\"reserved\":3/\"reserved\":101}"
+LOCAL_STATUS="${LOCAL_STATUS/\"available\"/\"exhausted\"}"
+[[ "$(_cb_rest_core_observation 2)" == "0 5000 ${local_reset}" ]] || exit 1
+[[ ! -f "$TIMEOUT_CALL_LOG" ]] || exit 1
+LOCAL_STATUS="$valid_status"
+
+for invalid_status in \
+	'{"state":"unknown"}' \
+	"${LOCAL_STATUS/\"observation_age_seconds\":0/\"observation_age_seconds\":3}" \
+	"${LOCAL_STATUS/\"local_response_headers\"/\"projection\"}" \
+	"${LOCAL_STATUS/\"reserved\":3/\"reserved\":-1}" \
+	"${LOCAL_STATUS/\"reset\":${local_reset}/\"reset\":1}" \
+	'not-json'; do
+	valid_status="$LOCAL_STATUS"
+	LOCAL_STATUS="$invalid_status"
+	rm -f "$TIMEOUT_CALL_LOG"
+	if _cb_rest_core_observation 2 >/dev/null 2>&1; then
+		printf 'FAIL: unusable local evidence granted an observation\n' >&2
+		exit 1
+	fi
+	[[ -f "$TIMEOUT_CALL_LOG" ]] || exit 1
+	LOCAL_STATUS="$valid_status"
+done
+export GH_HOST="example.invalid"
+if _cb_rest_core_observation 2 >/dev/null 2>&1; then
+	printf 'FAIL: github.com transport evidence reused for another host\n' >&2
+	exit 1
+fi
+unset GH_HOST
+
 printf 'PASS pulse-rate-limit-circuit-breaker-timeout\n'

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -196,7 +196,9 @@ reset_test_state() {
 	STUB_GH_LIMIT=5000
 	export STUB_GH_CORE_REMAINING=5000
 	export STUB_GH_CORE_LIMIT=5000
-	export STUB_GH_CORE_RESET="$(($(date +%s) + 3600))"
+	# Keep full-window boundary assertions inside the clamped window even when
+	# subprocess work crosses a second. Decay tests set their own reset epochs.
+	export STUB_GH_CORE_RESET="$(($(date +%s) + 7200))"
 	export AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD="0.05"
 	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK=0
 	export AIDEVOPS_PULSE_REST_CORE_RESERVE=500


### PR DESCRIPTION
## Summary

Ref #31401. This scoped fix does not close the broader useful-throughput assessment.

- Reuse fresh, quota-owner-scoped transport response-header evidence before making another REST budget probe. Reproduced the old path returning unknown when that probe is paced (exit 75), despite available local evidence.
- Subtract outstanding reservations, reject stale/malformed/cross-host evidence, and keep active server cooldowns at zero usable headroom even after quota reset/header TTL expiry.
- Preserve atomic HTTP admission, pacing, permission, ownership, and release gates. No concurrency limits or reserve policy changed.
- Stabilize the existing full-window threshold test fixture against crossing a wall-clock second; dedicated decay tests remain intact.

## Files and reference pattern

`.agents/scripts/pulse-rest-observation.sh` is a small sourced observation module used by `.agents/scripts/pulse-rate-limit-circuit-breaker.sh`. It consumes the existing read-only status contract in `.agents/scripts/gh_transport_recovery.py`, adding only the cooldown deadline to that output. Regression coverage extends the existing timeout and circuit-breaker test files.

## Verification

- Red/green paced-probe regression in `test-pulse-rate-limit-circuit-breaker-timeout.sh`.
- `test-rate-limit-circuit-breaker.sh`: 51/51 passed.
- `test-pulse-graphql-budget-priority.sh`: passed.
- `python3 .agents/scripts/tests/test-gh-transport-budget.py`: 33 tests passed.
- ShellCheck: clean for changed shell files.
- `.agents/scripts/linters-local.sh`: exit 0; existing comment-spacing shfmt advisory in the circuit-breaker test is unchanged by this fix.

## Runtime Testing

Risk: high (scheduler budget observation). Testing level: runtime-verified.

Executed the modified `pulse-rate-limit-circuit-breaker.sh check` against current managed transport: exit 0, 1.47 seconds. Isolated executable regression coverage verifies no HTTP probe occurs with usable local evidence, active cooldowns remain zero, and invalid evidence falls back to the existing probe. This is not proof of sustained worker concurrency; post-deployment current-state and delivery evidence remain required under #31401.

## Review

Primary diff inspection plus independent review. The reviewer identified the cooldown-expiry edge case; it was independently verified, fixed, and covered by a regression. Final review found no remaining material defect.

Reviewed local bundle SHA-256: `80392c2163b5b7e883bf8859cead09f4086690a79d1635b96490bd7284452b32`.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.328 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 19h 8m and 2,281,666 tokens on this with the user in an interactive session.