### PR TITLE
GH#31454: Validate indented completion bookkeeping rows

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -701,7 +701,7 @@ _validate_completion_bookkeeping_todo() {
 	fi
 	task_pattern="${task_id//./\\.}"
 	issue_mapping_lines=$(grep -E \
-		"^- \[[ x]\] t[0-9]+([.][0-9]+)* .*ref:GH#${issue_number}([^0-9]|$)" \
+		"^[[:blank:]]*- \[[ x]\] t[0-9]+([.][0-9]+)* .*ref:GH#${issue_number}([^0-9]|$)" \
 		"$todo_file" 2>/dev/null || true)
 	issue_mapping_count=$(printf '%s\n' "$issue_mapping_lines" | grep -c . || true)
 	if [[ "$issue_mapping_count" -ne 1 ]]; then
@@ -710,7 +710,7 @@ _validate_completion_bookkeeping_todo() {
 	fi
 	completion_line="$issue_mapping_lines"
 	if ! printf '%s\n' "$completion_line" | grep -Eq \
-		"^- \[x\] ${task_pattern}([[:space:]]|$)" ||
+		"^[[:blank:]]*- \[x\] ${task_pattern}([[:space:]]|$)" ||
 		! printf '%s\n' "$completion_line" | grep -Eq "pr:#${proof_pr}([^0-9]|$)" ||
 		! printf '%s\n' "$completion_line" | grep -Eq 'completed:[0-9]{4}-[0-9]{2}-[0-9]{2}([^0-9]|$)'; then
 		print_error "Completion bookkeeping TODO.md proof must complete ${task_id} with merged PR #${proof_pr}"
@@ -734,7 +734,7 @@ _validate_completion_bookkeeping_todo() {
 			patch_payload="${patch_line:1}"
 			[[ "$patch_payload" =~ ^[[:space:]]*$ ]] && continue
 			if ! printf '%s\n' "$patch_payload" | grep -Eq \
-				"^- \[[ x]\] ${task_pattern}([[:space:]]|$)"; then
+				"^[[:blank:]]*- \[[ x]\] ${task_pattern}([[:space:]]|$)"; then
 				print_error "Completion bookkeeping TODO.md diff changes content outside task ${task_id}"
 				return 1
 			fi

--- a/.agents/scripts/tests/test-full-loop-closed-issue-bookkeeping.sh
+++ b/.agents/scripts/tests/test-full-loop-closed-issue-bookkeeping.sh
@@ -183,6 +183,13 @@ _validate_explicit_pr_metadata() {
 	return 0
 }
 
+_validate_pending_runtime_metadata() {
+	# This harness supplies only low-risk metadata fixtures; runtime-risk
+	# derivation has separate coverage and does not use this synthetic git stub.
+	[[ "$1" == "low" && "$2" == "self-assessed" ]]
+	return $?
+}
+
 _stage_and_commit() {
 	local commit_message="$1"
 	[[ -n "$commit_message" ]] || return 1
@@ -548,6 +555,43 @@ test_unrelated_todo_change_refusal() {
 	return 0
 }
 
+test_indented_completion() {
+	local indent=""
+	local rc=0
+	for indent in '  ' $'\t'; do
+		reset_case
+		printf '%s- [x] t4242 Child ref:GH#42 pr:#900 completed:2026-08-04\n' "$indent" >"${FIXTURE_ROOT}/TODO.md"
+		printf -v TEST_TODO_PATCH '@@ -1 +1 @@\n-%s- [ ] t4242 Child ref:GH#42\n+%s- [x] t4242 Child ref:GH#42 pr:#900 completed:2026-08-04' "$indent" "$indent"
+		rc=0
+		invoke_bookkeeping >/dev/null || rc=$?
+		if [[ "$rc" -eq 0 && "$(call_count create-pr)" -eq 1 ]]; then
+			pass "indented child completion preserves the bookkeeping contract"
+		else
+			fail "indented child completion preserves the bookkeeping contract" "rc=${rc}"
+		fi
+	done
+	reset_case
+	printf '  - [x] t4242 Duplicate ref:GH#42 pr:#900 completed:2026-08-04\n' >>"${FIXTURE_ROOT}/TODO.md"
+	rc=0
+	invoke_bookkeeping >/dev/null || rc=$?
+	if [[ "$rc" -ne 0 && "$(call_count push)" -eq 0 ]]; then
+		pass "mixed-indent duplicate issue mappings remain rejected"
+	else
+		fail "mixed-indent duplicate issue mappings remain rejected" "rc=${rc}"
+	fi
+	reset_case
+	TEST_TODO_PATCH=$'@@ -1 +1 @@\n-  - [ ] t9999 Other ref:GH#99\n+  - [x] t9999 Other ref:GH#99'
+	rc=0
+	invoke_bookkeeping >/dev/null || rc=$?
+	if [[ "$rc" -ne 0 && "$(call_count push)" -eq 0 ]]; then
+		pass "unrelated indented task changes remain rejected"
+	else
+		fail "unrelated indented task changes remain rejected" "rc=${rc}"
+	fi
+	return 0
+}
+
+test_indented_completion
 test_completed_success
 test_not_planned_success
 test_default_closed_refusal


### PR DESCRIPTION
## Summary

Accept leading horizontal whitespace in all three task-row checks. Preserve exact identity, unique mapping and unrelated-change rejection. Update the isolated fixture for the existing pending-runtime-metadata preflight. Direct diff review confirms no authorization or publication policy change.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/tests/test-full-loop-closed-issue-bookkeeping.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: bash .agents/scripts/tests/test-full-loop-closed-issue-bookkeeping.sh passed 17 cases; red/green coverage includes spaces, tabs, mixed-indent duplicate mapping and unrelated nested edits; ShellCheck and all local quality gates passed

Resolves #31454


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.329 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 22h 50m and 2,569,541 tokens on this with the user in an interactive session.