### PR TITLE
GH#31296: reduce operation-output and helper-discovery round trips (t18410)

### DIFF
--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -30,6 +30,18 @@ next decision requires content. Exact reads, JSON, diffs, security, secret, and
 credential commands bypass the store and retain native output semantics. Storage
 failure also fails open to native execution rather than blocking the operation.
 
+`worker-activity-helper.sh summary` is an automatic compaction candidate because
+its successful global diagnostic can be large while the immediate decision
+normally needs counts and bounded warning/failure evidence. Run it through the
+sandbox to retain the complete private result behind an opaque ID:
+
+```bash
+output-sandbox-helper.sh run -- worker-activity-helper.sh summary
+```
+
+Use the helper directly when exact rows are required. Structured `--json` output
+continues to bypass compaction.
+
 `aidevops update` applies this contract automatically for non-TTY setup output.
 Use `--compact` to request it explicitly or `--verbose` to retain native streaming.
 The compact path verifies the setup completion sentinel before reporting success.
@@ -48,6 +60,11 @@ state is unchanged and resets after a transition. Failed-check links are emitted
 once; PR-head changes and API loss remain explicit. Exit `8` means checks are
 still pending at timeout, `1` means terminal failure, and `2` means indeterminate
 API failure. These states must not be collapsed into a generic failure.
+
+Helper discovery is also read-only: `full-loop-helper.sh help`, `--help`, and
+`COMMAND --help` print usage without starting, merging, cancelling, or otherwise
+mutating a lifecycle. Unknown commands return only a bounded diagnostic plus the
+canonical help command instead of repeating the full catalogue.
 
 ## Bounded interactive operations
 

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -331,6 +331,14 @@ _run_foreground() {
 main() {
 	local command="${1:-help}"
 	shift || true
+	# Command help is an introspection request, not an operation. Handle it
+	# before dispatch so probes such as `start --help` cannot create loop state.
+	case "${1:-}" in
+	help | --help | -h)
+		show_help
+		return 0
+		;;
+	esac
 	case "$command" in
 	start) cmd_start "$@" ;; resume) cmd_resume ;; status) cmd_status "$@" ;;
 	cancel) cmd_cancel ;; logs) cmd_logs "$@" ;; _run_foreground) _run_foreground "$@" ;;
@@ -348,7 +356,7 @@ main() {
 	help | --help | -h) show_help ;;
 	*)
 		print_error "Unknown command: $command"
-		show_help
+		printf 'Run full-loop-helper.sh help for supported commands.\n' >&2
 		return 1
 		;;
 	esac

--- a/.agents/scripts/output-sandbox-helper.sh
+++ b/.agents/scripts/output-sandbox-helper.sh
@@ -322,7 +322,7 @@ is_toolchain_compaction_candidate() {
 
 is_script_compaction_candidate() {
 	local command_text="$1"
-	local pattern='(^|/)(linters-local\.sh)( |$)|^bash [^[:space:]]*(test|lint)[^[:space:]]*\.sh( |$)'
+	local pattern='(^|/)(linters-local\.sh)( |$)|(^|/)(worker-activity-helper\.sh) summary( |$)|^bash [^[:space:]]*(test|lint)[^[:space:]]*\.sh( |$)'
 	[[ "$command_text" =~ $pattern ]]
 	return $?
 }


### PR DESCRIPTION
## Summary

Make full-loop command help side-effect free, bound unknown-command diagnostics, and compact verbose worker activity summaries while retaining exact evidence.

## Files Changed

.agents/reference/context-efficient-output.md, .agents/scripts/full-loop-helper.sh, .agents/scripts/output-sandbox-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Output-sandbox suite 49/49 passed; lifecycle-state checksum unchanged across start --help; 20,950-byte activity output compacted with an opaque full-log ID; ShellCheck, changed-file lint, and git diff --check passed.

Resolves #31296


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.329 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 11m and 155,653 tokens on this with the user in an interactive session.