### PR TITLE
GH#31378: fix source grant lifetime at human confirmation

### DIFF
--- a/.agents/scripts/source-access-helper.py
+++ b/.agents/scripts/source-access-helper.py
@@ -190,6 +190,13 @@ def _sign_payload(config: Config, payload: dict[str, Any]) -> str:
         return signature_path.read_text(encoding="utf-8")
 
 
+def _confirmed_timestamp(spec: ApprovalSpec, prepared_at: int) -> int:
+    confirmed_at = int(time.time() if spec.now is None else spec.now)
+    if confirmed_at < prepared_at:
+        raise SourceAccessError("source-access clock moved backwards during confirmation")
+    return confirmed_at
+
+
 def approve_request(config: Config, spec: ApprovalSpec) -> dict[str, Any]:
     issued_at = int(time.time() if spec.now is None else spec.now)
     request = _load_request(config, spec.home, spec.request_id, spec.expected_uid)
@@ -212,6 +219,7 @@ def approve_request(config: Config, spec: ApprovalSpec) -> dict[str, Any]:
     confirmation_scope = {**request, "ttl_seconds": spec.ttl_seconds}
     if spec.confirm is not None and not spec.confirm(confirmation_scope):
         raise SourceAccessError("source-access approval cancelled")
+    issued_at = _confirmed_timestamp(spec, issued_at)
 
     approval_id = scope_id(session_id, spec.expected_uid, path, reason)
     snapshot_path = (
@@ -326,6 +334,7 @@ def _approve_manifest_request(
     }
     if spec.confirm is not None and not spec.confirm(confirmation_scope):
         raise SourceAccessError("source-access approval cancelled")
+    issued_at = _confirmed_timestamp(spec, issued_at)
     payload = {
         "schema": SCHEMA_MANIFEST_PAYLOAD,
         "approval_id": approval_id,

--- a/.agents/scripts/tests/test-source-access-helper.py
+++ b/.agents/scripts/tests/test-source-access-helper.py
@@ -139,6 +139,64 @@ class SourceAccessHelperTests(unittest.TestCase):
         self.assertEqual(snapshot_path.read_bytes(), self.source.read_bytes())
         self.assertEqual(snapshot_path.stat().st_mode & 0o777, 0o444)
 
+    def _confirmation_request(self, manifest: bool) -> str:
+        if not manifest:
+            return self._request()
+        return HELPER.create_manifest_request(
+            self.config,
+            HELPER.ManifestRequestSpec(
+                self.session, self.uid, self.home,
+                (str(self.source), str(self.other_source)),
+                HELPER.OVERRIDABLE_REASON, self.now,
+            ),
+        )
+
+    def test_grant_lifetime_starts_at_human_confirmation(self) -> None:
+        for manifest in (False, True):
+            with self.subTest(manifest=manifest):
+                request_id = self._confirmation_request(manifest)
+                confirmed_at = self.now + 7 * 24 * 60 * 60
+                with mock.patch.object(HELPER.time, "time", return_value=self.now) as clock:
+                    def confirm(_request: dict[str, object]) -> bool:
+                        clock.return_value = confirmed_at
+                        return True
+
+                    payload = HELPER.approve_request(
+                        self.config,
+                        HELPER.ApprovalSpec(
+                            request_id, self.home, self.uid, HELPER.MAX_TTL_SECONDS,
+                            confirm=confirm,
+                        ),
+                    )
+                self.assertEqual(payload["issued_at"], confirmed_at)
+                self.assertEqual(payload["expires_at"], confirmed_at + HELPER.MAX_TTL_SECONDS)
+                self.assertTrue(self._verify(now=confirmed_at + 1))
+                self.assertFalse(self._verify(now=confirmed_at + HELPER.MAX_TTL_SECONDS))
+
+    def test_confirmation_cancellation_and_clock_rollback_do_not_sign(self) -> None:
+        for manifest in (False, True):
+            for accepted in (False, True):
+                with self.subTest(manifest=manifest, accepted=accepted):
+                    request_id = self._confirmation_request(manifest)
+                    with mock.patch.object(HELPER.time, "time", return_value=self.now) as clock:
+                        def confirm(_request: dict[str, object]) -> bool:
+                            clock.return_value = self.now - 1
+                            return accepted
+
+                        message = "clock moved backwards" if accepted else "approval cancelled"
+                        with mock.patch.object(HELPER, "_sign_payload") as sign:
+                            with self.assertRaisesRegex(HELPER.SourceAccessError, message):
+                                HELPER.approve_request(
+                                    self.config,
+                                    HELPER.ApprovalSpec(
+                                        request_id, self.home, self.uid, HELPER.MAX_TTL_SECONDS,
+                                        confirm=confirm,
+                                    ),
+                                )
+                            sign.assert_not_called()
+                    self.assertFalse(self._verify())
+                    self.assertFalse((self.config.state_dir / "snapshots").exists())
+
     def test_one_manifest_approves_three_exact_paths_with_one_confirmation(self) -> None:
         request_id = HELPER.create_manifest_request(
             self.config,


### PR DESCRIPTION
## Summary

Ref #31378. Start a newly signed source grant's lifetime when the human confirms, not when the broker starts preparing the prompt. Apply the same rule to single-file and manifest approvals, and fail closed if the wall clock moves backwards before confirmation completes.

## Implementation

- `.agents/scripts/source-access-helper.py`: sample the approval timestamp after successful confirmation and before signing or publishing snapshots. Existing request age checks, root/TTY boundary, scope validation, signed schemas and historical receipts are unchanged.
- `.agents/scripts/tests/test-source-access-helper.py`: extend existing fake-clock, fake-key and fake-repository fixtures for both approval shapes. No new infrastructure or privileged operations.

## Runtime Testing

`runtime-verified` using the existing broker fixture runtime, not a live root broker deployment.

- The new seven-day confirmation-delay regression failed before the fix for both shapes and passed after it.
- Full Python source-access suite: 22 tests passed, including exact expiry, cancellation and rollback without signing or snapshot publication.
- Python compilation and `linters-local.sh --changed`: passed.
- Independent security closeout review: CLEAN; reviewed local patch bundle SHA-256 `be9fb03857ca2723d15996e555063629af9fd3a784a245a050ddf006132dd598`.

## Scope and compatibility

This fixes a delay while an already-prepared confirmation prompt is open. It does not remove legacy request expiry or implement durable proposals, issue/source bundling, or live plugin deployment. Those #31378 criteria remain open. No new release is requested.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.329 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 9h 17m and 863,672 tokens on this with the user in an interactive session.