### PR TITLE
GH#31378: bound and validate source request record reads

### DIFF
--- a/.agents/scripts/source_access_core.py
+++ b/.agents/scripts/source_access_core.py
@@ -535,15 +535,17 @@ def _read_request_record(request_path: Path, expected_uid: int) -> dict[str, Any
         _require_source(len(content) <= MAX_REQUEST_BYTES, "source-access request is too large")
         current = request_path.lstat()
         final = os.fstat(descriptor)
-        identity_fields = ("st_dev", "st_ino", "st_mode", "st_nlink", "st_uid",
-                           "st_size", "st_mtime_ns", "st_ctime_ns")
+        identity_fields = (
+            "st_dev", "st_ino", "st_mode", "st_nlink", "st_uid",
+            "st_size", "st_mtime_ns", "st_ctime_ns",
+        )
         _require_source(
             (current.st_dev, current.st_ino) == (metadata.st_dev, metadata.st_ino)
             and all(getattr(final, field) == getattr(metadata, field) for field in identity_fields),
             "source-access request changed while reading",
         )
-        request = json.loads(content)
-    except (OSError, ValueError) as exc:
+        request = json.loads(content.decode("utf-8"))
+    except (OSError, ValueError, RecursionError) as exc:
         raise SourceAccessError("source-access request was not found or is malformed") from exc
     finally:
         os.close(descriptor)

--- a/.agents/scripts/source_access_core.py
+++ b/.agents/scripts/source_access_core.py
@@ -33,6 +33,7 @@ MAX_TTL_SECONDS = 12 * 60 * 60
 REQUEST_REUSE_SECONDS = 60 * 60
 MAX_SOURCE_BYTES = 10 * 1024 * 1024
 MAX_MANIFEST_ENTRIES = 32
+MAX_REQUEST_BYTES = 256 * 1024
 ID_PATTERN = re.compile(r"^[a-f0-9]{32,64}$")
 SESSION_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{6,256}$")
 ALLOWED_SUFFIXES = frozenset(
@@ -511,6 +512,45 @@ def validate_key_material(config: Config) -> None:
     _require_source(trust_marker == _trust_marker_content(derived_public_key), trust_error)
 
 
+def _read_request_record(request_path: Path, expected_uid: int) -> dict[str, Any]:
+    """Read bounded untrusted metadata through the descriptor we validate."""
+    trust_error = "source-access request ownership or permissions are unsafe"
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        descriptor = os.open(request_path, flags)
+    except OSError as exc:
+        raise SourceAccessError(trust_error) from exc
+    try:
+        metadata = os.fstat(descriptor)
+        _require_source(
+            stat.S_ISREG(metadata.st_mode)
+            and metadata.st_nlink == 1
+            and metadata.st_uid == expected_uid
+            and metadata.st_mode & 0o022 == 0,
+            trust_error,
+        )
+        _require_source(metadata.st_size <= MAX_REQUEST_BYTES, "source-access request is too large")
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            content = handle.read(MAX_REQUEST_BYTES + 1)
+        _require_source(len(content) <= MAX_REQUEST_BYTES, "source-access request is too large")
+        current = request_path.lstat()
+        final = os.fstat(descriptor)
+        identity_fields = ("st_dev", "st_ino", "st_mode", "st_nlink", "st_uid",
+                           "st_size", "st_mtime_ns", "st_ctime_ns")
+        _require_source(
+            (current.st_dev, current.st_ino) == (metadata.st_dev, metadata.st_ino)
+            and all(getattr(final, field) == getattr(metadata, field) for field in identity_fields),
+            "source-access request changed while reading",
+        )
+        request = json.loads(content)
+    except (OSError, ValueError) as exc:
+        raise SourceAccessError("source-access request was not found or is malformed") from exc
+    finally:
+        os.close(descriptor)
+    _require_source(isinstance(request, dict), "source-access request must be an object")
+    return request
+
+
 def _load_request(
     config: Config, home: Path, request_id: str, expected_uid: int
 ) -> dict[str, Any]:
@@ -519,10 +559,7 @@ def _load_request(
     trust_error = "source-access request ownership or permissions are unsafe"
     _require_source(_trusted_directory(request_path.parent, expected_uid), trust_error)
     _require_source(_trusted_file(request_path, expected_uid), trust_error)
-    try:
-        request = json.loads(request_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise SourceAccessError("source-access request was not found or is malformed") from exc
+    request = _read_request_record(request_path, expected_uid)
     schema_error = "source-access request schema or identifier is invalid"
     _require_source(
         request.get("schema") in (SCHEMA_REQUEST, SCHEMA_MANIFEST_REQUEST), schema_error

--- a/.agents/scripts/tests/test-source-access-helper.py
+++ b/.agents/scripts/tests/test-source-access-helper.py
@@ -94,6 +94,62 @@ class SourceAccessHelperTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.temp.cleanup()
 
+    def test_request_records_are_bounded_objects(self) -> None:
+        request_id = self._request()
+        path = self.config.request_root / f"{request_id}.json"
+        for content in (b"[]", b"null", b"1", b"\xff", b"{"):
+            with self.subTest(content=content):
+                path.write_bytes(content)
+                with self.assertRaises(HELPER.SourceAccessError):
+                    HELPER._load_request(self.config, self.home, request_id, self.uid)
+        path.write_bytes(b" " * (HELPER._SOURCE_CORE.MAX_REQUEST_BYTES + 1))
+        with self.assertRaisesRegex(HELPER.SourceAccessError, "too large"):
+            HELPER._load_request(self.config, self.home, request_id, self.uid)
+
+    def test_request_descriptor_rejects_unsafe_identity(self) -> None:
+        request_id = self._request()
+        path = self.config.request_root / f"{request_id}.json"
+        reader = HELPER._SOURCE_CORE._read_request_record
+        with self.assertRaises(HELPER.SourceAccessError):
+            reader(path, self.uid + 1)
+        hard_link = path.with_suffix(".hardlink")
+        os.link(path, hard_link)
+        with self.assertRaises(HELPER.SourceAccessError):
+            reader(path, self.uid)
+        hard_link.unlink()
+        path.chmod(0o666)
+        with self.assertRaises(HELPER.SourceAccessError):
+            reader(path, self.uid)
+        path.chmod(0o600)
+        link = path.with_suffix(".symlink")
+        link.symlink_to(path)
+        with self.assertRaises(HELPER.SourceAccessError):
+            reader(link, self.uid)
+        fifo = path.with_suffix(".fifo")
+        os.mkfifo(fifo)
+        with self.assertRaises(HELPER.SourceAccessError):
+            reader(fifo, self.uid)
+
+    def test_request_replacement_during_read_fails_closed(self) -> None:
+        request_id = self._request()
+        path = self.config.request_root / f"{request_id}.json"
+        original = path.read_bytes()
+        real_fstat = os.fstat
+        calls = 0
+
+        def replaced_fstat(descriptor: int) -> os.stat_result:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                replacement = path.with_suffix(".replacement")
+                replacement.write_bytes(original)
+                replacement.replace(path)
+            return real_fstat(descriptor)
+
+        with mock.patch.object(HELPER._SOURCE_CORE.os, "fstat", side_effect=replaced_fstat):
+            with self.assertRaisesRegex(HELPER.SourceAccessError, "changed while reading|unsafe"):
+                HELPER._load_request(self.config, self.home, request_id, self.uid)
+
     def _request(self, path: Path | None = None) -> str:
         return HELPER.create_request(
             self.config,

--- a/.agents/scripts/tests/test-source-access-helper.py
+++ b/.agents/scripts/tests/test-source-access-helper.py
@@ -97,7 +97,7 @@ class SourceAccessHelperTests(unittest.TestCase):
     def test_request_records_are_bounded_objects(self) -> None:
         request_id = self._request()
         path = self.config.request_root / f"{request_id}.json"
-        for content in (b"[]", b"null", b"1", b"\xff", b"{"):
+        for content in (b"[]", b"null", b"1", b"\xff", b"{", b"[" * 2000 + b"]" * 2000):
             with self.subTest(content=content):
                 path.write_bytes(content)
                 with self.assertRaises(HELPER.SourceAccessError):
@@ -140,14 +140,14 @@ class SourceAccessHelperTests(unittest.TestCase):
         def replaced_fstat(descriptor: int) -> os.stat_result:
             nonlocal calls
             calls += 1
-            if calls == 1:
+            if calls == 2:
                 replacement = path.with_suffix(".replacement")
                 replacement.write_bytes(original)
                 replacement.replace(path)
             return real_fstat(descriptor)
 
         with mock.patch.object(HELPER._SOURCE_CORE.os, "fstat", side_effect=replaced_fstat):
-            with self.assertRaisesRegex(HELPER.SourceAccessError, "changed while reading|unsafe"):
+            with self.assertRaisesRegex(HELPER.SourceAccessError, "changed while reading"):
                 HELPER._load_request(self.config, self.home, request_id, self.uid)
 
     def _request(self, path: Path | None = None) -> str:


### PR DESCRIPTION
## Summary

For #31378. Harden the untrusted request-record reader before introducing durable proposals. This is a prerequisite, not delivery of the durable-proposal or combined-approval feature.

- Read through the descriptor whose UID, file type, permissions and link count are validated, rather than validating a pathname and then reopening it through `read_text`.
- Bound metadata to 256 KiB, use nonblocking/no-follow opening, and reject concurrent replacement or metadata changes.
- Reject malformed, non-object and excessively nested JSON with a typed broker error. Preserve UTF-8 and existing v1/v2 schema/expiry semantics.

## Files and reference pattern

`.agents/scripts/source_access_core.py`: `_read_request_record` and `_load_request`, following the existing descriptor-based `secure_source_content` pattern. Regression cases extend `.agents/scripts/tests/test-source-access-helper.py` only.

## Runtime Testing

`runtime-verified` using fake repositories and broker roots: all 25 Python broker tests pass, including existing single-file/manifest signing and verification. New cases cover oversized/malformed/non-object/deeply nested records, wrong UID, writable files, symlinks, hard links, FIFOs and replacement during reading. Local changed-file gates and `git diff --check` pass. Independent security closeout of the exact branch bundle: CLEAN.

## Limits

No source-grant authority, schemas, TTLs, plugin permissions, issue signing or deployment changes. Durable proposals, session-liveness validation and the combined ceremony remain open under #31378. No release is requested.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.329 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 9h 50m and 1,078,590 tokens on this with the user in an interactive session.