### PR TITLE
GH#31445: distinguish pulse ownership from explicit holds

### DIFF
--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -40,6 +40,15 @@ BLOCKING_LABELS = frozenset({
     "consolidated",
     "duplicate",
 })
+EXPLICIT_HOLD_LABELS = frozenset({
+    "needs-maintainer-review",
+    "needs-maintainer-permissions",
+    "no-auto-dispatch",
+    "infrastructure",
+    "hold-for-review",
+    "blocked",
+    "status:blocked",
+})
 PERSISTENT_DASHBOARD_LABELS = frozenset({"persistent", "quality-review"})
 
 
@@ -207,6 +216,7 @@ def _count_issue(
     labels = _issue_labels(issue)
     assigned = bool(issue.get("assignees"))
     blocked = bool(labels & BLOCKING_LABELS)
+    explicitly_held = bool(labels & EXPLICIT_HOLD_LABELS)
     dependency_inconsistent = bool(issue.get("dependency_inconsistent"))
     has_tier = any(label.startswith("tier:") for label in labels)
     has_status = any(label.startswith("status:") for label in labels)
@@ -220,7 +230,7 @@ def _count_issue(
     aggregate["needs_status"] += int(not has_status)
     aggregate["malformed_metadata"] += int(not has_tier or not has_status)
     aggregate["blocked_labels"] += int(blocked)
-    aggregate["blocked_explicit_hold"] += int(blocked)
+    aggregate["blocked_explicit_hold"] += int(explicitly_held)
     aggregate["dependency_inconsistent_available"] += int(dependency_inconsistent)
     aggregate["parent_task"] += int("parent-task" in labels)
     aggregate["nmr"] += int(is_nmr)

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -286,7 +286,7 @@ end) as $max_workers |
           ("eligible_depth_target=" + ($threshold | tostring)),
           "dispatch_alive=true",
           ("auto_dispatch_open=" + (($queue.aggregate.auto_dispatch_open // 0) | tostring)),
-          ("assigned_in_flight=" + (($queue.aggregate.assigned_in_flight // $queue.aggregate.assigned // 0) | tostring)),
+          ("assigned_or_in_flight=" + (($queue.aggregate.assigned // $queue.aggregate.assigned_in_flight // 0) | tostring)),
           ("blocked_explicit_hold=" + (($queue.aggregate.blocked_explicit_hold // $queue.aggregate.blocked_labels // 0) | tostring)),
           ("excluded_persistent_dashboard=" + ($excluded_persistent_dashboard | tostring)),
           ("needs_maintainer_review=" + (($queue.aggregate.nmr // 0) | tostring)),

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -288,7 +288,8 @@ if [[ "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "shortfall" || "${PULSE_CHECK_QUEUE_FI
   {"number":11,"title":"private eligible","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
   {"number":12,"title":"private assigned","updatedAt":"2000-01-01T00:00:00Z","assignees":[{"login":"worker"}],"labels":[{"name":"auto-dispatch"},{"name":"status:queued"},{"name":"tier:standard"}]},
   {"number":13,"title":"private nmr","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:thinking"},{"name":"needs-maintainer-review"}]},
-  {"number":14,"title":"private malformed","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]}
+  {"number":14,"title":"private malformed","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]},
+  {"number":15,"title":"private active review","updatedAt":"2000-01-01T00:00:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"auto-dispatch"},{"name":"status:in-review"},{"name":"tier:standard"}]}
 ]
 JSON
   else
@@ -596,8 +597,10 @@ assert_eq "active workers do not hide eligible queue shortfall" "auto-dispatch-m
 assert_eq "queue shortfall remains a maintainer advisory" "medium" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.findings[] | select(.id == "pulse-eligible-queue-under-target") | .severity')"
 assert_eq "queue shortfall does not auto-file a non-actionable issue" "false" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.findings[] | select(.id == "pulse-eligible-queue-under-target") | .autofile')"
 assert_eq "shortfall fixture has one eligible issue" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.eligible_available_unassigned')"
-assert_eq "shortfall fixture distinguishes assigned work" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.assigned_in_flight')"
+assert_eq "shortfall fixture distinguishes assigned work" "2" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.assigned_in_flight')"
 assert_eq "shortfall fixture distinguishes held work" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.blocked_explicit_hold')"
+assert_eq "active review ownership is not an explicit hold" "2" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.blocked_labels')"
+assert_contains "shortfall evidence does not claim assignment proves liveness" "assigned_or_in_flight=2" "$SHORTFALL_OUT"
 assert_contains "NMR advisory names updatedAt inactivity basis" "issue_updatedAt_not_label_application_time" "$SHORTFALL_OUT"
 assert_eq "inactive NMR holds remain visible" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '[.findings[] | select(.id == "pulse-inactive-nmr-holds")] | length')"
 assert_eq "inactive NMR holds remain medium severity" "medium" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.findings[] | select(.id == "pulse-inactive-nmr-holds") | .severity')"


### PR DESCRIPTION
## Summary

Correct Pulse queue diagnostics so active review ownership is not reported as an explicit hold, and label assigned work as assigned-or-in-flight rather than proof of liveness.

## Files Changed

.agents/scripts/pulse-check-queue-scan.py, .agents/scripts/pulse-check-report.jq, .agents/scripts/tests/test-pulse-check-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with pulse-check-helper.sh --json; test-pulse-check-helper.sh passed 127 assertions; test-pulse-event-refill.sh passed 26; test-terminal-blocker-circuit.sh passed 17; linters-local.sh --changed passed.

Resolves #31445


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.329 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 19m and 211,435 tokens on this with the user in an interactive session.