### PR TITLE
GH#31405: fix: resume bounded cleanup after slow repository operations

### DIFF
--- a/.agents/scripts/cleanup-worktrees-async-helper.sh
+++ b/.agents/scripts/cleanup-worktrees-async-helper.sh
@@ -96,79 +96,8 @@ fi
 # LOCK MANAGEMENT (mkdir-based — POSIX atomic, macOS-safe)
 # ============================================================
 
-_lock_release() {
-	rm -rf "$LOCK_DIR" 2>/dev/null || true
-	return 0
-}
-
-_lock_signal_exit() {
-	local exit_code="$1"
-	trap - EXIT INT TERM
-	_lock_release
-	exit "$exit_code"
-	return 1
-}
-
-_lock_install_traps() {
-	trap '_lock_release' EXIT
-	trap '_lock_signal_exit 130' INT
-	trap '_lock_signal_exit 143' TERM
-	return 0
-}
-
-# Check whether the PID that holds the lock is still alive.
-# Uses kill -0 (existence) + ps comm= (command-aware, guards against PID reuse).
-# Returns 0 if alive, 1 if dead or indeterminate.
-_is_pid_alive() {
-	local pid="$1"
-	[[ -z "$pid" ]] && return 1
-	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
-
-	# kill -0: fails immediately if process does not exist
-	if ! kill -0 "$pid" 2>/dev/null; then
-		return 1
-	fi
-
-	# Command sanity check (t2421 pattern): ensure the process is actually
-	# a shell or script process, not a recycled PID running something unrelated.
-	local comm
-	comm=$(ps -p "$pid" -o comm= 2>/dev/null || true)
-	if [[ -z "$comm" ]]; then
-		# ps failed — treat as dead to unblock cleanup
-		return 1
-	fi
-
-	return 0
-}
-
-# Attempt to acquire the lock directory. On success, writes PID file and
-# registers a trap. Returns 1 (skip this run) if another live instance holds
-# the lock. Reclaims the lock if the holder PID is dead (crash recovery).
-_lock_acquire() {
-	if mkdir "$LOCK_DIR" 2>/dev/null; then
-		printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
-		_lock_install_traps
-		return 0
-	fi
-
-	# Lock exists — check for stale (dead) PID
-	if [[ -f "$PID_FILE" ]]; then
-		local lock_pid
-		lock_pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
-		if [[ -n "$lock_pid" ]] && ! _is_pid_alive "$lock_pid"; then
-			echo "[cleanup-worktrees-async] Reclaiming stale lock (PID ${lock_pid} no longer alive)" >>"$LOGFILE"
-			rm -rf "$LOCK_DIR" 2>/dev/null || true
-			if mkdir "$LOCK_DIR" 2>/dev/null; then
-				printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
-				_lock_install_traps
-				return 0
-			fi
-		fi
-	fi
-
-	# Another live instance is running — skip this invocation
-	return 1
-}
+# shellcheck source=cleanup-worktrees-lock.sh
+source "${SCRIPT_DIR}/cleanup-worktrees-lock.sh"
 
 # ============================================================
 # CADENCE GATE

--- a/.agents/scripts/cleanup-worktrees-lock.sh
+++ b/.agents/scripts/cleanup-worktrees-lock.sh
@@ -53,9 +53,20 @@ _lock_record_owner() {
 	return 0
 }
 
+_lock_finish_acquire() {
+	if _lock_record_owner; then
+		return 0
+	fi
+	# This process just created the directory. Never strand an ownerless lock
+	# when a PID write fails (for example, during the disk-pressure incident).
+	rm -f "$PID_FILE" 2>/dev/null || true
+	rmdir "$LOCK_DIR" 2>/dev/null || true
+	return 1
+}
+
 _lock_acquire() {
 	if mkdir "$LOCK_DIR" 2>/dev/null; then
-		_lock_record_owner
+		_lock_finish_acquire
 		return $?
 	fi
 	if [[ -f "$PID_FILE" ]]; then
@@ -65,7 +76,7 @@ _lock_acquire() {
 			echo "[cleanup-worktrees] Reclaiming stale lock (PID ${lock_pid} no longer alive)" >>"$LOGFILE"
 			rm -rf "$LOCK_DIR" 2>/dev/null || true
 			if mkdir "$LOCK_DIR" 2>/dev/null; then
-				_lock_record_owner
+				_lock_finish_acquire
 				return $?
 			fi
 		fi

--- a/.agents/scripts/cleanup-worktrees-lock.sh
+++ b/.agents/scripts/cleanup-worktrees-lock.sh
@@ -7,11 +7,11 @@
 
 _lock_release() {
 	local recorded_pid=""
-	[[ -f "$PID_FILE" ]] || return 0
-	recorded_pid=$(<"$PID_FILE")
+	[[ -f "${_CLEANUP_LOCK_PID_FILE:-}" ]] || return 0
+	recorded_pid=$(<"$_CLEANUP_LOCK_PID_FILE")
 	[[ "$recorded_pid" == "${_CLEANUP_LOCK_OWNER_PID:-}" ]] || return 0
-	rm -f "$PID_FILE" 2>/dev/null || true
-	rmdir "$LOCK_DIR" 2>/dev/null || true
+	rm -f "$_CLEANUP_LOCK_PID_FILE" 2>/dev/null || true
+	rmdir "$_CLEANUP_LOCK_PATH" 2>/dev/null || true
 	return 0
 }
 
@@ -46,6 +46,9 @@ _lock_record_owner() {
 	fi
 	[[ "$_CLEANUP_LOCK_OWNER_PID" =~ ^[1-9][0-9]*$ ]] || return 1
 	printf '%s\n' "$_CLEANUP_LOCK_OWNER_PID" >"$PID_FILE" || return 1
+	# Bash 3.2 unwinds function locals before EXIT on explicit exit paths.
+	_CLEANUP_LOCK_PID_FILE="$PID_FILE"
+	_CLEANUP_LOCK_PATH="$LOCK_DIR"
 	_lock_install_traps
 	return 0
 }

--- a/.agents/scripts/cleanup-worktrees-lock.sh
+++ b/.agents/scripts/cleanup-worktrees-lock.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Shared mkdir lock for asynchronous and watchdog-bounded worktree cleanup.
+# Caller supplies LOCK_DIR, PID_FILE and LOGFILE; source in a dedicated process
+# because acquisition owns EXIT/INT/TERM traps for that process only.
+
+_lock_release() {
+	local recorded_pid=""
+	[[ -f "$PID_FILE" ]] || return 0
+	recorded_pid=$(<"$PID_FILE")
+	[[ "$recorded_pid" == "${_CLEANUP_LOCK_OWNER_PID:-}" ]] || return 0
+	rm -f "$PID_FILE" 2>/dev/null || true
+	rmdir "$LOCK_DIR" 2>/dev/null || true
+	return 0
+}
+
+_lock_signal_exit() {
+	local exit_code="$1"
+	trap - EXIT INT TERM
+	_lock_release
+	exit "$exit_code"
+}
+
+_lock_install_traps() {
+	trap '_lock_release' EXIT
+	trap '_lock_signal_exit 130' INT
+	trap '_lock_signal_exit 143' TERM
+	return 0
+}
+
+_is_pid_alive() {
+	local pid="$1"
+	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
+	kill -0 "$pid" 2>/dev/null || return 1
+	# A live PID remains protected when process metadata is unavailable.
+	return 0
+}
+
+_lock_record_owner() {
+	# Match the watchdog's Bash 3.2-compatible executor-PID convention; $$ is
+	# the outer cycle PID in a subshell and would strand a killed bounded lock.
+	_CLEANUP_LOCK_OWNER_PID="${BASHPID:-}"
+	if [[ -z "$_CLEANUP_LOCK_OWNER_PID" ]]; then
+		_CLEANUP_LOCK_OWNER_PID="$(exec sh -c 'printf "%s" "$PPID"')" || return 1
+	fi
+	[[ "$_CLEANUP_LOCK_OWNER_PID" =~ ^[1-9][0-9]*$ ]] || return 1
+	printf '%s\n' "$_CLEANUP_LOCK_OWNER_PID" >"$PID_FILE" || return 1
+	_lock_install_traps
+	return 0
+}
+
+_lock_acquire() {
+	if mkdir "$LOCK_DIR" 2>/dev/null; then
+		_lock_record_owner
+		return $?
+	fi
+	if [[ -f "$PID_FILE" ]]; then
+		local lock_pid=""
+		lock_pid=$(<"$PID_FILE")
+		if [[ -n "$lock_pid" ]] && ! _is_pid_alive "$lock_pid"; then
+			echo "[cleanup-worktrees] Reclaiming stale lock (PID ${lock_pid} no longer alive)" >>"$LOGFILE"
+			rm -rf "$LOCK_DIR" 2>/dev/null || true
+			if mkdir "$LOCK_DIR" 2>/dev/null; then
+				_lock_record_owner
+				return $?
+			fi
+		fi
+	fi
+	return 1
+}

--- a/.agents/scripts/pulse-cleanup-progress.sh
+++ b/.agents/scripts/pulse-cleanup-progress.sh
@@ -78,7 +78,34 @@ _pc_progress_run_job() {
 	return 0
 }
 
+_pc_progress_locked() (
+	local budget="$1"
+	local log_dir="${AIDEVOPS_LOG_DIR:-${HOME}/.aidevops/logs}"
+	local LOCK_DIR="${log_dir}/cleanup_worktrees.lock"
+	local PID_FILE="${LOCK_DIR}/pid"
+	# Scoped process traps must not replace the caller's exit/signal handlers.
+	# shellcheck source=./cleanup-worktrees-lock.sh
+	source "${BASH_SOURCE[0]%/*}/cleanup-worktrees-lock.sh" || exit 1
+	mkdir -p "$log_dir" || exit 1
+	if ! _lock_acquire; then
+		printf '0 0 0 1\n'
+		exit 0
+	fi
+	_pc_cleanup_resumable_unlocked "$budget" >>"${LOGFILE:-/dev/null}" || exit $?
+	printf '%s %s %s %s\n' "$CLEANUP_WORKTREES_REMOVED_COUNT" "$CLEANUP_WORKTREES_ARCHIVED_COUNT" \
+		"$CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT" "$CLEANUP_WORKTREES_SKIPPED"
+)
+
 _pc_cleanup_resumable() {
+	local result=""
+	assert_git_available || return 1
+	result=$(_pc_progress_locked "$1") || return $?
+	read -r CLEANUP_WORKTREES_REMOVED_COUNT CLEANUP_WORKTREES_ARCHIVED_COUNT \
+		CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT CLEANUP_WORKTREES_SKIPPED <<<"$result"
+	return $?
+}
+
+_pc_cleanup_resumable_unlocked() {
 	local budget="$1" deadline=0 cursor="" saved="" manifest="" job=""
 	local repos_json="${HOME}/.config/aidevops/repos.json"
 	local state_dir="${PULSE_STATE_DIR:-${HOME}/.aidevops/.agent-workspace/pulse}"

--- a/.agents/scripts/pulse-cleanup-progress.sh
+++ b/.agents/scripts/pulse-cleanup-progress.sh
@@ -18,8 +18,10 @@ _pc_progress_repo_jobs() {
 		branch: (map(select(startswith("branch refs/heads/")) | ltrimstr("branch refs/heads/"))[0] // "")
 		}) | map(select(.path != "" and (.path | test("[\\r\\n]") | not)))') || return 1
 	jq -cn --arg repo "$repo" '["merged",$repo]'
+	# Git lists the main worktree first. Exclude it even when repos.json uses
+	# an alias or a linked path rather than the canonical inventory spelling.
 	jq -c --arg repo "$repo" --arg slug "$slug" --arg main "$main_branch" '
-		.[] | select(.path != $repo) | ["orphan",$repo,$slug,.path,.branch,$main]' <<<"$inventory"
+		.[1:][] | select(.path != $repo) | ["orphan",$repo,$slug,.path,.branch,$main]' <<<"$inventory"
 	return $?
 }
 

--- a/.agents/scripts/pulse-cleanup-progress.sh
+++ b/.agents/scripts/pulse-cleanup-progress.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# Sourced by pulse-cleanup-worktree-removal.sh for watchdog-bounded invocations.
+# Cursor data controls ordering only; every job invokes existing removal guards.
+
+_pc_progress_repo_jobs() {
+	local repo="$1" slug="" main_branch="" inventory=""
+	git -C "$repo" rev-parse --git-dir >/dev/null 2>&1 || return 0
+	# Match the legacy cleanup's live-remote identity, not a possibly stale slug
+	# in repos.json. The candidate's existing guards still validate removability.
+	slug=$(git -C "$repo" remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||') || slug=""
+	main_branch=$(git -C "$repo" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) || main_branch=origin/main
+	main_branch="${main_branch#origin/}"
+	inventory=$(git -C "$repo" worktree list --porcelain -z | jq -Rsc '
+		split("\u0000\u0000") | map(split("\u0000") | {
+		path: (map(select(startswith("worktree ")) | ltrimstr("worktree "))[0] // ""),
+		branch: (map(select(startswith("branch refs/heads/")) | ltrimstr("branch refs/heads/"))[0] // "")
+		}) | map(select(.path != "" and (.path | test("[\\r\\n]") | not)))') || return 1
+	jq -cn --arg repo "$repo" '["merged",$repo]'
+	jq -c --arg repo "$repo" --arg slug "$slug" --arg main "$main_branch" '
+		.[] | select(.path != $repo) | ["orphan",$repo,$slug,.path,.branch,$main]' <<<"$inventory"
+	return $?
+}
+
+_pc_progress_jobs() {
+	local repos_json="$1" record="" repo=""
+	while IFS= read -r record; do
+		repo=$(jq -r '.path // empty' <<<"$record") || return 1
+		[[ -n "$repo" ]] || continue
+		_pc_progress_repo_jobs "$repo" || return 1
+	done < <(jq -c '.initialized_repos[] | select((.local_only // false) == false) | select((.path // "" | test("[\\r\\n]")) | not)' "$repos_json")
+	printf '["relocate"]\n["outliers"]\n'
+	return 0
+}
+
+_pc_progress_checkpoint() {
+	local cursor="$1" next_job="$2" temporary=""
+	temporary=$(mktemp "${cursor}.XXXXXX") || return 1
+	if ! printf '%s\n' "$next_job" >"$temporary" || ! mv -f "$temporary" "$cursor"; then
+		rm -f "$temporary"
+		return 1
+	fi
+	return 0
+}
+
+_pc_progress_run_job() {
+	local job="$1" repos_json="$2" kind="" repo="" count=0
+	kind=$(jq -r '.[0]' <<<"$job") || return 1
+	case "$kind" in
+	merged)
+		repo=$(jq -r '.[1]' <<<"$job") || return 1
+		local helper="${_PULSE_CLEANUP_SCRIPT_DIR}/worktree-helper.sh"
+		[[ -x "$helper" ]] || return 0
+		count=$(_pc_cleanup_merged_repo "$helper" "$repo") || count=0
+		;;
+	orphan)
+		local slug="" path="" branch="" main_branch=""
+		repo=$(jq -r '.[1]' <<<"$job") || return 1
+		slug=$(jq -r '.[2]' <<<"$job") || return 1
+		path=$(jq -r '.[3]' <<<"$job") || return 1
+		branch=$(jq -r '.[4]' <<<"$job") || return 1
+		main_branch=$(jq -r '.[5]' <<<"$job") || return 1
+		[[ -d "$path" && "$path" != "$repo" ]] || return 0
+		if _cleanup_single_worktree "$repo" "$path" "$branch" "$(date +%s)" "$slug" "$main_branch"; then count=1; fi
+		;;
+	relocate) _pc_relocate_registered_worktrees "$repos_json" >/dev/null || true ;;
+	outliers) count=$(_pc_cleanup_orphan_sibling_dirs "$repos_json" "$(date +%s)") || count=0 ;;
+	*) return 1 ;;
+	esac
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	CLEANUP_WORKTREES_REMOVED_COUNT=$((CLEANUP_WORKTREES_REMOVED_COUNT + count))
+	return 0
+}
+
+_pc_cleanup_resumable() {
+	local budget="$1" deadline=0 cursor="" saved="" manifest="" job=""
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+	local state_dir="${PULSE_STATE_DIR:-${HOME}/.aidevops/.agent-workspace/pulse}"
+	local jobs=() start=0 index=0 offset=0 next=0 api_checked=0 remaining=""
+	CLEANUP_WORKTREES_SKIPPED=0
+	CLEANUP_WORKTREES_REMOVED_COUNT=0
+	CLEANUP_WORKTREES_ARCHIVED_COUNT=0
+	CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT=0
+	[[ "$budget" =~ ^[0-9]+$ && "$budget" -ge 1 ]] || return 1
+	deadline=$(($(date +%s) + budget))
+	command -v jq >/dev/null 2>&1 || return 1
+	[[ -f "$repos_json" ]] || { cleanup_worktrees; return $?; }
+	jq -e '.initialized_repos | type == "array"' "$repos_json" >/dev/null || return 1
+	# Preserve the existing API-free fixture pass before any quota gate, even
+	# when this invocation resumes halfway through the repository queue.
+	CLEANUP_WORKTREES_REMOVED_COUNT=$(_pc_cleanup_fixture_passes) || CLEANUP_WORKTREES_REMOVED_COUNT=0
+	[[ "$CLEANUP_WORKTREES_REMOVED_COUNT" =~ ^[0-9]+$ ]] || CLEANUP_WORKTREES_REMOVED_COUNT=0
+	mkdir -p "$state_dir" || return 1
+	cursor="${state_dir}/worktree-cleanup-next.json"
+	[[ ! -f "$cursor" ]] || saved=$(<"$cursor")
+	manifest=$(_pc_progress_jobs "$repos_json") || return 1
+	while IFS= read -r job; do
+		[[ "$job" != "$saved" ]] || start="${#jobs[@]}"
+		jobs+=("$job")
+	done <<<"$manifest"
+	_pc_log_local_only_worktree_skips "$repos_json"
+	for ((offset = 0; offset < ${#jobs[@]}; offset++)); do
+		[[ "$(date +%s)" -lt "$deadline" ]] || break
+		index=$(((start + offset) % ${#jobs[@]}))
+		next=$(((index + 1) % ${#jobs[@]}))
+		# Write ahead: watchdog termination retries this job after a fair rotation,
+		# never indefinitely before the same later repository or orphan candidate.
+		_pc_progress_checkpoint "$cursor" "${jobs[$next]}" || return 1
+		if [[ "$api_checked" -eq 0 ]]; then
+			api_checked=1
+			remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null) || remaining=""
+			if [[ "$remaining" =~ ^[0-9]+$ && "$remaining" -lt 100 ]]; then
+				CLEANUP_WORKTREES_SKIPPED=1
+				break
+			fi
+		fi
+		_pc_progress_run_job "${jobs[$index]}" "$repos_json" || return 1
+	done
+	echo "[pulse-cleanup] resumable progress: attempted=${offset}, removed=${CLEANUP_WORKTREES_REMOVED_COUNT}, budget=${budget}s" >>"${LOGFILE:-/dev/null}"
+	return 0
+}

--- a/.agents/scripts/pulse-cleanup-progress.sh
+++ b/.agents/scripts/pulse-cleanup-progress.sh
@@ -4,6 +4,9 @@
 # Sourced by pulse-cleanup-worktree-removal.sh for watchdog-bounded invocations.
 # Cursor data controls ordering only; every job invokes existing removal guards.
 
+# shellcheck source=./canonical-guard-helper.sh
+source "${BASH_SOURCE[0]%/*}/canonical-guard-helper.sh" || return 1
+
 _pc_progress_repo_jobs() {
 	local repo="$1" slug="" main_branch="" inventory=""
 	git -C "$repo" rev-parse --git-dir >/dev/null 2>&1 || return 0
@@ -84,6 +87,7 @@ _pc_cleanup_resumable() {
 	CLEANUP_WORKTREES_REMOVED_COUNT=0
 	CLEANUP_WORKTREES_ARCHIVED_COUNT=0
 	CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT=0
+	assert_git_available || return 1
 	[[ "$budget" =~ ^[0-9]+$ && "$budget" -ge 1 ]] || return 1
 	deadline=$(($(date +%s) + budget))
 	command -v jq >/dev/null 2>&1 || return 1

--- a/.agents/scripts/pulse-cleanup-worktree-removal.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-removal.sh
@@ -1237,6 +1237,14 @@ _pc_cleanup_fixture_passes() {
 }
 
 cleanup_worktrees() {
+	# The caller still owns the hard watchdog. Bounded invocations persist fair
+	# progress before each guarded operation so interruption cannot pin the queue.
+	if [[ -n "${1:-}" ]]; then
+		# shellcheck source=./pulse-cleanup-progress.sh
+		source "${_PULSE_CLEANUP_SCRIPT_DIR}/pulse-cleanup-progress.sh"
+		_pc_cleanup_resumable "$1"
+		return $?
+	fi
 	CLEANUP_WORKTREES_SKIPPED=0
 	CLEANUP_WORKTREES_REMOVED_COUNT=0
 	CLEANUP_WORKTREES_ARCHIVED_COUNT=0

--- a/.agents/scripts/pulse-cleanup-worktree-state.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-state.sh
@@ -629,6 +629,24 @@ _pc_count_verified_worktree_removals() {
 	return 0
 }
 
+_pc_cleanup_merged_repo() {
+	local helper="$1" repo_path="$2"
+	local clean_result="" count=0 wt_count=0
+	git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1 || { printf '0\n'; return 0; }
+	wt_count=$(git -C "$repo_path" worktree list | wc -l | tr -d ' ')
+	if [[ "${wt_count:-0}" -le 1 ]]; then
+		printf '0\n'
+		return 0
+	fi
+	clean_result=$(cd "$repo_path" && bash "$helper" clean --auto --force-merged 2>&1) || true
+	count=$(_pc_count_verified_worktree_removals "$clean_result")
+	if [[ "$count" -gt 0 ]]; then
+		echo "[pulse-wrapper] Worktree cleanup ($(basename "$repo_path")): $count worktree(s) removed" >>"$LOGFILE"
+	fi
+	printf '%s\n' "$count"
+	return 0
+}
+
 _cleanup_merged_prs_for_all_repos() {
 	# t2559 Layer 3: fail-loud when git is missing from PATH. This runs before
 	# we invoke worktree-helper.sh clean across every repo — if git isn't
@@ -674,25 +692,9 @@ _cleanup_merged_prs_for_all_repos() {
 				continue
 			fi
 
-			local wt_count
-			wt_count=$(git -C "$repo_path" worktree list | wc -l | tr -d ' ')
-			# Skip repos with only 1 worktree (the main one) — nothing to clean
-			if [[ "${wt_count:-0}" -le 1 ]]; then
-				continue
-			fi
-
-			# Run helper in a subshell cd'd to the repo (it uses git rev-parse --show-toplevel)
-			local clean_result
-			clean_result=$(cd "$repo_path" && bash "$helper" clean --auto --force-merged 2>&1) || true
-
 			local count
-			count=$(_pc_count_verified_worktree_removals "$clean_result")
-			if [[ "$count" -gt 0 ]]; then
-				local repo_name
-				repo_name=$(basename "$repo_path")
-				echo "[pulse-wrapper] Worktree cleanup ($repo_name): $count worktree(s) removed" >>"$LOGFILE"
-				total_removed=$((total_removed + count))
-			fi
+			count=$(_pc_cleanup_merged_repo "$helper" "$repo_path")
+			total_removed=$((total_removed + count))
 		done <<<"$repo_records"
 	else
 		# Fallback: just clean the current repo (legacy behaviour)

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1447,7 +1447,7 @@ _dispatch_worktree_capacity_gate() {
 }
 
 _dispatch_run_guarded_disk_cleanup() {
-	cleanup_worktrees
+	cleanup_worktrees "${1:-60}"
 	return $?
 }
 
@@ -1483,7 +1483,7 @@ _dispatch_cleanup_disk_pressure() {
 
 	echo "[dispatch_with_dedup] Disk pressure for #${issue_number} in ${repo_slug}: reason=${before_reason}, available=${before_kb}KB/${before_percent}%; attempting guarded all-repository cleanup once this Pulse cycle (timeout ${cleanup_timeout}s)" >>"$LOGFILE"
 	run_stage_with_timeout "dispatch_disk_pressure_cleanup" "$cleanup_timeout" \
-		_dispatch_run_guarded_disk_cleanup || cleanup_rc=$?
+		_dispatch_run_guarded_disk_cleanup "$cleanup_timeout" || cleanup_rc=$?
 	aidevops_worktree_capacity_check "$target_path" || after_rc=$?
 	if [[ "$after_rc" -eq 0 ]]; then
 		echo "[dispatch_with_dedup] Guarded disk-pressure cleanup recovered dispatch capacity for #${issue_number} in ${repo_slug}: ${before_kb}KB/${before_percent}% -> ${AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB}KB/${AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT}% (cleanup_rc=${cleanup_rc})" >>"$LOGFILE"

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -211,7 +211,7 @@ _preflight_cleanup_and_ledger() {
 			"${HOME}/.aidevops/logs/cleanup_worktrees.log" "worktrees"
 	else
 		# Fallback: synchronous with short timeout (old GH#18979 behaviour)
-		run_stage_with_timeout "cleanup_worktrees" 60 cleanup_worktrees || true
+		run_stage_with_timeout "cleanup_worktrees" 60 cleanup_worktrees 60 || true
 	fi
 	# GH#21997/GH#29292: Stash cleanup uses the same isolated async launcher so
 	# slow auditing cannot stall preflight or share the parent pulse lifetime.

--- a/.agents/scripts/tests/test-cleanup-worktrees-async.sh
+++ b/.agents/scripts/tests/test-cleanup-worktrees-async.sh
@@ -78,6 +78,7 @@ run_helper_in_isolation() {
 
 	local stub_dir="${TEST_DIR}/scripts"
 	mkdir -p "$stub_dir"
+	cp "${SCRIPT_DIR}/../cleanup-worktrees-lock.sh" "${stub_dir}/cleanup-worktrees-lock.sh"
 
 	# Stub shared-constants.sh — defines nothing, just marks it was sourced
 	cat >"${stub_dir}/shared-constants.sh" <<'STUB'
@@ -428,6 +429,7 @@ test_term_exits_and_releases_lock() {
 	local helper_pid=""
 	local attempts=0
 	mkdir -p "$stub_dir"
+	cp "${SCRIPT_DIR}/../cleanup-worktrees-lock.sh" "${stub_dir}/cleanup-worktrees-lock.sh"
 	rm -rf "$lock_dir"
 	rm -f "$mock_ran"
 
@@ -497,6 +499,13 @@ test_async_lock_helpers_install_terminating_traps() {
 		cleanup-remote-branches-async-helper.sh \
 		opencode-db-archive-async-helper.sh; do
 		helper_path="${scripts_dir}/${helper_name}"
+		if [[ "$helper_name" == cleanup-worktrees-async-helper.sh ]]; then
+			# shellcheck disable=SC2016 # Verify the literal shared-library source contract.
+			if ! grep -Fq 'source "${SCRIPT_DIR}/cleanup-worktrees-lock.sh"' "$helper_path"; then
+				invalid_helpers="${invalid_helpers}${invalid_helpers:+, }${helper_name}"
+			fi
+			helper_path="${scripts_dir}/cleanup-worktrees-lock.sh"
+		fi
 		if ! grep -Fq "trap '_lock_signal_exit 130' INT" "$helper_path" ||
 			! grep -Fq "trap '_lock_signal_exit 143' TERM" "$helper_path"; then
 			invalid_helpers="${invalid_helpers}${invalid_helpers:+, }${helper_name}"

--- a/.agents/scripts/tests/test-pulse-cleanup-progress.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-progress.sh
@@ -8,6 +8,7 @@ TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 export HOME="${TEST_ROOT}/home"
 export PULSE_STATE_DIR="${TEST_ROOT}/state"
+export AIDEVOPS_LOG_DIR="${TEST_ROOT}/logs"
 export LOGFILE="${TEST_ROOT}/pulse.log"
 mkdir -p "${HOME}/.config/aidevops" "$PULSE_STATE_DIR"
 printf '{"initialized_repos":[]}\n' >"${HOME}/.config/aidevops/repos.json"
@@ -117,4 +118,36 @@ gh() { printf '99\n'; return 0; }
 printf '100\n' >"$CLOCK"
 _pc_cleanup_resumable 5
 [[ "$CLEANUP_WORKTREES_REMOVED_COUNT" == 1 && "$CLEANUP_WORKTREES_SKIPPED" == 1 ]]
+
+# Real overlapping processes share the asynchronous runner's lock namespace.
+gh() { printf '1000\n'; return 0; }
+_pc_cleanup_fixture_passes() { printf '0\n'; return 0; }
+_pc_progress_jobs() { printf '["merged","one"]\n["merged","two"]\n'; return 0; }
+_pc_progress_run_job() {
+	printf '%s\n' "$1" >>"${TEST_ROOT}/concurrent-calls"
+	: >"${TEST_ROOT}/holder-ready"
+	while [[ ! -e "${TEST_ROOT}/holder-release" ]]; do sleep 0.05; done
+	return 0
+}
+_pc_cleanup_resumable 10 &
+holder=$!
+for ((attempt = 0; attempt < 100; attempt++)); do
+	[[ ! -e "${TEST_ROOT}/holder-ready" ]] || break
+	sleep 0.05
+done
+if [[ ! -e "${TEST_ROOT}/holder-ready" ]]; then
+	: >"${TEST_ROOT}/holder-release"
+	wait "$holder" || true
+	printf 'FAIL cleanup holder did not start\n' >&2
+	exit 1
+fi
+before_cursor=$(<"${PULSE_STATE_DIR}/worktree-cleanup-next.json")
+concurrency_rc=0
+_pc_cleanup_resumable 10 || concurrency_rc=1
+[[ "$CLEANUP_WORKTREES_SKIPPED" == 1 ]] || concurrency_rc=1
+[[ "$(<"${PULSE_STATE_DIR}/worktree-cleanup-next.json")" == "$before_cursor" ]] || concurrency_rc=1
+[[ "$(wc -l <"${TEST_ROOT}/concurrent-calls" | tr -d ' ')" == 1 ]] || concurrency_rc=1
+: >"${TEST_ROOT}/holder-release"
+wait "$holder" || concurrency_rc=1
+[[ "$concurrency_rc" == 0 && ! -d "${AIDEVOPS_LOG_DIR}/cleanup_worktrees.lock" ]]
 printf 'PASS bounded cleanup fairness, timeout continuation, cursor validation, fail-closed persistence and guard refusal\n'

--- a/.agents/scripts/tests/test-pulse-cleanup-progress.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-progress.sh
@@ -31,6 +31,16 @@ _pc_progress_run_job() {
 	return 0
 }
 
+# Missing Git fails before fixture cleanup, inventory, or cursor persistence.
+rc=0
+guard_output=$(
+	_pc_cleanup_fixture_passes() { exit 99; }
+	_pc_progress_checkpoint() { exit 99; }
+	PATH="${TEST_ROOT}/missing-bin" _pc_cleanup_resumable 5 2>&1
+) || rc=$?
+[[ "$rc" == 1 && "$guard_output" == *"git not available in PATH"* ]]
+[[ ! -e "${PULSE_STATE_DIR}/worktree-cleanup-next.json" && ! -e "$CALLS" ]]
+
 # A slow first repository consumes the budget. Next invocation starts at its
 # orphan phase, reaches the later repo, and only then rotates back to slow work.
 _pc_cleanup_resumable 5

--- a/.agents/scripts/tests/test-pulse-cleanup-progress.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-progress.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+export PULSE_STATE_DIR="${TEST_ROOT}/state"
+export LOGFILE="${TEST_ROOT}/pulse.log"
+mkdir -p "${HOME}/.config/aidevops" "$PULSE_STATE_DIR"
+printf '{"initialized_repos":[]}\n' >"${HOME}/.config/aidevops/repos.json"
+CALLS="${TEST_ROOT}/calls"
+CLOCK="${TEST_ROOT}/clock"
+printf '100\n' >"$CLOCK"
+
+# shellcheck source=../pulse-cleanup-progress.sh
+source "${SCRIPT_DIR}/pulse-cleanup-progress.sh"
+_pc_log_local_only_worktree_skips() { return 0; }
+_pc_cleanup_fixture_passes() { printf '0\n'; return 0; }
+gh() { printf '1000\n'; return 0; }
+date() { command cat "$CLOCK"; return 0; }
+_pc_progress_jobs() {
+	printf '["merged","slow"]\n["orphan","slow"]\n["merged","later"]\n'
+	return 0
+}
+_pc_progress_run_job() {
+	printf '%s\n' "$1" >>"$CALLS"
+	if [[ "$1" == '["merged","slow"]' ]]; then printf '110\n' >"$CLOCK"; fi
+	return 0
+}
+
+# A slow first repository consumes the budget. Next invocation starts at its
+# orphan phase, reaches the later repo, and only then rotates back to slow work.
+_pc_cleanup_resumable 5
+[[ "$(wc -l <"$CALLS" | tr -d ' ')" == 1 ]]
+[[ "$(<"${PULSE_STATE_DIR}/worktree-cleanup-next.json")" == '["orphan","slow"]' ]]
+printf '100\n' >"$CLOCK"
+_pc_cleanup_resumable 5
+[[ "$(wc -l <"$CALLS" | tr -d ' ')" == 4 ]]
+[[ "$(sed -n '2p' "$CALLS")" == '["orphan","slow"]' ]]
+[[ "$(sed -n '3p' "$CALLS")" == '["merged","later"]' ]]
+
+# Abrupt termination after entering a job leaves its successor durably recorded.
+printf '100\n' >"$CLOCK"
+rm -f "${PULSE_STATE_DIR}/worktree-cleanup-next.json"
+rc=0
+(
+	_pc_progress_run_job() { exit 124; }
+	_pc_cleanup_resumable 5
+) || rc=$?
+[[ "$rc" == 124 ]]
+[[ "$(<"${PULSE_STATE_DIR}/worktree-cleanup-next.json")" == '["orphan","slow"]' ]]
+
+# Malformed/stale progress cannot introduce an operation outside fresh inventory.
+printf '["invented","untrusted"]\n' >"${PULSE_STATE_DIR}/worktree-cleanup-next.json"
+printf '100\n' >"$CLOCK"
+_pc_cleanup_resumable 5
+[[ "$(tail -n 1 "$CALLS")" == '["merged","slow"]' ]]
+
+# Failure to persist progress fails closed before invoking any cleanup job.
+before=$(wc -l <"$CALLS" | tr -d ' ')
+printf '100\n' >"$CLOCK"
+rc=0
+(
+	_pc_progress_checkpoint() { return 1; }
+	_pc_cleanup_resumable 5
+) || rc=$?
+[[ "$rc" == 1 ]]
+[[ "$(wc -l <"$CALLS" | tr -d ' ')" == "$before" ]]
+
+# Restore production executor and prove orphan refusal is not counted as removal.
+source "${SCRIPT_DIR}/pulse-cleanup-progress.sh"
+mkdir -p "${TEST_ROOT}/linked path"
+_cleanup_single_worktree() {
+	[[ "$2" == "${TEST_ROOT}/linked path" ]] || exit 1
+	return 1
+}
+CLEANUP_WORKTREES_REMOVED_COUNT=0
+job=$(jq -cn --arg path "${TEST_ROOT}/linked path" '["orphan","/canonical","owner/repo",$path,"","main"]')
+_pc_progress_run_job "$job" "${HOME}/.config/aidevops/repos.json"
+[[ "$CLEANUP_WORKTREES_REMOVED_COUNT" == 0 ]]
+
+# Exercise the production NUL-delimited inventory parser, live remote slug,
+# detached candidates, paths with spaces, and local-only repository exclusion.
+git() {
+	[[ "$*" != *"/hidden"* ]] || exit 1
+	case "$*" in
+	*"rev-parse --git-dir") printf '.git\n' ;;
+	*"remote get-url origin") printf 'git@github.com:owner/live.git\n' ;;
+	*"symbolic-ref --short refs/remotes/origin/HEAD") printf 'origin/trunk\n' ;;
+	*"worktree list --porcelain -z") printf 'worktree /canonical\0HEAD abc\0branch refs/heads/trunk\0\0worktree /linked path\0HEAD def\0detached\0\0' ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+printf '{"initialized_repos":[{"path":"/canonical","slug":"stale/name"},{"path":"/hidden","local_only":true}]}\n' >"${HOME}/.config/aidevops/repos.json"
+inventory=$(_pc_progress_jobs "${HOME}/.config/aidevops/repos.json")
+jq -es '.[1] == ["orphan","/canonical","owner/live","/linked path","","trunk"] and length == 4' <<<"$inventory" >/dev/null
+
+# The API-free fixture pass still executes on every invocation at low quota.
+_pc_cleanup_fixture_passes() { printf '1\n'; return 0; }
+gh() { printf '99\n'; return 0; }
+printf '100\n' >"$CLOCK"
+_pc_cleanup_resumable 5
+[[ "$CLEANUP_WORKTREES_REMOVED_COUNT" == 1 && "$CLEANUP_WORKTREES_SKIPPED" == 1 ]]
+printf 'PASS bounded cleanup fairness, timeout continuation, cursor validation, fail-closed persistence and guard refusal\n'

--- a/.agents/scripts/tests/test-pulse-cleanup-progress.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-progress.sh
@@ -152,4 +152,25 @@ _pc_cleanup_resumable 10 || concurrency_rc=1
 : >"${TEST_ROOT}/holder-release"
 wait "$holder" || concurrency_rc=1
 [[ "$concurrency_rc" == 0 && ! -d "${AIDEVOPS_LOG_DIR}/cleanup_worktrees.lock" ]]
+
+# Owner-write failure rolls back both newly acquired and reclaimed directories.
+(
+	# shellcheck source=../cleanup-worktrees-lock.sh
+	source "${SCRIPT_DIR}/cleanup-worktrees-lock.sh"
+	LOCK_DIR="${TEST_ROOT}/owner-write.lock"
+	PID_FILE="${LOCK_DIR}/pid"
+	_lock_record_owner() { : >"$PID_FILE"; return 1; }
+	if _lock_acquire; then exit 1; fi
+	[[ ! -d "$LOCK_DIR" ]]
+	mkdir "$LOCK_DIR"
+	printf '99999999\n' >"$PID_FILE"
+	_is_pid_alive() { return 1; }
+	if _lock_acquire; then exit 1; fi
+	[[ ! -d "$LOCK_DIR" ]]
+	# Restore the real owner writer and show that the next invocation succeeds.
+	source "${SCRIPT_DIR}/cleanup-worktrees-lock.sh"
+	_lock_acquire
+	[[ -s "$PID_FILE" ]]
+)
+[[ ! -d "${TEST_ROOT}/owner-write.lock" ]]
 printf 'PASS bounded cleanup fairness, timeout continuation, cursor validation, fail-closed persistence and guard refusal\n'

--- a/.agents/scripts/tests/test-pulse-cleanup-progress.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-progress.sh
@@ -63,6 +63,7 @@ rc=0
 ) || rc=$?
 [[ "$rc" == 124 ]]
 [[ "$(<"${PULSE_STATE_DIR}/worktree-cleanup-next.json")" == '["orphan","slow"]' ]]
+[[ ! -d "${AIDEVOPS_LOG_DIR}/cleanup_worktrees.lock" ]]
 
 # Malformed/stale progress cannot introduce an operation outside fresh inventory.
 printf '["invented","untrusted"]\n' >"${PULSE_STATE_DIR}/worktree-cleanup-next.json"
@@ -80,6 +81,7 @@ rc=0
 ) || rc=$?
 [[ "$rc" == 1 ]]
 [[ "$(wc -l <"$CALLS" | tr -d ' ')" == "$before" ]]
+[[ ! -d "${AIDEVOPS_LOG_DIR}/cleanup_worktrees.lock" ]]
 
 # Restore production executor and prove orphan refusal is not counted as removal.
 source "${SCRIPT_DIR}/pulse-cleanup-progress.sh"

--- a/.agents/scripts/tests/test-pulse-cleanup-progress.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-progress.sh
@@ -83,17 +83,8 @@ rc=0
 [[ "$(wc -l <"$CALLS" | tr -d ' ')" == "$before" ]]
 [[ ! -d "${AIDEVOPS_LOG_DIR}/cleanup_worktrees.lock" ]]
 
-# Restore production executor and prove orphan refusal is not counted as removal.
+# Restore production inventory for the following parser checks.
 source "${SCRIPT_DIR}/pulse-cleanup-progress.sh"
-mkdir -p "${TEST_ROOT}/linked path"
-_cleanup_single_worktree() {
-	[[ "$2" == "${TEST_ROOT}/linked path" ]] || exit 1
-	return 1
-}
-CLEANUP_WORKTREES_REMOVED_COUNT=0
-job=$(jq -cn --arg path "${TEST_ROOT}/linked path" '["orphan","/canonical","owner/repo",$path,"","main"]')
-_pc_progress_run_job "$job" "${HOME}/.config/aidevops/repos.json"
-[[ "$CLEANUP_WORKTREES_REMOVED_COUNT" == 0 ]]
 
 # Exercise the production NUL-delimited inventory parser, live remote slug,
 # detached candidates, paths with spaces, and local-only repository exclusion.
@@ -152,6 +143,18 @@ _pc_cleanup_resumable 10 || concurrency_rc=1
 : >"${TEST_ROOT}/holder-release"
 wait "$holder" || concurrency_rc=1
 [[ "$concurrency_rc" == 0 && ! -d "${AIDEVOPS_LOG_DIR}/cleanup_worktrees.lock" ]]
+
+# After all job mocks, restore the executor and verify real refusal accounting.
+source "${SCRIPT_DIR}/pulse-cleanup-progress.sh"
+mkdir -p "${TEST_ROOT}/linked path"
+_cleanup_single_worktree() {
+	[[ "$2" == "${TEST_ROOT}/linked path" ]] || exit 1
+	return 1
+}
+CLEANUP_WORKTREES_REMOVED_COUNT=0
+job=$(jq -cn --arg path "${TEST_ROOT}/linked path" '["orphan","/canonical","owner/repo",$path,"","main"]')
+_pc_progress_run_job "$job" "${HOME}/.config/aidevops/repos.json"
+[[ "$CLEANUP_WORKTREES_REMOVED_COUNT" == 0 ]]
 
 # Owner-write failure rolls back both newly acquired and reclaimed directories.
 (

--- a/.agents/scripts/tests/test-pulse-cleanup-progress.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-progress.sh
@@ -98,6 +98,8 @@ git() {
 printf '{"initialized_repos":[{"path":"/canonical","slug":"stale/name"},{"path":"/hidden","local_only":true}]}\n' >"${HOME}/.config/aidevops/repos.json"
 inventory=$(_pc_progress_jobs "${HOME}/.config/aidevops/repos.json")
 jq -es '.[1] == ["orphan","/canonical","owner/live","/linked path","","trunk"] and length == 4' <<<"$inventory" >/dev/null
+aliased_inventory=$(_pc_progress_repo_jobs /alias)
+jq -es '[.[] | select(.[0] == "orphan") | .[3]] == ["/linked path"]' <<<"$aliased_inventory" >/dev/null
 
 # The API-free fixture pass still executes on every invocation at low quota.
 _pc_cleanup_fixture_passes() { printf '1\n'; return 0; }


### PR DESCRIPTION
## Summary

- Add resumable ordering for watchdog-bounded disk-pressure cleanup. Persist the
  successor before every existing guarded operation, so a slow merged-PR scan
  cannot repeatedly starve orphan candidates and later repositories.
- Preserve the 60-second default, the once-per-Pulse-cycle admission guard, the
  API-free fixture pass, low-quota deferral, and post-cleanup capacity recheck.
- Rebuild the inventory each run; cursor contents can select only an existing
  job, never introduce a path or authorize removal. Failed cursor persistence
  fails closed. Use live Git remote identity and NUL-delimited worktree records.
- Wire the synchronous preflight fallback to the same bounded mode. Share the
  existing cleanup-wide lock with asynchronous cleanup, using scoped signal traps
  and the actual executor PID rather than an outer cycle PID.

## Files and reference pattern

- `.agents/scripts/pulse-cleanup-progress.sh`: deadline, fresh inventory and
  atomic write-ahead cursor; calls the existing cleanup safety owners.
- `pulse-cleanup-worktree-removal.sh`, `pulse-cleanup-worktree-state.sh`,
  `pulse-dispatch-core.sh`, `pulse-dispatch-preflight-lib.sh` under
  `.agents/scripts/`: existing cleanup/capacity boundaries, unchanged thresholds.
- `.agents/scripts/tests/test-pulse-cleanup-progress.sh`: isolated progress and
  interruption fixtures, without deleting live worktrees or filling a real disk.
- `.agents/scripts/cleanup-worktrees-lock.sh` and the asynchronous helper: shared
  lock acquisition, ownership-aware release and signal lifecycle.

## Runtime Testing

- **Risk level:** Critical — cleanup orchestration; existing deletion guards are
  preserved rather than weakened.
- **Verification:** runtime-verified with isolated production-function fixtures;
  independent review required before readiness/merge.
- New progress fixture PASS: slow-first-repository deadline, abrupt exit,
  successor resume, stale/malformed cursor, failed persistence, detached/path-with-
  spaces inventory, live remote slug, local-only exclusion, low-quota fixture pass
  and guard refusal accounting.
- Existing dispatch capacity suite: 11/11 PASS.
- Existing dirty/unpushed preservation suite: 5/5 PASS.
- Existing worker-owned/no-PR cleanup suite: 33/33 PASS.
- Existing temp-worktree cleanup suite: 14/14 PASS.
- Existing non-Git-cwd/verified-removal-accounting suite: PASS.
- Progress fixtures additionally prove missing Git performs no cleanup or cursor
  work, aliased repo paths exclude the actual canonical worktree, and a second
  real process cannot advance the cursor or start work while the lock is held.
- Existing asynchronous cleanup suite: 17/17 PASS, including stale PID recovery,
  live lock refusal, cadence, TERM exit and lock release.
- Shared-lock repair `c2684976c`: progress and asynchronous suites PASS; ShellCheck
  and changed-file lint PASS. Formatting advisories are not suppressed.

## Scope and remaining incident evidence

This implements the verified timeout/progress defect. It does not blindly apply
the report's suggestions to retry once per dispatch candidate, remove detached
worktrees unconditionally, or replace registry ownership with argv matching.
Current `_cleanup_single_worktree` already processes detached candidates with
live-owner/dirty/unpushed guards. Current headless-runtime worker claims pass
`--owner-pid "$$"` explicitly, and provider launch strips inherited OpenCode PID
metadata. The reported remote host's historical wrong-parent records still need
producer/version evidence before any owner override or incident reclamation.
Keep the broader incident open for that verification rather than claiming this
PR safely deletes its protected backlog.

For #31405

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.329 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 10h 7m and 1,321,577 tokens on this with the user in an interactive session.