### PR TITLE
GH#31442: reconcile attributed GitHub quota state

### DIFF
--- a/.agents/reference/github-api-transport.md
+++ b/.agents/reference/github-api-transport.md
@@ -109,6 +109,16 @@ child environment; credentials are never exported to a long-lived parent.
   Multiple PATs for that owner share an allowance. Unresolved callers share a
   conservative host scope. This is local coordination, **not distributed fleet
   admission**. Permission-scoped cache identity remains a separate concern.
+- Status reports the number of bound credentials and an anonymous ambiguity
+  reason. It never exposes credential fingerprints or owner values. When a
+  previously unresolved scope retains stale evidence, stop all local GitHub
+  requests, set one trusted owner consistently for every caller using that state,
+  then run `python3 .agents/scripts/gh_transport_budget.py reconcile`. Reconciliation refuses
+  active or uncertain requests, preserves live server cooldowns, reverses the
+  unresolved alias into the configured owner, and makes the next normal GET the
+  single serialized source of fresh quota. It is idempotent and cannot be used
+  repeatedly or with a different owner to discard attributed pacing evidence.
+  Do not use it to combine credentials belonging to different GitHub users or installations.
 
 Mutations, streamed inputs, inherited file descriptors, anonymous requests,
 GraphQL, interactive terminals and unsupported CLI shapes retain native

--- a/.agents/scripts/gh-transport-governor.py
+++ b/.agents/scripts/gh-transport-governor.py
@@ -23,7 +23,7 @@ import tempfile
 import time
 from pathlib import Path
 
-from gh_transport_budget import Budget, Deferred, credential_identity, private_directory, scope_key
+from gh_transport_budget import Budget, Deferred, credential_identity, private_directory, quota_owner, scope_key
 
 
 VALUE_FLAGS = {
@@ -227,7 +227,8 @@ def run(metadata: Path, executable: str, args: list[str]) -> int:
             # Do not mix anonymous-IP and authenticated-user allowances or
             # trust an identity which could change before native execution.
             return 125
-        budget = Budget(directory, scope_key(host), credential)
+        owner, attributed = quota_owner()
+        budget = Budget(directory, scope_key(host, owner), credential, attributed=attributed)
         reservation = _acquire(budget, resource)
         with tempfile.TemporaryFile(dir=temp_dir) as output:
             native_args = args if include else [*args, "--include"]

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -42,10 +42,19 @@ def private_directory(path: Path) -> None:
     path.chmod(0o700)
 
 
-def scope_key(host: str) -> str:
+def quota_owner() -> tuple[str, bool]:
+    owner = os.environ.get("AIDEVOPS_GH_QUOTA_OWNER", "")
+    if not owner or owner == "unresolved":
+        return "unresolved", False
+    if "\0" in owner or len(owner) > 256:
+        raise ValueError("invalid GitHub quota owner")
+    return owner, True
+
+
+def scope_key(host: str, owner: str | None = None) -> str:
     # Only trusted launch context may name a quota owner. A credential digest is
     # not a quota owner: two PATs can spend the same user's allowance.
-    owner = os.environ.get("AIDEVOPS_GH_QUOTA_OWNER", "unresolved")
+    owner = quota_owner()[0] if owner is None else owner
     return hashlib.sha256(f"{host}\0{owner}".encode()).hexdigest()
 
 
@@ -80,7 +89,8 @@ def process_birth(pid: int) -> str:
 
 
 class Budget:
-    def __init__(self, directory: Path, scope: str, credential: str | None = None):
+    def __init__(self, directory: Path, scope: str, credential: str | None = None,
+                 *, attributed: bool = False):
         private_directory(directory)
         self.path = directory / "admission.sqlite3"
         if self.path.is_symlink():
@@ -93,8 +103,10 @@ class Budget:
             raise ValueError("transport state file is not owned by this user")
         self.path.chmod(0o600)
         self.db = sqlite3.connect(self.path, timeout=2, isolation_level=None)
+        requested_scope = scope
         self.scope = scope
         self.credential = credential or scope
+        self.attributed = False
         self.birth = process_birth(os.getpid())
         self.db.executescript("""
             CREATE TABLE IF NOT EXISTS quota (
@@ -121,9 +133,14 @@ class Budget:
                 scope TEXT NOT NULL, resource TEXT NOT NULL, reset REAL NOT NULL,
                 retry_at REAL NOT NULL, remaining INTEGER NOT NULL,
                 PRIMARY KEY(scope, resource));
+            CREATE TABLE IF NOT EXISTS reconciliation (
+                source TEXT PRIMARY KEY, owner TEXT NOT NULL, reconciled REAL NOT NULL);
         """)
         with self.transaction():
             self._bind_scope()
+        # A configured owner is authoritative only after its requested scope is
+        # canonical. A legacy owner->unresolved alias still needs reconciliation.
+        self.attributed = attributed and self.scope == requested_scope
 
     def _root(self, scope: str) -> str:
         for _ in range(256):
@@ -296,12 +313,136 @@ class Budget:
         self.db.close()
 
 
+def _scope_root(db, scope: str) -> str:
+    for _ in range(256):
+        row = db.execute("SELECT target FROM alias WHERE scope=?", (scope,)).fetchone()
+        if not row:
+            return scope
+        scope = row[0]
+    raise ValueError("quota scope alias cycle")
+
+
+def reconcile_scope(directory: Path, unresolved_scope: str, owner_scope: str,
+                    *, now: float | None = None) -> dict:
+    """Replace ambiguous local evidence with one attributed bootstrap boundary."""
+    if unresolved_scope == owner_scope:
+        raise ValueError("a configured GitHub quota owner is required")
+    now = time.time() if now is None else now
+    private_directory(directory)
+    path = directory / "admission.sqlite3"
+    if not path.is_file() or path.is_symlink():
+        return {"state": "no_state"}
+    if path.stat().st_uid != os.getuid():
+        raise ValueError("transport state file is not owned by this user")
+    db = sqlite3.connect(path, timeout=2, isolation_level=None)
+    try:
+        db.execute("BEGIN IMMEDIATE")
+        db.execute("CREATE TABLE IF NOT EXISTS reconciliation ("
+                   "source TEXT PRIMARY KEY,owner TEXT NOT NULL,reconciled REAL NOT NULL)")
+        receipt = db.execute(
+            "SELECT owner FROM reconciliation WHERE source=?", (unresolved_scope,)
+        ).fetchone()
+        if receipt:
+            if receipt[0] != owner_scope:
+                raise ValueError("quota state is reconciled to a different configured owner")
+            db.execute("COMMIT")
+            return {"state": "already_reconciled"}
+        source_root = _scope_root(db, unresolved_scope)
+        owner_root = _scope_root(db, owner_scope)
+        if source_root == owner_scope and owner_root == owner_scope:
+            db.execute("INSERT OR REPLACE INTO reconciliation VALUES(?,?,?)",
+                       (unresolved_scope, owner_scope, now))
+            db.execute("COMMIT")
+            return {"state": "already_reconciled"}
+
+        tables = ("quota", "reservation", "binding", "alias", "revalidation",
+                  "admission_history", "pacing")
+        scopes = {unresolved_scope, owner_scope, source_root, owner_root}
+        for table in tables:
+            columns = ("scope", "target") if table == "alias" else ("scope",)
+            for column in columns:
+                scopes.update(row[0] for row in db.execute(
+                    f"SELECT DISTINCT {column} FROM {table}"
+                ).fetchall())
+        source_component = {scope for scope in scopes if _scope_root(db, scope) == source_root}
+        owner_component = {scope for scope in scopes if _scope_root(db, scope) == owner_root}
+        if source_root != owner_root:
+            owner_has_state = any(
+                db.execute(f"SELECT 1 FROM {table} WHERE scope=? LIMIT 1", (scope,)).fetchone()
+                for scope in owner_component
+                for table in ("quota", "reservation", "binding", "revalidation",
+                              "admission_history", "pacing")
+            )
+            if owner_has_state:
+                raise ValueError("configured quota owner already has independent state")
+        component = source_component | owner_component | {unresolved_scope, owner_scope}
+        reservation_count = sum(db.execute(
+            "SELECT COUNT(*) FROM reservation WHERE scope=?", (scope,)
+        ).fetchone()[0] for scope in component)
+        if reservation_count:
+            raise Deferred("quota reconciliation requires no active or uncertain requests")
+
+        cooldowns: dict[str, tuple[float, int]] = {}
+        for scope in component:
+            for resource, blocked_until, quota_limit in db.execute(
+                "SELECT resource,blocked_until,quota_limit FROM quota WHERE scope=?", (scope,)
+            ).fetchall():
+                if blocked_until > now:
+                    previous = cooldowns.get(resource, (0.0, quota_limit))
+                    cooldowns[resource] = (max(previous[0], blocked_until),
+                                           min(previous[1], quota_limit))
+        bindings = sum(db.execute(
+            "SELECT COUNT(*) FROM binding WHERE scope=?", (scope,)
+        ).fetchone()[0] for scope in component)
+        for scope in component:
+            for table in ("quota", "revalidation", "admission_history", "pacing"):
+                db.execute(f"DELETE FROM {table} WHERE scope=?", (scope,))
+        for scope in component:
+            db.execute("DELETE FROM alias WHERE scope=? OR target=?", (scope, scope))
+        for scope in component - {owner_scope}:
+            db.execute("INSERT OR REPLACE INTO alias VALUES(?,?)", (scope, owner_scope))
+        for scope in component:
+            db.execute("UPDATE binding SET scope=? WHERE scope=?", (owner_scope, scope))
+        for resource, (blocked_until, quota_limit) in cooldowns.items():
+            db.execute(
+                "INSERT OR REPLACE INTO quota VALUES(?,?,?,?,?,?,?)",
+                (owner_scope, resource, 0, blocked_until, now, blocked_until, quota_limit),
+            )
+        db.execute("INSERT INTO reconciliation VALUES(?,?,?)",
+                   (unresolved_scope, owner_scope, now))
+        db.execute("COMMIT")
+        return {"state": "reconciled", "bindings_rebound": bindings,
+                "cooldowns_preserved": len(cooldowns)}
+    except BaseException:
+        if db.in_transaction:
+            db.execute("ROLLBACK")
+        raise
+    finally:
+        db.close()
+
+
 if __name__ == "__main__":
-    if sys.argv[1:] != ["status"]:
+    if sys.argv[1:] not in (["status"], ["reconcile"]):
         raise SystemExit(2)
     try:
-        print(json.dumps(admission_status(Path(os.environ.get(
+        directory = Path(os.environ.get(
             "AIDEVOPS_GH_TRANSPORT_STATE_DIR", str(Path.home() / ".aidevops/state/gh-transport"),
-        )).absolute(), scope_key("github.com"))))
-    except (OSError, ValueError, sqlite3.Error):
+        )).absolute()
+        owner, attributed = quota_owner()
+        if sys.argv[1] == "status":
+            print(json.dumps(admission_status(directory, scope_key("github.com", owner),
+                                              attributed=attributed)))
+        else:
+            if not attributed:
+                raise ValueError("set AIDEVOPS_GH_QUOTA_OWNER before reconciliation")
+            result = reconcile_scope(directory, scope_key("github.com", "unresolved"),
+                                     scope_key("github.com", owner))
+            print(json.dumps(result))
+    except Deferred as exc:
+        print(json.dumps({"state": "blocked", "reason": str(exc)}))
+        raise SystemExit(75)
+    except (OSError, ValueError, sqlite3.Error) as exc:
+        if sys.argv[1:] == ["reconcile"]:
+            print(json.dumps({"state": "error", "reason": str(exc)}))
+            raise SystemExit(2)
         print('{"state":"unknown"}')

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from gh_transport_capacity import capacity_wait
+from gh_transport_reconcile import reconcile_scope as _reconcile_scope
 from gh_transport_recovery import admission_status, mark_dead_reservations, probe_recovers, reserve_probe_allowed
 
 
@@ -313,112 +314,12 @@ class Budget:
         self.db.close()
 
 
-def _scope_root(db, scope: str) -> str:
-    for _ in range(256):
-        row = db.execute("SELECT target FROM alias WHERE scope=?", (scope,)).fetchone()
-        if not row:
-            return scope
-        scope = row[0]
-    raise ValueError("quota scope alias cycle")
-
-
 def reconcile_scope(directory: Path, unresolved_scope: str, owner_scope: str,
                     *, now: float | None = None) -> dict:
     """Replace ambiguous local evidence with one attributed bootstrap boundary."""
-    if unresolved_scope == owner_scope:
-        raise ValueError("a configured GitHub quota owner is required")
-    now = time.time() if now is None else now
     private_directory(directory)
-    path = directory / "admission.sqlite3"
-    if not path.is_file() or path.is_symlink():
-        return {"state": "no_state"}
-    if path.stat().st_uid != os.getuid():
-        raise ValueError("transport state file is not owned by this user")
-    db = sqlite3.connect(path, timeout=2, isolation_level=None)
-    try:
-        db.execute("BEGIN IMMEDIATE")
-        db.execute("CREATE TABLE IF NOT EXISTS reconciliation ("
-                   "source TEXT PRIMARY KEY,owner TEXT NOT NULL,reconciled REAL NOT NULL)")
-        receipt = db.execute(
-            "SELECT owner FROM reconciliation WHERE source=?", (unresolved_scope,)
-        ).fetchone()
-        if receipt:
-            if receipt[0] != owner_scope:
-                raise ValueError("quota state is reconciled to a different configured owner")
-            db.execute("COMMIT")
-            return {"state": "already_reconciled"}
-        source_root = _scope_root(db, unresolved_scope)
-        owner_root = _scope_root(db, owner_scope)
-        if source_root == owner_scope and owner_root == owner_scope:
-            db.execute("INSERT OR REPLACE INTO reconciliation VALUES(?,?,?)",
-                       (unresolved_scope, owner_scope, now))
-            db.execute("COMMIT")
-            return {"state": "already_reconciled"}
-
-        tables = ("quota", "reservation", "binding", "alias", "revalidation",
-                  "admission_history", "pacing")
-        scopes = {unresolved_scope, owner_scope, source_root, owner_root}
-        for table in tables:
-            columns = ("scope", "target") if table == "alias" else ("scope",)
-            for column in columns:
-                scopes.update(row[0] for row in db.execute(
-                    f"SELECT DISTINCT {column} FROM {table}"
-                ).fetchall())
-        source_component = {scope for scope in scopes if _scope_root(db, scope) == source_root}
-        owner_component = {scope for scope in scopes if _scope_root(db, scope) == owner_root}
-        if source_root != owner_root:
-            owner_has_state = any(
-                db.execute(f"SELECT 1 FROM {table} WHERE scope=? LIMIT 1", (scope,)).fetchone()
-                for scope in owner_component
-                for table in ("quota", "reservation", "binding", "revalidation",
-                              "admission_history", "pacing")
-            )
-            if owner_has_state:
-                raise ValueError("configured quota owner already has independent state")
-        component = source_component | owner_component | {unresolved_scope, owner_scope}
-        reservation_count = sum(db.execute(
-            "SELECT COUNT(*) FROM reservation WHERE scope=?", (scope,)
-        ).fetchone()[0] for scope in component)
-        if reservation_count:
-            raise Deferred("quota reconciliation requires no active or uncertain requests")
-
-        cooldowns: dict[str, tuple[float, int]] = {}
-        for scope in component:
-            for resource, blocked_until, quota_limit in db.execute(
-                "SELECT resource,blocked_until,quota_limit FROM quota WHERE scope=?", (scope,)
-            ).fetchall():
-                if blocked_until > now:
-                    previous = cooldowns.get(resource, (0.0, quota_limit))
-                    cooldowns[resource] = (max(previous[0], blocked_until),
-                                           min(previous[1], quota_limit))
-        bindings = sum(db.execute(
-            "SELECT COUNT(*) FROM binding WHERE scope=?", (scope,)
-        ).fetchone()[0] for scope in component)
-        for scope in component:
-            for table in ("quota", "revalidation", "admission_history", "pacing"):
-                db.execute(f"DELETE FROM {table} WHERE scope=?", (scope,))
-        for scope in component:
-            db.execute("DELETE FROM alias WHERE scope=? OR target=?", (scope, scope))
-        for scope in component - {owner_scope}:
-            db.execute("INSERT OR REPLACE INTO alias VALUES(?,?)", (scope, owner_scope))
-        for scope in component:
-            db.execute("UPDATE binding SET scope=? WHERE scope=?", (owner_scope, scope))
-        for resource, (blocked_until, quota_limit) in cooldowns.items():
-            db.execute(
-                "INSERT OR REPLACE INTO quota VALUES(?,?,?,?,?,?,?)",
-                (owner_scope, resource, 0, blocked_until, now, blocked_until, quota_limit),
-            )
-        db.execute("INSERT INTO reconciliation VALUES(?,?,?)",
-                   (unresolved_scope, owner_scope, now))
-        db.execute("COMMIT")
-        return {"state": "reconciled", "bindings_rebound": bindings,
-                "cooldowns_preserved": len(cooldowns)}
-    except BaseException:
-        if db.in_transaction:
-            db.execute("ROLLBACK")
-        raise
-    finally:
-        db.close()
+    return _reconcile_scope(directory, unresolved_scope, owner_scope,
+                            now=now, deferred_type=Deferred)
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from gh_transport_capacity import capacity_wait
+from gh_transport_identity import quota_owner
 from gh_transport_reconcile import reconcile_scope as _reconcile_scope
 from gh_transport_recovery import admission_status, mark_dead_reservations, probe_recovers, reserve_probe_allowed
 
@@ -41,15 +42,6 @@ def private_directory(path: Path) -> None:
     if path.stat().st_uid != os.getuid():
         raise ValueError("transport state directory is not owned by this user")
     path.chmod(0o700)
-
-
-def quota_owner() -> tuple[str, bool]:
-    owner = os.environ.get("AIDEVOPS_GH_QUOTA_OWNER", "")
-    if not owner or owner == "unresolved":
-        return "unresolved", False
-    if "\0" in owner or len(owner) > 256:
-        raise ValueError("invalid GitHub quota owner")
-    return owner, True
 
 
 def scope_key(host: str, owner: str | None = None) -> str:
@@ -319,7 +311,7 @@ def reconcile_scope(directory: Path, unresolved_scope: str, owner_scope: str,
     """Replace ambiguous local evidence with one attributed bootstrap boundary."""
     private_directory(directory)
     return _reconcile_scope(directory, unresolved_scope, owner_scope,
-                            now=now, deferred_type=Deferred)
+                            context=(now, Deferred))
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -10,11 +10,9 @@ This database coordinates local processes, not independently configured hosts.
 from __future__ import annotations
 
 import hashlib
-import json
 import os
 import sqlite3
 import subprocess
-import sys
 import time
 import uuid
 from contextlib import contextmanager
@@ -315,27 +313,5 @@ def reconcile_scope(directory: Path, unresolved_scope: str, owner_scope: str,
 
 
 if __name__ == "__main__":
-    if sys.argv[1:] not in (["status"], ["reconcile"]):
-        raise SystemExit(2)
-    try:
-        directory = Path(os.environ.get(
-            "AIDEVOPS_GH_TRANSPORT_STATE_DIR", str(Path.home() / ".aidevops/state/gh-transport"),
-        )).absolute()
-        owner, attributed = quota_owner()
-        if sys.argv[1] == "status":
-            print(json.dumps(admission_status(directory, scope_key("github.com", owner),
-                                              attributed=attributed)))
-        else:
-            if not attributed:
-                raise ValueError("set AIDEVOPS_GH_QUOTA_OWNER before reconciliation")
-            result = reconcile_scope(directory, scope_key("github.com", "unresolved"),
-                                     scope_key("github.com", owner))
-            print(json.dumps(result))
-    except Deferred as exc:
-        print(json.dumps({"state": "blocked", "reason": str(exc)}))
-        raise SystemExit(75)
-    except (OSError, ValueError, sqlite3.Error) as exc:
-        if sys.argv[1:] == ["reconcile"]:
-            print(json.dumps({"state": "error", "reason": str(exc)}))
-            raise SystemExit(2)
-        print('{"state":"unknown"}')
+    from gh_transport_budget_cli import main
+    main()

--- a/.agents/scripts/gh_transport_budget_cli.py
+++ b/.agents/scripts/gh_transport_budget_cli.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Command-line interface for GitHub transport admission state."""
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+from gh_transport_budget import Deferred, quota_owner, reconcile_scope, scope_key
+from gh_transport_recovery import admission_status
+
+
+def main() -> None:
+    """Report admission status or explicitly reconcile attributed state."""
+    if sys.argv[1:] not in (["status"], ["reconcile"]):
+        raise SystemExit(2)
+    try:
+        directory = Path(os.environ.get(
+            "AIDEVOPS_GH_TRANSPORT_STATE_DIR", str(Path.home() / ".aidevops/state/gh-transport"),
+        )).absolute()
+        owner, attributed = quota_owner()
+        if sys.argv[1] == "status":
+            print(json.dumps(admission_status(directory, scope_key("github.com", owner),
+                                              attributed=attributed)))
+            return
+        if not attributed:
+            raise ValueError("set AIDEVOPS_GH_QUOTA_OWNER before reconciliation")
+        result = reconcile_scope(directory, scope_key("github.com", "unresolved"),
+                                 scope_key("github.com", owner))
+        print(json.dumps(result))
+    except Deferred as exc:
+        print(json.dumps({"state": "blocked", "reason": str(exc)}))
+        raise SystemExit(75)
+    except (OSError, ValueError, sqlite3.Error) as exc:
+        if sys.argv[1:] == ["reconcile"]:
+            print(json.dumps({"state": "error", "reason": str(exc)}))
+            raise SystemExit(2)
+        print('{"state":"unknown"}')

--- a/.agents/scripts/gh_transport_identity.py
+++ b/.agents/scripts/gh_transport_identity.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Trusted GitHub quota-owner attribution."""
+
+import os
+
+
+def quota_owner() -> tuple[str, bool]:
+    """Return a validated configured owner and whether it is authoritative."""
+    owner = os.environ.get("AIDEVOPS_GH_QUOTA_OWNER", "")
+    if not owner or owner == "unresolved":
+        return "unresolved", False
+    if "\0" in owner or len(owner) > 256:
+        raise ValueError("invalid GitHub quota owner")
+    return owner, True

--- a/.agents/scripts/gh_transport_reconcile.py
+++ b/.agents/scripts/gh_transport_reconcile.py
@@ -131,10 +131,11 @@ class Reconciliation:
 
 
 def reconcile_scope(directory: Path, unresolved_scope: str, owner_scope: str,
-                    *, now: float | None, deferred_type) -> dict:
+                    *, context: tuple[float | None, type[BaseException]]) -> dict:
     """Run reconciliation under an immediate SQLite transaction."""
     if unresolved_scope == owner_scope:
         raise ValueError("a configured GitHub quota owner is required")
+    now, deferred_type = context
     path = directory / "admission.sqlite3"
     if not path.is_file() or path.is_symlink():
         return {"state": "no_state"}

--- a/.agents/scripts/gh_transport_reconcile.py
+++ b/.agents/scripts/gh_transport_reconcile.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Quiescent migration of unresolved GitHub quota evidence to a known owner."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+
+STATE_TABLES = ("quota", "reservation", "binding", "revalidation",
+                "admission_history", "pacing")
+SCOPED_TABLES = (*STATE_TABLES, "alias")
+CLEAR_TABLES = ("quota", "revalidation", "admission_history", "pacing")
+
+
+class Reconciliation:
+    """Apply one atomic, conservative scope migration."""
+
+    def __init__(self, db, source: str, owner: str, now: float, deferred_type):
+        self.db = db
+        self.source = source
+        self.owner = owner
+        self.now = now
+        self.deferred_type = deferred_type
+
+    def root(self, scope: str) -> str:
+        for _ in range(256):
+            row = self.db.execute("SELECT target FROM alias WHERE scope=?", (scope,)).fetchone()
+            if not row:
+                return scope
+            scope = row[0]
+        raise ValueError("quota scope alias cycle")
+
+    def receipt_state(self) -> dict | None:
+        receipt = self.db.execute(
+            "SELECT owner FROM reconciliation WHERE source=?", (self.source,)
+        ).fetchone()
+        if not receipt:
+            return None
+        if receipt[0] != self.owner:
+            raise ValueError("quota state is reconciled to a different configured owner")
+        return {"state": "already_reconciled"}
+
+    def known_scopes(self, source_root: str, owner_root: str) -> set[str]:
+        scopes = {self.source, self.owner, source_root, owner_root}
+        for table in SCOPED_TABLES:
+            columns = ("scope", "target") if table == "alias" else ("scope",)
+            for column in columns:
+                rows = self.db.execute(f"SELECT DISTINCT {column} FROM {table}").fetchall()
+                scopes.update(row[0] for row in rows)
+        return scopes
+
+    def component(self, scopes: set[str], root: str) -> set[str]:
+        return {scope for scope in scopes if self.root(scope) == root}
+
+    def has_state(self, scopes: set[str]) -> bool:
+        return any(
+            self.db.execute(f"SELECT 1 FROM {table} WHERE scope=? LIMIT 1", (scope,)).fetchone()
+            for scope in scopes
+            for table in STATE_TABLES
+        )
+
+    def require_quiescence(self, scopes: set[str]) -> None:
+        reservations = sum(self.db.execute(
+            "SELECT COUNT(*) FROM reservation WHERE scope=?", (scope,)
+        ).fetchone()[0] for scope in scopes)
+        if reservations:
+            raise self.deferred_type("quota reconciliation requires no active or uncertain requests")
+
+    def cooldowns(self, scopes: set[str]) -> dict[str, tuple[float, int]]:
+        preserved: dict[str, tuple[float, int]] = {}
+        for scope in scopes:
+            rows = self.db.execute(
+                "SELECT resource,blocked_until,quota_limit FROM quota WHERE scope=?", (scope,)
+            ).fetchall()
+            for resource, blocked_until, quota_limit in rows:
+                if blocked_until > self.now:
+                    previous = preserved.get(resource, (0.0, quota_limit))
+                    preserved[resource] = (max(previous[0], blocked_until),
+                                           min(previous[1], quota_limit))
+        return preserved
+
+    def rebind(self, scopes: set[str], cooldowns: dict[str, tuple[float, int]]) -> int:
+        bindings = sum(self.db.execute(
+            "SELECT COUNT(*) FROM binding WHERE scope=?", (scope,)
+        ).fetchone()[0] for scope in scopes)
+        for scope in scopes:
+            for table in CLEAR_TABLES:
+                self.db.execute(f"DELETE FROM {table} WHERE scope=?", (scope,))
+            self.db.execute("DELETE FROM alias WHERE scope=? OR target=?", (scope, scope))
+            self.db.execute("UPDATE binding SET scope=? WHERE scope=?", (self.owner, scope))
+        for scope in scopes - {self.owner}:
+            self.db.execute("INSERT OR REPLACE INTO alias VALUES(?,?)", (scope, self.owner))
+        for resource, (blocked_until, quota_limit) in cooldowns.items():
+            self.db.execute(
+                "INSERT OR REPLACE INTO quota VALUES(?,?,?,?,?,?,?)",
+                (self.owner, resource, 0, blocked_until, self.now, blocked_until, quota_limit),
+            )
+        return bindings
+
+    def record(self) -> None:
+        self.db.execute("INSERT OR REPLACE INTO reconciliation VALUES(?,?,?)",
+                        (self.source, self.owner, self.now))
+
+    def run(self) -> dict:
+        self.db.execute("CREATE TABLE IF NOT EXISTS reconciliation ("
+                        "source TEXT PRIMARY KEY,owner TEXT NOT NULL,reconciled REAL NOT NULL)")
+        prior = self.receipt_state()
+        if prior:
+            return prior
+        source_root = self.root(self.source)
+        owner_root = self.root(self.owner)
+        if source_root == self.owner and owner_root == self.owner:
+            self.record()
+            return {"state": "already_reconciled"}
+        scopes = self.known_scopes(source_root, owner_root)
+        source_component = self.component(scopes, source_root)
+        owner_component = self.component(scopes, owner_root)
+        if source_root != owner_root and self.has_state(owner_component):
+            raise ValueError("configured quota owner already has independent state")
+        component = source_component | owner_component | {self.source, self.owner}
+        self.require_quiescence(component)
+        cooldowns = self.cooldowns(component)
+        bindings = self.rebind(component, cooldowns)
+        self.record()
+        return {"state": "reconciled", "bindings_rebound": bindings,
+                "cooldowns_preserved": len(cooldowns)}
+
+
+def reconcile_scope(directory: Path, unresolved_scope: str, owner_scope: str,
+                    *, now: float | None, deferred_type) -> dict:
+    """Run reconciliation under an immediate SQLite transaction."""
+    if unresolved_scope == owner_scope:
+        raise ValueError("a configured GitHub quota owner is required")
+    path = directory / "admission.sqlite3"
+    if not path.is_file() or path.is_symlink():
+        return {"state": "no_state"}
+    if path.stat().st_uid != os.getuid():
+        raise ValueError("transport state file is not owned by this user")
+    db = sqlite3.connect(path, timeout=2, isolation_level=None)
+    try:
+        db.execute("BEGIN IMMEDIATE")
+        result = Reconciliation(
+            db, unresolved_scope, owner_scope, time.time() if now is None else now, deferred_type
+        ).run()
+        db.execute("COMMIT")
+        return result
+    except BaseException:
+        if db.in_transaction:
+            db.execute("ROLLBACK")
+        raise
+    finally:
+        db.close()

--- a/.agents/scripts/gh_transport_recovery.py
+++ b/.agents/scripts/gh_transport_recovery.py
@@ -49,18 +49,19 @@ def probe_recovers(budget, reservation, resource, row, reset_at):
         return False
     owners = sum(budget._root(binding[0]) == budget.scope for binding in
                  budget.db.execute("SELECT scope FROM binding").fetchall())
-    if owners != 1:
+    if owners != 1 and not budget.attributed:
         return False
     return own[0] >= row[2] and reset_at >= row[1]
 
 
-def admission_status(directory: Path, scope: str) -> dict:
+def admission_status(directory: Path, scope: str, *, attributed: bool = False) -> dict:
     """Read local core admission evidence without credentials, HTTP or mutations."""
     path = directory / "admission.sqlite3"
     if not path.is_file() or path.is_symlink():
         return {"state": "unknown"}
     db = sqlite3.connect(path.as_uri() + "?mode=ro", uri=True, timeout=2)
     try:
+        requested_scope = scope
         for _ in range(256):
             alias = db.execute("SELECT target FROM alias WHERE scope=?", (scope,)).fetchone()
             if not alias:
@@ -68,12 +69,25 @@ def admission_status(directory: Path, scope: str) -> dict:
             scope = alias[0]
         else:
             return {"state": "unknown"}
+        bindings = sum(1 for binding in db.execute("SELECT scope FROM binding").fetchall()
+                       if _read_root(db, binding[0]) == scope)
+        ambiguity = None
+        if attributed and requested_scope != scope:
+            ambiguity = "configured_owner_requires_reconciliation"
+        elif not attributed and bindings > 1:
+            ambiguity = "unresolved_scope_has_multiple_credentials"
+        diagnostics = {"scope_mode": "configured" if attributed else "unresolved",
+                       "bound_credentials": bindings, "ambiguity": ambiguity}
+        if ambiguity:
+            diagnostics["reconcile_command"] = (
+                "python3 .agents/scripts/gh_transport_budget.py reconcile"
+            )
         row = db.execute(
             "SELECT remaining,reset,observed,blocked_until,quota_limit FROM quota "
             "WHERE scope=? AND resource='core'", (scope,),
         ).fetchone()
         if not row:
-            return {"state": "unknown"}
+            return {"state": "unknown", **diagnostics}
         reserved = db.execute(
             "SELECT COUNT(*) FROM reservation WHERE scope=? AND resource='core'", (scope,),
         ).fetchone()[0]
@@ -86,9 +100,19 @@ def admission_status(directory: Path, scope: str) -> dict:
             state = "unknown"
         elif row[0] - reserved <= floor:
             state = "exhausted"
-        return {"state": state, "source": "local_response_headers", "remaining": row[0],
+        return {"state": state, "source": "local_response_headers", **diagnostics,
+                "remaining": row[0],
                 "limit": row[4], "reserved": reserved, "floor": floor,
                 "blocked_until": row[3],
                 "reset": int(row[1]), "observation_age_seconds": max(0, int(now - row[2]))}
     finally:
         db.close()
+
+
+def _read_root(db, scope: str) -> str:
+    for _ in range(256):
+        alias = db.execute("SELECT target FROM alias WHERE scope=?", (scope,)).fetchone()
+        if not alias:
+            return scope
+        scope = alias[0]
+    raise ValueError("quota scope alias cycle")

--- a/.agents/scripts/tests/test-gh-shim-transport-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-transport-cases.sh
@@ -4,7 +4,7 @@
 # Sourced by the existing hermetic gh shim harness after legacy-path coverage.
 
 printf '\nTest 27: shared raw transport controls and response-owned quota\n'
-for library in gh-transport-controls.sh gh-transport-governor.py gh_transport_budget.py gh_transport_recovery.py gh_transport_capacity.py shared-gh-secondary-cooldown.sh shared-gh-primary-cooldown.sh; do
+for library in gh-transport-controls.sh gh-transport-governor.py gh_transport_budget.py gh_transport_reconcile.py gh_transport_recovery.py gh_transport_capacity.py shared-gh-secondary-cooldown.sh shared-gh-primary-cooldown.sh; do
 	cp "${REPO_DIR}/.agents/scripts/${library}" "${TMP}/scripts/${library}"
 done
 mkdir -p "${TMP}/governor/tmp"

--- a/.agents/scripts/tests/test-gh-shim-transport-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-transport-cases.sh
@@ -4,7 +4,7 @@
 # Sourced by the existing hermetic gh shim harness after legacy-path coverage.
 
 printf '\nTest 27: shared raw transport controls and response-owned quota\n'
-for library in gh-transport-controls.sh gh-transport-governor.py gh_transport_budget.py gh_transport_reconcile.py gh_transport_recovery.py gh_transport_capacity.py shared-gh-secondary-cooldown.sh shared-gh-primary-cooldown.sh; do
+for library in gh-transport-controls.sh gh-transport-governor.py gh_transport_budget.py gh_transport_identity.py gh_transport_reconcile.py gh_transport_recovery.py gh_transport_capacity.py shared-gh-secondary-cooldown.sh shared-gh-primary-cooldown.sh; do
 	cp "${REPO_DIR}/.agents/scripts/${library}" "${TMP}/scripts/${library}"
 done
 mkdir -p "${TMP}/governor/tmp"

--- a/.agents/scripts/tests/test-gh-transport-budget.py
+++ b/.agents/scripts/tests/test-gh-transport-budget.py
@@ -5,7 +5,9 @@
 
 import importlib.util
 import io
+import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -14,7 +16,7 @@ from unittest.mock import Mock, patch
 
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
-from gh_transport_budget import Budget, Deferred, scope_key  # noqa: E402
+from gh_transport_budget import Budget, Deferred, quota_owner, reconcile_scope, scope_key  # noqa: E402
 
 SPEC = importlib.util.spec_from_file_location("governor", SCRIPTS / "gh-transport-governor.py")
 governor = importlib.util.module_from_spec(SPEC)
@@ -110,6 +112,117 @@ class AdmissionTests(unittest.TestCase):
         finally:
             other.close()
 
+    def test_configured_owner_recovers_shared_credential_balance(self):
+        self.seed(100)
+        other = Budget(self.directory, "owner-one", "different-credential", attributed=True)
+        try:
+            probe = other.acquire("core", now=1061)
+            other.finish(probe, "core", headers(4999), started=1061, now=1062)
+            self.assertEqual(other.db.execute("SELECT remaining FROM quota").fetchone()[0], 4999)
+        finally:
+            other.close()
+
+    def test_configured_owner_alias_cannot_recover_before_reconciliation(self):
+        self.seed(100)
+        other = Budget(self.directory, "owner-one", "different-credential")
+        configured = Budget(self.directory, "configured", "owner-one", attributed=True)
+        try:
+            self.assertFalse(configured.attributed)
+            probe = configured.acquire("core", now=1061)
+            configured.finish(probe, "core", headers(4999), started=1061, now=1062)
+            self.assertEqual(configured.db.execute("SELECT remaining FROM quota").fetchone()[0], 100)
+        finally:
+            configured.close()
+            other.close()
+
+    def test_status_marks_legacy_configured_alias_for_reconciliation(self):
+        from gh_transport_budget import admission_status
+        self.seed(100)
+        configured = Budget(self.directory, "configured", "owner-one", attributed=True)
+        try:
+            status = admission_status(self.directory, "configured", attributed=True)
+            self.assertEqual(status["ambiguity"], "configured_owner_requires_reconciliation")
+            self.assertEqual(status["reconcile_command"],
+                             "python3 .agents/scripts/gh_transport_budget.py reconcile")
+        finally:
+            configured.close()
+
+    def test_reconcile_requires_quiescence_without_mutating_state(self):
+        self.seed(100)
+        self.budget.acquire("core", now=1002)
+        before = list(self.budget.db.execute("SELECT * FROM quota"))
+        with self.assertRaisesRegex(Deferred, "no active or uncertain"):
+            reconcile_scope(self.directory, "owner-one", "configured", now=1003)
+        self.assertEqual(before, list(self.budget.db.execute("SELECT * FROM quota")))
+
+    def test_reconcile_refuses_uncertain_reservation(self):
+        self.seed(100)
+        request = self.budget.acquire("core", now=1002)
+        self.budget.finish(request, "core", {}, started=1002, now=1003)
+        with self.assertRaisesRegex(Deferred, "no active or uncertain"):
+            reconcile_scope(self.directory, "owner-one", "configured", now=1004)
+        self.assertEqual(self.budget.db.execute(
+            "SELECT uncertain FROM reservation"
+        ).fetchone()[0], 1)
+
+    def test_reconcile_preserves_cooldown_then_serializes_bootstrap(self):
+        self.seed(100)
+        self.budget.db.execute("UPDATE quota SET blocked_until=1100")
+        self.budget.db.execute("INSERT INTO pacing VALUES(?,?,?,?,?)",
+                               ("owner-one", "core", 2000, 1090, 100))
+        result = reconcile_scope(self.directory, "owner-one", "configured", now=1061)
+        self.assertEqual(result["state"], "reconciled")
+        configured = Budget(self.directory, "configured", "owner-one", attributed=True)
+        try:
+            with self.assertRaisesRegex(Deferred, "server resource cooldown"):
+                configured.acquire("core", now=1099)
+            probe = configured.acquire("core", now=1100)
+            with self.assertRaisesRegex(Deferred, "authoritative quota observation"):
+                configured.acquire("core", now=1100)
+            configured.finish(probe, "core", headers(4999, 2000), started=1100, now=1101)
+            self.assertEqual(configured.db.execute(
+                "SELECT remaining FROM quota WHERE scope='configured'"
+            ).fetchone()[0], 4999)
+            self.assertEqual(configured.db.execute("SELECT COUNT(*) FROM pacing").fetchone()[0], 0)
+        finally:
+            configured.close()
+
+    def test_reconcile_reverses_alias_once_and_preserves_other_scope(self):
+        self.seed(100)
+        other = Budget(self.directory, "owner-one", "different-credential")
+        independent = Budget(self.directory, "independent")
+        try:
+            independent_token = independent.acquire("core", now=1000)
+            independent.finish(independent_token, "core", headers(77), started=1000, now=1001)
+        finally:
+            other.close()
+            independent.close()
+        result = reconcile_scope(self.directory, "owner-one", "configured", now=1061)
+        self.assertEqual(result["bindings_rebound"], 2)
+        self.assertEqual(reconcile_scope(
+            self.directory, "owner-one", "configured", now=1062
+        )["state"], "already_reconciled")
+        with self.assertRaisesRegex(ValueError, "different configured owner"):
+            reconcile_scope(self.directory, "owner-one", "different-owner", now=1063)
+        self.assertEqual(self.budget._root("owner-one"), "configured")
+        self.assertEqual(self.budget.db.execute(
+            "SELECT remaining FROM quota WHERE scope='independent'"
+        ).fetchone()[0], 77)
+
+    def test_status_reports_unresolved_credential_ambiguity_without_identity(self):
+        from gh_transport_budget import admission_status
+        self.seed(100)
+        other = Budget(self.directory, "owner-one", "different-credential")
+        try:
+            with patch("gh_transport_recovery.time.time", return_value=1002):
+                status = admission_status(self.directory, "owner-one")
+            self.assertEqual(status["ambiguity"], "unresolved_scope_has_multiple_credentials")
+            self.assertEqual(status["bound_credentials"], 2)
+            self.assertIn("gh_transport_budget.py reconcile", status["reconcile_command"])
+            self.assertNotIn("different-credential", str(status))
+        finally:
+            other.close()
+
     def test_reserve_probe_never_spends_exhaustion_or_uncertain_last_point(self):
         self.seed(1)
         final = self.budget.acquire("core", now=1061)
@@ -176,6 +289,45 @@ class AdmissionTests(unittest.TestCase):
             first = scope_key("github.com")
         with patch.dict(os.environ, {"GH_TOKEN": "fixture-two"}):
             self.assertEqual(first, scope_key("github.com"))
+
+    def test_quota_owner_requires_explicit_valid_attribution(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(quota_owner(), ("unresolved", False))
+        with patch.dict(os.environ, {"AIDEVOPS_GH_QUOTA_OWNER": "account-one"}):
+            self.assertEqual(quota_owner(), ("account-one", True))
+        with patch.dict(os.environ, {"AIDEVOPS_GH_QUOTA_OWNER": "x" * 257}):
+            with self.assertRaisesRegex(ValueError, "invalid GitHub quota owner"):
+                quota_owner()
+
+    def test_reconcile_cli_bootstraps_configured_owner(self):
+        root = Path(os.environ.get(
+            "AIDEVOPS_TEMP_DIR", str(Path.home() / ".aidevops/.agent-workspace/tmp")
+        ))
+        with tempfile.TemporaryDirectory(prefix="gh-budget-cli-", dir=root) as temp:
+            directory = Path(temp)
+            unresolved = scope_key("github.com", "unresolved")
+            owner = scope_key("github.com", "account-one")
+            first = Budget(directory, unresolved, "credential-one")
+            second = Budget(directory, unresolved, "credential-two")
+            try:
+                token = first.acquire("core", now=1000)
+                first.finish(token, "core", headers(100), started=1000, now=1001)
+            finally:
+                first.close()
+                second.close()
+            environment = {**os.environ, "AIDEVOPS_GH_QUOTA_OWNER": "account-one",
+                           "AIDEVOPS_GH_TRANSPORT_STATE_DIR": str(directory)}
+            result = subprocess.run(
+                [sys.executable, str(SCRIPTS / "gh_transport_budget.py"), "reconcile"],
+                check=True, capture_output=True, text=True, env=environment,
+            )
+            self.assertEqual(json.loads(result.stdout)["state"], "reconciled")
+            configured = Budget(directory, owner, "credential-one", attributed=True)
+            try:
+                self.assertTrue(configured.attributed)
+                configured.acquire("core", now=1061)
+            finally:
+                configured.close()
 
     def test_owner_configuration_cannot_split_one_credential_budget(self):
         self.seed(0)


### PR DESCRIPTION
## Summary

Add an explicit, transactional reconciliation path for stale unresolved GitHub REST quota state, preserve live cooldowns, and expose anonymous ambiguity diagnostics.

## Files Changed

.agents/reference/github-api-transport.md, .agents/scripts/gh-transport-governor.py, .agents/scripts/gh_transport_budget.py, .agents/scripts/gh_transport_recovery.py, .agents/scripts/tests/test-gh-transport-budget.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: 43 focused transport tests and 161 gh shim tests pass; changed-file linters and independent high-risk review are clean.

Resolves #31442


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.329 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 37m and 261,155 tokens on this with the user in an interactive session.
