### PR TITLE
GH#31301: project lifecycle labels from active work

### DIFF
--- a/.agents/reference/auto-dispatch.md
+++ b/.agents/reference/auto-dispatch.md
@@ -83,7 +83,7 @@ When an issue carries `origin:interactive` AND has any human assignee, the pulse
 
 This closes the race where an interactive session claimed a task via `claim-task-id.sh` (applying `status:claimed` + owner assignment) and the pulse dispatched a duplicate worker before the session could open its PR.
 
-Full active lifecycle recognised: `status:queued`, `status:in-progress`, `status:in-review`, and `status:claimed` all keep owner/maintainer assignees in the blocking set.
+Full active lifecycle recognised: `status:queued`, `status:in-progress`, `status:in-review`, and `status:claimed` all keep owner/maintainer assignees in the blocking set. `status:claimed` identifies interactive implementation; `status:in-review` identifies an open non-draft PR ready for review.
 
 ## Issue-Sync TODO Auto-Completion (t2029 → t2166)
 
@@ -131,7 +131,7 @@ The task's brief `## How` section or `### Files Scope` references any file in th
 ### Decision tree (post-t2920)
 
 1. Brief references a dispatch-path file → use `#auto-dispatch` as normal. The t2819 detector replaces lower tier labels with `tier:thinking` before dispatch. The advisory tooling below emits non-blocking informational messages.
-2. Author implements the issue interactively → keep `#auto-dispatch` and start through `interactive-start-helper.sh ... --auto-dispatch`. The temporary `status:in-review` + assignee claim blocks concurrent dispatch; release and unassign restore automatic continuation.
+2. Author implements the issue interactively → keep `#auto-dispatch` and start through `interactive-start-helper.sh ... --auto-dispatch`. The temporary `status:claimed` + assignee claim blocks concurrent dispatch; release and unassign restore automatic continuation.
 3. A durable manual stop is explicitly required → use `#no-auto-dispatch` (or `interactive-session-helper.sh lockdown` when all pulse mutation must stop) and record the unresolved human decision or safety reason.
 4. No dispatch-path files in brief → normal dispatch rules apply.
 

--- a/.agents/reference/dispatch-blockers.md
+++ b/.agents/reference/dispatch-blockers.md
@@ -27,7 +27,7 @@ Applied to GitHub issues. The pulse checks these before spawning a worker.
 | `contributor` | `pulse-issue-reconcile.sh` | Contributor health dashboard — pulse-managed, not a dispatch target. |
 | `quality-review` | `pulse-issue-reconcile.sh` | Daily quality review tracker — pulse-managed. |
 | `routine-tracking` | `pulse-issue-reconcile.sh` | Routine execution tracking — pulse skips these unconditionally. |
-| `status:blocked` | `dispatch-dedup-helper.sh`, dependency and circuit-breaker recovery | Machine-recoverable structural block: incomplete dependencies, exhausted retry/cost limits, or infrastructure repair. Restore `status:available` only after the blocker is verified resolved. |
+| `status:blocked` | `dispatch-dedup-helper.sh`, dependency and circuit-breaker recovery | Machine-recoverable structural block or stopped partial draft. Its structured evidence must state the minimal reason and next action. Restore `status:available` only after the blocker is verified resolved. |
 
 Permission grants are limited to exact-pattern `bash` and `external_directory` requests, bound to the issue, request digest, worker session, branch, and worktree hash, and expire after four hours. Action-only permissions and credential-bearing or unbounded paths remain non-grantable.
 
@@ -84,7 +84,7 @@ These labels DO NOT block dispatch on their own. They become blockers only when 
 | Label | Block condition |
 |-------|----------------|
 | `origin:interactive` + any assignee | GH#18352: interactive session claimed this issue — blocks dispatch until `interactive-session-helper.sh release` |
-| `status:queued` / `status:in-progress` / `status:in-review` / `status:claimed` + non-passive assignee | Active lifecycle state with owner — safe to dispatch only when `_has_active_claim` returns false |
+| `status:queued` / `status:in-progress` / `status:in-review` / `status:claimed` + non-passive assignee | Active lifecycle state with owner — safe to dispatch only when `_has_active_claim` returns false. `status:in-review` is reserved for a non-draft review-ready PR; interactive ownership uses `status:claimed`. |
 
 ### PR Auto-Merge Blockers (block merge, not dispatch)
 

--- a/.agents/reference/dispatch-blockers.md
+++ b/.agents/reference/dispatch-blockers.md
@@ -27,7 +27,7 @@ Applied to GitHub issues. The pulse checks these before spawning a worker.
 | `contributor` | `pulse-issue-reconcile.sh` | Contributor health dashboard — pulse-managed, not a dispatch target. |
 | `quality-review` | `pulse-issue-reconcile.sh` | Daily quality review tracker — pulse-managed. |
 | `routine-tracking` | `pulse-issue-reconcile.sh` | Routine execution tracking — pulse skips these unconditionally. |
-| `status:blocked` | `dispatch-dedup-helper.sh`, dependency and circuit-breaker recovery | Machine-recoverable structural block: incomplete dependencies, exhausted retry/cost limits, or infrastructure repair. Restore `status:available` only after the blocker is verified resolved. |
+| `status:blocked` | `dispatch-dedup-helper.sh`, dependency and circuit-breaker recovery | Machine-recoverable structural block or stopped partial draft. Its structured evidence must state the minimal reason and next action. Restore `status:available` only after the blocker is verified resolved. |
 
 Permission grants are limited to exact-pattern `bash` and `external_directory` requests, bound to the issue, request digest, worker session, branch, and worktree hash, and expire after four hours. Action-only permissions and credential-bearing or unbounded paths remain non-grantable.
 
@@ -43,7 +43,7 @@ These labels DO NOT block dispatch on their own. They become blockers only when 
 | Label | Block condition |
 |-------|----------------|
 | `origin:interactive` + any assignee | GH#18352: interactive session claimed this issue — blocks dispatch until `interactive-session-helper.sh release` |
-| `status:queued` / `status:in-progress` / `status:in-review` / `status:claimed` + non-passive assignee | Active lifecycle state with owner — safe to dispatch only when `_has_active_claim` returns false |
+| `status:queued` / `status:in-progress` / `status:in-review` / `status:claimed` + non-passive assignee | Active lifecycle state with owner — safe to dispatch only when `_has_active_claim` returns false. `status:in-review` is reserved for a non-draft review-ready PR; interactive ownership uses `status:claimed`. |
 
 ### PR Auto-Merge Blockers (block merge, not dispatch)
 

--- a/.agents/reference/task-lifecycle.md
+++ b/.agents/reference/task-lifecycle.md
@@ -154,7 +154,7 @@ routine uncertainty into `#no-auto-dispatch`.
 - **Dispatch-path advisory (t2821, t2832, t2920)**: When a task's `### Files Scope` or `## How` section references a file in `.agents/configs/self-hosting-files.conf`, use `#auto-dispatch` as normal. The t2819 detector auto-elevates these workers to `tier:thinking`; runtime routing chooses the concrete model and reasoning level. Worker isolation, CI gates, watchdog kills, and the t2690 circuit breaker replace the historical `no-auto-dispatch` default. Interactive implementation keeps `#auto-dispatch`; its active claim is the temporary deduplication gate. **Durable opt-out (rare):** use `#no-auto-dispatch` only for explicit manual intent or a recorded unresolved safety/authority decision, never merely because the creating session will not implement the issue itself. Full decision tree: `reference/auto-dispatch.md` "Dispatch-Path Default (t2821 / t2920)".
 - **Quality gate**: Same readiness definition as `#auto-dispatch` above; do not maintain a second criteria list.
 - **Dispatch-label mutual exclusion**: `#auto-dispatch` and `#no-auto-dispatch` must never coexist. Managed issue-create/edit paths normalize conflicts without suppressing publication: an explicit manual hold wins a same-command conflict, and adding either label removes its opposite.
-- **Interactive workflow**: Keep worker-ready issues tagged `#auto-dispatch`; claim with `status:in-review` + assignment while working, then release with unassignment so unfinished work resumes automatically.
+- **Interactive workflow**: Keep worker-ready issues tagged `#auto-dispatch`; claim with `status:claimed` + assignment while working, then release with unassignment so unfinished work resumes automatically. Reserve `status:in-review` for an open non-draft PR that is actually ready for review.
 - **Server-side safety net (t2798)**: `.github/workflows/apply-status-available-default.yml` applies `status:available` to issues that carry `auto-dispatch` but have no `status:*` label — catches bypass-path creations (bare `gh issue create`, web UI) that skip `claim-task-id.sh`.
 
 **Session origin labels are provenance only**: Issues and PRs are automatically tagged with `origin:worker` (headless/pulse dispatch) or `origin:interactive` (user session). Applied by `claim-task-id.sh`, `issue-sync-helper.sh`, and `pulse-wrapper.sh`. In TODO.md, use `#worker` or `#interactive` tags to set origin explicitly; these map to the corresponding labels on push. Do not treat `origin:*` labels as workflow permission: `auto-dispatch` controls worker pickup on issues, and PR merge throughput is controlled by draft/hold state plus explicit merge-throughput preferences.
@@ -172,6 +172,19 @@ routine uncertainty into `#no-auto-dispatch`.
 **Admin merge authority:** Interactive sessions run as the repo admin/owner. For maintainer-owned or maintainer-approved work (`OWNER`/`MEMBER` PR author, maintainer-authored linked issue, trusted issue author, or valid crypto approval), `REVIEW_REQUIRED`, stale branch-protection state, or a self-blocking framework gate is not a user-action blocker once non-gate CI is green and no human `CHANGES_REQUESTED` review exists. Use `full-loop-helper.sh merge <N> <slug> --admin --squash` when needed; it records merge and cleanup evidence. Direct `gh pr merge` is blocked because it bypasses exact-head, review, receipt, and cleanup gates. Only keep the merge gated when the issue/PR originates from a non-maintainer and lacks cryptographic maintainer approval.
 
 **`origin:interactive` also skips pulse dispatch (GH#18352)**: When an issue carries `origin:interactive` AND has any human assignee, the pulse's deterministic dedup guard (`dispatch-dedup-helper.sh is-assigned`) treats the assignee as blocking — even if that assignee is the repo owner or maintainer, and regardless of the current `status:*` label. This closes the race where an interactive session claimed a task via `claim-task-id.sh` (applying `status:claimed` + owner assignment) and the pulse dispatched a duplicate worker before the session could open its PR. The full active lifecycle is now recognised: `status:queued`, `status:in-progress`, `status:in-review`, and `status:claimed` all keep owner/maintainer assignees in the blocking set.
+
+### Issue-List State Projection
+
+| Current evidence | Issue label | Reader action |
+|---|---|---|
+| Interactive owner working | `status:claimed` | Preserve the claim; do not dispatch. |
+| Worker actively running | `status:in-progress` | Preserve the claim; do not dispatch. |
+| Exact draft checkpoint stopped on evidence | `status:blocked` | Read the structured blocker reason and next action. |
+| Trusted correction validated for the exact checkpoint | `status:available` | Dispatch the existing exact-head continuation. |
+| Open, non-draft linked PR | `status:in-review` | Review or merge the PR. |
+| Linked PR merged | `status:done` | No implementation action. |
+
+These projections require a fresh authoritative issue/PR read. Unknown or ambiguous reads preserve the prior state; labels and stale prose never authorize continuation, clear a hold, or replace #31265's exact-head evidence contract.
 
 **Implementing a `#auto-dispatch` task interactively (MANDATORY):** Start with `interactive-start-helper.sh --issue N --repo owner/repo --task "description" --auto-dispatch`. Add `--background` only when the user explicitly requested it. All issue-started implementations claim with `--implementing`, export the local-only implementation marker, run the pre-edit loop check, and start full-loop before any code is written. External repositories skip managed issue mutations but still continue local implementation and the normal contribution PR flow.
 

--- a/.agents/reference/worker-discipline.md
+++ b/.agents/reference/worker-discipline.md
@@ -64,8 +64,14 @@ already-authorized outcome, the assigned AI executor owns brief correction:
    revision; concurrent changes or failed writes stop this expansion path. Keep
    the pre-push scope guard active; no broad globs or guard exceptions.
 4. Continue in the existing session/worktree through verification and delivery.
-   Perform at most one correction for unchanged evidence, not repeated identical
-   implementation attempts.
+    Perform at most one correction for unchanged evidence, not repeated identical
+    implementation attempts.
+
+Lifecycle integration must retain the canonical projection: `status:claimed` or
+`status:in-progress` means active implementation, `status:blocked` needs a
+structured reason/action, `status:available` is an executable continuation, and
+`status:in-review` requires a current open non-draft PR. Never use this scope
+recovery to weaken trust, hold, exact-head, or assignment-plus-active-state gates.
 
 An explicit hard boundary, another live owner, or genuinely new authority goes to
 the authorized AI brief owner/coordinator with exact issue/PR/checkpoint, brief

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -872,10 +872,11 @@ _stale_assignment_has_live_interactive_claim() {
 		return 1
 	fi
 
-	printf '%s' "$issue_meta_json" | jq -e --arg claimant "$claim_author" '
+	printf '%s' "$issue_meta_json" | jq -e --arg claimant "$claim_author" \
+		--arg in_progress 'status:in-progress' '
 		(.state | ascii_downcase) == "open" and
 		([.labels[]?.name] | any(. == "status:claimed" or
-			. == "status:in-progress" or . == "status:in-review")) and
+			. == $in_progress or . == "status:in-review")) and
 		([.assignees[]?.login] | index($claimant) != null)
 	' >/dev/null 2>&1 || return 1
 	return 0

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -874,7 +874,8 @@ _stale_assignment_has_live_interactive_claim() {
 
 	printf '%s' "$issue_meta_json" | jq -e --arg claimant "$claim_author" '
 		(.state | ascii_downcase) == "open" and
-		([.labels[]?.name] | index("status:in-review") != null) and
+		([.labels[]?.name] | any(. == "status:claimed" or
+			. == "status:in-progress" or . == "status:in-review")) and
 		([.assignees[]?.login] | index($claimant) != null)
 	' >/dev/null 2>&1 || return 1
 	return 0

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -654,6 +654,9 @@ _release_dispatch_claim() {
 		[[ "$terminal_blocker_rc" -eq 11 ]] && return 1
 		terminal_blocker_fragment="${_HRFF_TERMINAL_BLOCKER_FRAGMENT:-}"
 	fi
+	if [[ "$reason" == "${_HRW_REASON_DRAFT_CHECKPOINT:-worker_draft_checkpoint}" ]]; then
+		terminal_blocker_fragment=$'\nDraft checkpoint: partial work is blocked. Next action: verify the exact head and current brief before resuming.\n'
+	fi
 	comment_body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
 ${machine_readable_part}${terminal_blocker_fragment}
 <!-- ops:end -->"
@@ -668,7 +671,12 @@ ${machine_readable_part}${terminal_blocker_fragment}
 		return 0
 	fi
 	if [[ "$reason" == "${_HRW_REASON_DRAFT_CHECKPOINT:-worker_draft_checkpoint}" ]]; then
-		print_info "Preserving issue ownership and review state for draft checkpoint #${issue_number}"
+		if declare -F clear_active_status_on_release >/dev/null 2>&1; then
+			clear_active_status_on_release "$issue_number" "$repo_slug" "$runner_name" \
+				|| print_warning "Failed to project draft checkpoint state on #${issue_number} (non-fatal)"
+		fi
+		_unlock_issue_after_dispatch_release "$issue_number" "$repo_slug"
+		print_info "Projected draft checkpoint #${issue_number} as blocked partial work"
 		return 0
 	fi
 

--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -159,7 +159,7 @@ _isc_claim_ownership_class() {
 	now_epoch=$(date +%s)
 	printf '%s' "$metadata" | jq -r --arg user "$user" --argjson now "$now_epoch" '
 		(.state // "" | ascii_downcase) as $state |
-		([.labels[]?.name] | index("status:in-review") != null) as $in_review |
+		([.labels[]?.name] | any(. == "status:claimed" or . == "status:in-progress" or . == "status:in-review")) as $active |
 		[.assignees[]?.login] as $assignees |
 		[.comments[]?
 			| select((.body // "") | contains("Interactive session claimed by @"))
@@ -170,7 +170,7 @@ _isc_claim_ownership_class() {
 				| $created != null and ($now - $created) >= 0 and ($now - $created) < 7200)
 		] | sort_by(.createdAt) | reverse | first as $live_claim |
 		if $state != "open" then "invalid-state"
-		elif ($in_review | not) then "unclaimed"
+		elif ($active | not) then "unclaimed"
 		elif ($assignees | length) == 1 and $assignees[0] == $user then "own"
 		elif $live_claim != null then "foreign-interactive:" + $live_claim.author.login
 		else "foreign-worker" end
@@ -186,7 +186,7 @@ _isc_verified_caller_owns_claim() {
 	metadata=$(_isc_read_claim_metadata "$issue" "$slug") || return 1
 	printf '%s' "$metadata" | jq -e --arg user "$user" '
 		(.state | ascii_downcase) == "open" and
-		([.labels[]?.name] | index("status:in-review") != null) and
+		([.labels[]?.name] | index("status:claimed") != null) and
 		([.assignees[]?.login] == [$user])
 	' >/dev/null 2>&1
 	return $?
@@ -200,7 +200,7 @@ _isc_apply_new_claim() {
 	local defer_comment="$5"
 	shift 5
 	local -a transition_args=(--add-assignee "$user" "$@")
-	if ! set_issue_status "$issue" "$slug" "in-review" "${transition_args[@]}" >/dev/null 2>&1; then
+	if ! set_issue_status "$issue" "$slug" "claimed" "${transition_args[@]}" >/dev/null 2>&1; then
 		_isc_err "claim: ownership transition failed on #$issue; no stamp written"
 		return 1
 	fi
@@ -208,7 +208,7 @@ _isc_apply_new_claim() {
 		_isc_err "claim: ownership transition on #$issue could not be verified; no stamp written"
 		return 1
 	fi
-	_isc_info "claim: #$issue in $slug → status:in-review + sole assignee $user"
+	_isc_info "claim: #$issue in $slug → status:claimed + sole assignee $user"
 	_isc_write_stamp "$issue" "$slug" "$worktree_path" "$user"
 	if [[ "$defer_comment" -eq 0 || -n "$worktree_path" ]]; then
 		_isc_post_claim_comment "$issue" "$slug" "$user" "$worktree_path"
@@ -629,7 +629,7 @@ _isc_unassign_released_issue() {
 # -----------------------------------------------------------------------------
 # Subcommand: release
 # -----------------------------------------------------------------------------
-# Transition status:in-review -> status:available and delete the stamp.
+# Transition an interactive status:claimed ownership record to status:available.
 #
 # Arguments:
 #   $1 = issue number
@@ -638,8 +638,7 @@ _isc_unassign_released_issue() {
 #
 # Behaviour:
 #   - Idempotent: when the label is not set, only a requested unassignment runs.
-#   - Offline gh: warn and exit 0. The stamp is still deleted so local state
-#     matches the caller's intent.
+#   - Offline or unreadable gh: warn and preserve the stamp and remote state.
 #
 # Exit: 0 always.
 _isc_cmd_release() {
@@ -679,33 +678,32 @@ _isc_cmd_release() {
 		return 2
 	fi
 
-	# Always delete the stamp so local state reflects caller intent
-	_isc_delete_stamp "$issue" "$slug"
-
 	local user
 	if ! user=$(_isc_resolve_manageable_user "release" "$issue" "$slug" \
 		"gh offline — stamp deleted locally, label unchanged on #$issue"); then
 		return 0
 	fi
 
-	# Idempotency: skip only label work if not in-review. `_isc_has_in_review`
+	# Idempotency: release only an interactive status:claimed record. `_isc_has_claimed`
 	# has three return states (0 = present, 1 = absent, 2 = lookup failed),
 	# so we need the actual rc — but a bare call under `set -e` propagates
 	# non-zero returns before `rc=$?` can capture them. Use `|| rc=$?` which
 	# is a tested condition that `set -e` does not propagate. Default to 0
 	# so the "present" branch (rc=0) falls through to the transition below.
 	local has_rc=0
-	_isc_has_in_review "$issue" "$slug" || has_rc=$?
+	_isc_has_claimed "$issue" "$slug" || has_rc=$?
 	if [[ $has_rc -eq 1 ]]; then
 		if [[ $unassign -eq 0 ]]; then
-			_isc_info "release: #$issue not in status:in-review — no-op"
+			_isc_info "release: #$issue not in status:claimed — no-op"
+			_isc_delete_stamp "$issue" "$slug"
 			return 0
 		fi
 		_isc_unassign_released_issue "$issue" "$slug" "$user"
+		_isc_delete_stamp "$issue" "$slug"
 		return 0
 	fi
 	if [[ $has_rc -eq 2 ]]; then
-		_isc_warn "release: could not read labels for #$issue — skipping label transition"
+		_isc_warn "release: could not read labels for #$issue — preserving ownership state"
 		return 0
 	fi
 
@@ -730,6 +728,7 @@ _isc_cmd_release() {
 		${extra_flags[@]+"${extra_flags[@]}"} 2>&1 >/dev/null)
 	local _set_status_rc=$?
 	if [[ $_set_status_rc -eq 0 ]]; then
+		_isc_delete_stamp "$issue" "$slug"
 		_isc_info "release: #$issue → status:$_target_status"
 		return 0
 	fi

--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -158,7 +158,7 @@ _isc_claim_ownership_class() {
 	now_epoch=$(date +%s)
 	printf '%s' "$metadata" | jq -r --arg user "$user" --argjson now "$now_epoch" '
 		(.state // "" | ascii_downcase) as $state |
-		([.labels[]?.name] | index("status:in-review") != null) as $in_review |
+		([.labels[]?.name] | any(. == "status:claimed" or . == "status:in-progress" or . == "status:in-review")) as $active |
 		[.assignees[]?.login] as $assignees |
 		[.comments[]?
 			| select((.body // "") | contains("Interactive session claimed by @"))
@@ -169,7 +169,7 @@ _isc_claim_ownership_class() {
 				| $created != null and ($now - $created) >= 0 and ($now - $created) < 7200)
 		] | sort_by(.createdAt) | reverse | first as $live_claim |
 		if $state != "open" then "invalid-state"
-		elif ($in_review | not) then "unclaimed"
+		elif ($active | not) then "unclaimed"
 		elif ($assignees | length) == 1 and $assignees[0] == $user then "own"
 		elif $live_claim != null then "foreign-interactive:" + $live_claim.author.login
 		else "foreign-worker" end
@@ -185,7 +185,7 @@ _isc_verified_caller_owns_claim() {
 	metadata=$(_isc_read_claim_metadata "$issue" "$slug") || return 1
 	printf '%s' "$metadata" | jq -e --arg user "$user" '
 		(.state | ascii_downcase) == "open" and
-		([.labels[]?.name] | index("status:in-review") != null) and
+		([.labels[]?.name] | index("status:claimed") != null) and
 		([.assignees[]?.login] == [$user])
 	' >/dev/null 2>&1
 	return $?
@@ -199,7 +199,7 @@ _isc_apply_new_claim() {
 	local defer_comment="$5"
 	shift 5
 	local -a transition_args=(--add-assignee "$user" "$@")
-	if ! set_issue_status "$issue" "$slug" "in-review" "${transition_args[@]}" >/dev/null 2>&1; then
+	if ! set_issue_status "$issue" "$slug" "claimed" "${transition_args[@]}" >/dev/null 2>&1; then
 		_isc_err "claim: ownership transition failed on #$issue; no stamp written"
 		return 1
 	fi
@@ -207,7 +207,7 @@ _isc_apply_new_claim() {
 		_isc_err "claim: ownership transition on #$issue could not be verified; no stamp written"
 		return 1
 	fi
-	_isc_info "claim: #$issue in $slug → status:in-review + sole assignee $user"
+	_isc_info "claim: #$issue in $slug → status:claimed + sole assignee $user"
 	_isc_write_stamp "$issue" "$slug" "$worktree_path" "$user"
 	if [[ "$defer_comment" -eq 0 || -n "$worktree_path" ]]; then
 		_isc_post_claim_comment "$issue" "$slug" "$user" "$worktree_path"
@@ -626,7 +626,7 @@ _isc_unassign_released_issue() {
 # -----------------------------------------------------------------------------
 # Subcommand: release
 # -----------------------------------------------------------------------------
-# Transition status:in-review -> status:available and delete the stamp.
+# Transition an interactive status:claimed ownership record to status:available.
 #
 # Arguments:
 #   $1 = issue number
@@ -635,8 +635,7 @@ _isc_unassign_released_issue() {
 #
 # Behaviour:
 #   - Idempotent: when the label is not set, only a requested unassignment runs.
-#   - Offline gh: warn and exit 0. The stamp is still deleted so local state
-#     matches the caller's intent.
+#   - Offline or unreadable gh: warn and preserve the stamp and remote state.
 #
 # Exit: 0 always.
 _isc_cmd_release() {
@@ -676,33 +675,32 @@ _isc_cmd_release() {
 		return 2
 	fi
 
-	# Always delete the stamp so local state reflects caller intent
-	_isc_delete_stamp "$issue" "$slug"
-
 	local user
 	if ! user=$(_isc_resolve_manageable_user "release" "$issue" "$slug" \
 		"gh offline — stamp deleted locally, label unchanged on #$issue"); then
 		return 0
 	fi
 
-	# Idempotency: skip only label work if not in-review. `_isc_has_in_review`
+	# Idempotency: release only an interactive status:claimed record. `_isc_has_claimed`
 	# has three return states (0 = present, 1 = absent, 2 = lookup failed),
 	# so we need the actual rc — but a bare call under `set -e` propagates
 	# non-zero returns before `rc=$?` can capture them. Use `|| rc=$?` which
 	# is a tested condition that `set -e` does not propagate. Default to 0
 	# so the "present" branch (rc=0) falls through to the transition below.
 	local has_rc=0
-	_isc_has_in_review "$issue" "$slug" || has_rc=$?
+	_isc_has_claimed "$issue" "$slug" || has_rc=$?
 	if [[ $has_rc -eq 1 ]]; then
 		if [[ $unassign -eq 0 ]]; then
-			_isc_info "release: #$issue not in status:in-review — no-op"
+			_isc_info "release: #$issue not in status:claimed — no-op"
+			_isc_delete_stamp "$issue" "$slug"
 			return 0
 		fi
 		_isc_unassign_released_issue "$issue" "$slug" "$user"
+		_isc_delete_stamp "$issue" "$slug"
 		return 0
 	fi
 	if [[ $has_rc -eq 2 ]]; then
-		_isc_warn "release: could not read labels for #$issue — skipping label transition"
+		_isc_warn "release: could not read labels for #$issue — preserving ownership state"
 		return 0
 	fi
 
@@ -727,6 +725,7 @@ _isc_cmd_release() {
 		${extra_flags[@]+"${extra_flags[@]}"} 2>&1 >/dev/null)
 	local _set_status_rc=$?
 	if [[ $_set_status_rc -eq 0 ]]; then
+		_isc_delete_stamp "$issue" "$slug"
 		_isc_info "release: #$issue → status:$_target_status"
 		return 0
 	fi

--- a/.agents/scripts/interactive-session-helper-stamp.sh
+++ b/.agents/scripts/interactive-session-helper-stamp.sh
@@ -404,7 +404,7 @@ _isc_post_claim_comment() {
 <!-- ${ISC_CLAIM_AUDIT_SCHEMA} -->
 <!-- ops:start -->
 > Interactive session claimed by @${user}${worktree_note} on ${hostname}.
-> Pulse dispatch blocked via \`status:in-review\` + self-assignment.
+> Pulse dispatch blocked via \`status:claimed\` + self-assignment.
 <!-- ops:end -->
 EOF
 	)

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -6,7 +6,7 @@
 # Purpose: provide a mandatory, AI-driven acquire/release primitive for
 # interactive GitHub issue ownership. When an interactive session engages
 # with an issue in a maintainer-managed repo, this helper applies
-# `status:in-review` + self-assignment so the pulse's dispatch-dedup guard
+# `status:claimed` + self-assignment so the pulse's dispatch-dedup guard
 # (`dispatch-dedup-helper.sh is-assigned`) will not dispatch a parallel worker.
 # External non-maintainer repos skip these state/comment routines entirely.
 #
@@ -19,17 +19,17 @@
 #   a pulse bug), use `lockdown` instead — it applies `no-auto-dispatch` +
 #   `status:in-review` + self-assignment + conversation lock + audit comment.
 #
-# Why reuse status:in-review rather than a new label:
+# Why use status:claimed rather than a new label:
 #   - `_has_active_claim` in dispatch-dedup-helper.sh already treats it as an
 #     active claim that blocks dispatch.
 #   - `_normalize_stale_should_skip_reset` in pulse-issue-reconcile.sh already
 #     skips it during stale-recovery (only queued/in-progress get reset).
-#   - `ISSUE_STATUS_LABEL_PRECEDENCE` in shared-constants.sh already ranks it
-#     second after `done` for label-invariant reconciliation.
+#   - `ISSUE_STATUS_LABEL_PRECEDENCE` in shared-constants.sh already includes
+#     it in label-invariant reconciliation.
 #   - `.github/workflows/issue-sync.yml` already clears it on PR-close cleanup.
 # All the gating infrastructure is in place. The only gap this helper closes
-# is timing: today the label lands at PR open (via `full-loop-helper.sh
-# commit-and-pr`); we need it to land at interactive session engage.
+# is timing: the claim must land at interactive session engage without making
+# active implementation indistinguishable from a review-ready PR.
 #
 # AI-driven contract:
 #   The primary enforcement layer is an `AGENTS.md` rule telling the
@@ -248,12 +248,12 @@ _isc_normalize_owned_pr() {
 
 # Compatibility label probe used by release paths and focused regression tests.
 # Claim acquisition intentionally uses the richer ownership metadata above.
-_isc_has_in_review() {
+_isc_has_claimed() {
 	local issue="$1"
 	local slug="$2"
 	local json=""
 	json=$(gh issue view "$issue" --repo "$slug" --json labels 2>/dev/null) || return 2
-	printf '%s' "$json" | jq -e '(.labels // []) | any(.name == "status:in-review")' >/dev/null 2>&1
+	printf '%s' "$json" | jq -e '(.labels // []) | any(.name == "status:claimed")' >/dev/null 2>&1
 	return $?
 }
 

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -6,7 +6,7 @@
 # Purpose: provide a mandatory, AI-driven acquire/release primitive for
 # interactive GitHub issue ownership. When an interactive session engages
 # with an issue in a maintainer-managed repo, this helper applies
-# `status:in-review` + self-assignment so the pulse's dispatch-dedup guard
+# `status:claimed` + self-assignment so the pulse's dispatch-dedup guard
 # (`dispatch-dedup-helper.sh is-assigned`) will not dispatch a parallel worker.
 # External non-maintainer repos skip these state/comment routines entirely.
 #
@@ -19,17 +19,17 @@
 #   a pulse bug), use `lockdown` instead — it applies `no-auto-dispatch` +
 #   `status:in-review` + self-assignment + conversation lock + audit comment.
 #
-# Why reuse status:in-review rather than a new label:
+# Why use status:claimed rather than a new label:
 #   - `_has_active_claim` in dispatch-dedup-helper.sh already treats it as an
 #     active claim that blocks dispatch.
 #   - `_normalize_stale_should_skip_reset` in pulse-issue-reconcile.sh already
 #     skips it during stale-recovery (only queued/in-progress get reset).
-#   - `ISSUE_STATUS_LABEL_PRECEDENCE` in shared-constants.sh already ranks it
-#     second after `done` for label-invariant reconciliation.
+#   - `ISSUE_STATUS_LABEL_PRECEDENCE` in shared-constants.sh already includes
+#     it in label-invariant reconciliation.
 #   - `.github/workflows/issue-sync.yml` already clears it on PR-close cleanup.
 # All the gating infrastructure is in place. The only gap this helper closes
-# is timing: today the label lands at PR open (via `full-loop-helper.sh
-# commit-and-pr`); we need it to land at interactive session engage.
+# is timing: the claim must land at interactive session engage without making
+# active implementation indistinguishable from a review-ready PR.
 #
 # AI-driven contract:
 #   The primary enforcement layer is an `AGENTS.md` rule telling the
@@ -203,12 +203,12 @@ _isc_read_claim_metadata() {
 
 # Compatibility label probe used by release paths and focused regression tests.
 # Claim acquisition intentionally uses the richer ownership metadata above.
-_isc_has_in_review() {
+_isc_has_claimed() {
 	local issue="$1"
 	local slug="$2"
 	local json=""
 	json=$(gh issue view "$issue" --repo "$slug" --json labels 2>/dev/null) || return 2
-	printf '%s' "$json" | jq -e '(.labels // []) | any(.name == "status:in-review")' >/dev/null 2>&1
+	printf '%s' "$json" | jq -e '(.labels // []) | any(.name == "status:claimed")' >/dev/null 2>&1
 	return $?
 }
 

--- a/.agents/scripts/label-sync-helper.sh
+++ b/.agents/scripts/label-sync-helper.sh
@@ -51,11 +51,11 @@ GITHUB_DEFAULT_LABELS=(
 STATUS_LABELS=(
 	"status:available|0E8A16|Task is available for claiming"
 	"status:queued|FBCA04|Worker dispatched, not yet started"
-	"status:claimed|F9D0C4|Interactive session claimed this task"
+	"status:claimed|F9D0C4|Interactive implementation is actively claimed"
 	"status:in-progress|1D76DB|Worker actively running"
-	"status:in-review|5319E7|PR open, awaiting review/merge"
+	"status:in-review|5319E7|Non-draft PR ready for review/merge"
 	"status:done|6F42C1|Task is complete"
-	"status:blocked|D73A4A|Waiting on blocker task"
+	"status:blocked|D73A4A|Partial work blocked; inspect reason and next action"
 )
 
 # --- Status Exceptions (out-of-band, not managed by set_issue_status) ---

--- a/.agents/scripts/managed-label-provisioning-lib.sh
+++ b/.agents/scripts/managed-label-provisioning-lib.sh
@@ -79,7 +79,7 @@ managed_labels_ensure_tracking_set() {
 	local create_runner="$3"
 	local -a tracking_specs=(
 		"${_MANAGED_ORIGIN_LABEL_SPECS[@]}"
-		"status:in-review" "PR open, awaiting review/merge" "5319E7"
+		"status:in-review" "Non-draft PR ready for review/merge" "5319E7"
 		"bug" "Something isn't working" "D73A4A"
 	)
 	managed_labels_ensure_specs "$repo" "$inventory_runner" "$create_runner" \

--- a/.agents/scripts/pr-checkpoint-continuation-helper.sh
+++ b/.agents/scripts/pr-checkpoint-continuation-helper.sh
@@ -63,7 +63,7 @@ _pcc_claim_revised_checkpoint() {
 		owner_args+=(--remove-assignee "$PCC_EXPECTED_ASSIGNEE")
 	fi
 	PCC_OWNERSHIP_TRANSFERRED=1
-	set_issue_status "$PCC_LINKED_ISSUE" "$repo" in-review "${owner_args[@]}" >/dev/null || return 1
+	set_issue_status "$PCC_LINKED_ISSUE" "$repo" in-progress "${owner_args[@]}" >/dev/null || return 1
 	PCC_ISSUE_ASSIGNEE="$PCC_AUTHENTICATED_LOGIN"
 	"$helper" verify-pr-checkpoint-target "$pr" "$repo" "$head" "$ref" \
 		"$PCC_LINKED_ISSUE" "$PCC_ISSUE_ASSIGNEE" "$PCC_CHECKPOINT_ASSIGNEE" >/dev/null || return 1
@@ -325,7 +325,7 @@ _pcc_transfer_issue_ownership() {
 	[[ "$linked_issue" =~ ^[1-9][0-9]*$ && "$repo_slug" == */* ]] || return 1
 	[[ -n "$previous_assignee" && -n "$replacement_assignee" ]] || return 1
 	[[ "$previous_assignee" != "$replacement_assignee" ]] || return 0
-	set_issue_status "$linked_issue" "$repo_slug" "in-review" \
+	set_issue_status "$linked_issue" "$repo_slug" "in-progress" \
 		--add-assignee "$replacement_assignee" \
 		--remove-assignee "$previous_assignee" >/dev/null 2>&1 || return 1
 	return 0

--- a/.agents/scripts/pr-checkpoint-target-lib.sh
+++ b/.agents/scripts/pr-checkpoint-target-lib.sh
@@ -43,14 +43,13 @@ _pr_checkpoint_revised_target() {
 			.closingIssuesReferences = [{number:$issue,repository:{name:$parts[1],owner:{login:$parts[0]}}}]
 		' <<<"$pr_json") || return 1
 	fi
-	normalized_issue=$(jq --arg assignee "$assignee" --argjson claiming "$claiming" --arg interactive_label "$_PCTL_INTERACTIVE_LABEL" '
-		.labels |= map(select(.name != $interactive_label)) |
-		if $claiming or (.assignees | length) == 0 then .assignees = [{login:$assignee}] else . end |
-		.labels |= map(if .name == "status:available" then {name:"status:in-review"} else . end)
-	' <<<"$issue_json") || return 1
+	normalized_issue=$(jq --arg interactive_label "$_PCTL_INTERACTIVE_LABEL" \
+		'.labels |= map(select(.name != $interactive_label))' <<<"$issue_json") || return 1
 	_pr_checkpoint_pr_metadata_is_eligible "$normalized_pr" "$repo_slug" "$pr_number" \
 		"$linked_issue" "" "" "$(jq -r '.runner' <<<"$approval")" || return 1
-	_pr_checkpoint_issue_metadata_is_eligible "$normalized_issue" "$linked_issue" "$assignee" || return 1
+	# The revision validator above authorizes the original owner or an unassigned
+	# issue before this claim transfers ownership to the successor.
+	_pr_checkpoint_issue_metadata_is_eligible "$normalized_issue" "$linked_issue" "" "[]" "" "true" || return 1
 	printf '%s\n' "$approval"
 	return 0
 }
@@ -132,6 +131,7 @@ _pr_checkpoint_issue_metadata_is_eligible() {
 	local comments_json="${4:-[]}"
 	local checkpoint_runner="${5:-$expected_assignee}"
 	local interactive_checkpoint="false"
+	local allow_released="${6:-false}"
 
 	[[ "$linked_issue" =~ ^[1-9][0-9]*$ ]] || return 1
 	# A blocked release requires the revised envelope regardless of provenance.
@@ -150,7 +150,8 @@ _pr_checkpoint_issue_metadata_is_eligible() {
 	fi
 	printf '%s' "$issue_json" | jq -e --argjson issue "$linked_issue" \
 		--arg expected_assignee "$expected_assignee" \
-		--arg interactive_checkpoint "$interactive_checkpoint" --arg interactive_label "$_PCTL_INTERACTIVE_LABEL" '
+		--arg interactive_checkpoint "$interactive_checkpoint" --arg interactive_label "$_PCTL_INTERACTIVE_LABEL" \
+		--argjson allow_released "$allow_released" '
 		def names: [.labels[]? | if type == "string" then . else (.name // empty) end];
 		def lifecycle_statuses: [names[] | select(startswith("status:"))];
 		def runnable_status:
@@ -158,7 +159,8 @@ _pr_checkpoint_issue_metadata_is_eligible() {
 			(($statuses | length) == 1) and
 			($statuses[0] == "status:queued" or
 				$statuses[0] == "status:in-progress" or
-				$statuses[0] == "status:in-review");
+				$statuses[0] == "status:in-review" or
+				($allow_released and $statuses[0] == "status:available" and ((.assignees // []) | length) == 0));
 		def protected: names | any(
 			. == "needs-maintainer-review" or . == "needs-maintainer-permissions" or
 			. == "no-auto-dispatch" or . == "hold-for-review" or . == "persistent" or
@@ -168,9 +170,11 @@ _pr_checkpoint_issue_metadata_is_eligible() {
 		);
 		(.number == $issue) and (((.state // "") | ascii_downcase) == "open") and
 		((.pull_request // null) == null) and runnable_status and (protected | not) and
-		((.assignees // []) | length == 1) and
-		(((.assignees[0].login // "") | length) > 0) and
-		(($expected_assignee | length) == 0 or .assignees[0].login == $expected_assignee)
+		(((.assignees // []) | length) == 1 or
+			($allow_released and ((.assignees // []) | length) == 0)) and
+		(($allow_released and ((.assignees // []) | length) == 0) or
+			(((.assignees[0].login // "") | length) > 0 and
+			(($expected_assignee | length) == 0 or .assignees[0].login == $expected_assignee)))
 	' >/dev/null 2>&1 || return 1
 	return 0
 }

--- a/.agents/scripts/pr-checkpoint-target-lib.sh
+++ b/.agents/scripts/pr-checkpoint-target-lib.sh
@@ -49,7 +49,7 @@ _pr_checkpoint_revised_target() {
 		"$linked_issue" "" "" "$(jq -r '.runner' <<<"$approval")" || return 1
 	# The revision validator above authorizes the original owner or an unassigned
 	# issue before this claim transfers ownership to the successor.
-	_pr_checkpoint_issue_metadata_is_eligible "$normalized_issue" "$linked_issue" "" "[]" "" "true" || return 1
+	_pr_checkpoint_issue_metadata_is_eligible "$normalized_issue" "$linked_issue" "" "[]" "" true || return 1
 	printf '%s\n' "$approval"
 	return 0
 }

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -308,7 +308,7 @@ aidevops_gh_slurp_status_message() {
 			"$AIDEVOPS_GH_MIN_SLURP_VERSION" "$(aidevops_gh_slurp_remediation_guidance)"
 		return 0
 	fi
-	installed=$(aidevops_gh_installed_version) || installed="unknown"
+	installed=$(aidevops_gh_installed_version) || installed='unknown'
 	if [[ "$installed" == "unknown" ]]; then
 		printf 'GitHub CLI (gh) version could not be parsed; gh api --paginate --slurp requires gh >= %s; gh --version output is malformed or empty. %s' \
 			"$AIDEVOPS_GH_MIN_SLURP_VERSION" "$(aidevops_gh_slurp_remediation_guidance "$installed")"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1285,33 +1285,11 @@ _source_shared_module_with_retry "${_SC_SELF%/*}/shared-gh-wrappers.sh"
 
 
 #######################################
-# Clear active-lifecycle status labels on dispatch claim release (t2420).
+# Project an authoritative lifecycle label on dispatch claim release (t2420).
 #
-# Removes only the four ACTIVE status labels (queued, claimed, in-progress,
-# in-review) and optionally the worker's assignment. PRESERVES terminal
-# states (done, blocked) and the eligible state (available) — those are set
-# by authoritative paths (PR merge, blocker triage, explicit re-queue) and
-# must survive a worker's claim release.
-#
-# Why not set_issue_status "" ? Because it would strip status:done set by
-# the PR merge path if the CLAIM_RELEASED comment races ahead — a worker
-# that succeeds, creates a PR, the PR merges (setting status:done), and
-# then the worker's EXIT trap fires CLAIM_RELEASED would regress the state.
-# This helper is the targeted, race-safe alternative.
-#
-# Why not just skip label cleanup entirely? Because without it, orphan
-# labels pin an issue as "active" even though no worker holds the claim,
-# blocking pulse re-dispatch via the t1996 combined-signal guard
-# (active-status + assignee = block). Observed in production: #19864 and
-# #19738 were both pinned status:queued/claimed for 40+ minutes after
-# worker completion, with dead PIDs (one case was PID 11742 reused by
-# Brave Browser — see t2421).
-#
-# Origin labels are provenance only. An interactive session may create an
-# auto-dispatch issue that a headless worker validly claims, so release must
-# not skip cleanup solely because origin:interactive is present (GH#29897).
-# The exact worker_login removal and linked-PR safeguards below preserve live
-# interactive ownership and completed-work audit state.
+# The current exact linked-PR state selects the projection: no linked PR is
+# available, an open draft is blocked, an open non-draft PR is in-review, and
+# a merged PR is done. Unreadable or ambiguous PR metadata is a no-write error.
 #
 # Args:
 #   $1 — issue number
@@ -1334,88 +1312,44 @@ clear_active_status_on_release() {
 		return 0
 	fi
 
-	local labels_json=""
-	labels_json=$(gh issue view "$issue_num" --repo "$repo_slug" \
-		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || labels_json=""
-
-	# Defensive: if a linked PR exists for this issue (OPEN or MERGED),
-	# preserve the worker's assignee and status:in-review.
-	#
-	# OPEN linked PR: the PR pipeline owns final cleanup on merge (see
-	# pulse-merge.sh::_release_interactive_claim_on_merge for the
-	# interactive mirror). Stripping here strands the PR in
-	# maintainer-gate Job 1 Check 2 because the assignee check fires
-	# after CLAIM_RELEASED but before PR merge. GH#20195/t2451 closed
-	# that trust-gate loop.
-	#
-	# MERGED linked PR: preserves the closing-time audit trail on the
-	# issues list — the assignee identifies which runner's worker
-	# completed the work once the issue auto-closes. Without this, a
-	# fast merge (CI green before the worker exit trap fires — observed
-	# as little as 16s) races the unassign and erases the audit trail.
-	# t2746/GH#20520.
-	#
-	# We still remove queued, claimed, and in-progress — those never
-	# outlive the worker process regardless of PR state. When no linked PR
-	# exists, add status:available in the same edit so failed workers do not
-	# leave issues pinned as assigned-but-queued until the next stale sweep.
-	#
-	# CLOSED-not-merged PRs do NOT trigger preserve: the work didn't
-	# complete, and leaving the assignee on the issue would block
-	# future dispatch via the combined-signal dedup rule (t1996).
-	#
-	# Closing-keyword regex matches pulse-merge.sh::_extract_linked_issue
-	# character-for-character (case-insensitive) so behaviour is consistent
-	# across the merge path and the release path. Do NOT widen this to
-	# `Ref` or `For` — those are planning references that MUST NOT block
-	# assignee cleanup (see t2046).
-	local has_linked_pr=false
-	local has_open_linked_pr=0
-	local linked_open_pr_numbers=""
-	local linked_prs_json=""
+	# The release event alone does not identify a review-ready PR. Read the
+	# current linked PR state before writing: drafts project as blocked partial
+	# work, while only non-draft OPEN PRs project as in-review. A failed or
+	# ambiguous read preserves the prior projection rather than guessing.
+	local linked_prs_json="" projection=""
+	local -a release_args=()
+	[[ -z "$worker_login" ]] || release_args+=(--remove-assignee "$worker_login")
 	linked_prs_json=$(gh pr list --repo "$repo_slug" --state all \
 		--search "#${issue_num} in:body" \
-		--json number,state,body --limit 20 2>/dev/null || true)
-	if [[ -z "$linked_prs_json" ]]; then
-		linked_prs_json="[]"
-	fi
-	if printf '%s' "$linked_prs_json" | jq -e --arg num "$issue_num" \
-		'[.[] | select((.state == "OPEN" or .state == "MERGED") and ((.body // "") | test("(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]*#" + $num + "\\b"; "i")))] | length > 0' \
-		>/dev/null 2>&1; then
-		has_linked_pr=true
-	fi
-	linked_open_pr_numbers=$(printf '%s' "$linked_prs_json" | jq -r --arg num "$issue_num" \
-		'.[] | select(.state == "OPEN" and ((.body // "") | test("(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]*#" + $num + "\\b"; "i"))) | .number' \
-		2>/dev/null || true)
-	if [[ -n "$linked_open_pr_numbers" ]]; then
-		has_open_linked_pr=1
-	fi
-
-	local -a _flags=()
-	_flags+=(--remove-label "status:queued")
-	_flags+=(--remove-label "status:claimed")
-	_flags+=(--remove-label "status:in-progress")
-
-	if [[ "$has_linked_pr" != "true" ]]; then
-		_flags+=(--remove-label "status:in-review")
-		_flags+=(--add-label "status:available")
-		if [[ -n "$worker_login" ]]; then
-			_flags+=(--remove-assignee "$worker_login")
-		fi
-	elif [[ "$has_open_linked_pr" -eq 1 && ",${labels_json}," != *",status:done,"* ]]; then
-		_flags+=(--remove-label "status:available")
-		_flags+=(--add-label "status:in-review")
-	fi
-
-	gh issue edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null || return 1
-	if [[ "$has_open_linked_pr" -eq 1 ]]; then
-		local linked_pr_number=""
-		while IFS= read -r linked_pr_number; do
-			[[ -z "$linked_pr_number" ]] && continue
-			set_issue_status "$linked_pr_number" "$repo_slug" "in-review" >/dev/null 2>&1 || true
-		done <<<"$linked_open_pr_numbers"
-	fi
-	return 0
+		--json number,state,isDraft,body --limit 20 2>/dev/null) || return 1
+	projection=$(printf '%s' "$linked_prs_json" | jq -r --arg num "$issue_num" '
+		[.[] | select((.body // "") | test("(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]*#" + $num + "\\b"; "i"))]
+		| if length == 0 then "available"
+		elif ([.[] | select(.state == "OPEN")] | length) != 0 and
+			([.[] | select(.state == "OPEN")] | length) != 1 then "ambiguous"
+		elif any(.state == "OPEN" and .isDraft == true) then "blocked"
+		elif any(.state == "OPEN" and .isDraft == false) then "in-review"
+		elif any(.state == "MERGED") then "done"
+		else "available" end
+	' 2>/dev/null) || return 1
+	case "$projection" in
+	available)
+		set_issue_status "$issue_num" "$repo_slug" available \
+			${release_args[@]+"${release_args[@]}"} >/dev/null 2>&1
+		;;
+	blocked)
+		set_issue_status "$issue_num" "$repo_slug" blocked \
+			${release_args[@]+"${release_args[@]}"} >/dev/null 2>&1
+		;;
+	in-review)
+		set_issue_status "$issue_num" "$repo_slug" in-review >/dev/null 2>&1
+		;;
+	done)
+		set_issue_status "$issue_num" "$repo_slug" "done" >/dev/null 2>&1
+		;;
+	*) return 1 ;;
+	esac
+	return $?
 }
 
 # =============================================================================

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -464,11 +464,11 @@ _status_label_contract() {
 	printf '%s\t%s\t%s\n' \
 		"status:available" "0e8a16" "Task is available for claiming" \
 		"status:queued" "fbca04" "Worker dispatched, not yet started" \
-		"status:claimed" "f9d0c4" "Interactive session claimed this task" \
+		"status:claimed" "f9d0c4" "Interactive implementation is actively claimed" \
 		"status:in-progress" "1d76db" "Worker actively running" \
-		"status:in-review" "5319e7" "PR open, awaiting review/merge" \
+		"status:in-review" "5319e7" "Non-draft PR ready for review/merge" \
 		"status:done" "6f42c1" "Task is complete" \
-		"status:blocked" "d93f0b" "Waiting on blocker task"
+		"status:blocked" "d93f0b" "Partial work blocked; inspect reason and next action"
 	return 0
 }
 

--- a/.agents/scripts/terminal-blocker-circuit.sh
+++ b/.agents/scripts/terminal-blocker-circuit.sh
@@ -325,7 +325,7 @@ _terminal_blocker_recovery() {
 	[[ "$issue" =~ ^[0-9]+$ ]] || issue="$_TBC_UNKNOWN"
 	# Correlate attempts without publishing runner names or arbitrary env text.
 	attempt=$(_terminal_blocker_hash "${AIDEVOPS_ATTEMPT_ID:-${WORKER_SESSION_KEY:-unknown}}") || attempt="$_TBC_UNKNOWN"
-	printf 'Terminal blocker: reason=%s owner=%s task=%s attempt=%s.\nNext action: %s\nRaw evidence remains in protected worker telemetry.\n' \
+	printf 'Terminal blocker: reason=%s owner=%s task=%s attempt=%s.\nProjected state: status:blocked.\nNext action: %s\nRaw evidence remains in protected worker telemetry.\n' \
 		"$reason" "$owner" "$issue" "$attempt" "$action"
 	return 0
 }

--- a/.agents/scripts/terminal-blocker-circuit.sh
+++ b/.agents/scripts/terminal-blocker-circuit.sh
@@ -267,7 +267,7 @@ _terminal_blocker_recovery() {
 	[[ "$issue" =~ ^[0-9]+$ ]] || issue="$_TBC_UNKNOWN"
 	# Correlate attempts without publishing runner names or arbitrary env text.
 	attempt=$(_terminal_blocker_hash "${AIDEVOPS_ATTEMPT_ID:-${WORKER_SESSION_KEY:-unknown}}") || attempt="$_TBC_UNKNOWN"
-	printf 'Terminal blocker: reason=%s owner=%s task=%s attempt=%s.\nNext action: %s\nRaw evidence remains in protected worker telemetry.\n' \
+	printf 'Terminal blocker: reason=%s owner=%s task=%s attempt=%s.\nProjected state: status:blocked.\nNext action: %s\nRaw evidence remains in protected worker telemetry.\n' \
 		"$reason" "$owner" "$issue" "$attempt" "$action"
 	return 0
 }

--- a/.agents/scripts/tests/test-claim-release-label-mutation.sh
+++ b/.agents/scripts/tests/test-claim-release-label-mutation.sh
@@ -8,8 +8,7 @@
 #
 #   1. Removes the 4 active-lifecycle status labels (queued, claimed,
 #      in-progress, in-review) in a single gh issue edit call
-#   2. Preserves terminal states — NEVER emits --remove-label for
-#      status:done, status:blocked, or status:available
+#   2. Converges every core status to the fresh release projection
 #   3. Adds status:available when no linked PR owns the issue
 #   4. Removes the worker_login as assignee when provided
 #   5. Skips assignee mutation when worker_login is empty
@@ -67,13 +66,28 @@ export GH_VIEW_LABELS="${TEST_ROOT}/gh_view_labels.txt"
 write_stub_gh() {
 	: >"$GH_CALLS_FILE"
 	: >"$GH_VIEW_LABELS"
-	cat >"${STUB_DIR}/gh" <<'STUBEOF'
+cat >"${STUB_DIR}/gh" <<'STUBEOF'
 #!/usr/bin/env bash
 # Stub gh — serves `gh issue view --json labels` from GH_VIEW_LABELS,
 # and records all other calls to GH_CALLS_FILE.
+if [[ "$1" == "api" && "$2" == /repos/*/labels\?per_page=100 ]]; then
+	printf '%s\t%s\t%s\n' \
+		"status:available" "0e8a16" "Task is available for claiming" \
+		"status:queued" "fbca04" "Worker dispatched, not yet started" \
+		"status:claimed" "f9d0c4" "Interactive implementation is actively claimed" \
+		"status:in-progress" "1d76db" "Worker actively running" \
+		"status:in-review" "5319e7" "Non-draft PR ready for review/merge" \
+		"status:done" "6f42c1" "Task is complete" \
+		"status:blocked" "d93f0b" "Partial work blocked; inspect reason and next action"
+	exit 0
+fi
 if [[ "$1" == "issue" && "$2" == "view" ]]; then
 	# Emit whatever the test put in GH_VIEW_LABELS (jq output string form)
 	cat "${GH_VIEW_LABELS}" 2>/dev/null || true
+	exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+	printf '%s\n' '[]'
 	exit 0
 fi
 printf '%s\n' "$*" >>"${GH_CALLS_FILE}"
@@ -137,8 +151,8 @@ assert_grep "remove-label status:claimed" "removes status:claimed"
 assert_grep "remove-label status:in-progress" "removes status:in-progress"
 assert_grep "remove-label status:in-review" "removes status:in-review"
 assert_grep "add-label status:available" "adds status:available when no linked PR"
-assert_not_grep "remove-label status:done" "preserves status:done"
-assert_not_grep "remove-label status:blocked" "preserves status:blocked"
+assert_grep "remove-label status:done" "clears stale status:done"
+assert_grep "remove-label status:blocked" "clears stale status:blocked"
 assert_not_grep "remove-label status:available" "preserves status:available"
 
 # -------------------------------------------------------------------

--- a/.agents/scripts/tests/test-clear-active-status-on-release-preserves-merged-pr.sh
+++ b/.agents/scripts/tests/test-clear-active-status-on-release-preserves-merged-pr.sh
@@ -72,8 +72,19 @@ write_stub_gh() {
 	: >"$GH_CALLS_FILE"
 	: >"$GH_VIEW_LABELS"
 	: >"$GH_PR_LIST_JSON"
-	cat >"${STUB_DIR}/gh" <<'STUBEOF'
+cat >"${STUB_DIR}/gh" <<'STUBEOF'
 #!/usr/bin/env bash
+if [[ "$1" == "api" && "$2" == /repos/*/labels\?per_page=100 ]]; then
+	printf '%s\t%s\t%s\n' \
+		"status:available" "0e8a16" "Task is available for claiming" \
+		"status:queued" "fbca04" "Worker dispatched, not yet started" \
+		"status:claimed" "f9d0c4" "Interactive implementation is actively claimed" \
+		"status:in-progress" "1d76db" "Worker actively running" \
+		"status:in-review" "5319e7" "Non-draft PR ready for review/merge" \
+		"status:done" "6f42c1" "Task is complete" \
+		"status:blocked" "d93f0b" "Partial work blocked; inspect reason and next action"
+	exit 0
+fi
 if [[ "$1" == "issue" && "$2" == "view" ]]; then
 	cat "${GH_VIEW_LABELS}" 2>/dev/null || true
 	exit 0
@@ -133,7 +144,7 @@ clear_active_status_on_release 20520 owner/repo alice
 assert_grep "remove-label status:queued" "removes queued when PR merged"
 assert_grep "remove-label status:claimed" "removes claimed when PR merged"
 assert_grep "remove-label status:in-progress" "removes in-progress when PR merged"
-assert_not_grep "remove-label status:in-review" "preserves in-review when PR merged (Resolves)"
+assert_grep "add-label status:done" "projects merged PR as done (Resolves)"
 assert_not_grep "remove-assignee" "preserves assignee when PR merged (Resolves)"
 
 # -------------------------------------------------------------------
@@ -142,7 +153,7 @@ assert_not_grep "remove-assignee" "preserves assignee when PR merged (Resolves)"
 reset_stub
 printf '[{"number":99,"state":"MERGED","body":"Fixes #20520 end-to-end."}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20520 owner/repo alice
-assert_not_grep "remove-label status:in-review" "preserves in-review when PR merged (Fixes)"
+assert_grep "add-label status:done" "projects merged PR as done (Fixes)"
 assert_not_grep "remove-assignee" "preserves assignee when PR merged (Fixes)"
 
 # -------------------------------------------------------------------
@@ -212,7 +223,7 @@ reset_stub
 printf '[{"number":7,"state":"MERGED","body":"Resolves #20520"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20520 owner/repo ""
 assert_not_grep "remove-assignee" "no assignee call when worker_login empty (merged PR)"
-assert_not_grep "remove-label status:in-review" "preserves in-review with empty worker_login (merged PR)"
+assert_grep "add-label status:done" "projects merged PR as done with empty worker_login"
 assert_grep "remove-label status:queued" "still removes queued with empty worker_login (merged PR)"
 
 # -------------------------------------------------------------------

--- a/.agents/scripts/tests/test-clear-active-status-on-release-preserves-pr.sh
+++ b/.agents/scripts/tests/test-clear-active-status-on-release-preserves-pr.sh
@@ -66,13 +66,25 @@ write_stub_gh() {
 	: >"$GH_CALLS_FILE"
 	: >"$GH_VIEW_LABELS"
 	: >"$GH_PR_LIST_JSON"
-	cat >"${STUB_DIR}/gh" <<'STUBEOF'
+cat >"${STUB_DIR}/gh" <<'STUBEOF'
 #!/usr/bin/env bash
+if [[ "$1" == "api" && "$2" == /repos/*/labels\?per_page=100 ]]; then
+	printf '%s\t%s\t%s\n' \
+		"status:available" "0e8a16" "Task is available for claiming" \
+		"status:queued" "fbca04" "Worker dispatched, not yet started" \
+		"status:claimed" "f9d0c4" "Interactive implementation is actively claimed" \
+		"status:in-progress" "1d76db" "Worker actively running" \
+		"status:in-review" "5319e7" "Non-draft PR ready for review/merge" \
+		"status:done" "6f42c1" "Task is complete" \
+		"status:blocked" "d93f0b" "Partial work blocked; inspect reason and next action"
+	exit 0
+fi
 if [[ "$1" == "issue" && "$2" == "view" ]]; then
 	cat "${GH_VIEW_LABELS}" 2>/dev/null || true
 	exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
+	[[ "${GH_PR_LIST_FAIL:-0}" == "1" ]] && exit 1
 	cat "${GH_PR_LIST_JSON}" 2>/dev/null || true
 	exit 0
 fi
@@ -122,22 +134,39 @@ assert_not_grep() {
 # Case 1: Resolves #N in body → preserve assignee + in-review
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":20188,"state":"OPEN","body":"Some description.\\n\\nResolves #20156"}]' >"$GH_PR_LIST_JSON"
+	printf '[{"number":20188,"state":"OPEN","isDraft":false,"body":"Some description.\\n\\nResolves #20156"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_grep "remove-label status:queued" "removes queued when PR open"
 assert_grep "remove-label status:claimed" "removes claimed when PR open"
 assert_grep "remove-label status:in-progress" "removes in-progress when PR open"
 assert_grep "remove-label status:available" "removes available when PR open"
 assert_grep "add-label status:in-review" "ensures issue in-review when PR open"
-assert_grep "issue edit 20188 --repo owner/repo" "normalizes linked PR status when PR open"
+assert_not_grep "issue edit 20188 --repo owner/repo" "does not label an already-ready PR"
 assert_not_grep "remove-label status:in-review" "preserves in-review when PR open (Resolves)"
 assert_not_grep "remove-assignee" "preserves assignee when PR open (Resolves)"
+
+# -------------------------------------------------------------------
+# Case 1b: open draft checkpoint is blocked, released, and never review-ready
+# -------------------------------------------------------------------
+reset_stub
+printf '[{"number":20189,"state":"OPEN","isDraft":true,"body":"Resolves #20156"}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20156 owner/repo alice
+assert_grep "add-label status:blocked" "projects open draft as blocked partial work"
+assert_grep "remove-assignee alice" "releases draft checkpoint owner"
+assert_not_grep "add-label status:in-review" "draft checkpoint is never review-ready"
+
+# -------------------------------------------------------------------
+# Case 1c: unavailable PR metadata preserves the prior projection
+# -------------------------------------------------------------------
+reset_stub
+GH_PR_LIST_FAIL=1 clear_active_status_on_release 20156 owner/repo alice
+assert_not_grep "issue edit" "unreadable PR metadata performs no lifecycle write"
 
 # -------------------------------------------------------------------
 # Case 2: Fixes #N in body → preserve assignee + in-review
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":99,"state":"OPEN","body":"Fixes #20156 and adds coverage."}]' >"$GH_PR_LIST_JSON"
+	printf '[{"number":99,"state":"OPEN","isDraft":false,"body":"Fixes #20156 and adds coverage."}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_not_grep "remove-label status:in-review" "preserves in-review when PR open (Fixes)"
 assert_not_grep "remove-assignee" "preserves assignee when PR open (Fixes)"
@@ -146,7 +175,7 @@ assert_not_grep "remove-assignee" "preserves assignee when PR open (Fixes)"
 # Case 3: Closes #N in body → preserve assignee + in-review
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":42,"state":"OPEN","body":"closes #20156"}]' >"$GH_PR_LIST_JSON"
+	printf '[{"number":42,"state":"OPEN","isDraft":false,"body":"closes #20156"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_not_grep "remove-label status:in-review" "preserves in-review when PR open (closes, lowercase)"
 assert_not_grep "remove-assignee" "preserves assignee when PR open (closes, lowercase)"
@@ -155,7 +184,7 @@ assert_not_grep "remove-assignee" "preserves assignee when PR open (closes, lowe
 # Case 4: Case-insensitive keyword matching (RESOLVES, FIXES, CLOSES)
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":7,"state":"OPEN","body":"RESOLVES #20156"}]' >"$GH_PR_LIST_JSON"
+	printf '[{"number":7,"state":"OPEN","isDraft":false,"body":"RESOLVES #20156"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_not_grep "remove-assignee" "case-insensitive RESOLVES preserves assignee"
 
@@ -164,7 +193,7 @@ assert_not_grep "remove-assignee" "case-insensitive RESOLVES preserves assignee"
 #         still preserves in-review
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":7,"state":"OPEN","body":"Resolves #20156"}]' >"$GH_PR_LIST_JSON"
+	printf '[{"number":7,"state":"OPEN","isDraft":false,"body":"Resolves #20156"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo ""
 assert_not_grep "remove-assignee" "no assignee call when worker_login empty"
 assert_not_grep "remove-label status:in-review" "preserves in-review with empty worker_login"

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -114,11 +114,11 @@ auth)
 			printf '%s\t%s\t%s\n' \
 				"status:available" "0e8a16" "Task is available for claiming" \
 				"status:queued" "fbca04" "Worker dispatched, not yet started" \
-				"status:claimed" "f9d0c4" "Interactive session claimed this task" \
+				"status:claimed" "f9d0c4" "Interactive implementation is actively claimed" \
 				"status:in-progress" "1d76db" "Worker actively running" \
-				"status:in-review" "5319e7" "PR open, awaiting review/merge" \
+				"status:in-review" "5319e7" "Non-draft PR ready for review/merge" \
 				"status:done" "6f42c1" "Task is complete" \
-				"status:blocked" "d93f0b" "Waiting on blocker task"
+				"status:blocked" "d93f0b" "Partial work blocked; inspect reason and next action"
 			exit 0
 		fi
 		if [[ "$2" == /repos/*/issues/* ]]; then
@@ -129,9 +129,12 @@ auth)
 				exit 0
 			fi
 			labels_arr=""
-			if [[ "${STUB_ISSUE_HAS_IN_REVIEW:-0}" == "1" ]]; then
-				labels_arr='{"name":"status:in-review"}'
-			fi
+		if [[ "${STUB_ISSUE_HAS_IN_REVIEW:-0}" == "1" ]]; then
+			labels_arr='{"name":"status:in-review"}'
+		fi
+		if [[ "${STUB_ISSUE_HAS_CLAIMED:-0}" == "1" ]]; then
+			labels_arr="${labels_arr:+$labels_arr,}{\"name\":\"status:claimed\"}"
+		fi
 			if [[ "${STUB_ISSUE_HAS_AUTO_DISPATCH:-0}" == "1" ]]; then
 				labels_arr="${labels_arr:+$labels_arr,}{\"name\":\"auto-dispatch\"}"
 			fi
@@ -192,6 +195,9 @@ issue)
 		labels_arr=""
 		if [[ "${STUB_ISSUE_HAS_IN_REVIEW:-0}" == "1" ]]; then
 			labels_arr="${labels_arr:+$labels_arr,}{\"name\":\"status:in-review\"}"
+		fi
+		if [[ "${STUB_ISSUE_HAS_CLAIMED:-0}" == "1" ]]; then
+			labels_arr="${labels_arr:+$labels_arr,}{\"name\":\"status:claimed\"}"
 		fi
 		if [[ "${STUB_ISSUE_HAS_AUTO_DISPATCH:-0}" == "1" ]]; then
 			labels_arr="${labels_arr:+$labels_arr,}{\"name\":\"auto-dispatch\"}"
@@ -687,10 +693,10 @@ fi
 # Verify the label-apply branch actually ran (gh issue edit was called with
 # the add-label flag). This closes the test gap where Test 1 only checks the
 # stamp, not whether the label transition API call happened.
-if grep -q 'issue edit 56001' "$STUB_LOG" && grep -q 'add-label status:in-review' "$STUB_LOG"; then
-	print_result "GH#18786: claim applies status:in-review when absent" 0
+if grep -q 'issue edit 56001' "$STUB_LOG" && grep -q 'add-label status:claimed' "$STUB_LOG"; then
+	print_result "GH#18786: claim applies status:claimed when absent" 0
 else
-	print_result "GH#18786: claim applies status:in-review when absent" 1 \
+	print_result "GH#18786: claim applies status:claimed when absent" 1 \
 		"(stub log: $(tr '\n' '|' <"$STUB_LOG"))"
 fi
 
@@ -698,7 +704,7 @@ fi
 rm -f "${claim_dir}"/*.json 2>/dev/null || true
 : >"$STUB_LOG"
 
-idempotent_out=$(STUB_ISSUE_HAS_IN_REVIEW=1 STUB_GH_MODE=online \
+idempotent_out=$(STUB_ISSUE_HAS_CLAIMED=1 STUB_GH_MODE=online \
 	"$HELPER_PATH" claim 56001 regress/test --worktree /tmp/regress-wt \
 	2>&1)
 idempotent_rc=$?
@@ -791,22 +797,22 @@ else
 		"(rc=$release_sub_rc, stamp exists=$([[ -f "$release_stamp" ]] && echo yes || echo no))"
 fi
 
-# --- Case (f): _isc_has_in_review jq query is not broken (dead-code gate) ---
+# --- Case (f): _isc_has_claimed jq query is not broken (dead-code gate) ---
 # The previous `any(.name; ...)` form raised "Cannot index array with string".
 # Assert the repaired query correctly distinguishes present from absent and
 # from lookup-failure by driving _isc_has_in_review directly with stub modes.
-export STUB_ISSUE_HAS_IN_REVIEW=1
-_isc_has_in_review 56003 regress/test
+export STUB_ISSUE_HAS_CLAIMED=1
+_isc_has_claimed 56003 regress/test
 jq_present_rc=$?
 
-export STUB_ISSUE_HAS_IN_REVIEW=0
-_isc_has_in_review 56003 regress/test
+export STUB_ISSUE_HAS_CLAIMED=0
+_isc_has_claimed 56003 regress/test
 jq_absent_rc=$?
 
 if [[ $jq_present_rc -eq 0 && $jq_absent_rc -eq 1 ]]; then
-	print_result "GH#18786: _isc_has_in_review jq query returns 0/1 correctly" 0
+	print_result "GH#18786: _isc_has_claimed jq query returns 0/1 correctly" 0
 else
-	print_result "GH#18786: _isc_has_in_review jq query returns 0/1 correctly" 1 \
+	print_result "GH#18786: _isc_has_claimed jq query returns 0/1 correctly" 1 \
 		"(present_rc=$jq_present_rc, absent_rc=$jq_absent_rc, expected 0/1)"
 fi
 
@@ -943,7 +949,7 @@ ad_impl_stamp="${claim_dir}/carveout-test-60002.json"
 
 if [[ $ad_impl_rc -eq 0 && -f "$ad_impl_stamp" ]] &&
 	grep -q 'issue edit 60002' "$STUB_LOG" &&
-	grep -q 'add-label status:in-review' "$STUB_LOG"; then
+	grep -q 'add-label status:claimed' "$STUB_LOG"; then
 	print_result "GH#20946: auto-dispatch claim WITH --implementing proceeds" 0
 else
 	print_result "GH#20946: auto-dispatch claim WITH --implementing proceeds" 1 \
@@ -970,7 +976,7 @@ ad_pt_stamp="${claim_dir}/carveout-test-60003.json"
 
 if [[ $ad_pt_rc -eq 0 && -f "$ad_pt_stamp" ]] &&
 	grep -q 'issue edit 60003' "$STUB_LOG" &&
-	grep -q 'add-label status:in-review' "$STUB_LOG"; then
+	grep -q 'add-label status:claimed' "$STUB_LOG"; then
 	print_result "GH#20946: auto-dispatch + parent-task claim proceeds (no flag)" 0
 else
 	print_result "GH#20946: auto-dispatch + parent-task claim proceeds (no flag)" 1 \
@@ -1149,7 +1155,7 @@ export STUB_PERMISSION=admin
 export STUB_GH_MODE=online
 _isc_cmd_claim 70001 testowner/testrepo --worktree /tmp/wt-fake >/dev/null 2>&1
 : >"$STUB_LOG"
-export STUB_ISSUE_HAS_IN_REVIEW=1
+export STUB_ISSUE_HAS_CLAIMED=1
 export STUB_ISSUE_STATE=OPEN
 _isc_cmd_release 70001 testowner/testrepo >/dev/null 2>&1
 release_open_rc=$?
@@ -1169,7 +1175,7 @@ fi
 # =============================================================================
 _isc_cmd_claim 70002 testowner/testrepo --worktree /tmp/wt-fake >/dev/null 2>&1
 : >"$STUB_LOG"
-export STUB_ISSUE_HAS_IN_REVIEW=1
+export STUB_ISSUE_HAS_CLAIMED=1
 export STUB_ISSUE_STATE=CLOSED
 _isc_cmd_release 70002 testowner/testrepo >/dev/null 2>&1
 release_closed_rc=$?
@@ -1188,7 +1194,7 @@ fi
 # same closed-issue invariant when that path supplies `closed` (GH#27869).
 _isc_cmd_claim 70004 testowner/testrepo --worktree /tmp/wt-fake >/dev/null 2>&1
 : >"$STUB_LOG"
-export STUB_ISSUE_HAS_IN_REVIEW=1
+export STUB_ISSUE_HAS_CLAIMED=1
 export STUB_ISSUE_STATE=closed
 _isc_cmd_release 70004 testowner/testrepo >/dev/null 2>&1
 release_rest_closed_rc=$?
@@ -1203,7 +1209,7 @@ else
 fi
 
 # Reset stub state
-export STUB_ISSUE_HAS_IN_REVIEW=0
+export STUB_ISSUE_HAS_CLAIMED=0
 
 # =============================================================================
 # Test 25 — GH#27834: release --unassign remains actionable after another

--- a/.agents/scripts/tests/test-pr-checkpoint-continuation-helper.sh
+++ b/.agents/scripts/tests/test-pr-checkpoint-continuation-helper.sh
@@ -263,7 +263,7 @@ STUB_ISSUE_JSON="$(valid_issue_json '' 'stale-runner')"
 STATUS_CALLS=""
 DISPATCH_RESULT=0
 if _pcc_dispatch "owner/repo" "${TEST_ROOT}/repo" "42" "123" "stale-runner" "current-runner" >/dev/null &&
-	[[ "$STATUS_CALLS" == '123 owner/repo in-review --add-assignee current-runner --remove-assignee stale-runner' ]] &&
+	[[ "$STATUS_CALLS" == '123 owner/repo in-progress --add-assignee current-runner --remove-assignee stale-runner' ]] &&
 	[[ "$PCC_ISSUE_ASSIGNEE" == "current-runner" ]] &&
 	[[ "$(_prrts_worker_login 42)" == "current-runner" ]]; then
 	print_result "cross-runner continuation transfers exact issue ownership before launch" 0
@@ -276,7 +276,7 @@ STUB_ISSUE_JSON="$(valid_issue_json '[{"name":"status:queued"}]' 'stale-runner')
 STATUS_CALLS=""
 DISPATCH_RESULT=1
 if ! _pcc_dispatch "owner/repo" "${TEST_ROOT}/repo" "42" "123" "stale-runner" "current-runner" >/dev/null &&
-	[[ "$STATUS_CALLS" == $'123 owner/repo in-review --add-assignee current-runner --remove-assignee stale-runner\n123 owner/repo queued --add-assignee stale-runner --remove-assignee current-runner' ]] &&
+	[[ "$STATUS_CALLS" == $'123 owner/repo in-progress --add-assignee current-runner --remove-assignee stale-runner\n123 owner/repo queued --add-assignee stale-runner --remove-assignee current-runner' ]] &&
 	[[ "$PCC_ISSUE_ASSIGNEE" == "stale-runner" && "$PCC_OWNERSHIP_TRANSFERRED" -eq 0 ]] &&
 	printf '%s' "$STUB_ISSUE_JSON" | jq -e '
 		.assignees[0].login == "stale-runner" and

--- a/.agents/scripts/tests/test-status-label-state-machine.sh
+++ b/.agents/scripts/tests/test-status-label-state-machine.sh
@@ -129,12 +129,12 @@ if [[ "${1:-}" == "api" && "${2:-}" == /repos/*/labels\?per_page=100 ]]; then
 	printf '%s\t%s\t%s\n' \
 		"status:available" "0e8a16" "Task is available for claiming" \
 		"status:queued" "fbca04" "Worker dispatched, not yet started" \
-		"status:claimed" "f9d0c4" "Interactive session claimed this task" \
+		"status:claimed" "f9d0c4" "Interactive implementation is actively claimed" \
 		"status:in-progress" "1d76db" "Worker actively running" \
-		"status:in-review" "5319e7" "PR open, awaiting review/merge" \
+		"status:in-review" "5319e7" "Non-draft PR ready for review/merge" \
 		"status:done" "6f42c1" "Task is complete"
 	if [[ -f "${STATUS_LABEL_STATE_FILE}" || "${STUB_LABEL_MODE:-exact}" == "exact" ]]; then
-		printf '%s\t%s\t%s\n' "status:blocked" "d93f0b" "Waiting on blocker task"
+		printf '%s\t%s\t%s\n' "status:blocked" "d93f0b" "Partial work blocked; inspect reason and next action"
 	elif [[ "${STUB_LABEL_MODE:-exact}" == "drifted" ]]; then
 		printf '%s\t%s\t%s\n' "status:blocked" "ffffff" "Drifted definition"
 	fi

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -74,7 +74,7 @@ Extract first positional arg; if ` -- ` present, use suffix (t158). Resolve `t\d
 
 **Implementation context (t1901):** Read issue body's "Worker Guidance"/"How" section first. When present, follow file paths, implementation steps, and verification commands directly. When absent or incomplete, do not stop by default: do bounded discovery from the issue title/body, search exact error terms, inspect likely target files, and proceed if the problem is actionable. Exit `BLOCKED` for "missing implementation context" only when the issue is too vague to identify expected behavior, target area, or safe verification after bounded discovery. Headless runtime treats that exact blocker as recoverable once: it resumes the session with a brief-recovery prompt to improve the linked issue body and retry before recording `BLOCKED`.
 
-- **Interactive claim (t2056 — STRUCTURAL):** `full-loop-helper.sh start` automatically calls `interactive-session-helper.sh claim` for non-headless sessions when an issue number is present in the prompt. The helper first verifies maintainer-equivalent repo access; managed repos get `status:in-review` + self-assignment + a claim comment to block pulse dispatch, while external upstream repos skip claim/label/comment routines and should use the normal PR contribution flow.
+- **Interactive claim (t2056 — STRUCTURAL):** `full-loop-helper.sh start` automatically calls `interactive-session-helper.sh claim` for non-headless sessions when an issue number is present in the prompt. The helper first verifies maintainer-equivalent repo access; managed repos get `status:claimed` + self-assignment + a claim comment to block pulse dispatch, while external upstream repos skip claim/label/comment routines and should use the normal PR contribution flow.
 - **Maintainer gate pre-check (GH#17810/GH#22854 — MANDATORY):** Verify issue is not blocked by `hold-for-review` or structural dispatch blockers. `needs-maintainer-review` remains a non-maintainer trust gate: headless workers block on it, while OWNER/MEMBER interactive sessions may continue only when the issue author and all comments are maintainer-only. Headless workers must also verify the issue has an assignee. OWNER/MEMBER interactive sessions on managed repos treat a missing assignee as actionable state: `full-loop-helper.sh start` claims/self-assigns the open issue and continues. External upstream repos do not use the maintainer gate/claim routine. Exit BLOCKED only for the enforced gate in the current mode.
 - **Approval freshness:** Before reporting that cryptographic approval is missing or requesting another signature, run `approval-helper.sh verify issue <number> <owner/repo>` against current GitHub state. Do not infer approval from cached labels or local `sudo` availability.
 - **Decomposition (t1408.2):** Skip if `--no-decompose` or has subtasks. `task-decompose-helper.sh classify "$TASK_DESC"`. Composite headless → auto-decompose, exit `DECOMPOSED: ...`. Max depth 3.
@@ -96,7 +96,7 @@ entrypoint instead of calling `full-loop-helper.sh start` directly:
 ```
 
 This route keeps worker-ready issues eligible for `auto-dispatch` while the
-temporary `status:in-review` + assignee claim blocks concurrent pickup. Release
+temporary `status:claimed` + assignee claim blocks concurrent pickup. Release
 with unassignment restores automatic continuation when unfinished work remains.
 Do not add `no-auto-dispatch` merely because implementation starts interactively;
 reserve `lockdown` for an explicit durable hold or whole-pulse insulation.

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -61,7 +61,7 @@ Extract first positional arg; if ` -- ` present, use suffix (t158). Resolve `t\d
 
 **Implementation context (t1901):** Read issue body's "Worker Guidance"/"How" section first. When present, follow file paths, implementation steps, and verification commands directly. When absent or incomplete, do not stop by default: do bounded discovery from the issue title/body, search exact error terms, inspect likely target files, and proceed if the problem is actionable. Exit `BLOCKED` for "missing implementation context" only when the issue is too vague to identify expected behavior, target area, or safe verification after bounded discovery. Headless runtime treats that exact blocker as recoverable once: it resumes the session with a brief-recovery prompt to improve the linked issue body and retry before recording `BLOCKED`.
 
-- **Interactive claim (t2056 — STRUCTURAL):** `full-loop-helper.sh start` automatically calls `interactive-session-helper.sh claim` for non-headless sessions when an issue number is present in the prompt. The helper first verifies maintainer-equivalent repo access; managed repos get `status:in-review` + self-assignment + a claim comment to block pulse dispatch, while external upstream repos skip claim/label/comment routines and should use the normal PR contribution flow.
+- **Interactive claim (t2056 — STRUCTURAL):** `full-loop-helper.sh start` automatically calls `interactive-session-helper.sh claim` for non-headless sessions when an issue number is present in the prompt. The helper first verifies maintainer-equivalent repo access; managed repos get `status:claimed` + self-assignment + a claim comment to block pulse dispatch, while external upstream repos skip claim/label/comment routines and should use the normal PR contribution flow.
 - **Maintainer gate pre-check (GH#17810/GH#22854 — MANDATORY):** Verify issue is not blocked by `hold-for-review` or structural dispatch blockers. `needs-maintainer-review` remains a non-maintainer trust gate: headless workers block on it, while OWNER/MEMBER interactive sessions may continue only when the issue author and all comments are maintainer-only. Headless workers must also verify the issue has an assignee. OWNER/MEMBER interactive sessions on managed repos treat a missing assignee as actionable state: `full-loop-helper.sh start` claims/self-assigns the open issue and continues. External upstream repos do not use the maintainer gate/claim routine. Exit BLOCKED only for the enforced gate in the current mode.
 - **Approval freshness:** Before reporting that cryptographic approval is missing or requesting another signature, run `approval-helper.sh verify issue <number> <owner/repo>` against current GitHub state. Do not infer approval from cached labels or local `sudo` availability.
 - **Decomposition (t1408.2):** Skip if `--no-decompose` or has subtasks. `task-decompose-helper.sh classify "$TASK_DESC"`. Composite headless → auto-decompose, exit `DECOMPOSED: ...`. Max depth 3.
@@ -83,7 +83,7 @@ entrypoint instead of calling `full-loop-helper.sh start` directly:
 ```
 
 This route keeps worker-ready issues eligible for `auto-dispatch` while the
-temporary `status:in-review` + assignee claim blocks concurrent pickup. Release
+temporary `status:claimed` + assignee claim blocks concurrent pickup. Release
 with unassignment restores automatic continuation when unfinished work remains.
 Do not add `no-auto-dispatch` merely because implementation starts interactively;
 reserve `lockdown` for an explicit durable hold or whole-pulse insulation.

--- a/todo/tasks/issue-31301-brief.md
+++ b/todo/tasks/issue-31301-brief.md
@@ -1,0 +1,50 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+## What
+
+Make issue-list labels distinguish active implementation, a blocked partial draft, executable continuation, and genuine review-ready work.
+
+## Why
+
+A draft checkpoint and active interactive claim must not appear review-ready. State projection must preserve #31265 authenticated exact-draft continuation and must not affect #31241.
+
+## How
+
+Use existing lifecycle labels only: `status:claimed` / `status:in-progress` for active ownership, `status:blocked` for an evidenced partial checkpoint with its existing reason/action evidence, `status:available` for a verified executable continuation, and `status:in-review` only for an open non-draft PR ready for review. Keep assignment-plus-active-state dedup, all trust/hold gates, fresh evidence fences, idempotency, and conservative handling of unavailable reads. Never infer current state from prose or timestamps, broadly relabel live work, or turn a corrected body into permission to clear a security/authority hold.
+
+### Files Scope
+
+- `.agents/scripts/dispatch-dedup-stale.sh`
+- `.agents/scripts/shared-constants.sh`
+- `.agents/scripts/shared-gh-wrappers-status.sh`
+- `.agents/scripts/managed-label-provisioning-lib.sh`
+- `.agents/scripts/label-sync-helper.sh`
+- `.agents/reference/task-lifecycle.md`
+- `.agents/reference/dispatch-blockers.md`
+- `.agents/reference/auto-dispatch.md`
+- `.agents/reference/worker-discipline.md`
+- `.agents/scripts/commands/full-loop.md`
+- `.agents/scripts/interactive-session-helper.sh`
+- `.agents/scripts/interactive-session-helper-commands.sh`
+- `.agents/scripts/terminal-blocker-circuit.sh`
+- `.agents/scripts/headless-runtime-failure.sh`
+- `.agents/scripts/dispatch-claim-helper.sh`
+- `.agents/scripts/pr-checkpoint-target-lib.sh`
+- `.agents/scripts/pr-checkpoint-continuation-helper.sh`
+- Existing lifecycle test fixtures covering claims, release, checkpoint continuation, stale PR continuation, status labels, and revision validation.
+
+## Acceptance
+
+- [ ] Labels alone distinguish active implementation, blocked partial work, executable continuation, and non-draft review-ready work.
+- [ ] Blocked states retain a minimal evidence-backed next action; verified correction and continuation clear only stale blockers.
+- [ ] Relabelling cannot release a live claim, bypass approval, dispatch a duplicate, or mark an incomplete draft review-ready.
+- [ ] Fresh reads make transitions idempotent; unknown reads preserve the prior projection.
+- [ ] Existing labels are reused and historical contradictions are handled per issue without a blanket migration.
+
+## Verification
+
+Extend mocked claim/release and checkpoint-continuation suites for blocked-to-corrected-to-continuation, live-owner race, unavailable read, draft-ready, and merge. Assert issue-label projection and unchanged dispatch authority at each step. Run focused ShellCheck and affected tests. No release.
+
+<!-- aidevops:origin:interactive -->
+<!-- aidevops:sig -->


### PR DESCRIPTION
## Summary

- Distinguish active implementation, blocked draft checkpoints, executable continuations, and non-draft review-ready PRs using the existing lifecycle labels.
- Project lifecycle state from fresh linked-PR metadata and preserve state on unreadable or ambiguous data.
- Keep exact-head checkpoint approval, assignment, and hold protections intact across handoff and release.
- Replace stale-base PR #31363 with the same verified implementation on a fresh `main` comparison.

## Verification

- `.agents/scripts/linters-local.sh --changed`
- Focused ShellCheck across all changed shell files
- `.agents/scripts/tests/test-status-label-state-machine.sh`
- `.agents/scripts/tests/test-claim-release-label-mutation.sh`
- `.agents/scripts/tests/test-clear-active-status-on-release-preserves-pr.sh`
- `.agents/scripts/tests/test-clear-active-status-on-release-preserves-merged-pr.sh`
- `.agents/scripts/tests/test-interactive-session-claim.sh`
- `.agents/scripts/tests/test-pr-checkpoint-continuation-helper.sh`
- `python3 .agents/scripts/tests/test-pr-checkpoint-revision.py`

## Runtime Testing

Self-assessed with mocked lifecycle transitions and exact-state regression suites; no live repository migration or broad relabelling is performed.

Resolves #31301

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.319 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 28m and 692,857 tokens on this as a headless worker.
