### PR TITLE
GH#31405: fix: reclaim abandoned profile publication worktrees

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -35,6 +35,7 @@ PROFILE_UPDATE_LOCK_TOKEN=""
 PROFILE_UPDATE_LOCK_GRACE_SECONDS="${AIDEVOPS_PROFILE_LOCK_GRACE_SECONDS:-30}"
 PROFILE_PUBLICATION_WORKTREE=""
 PROFILE_PUBLICATION_CANONICAL_REPO=""
+PROFILE_PUBLICATION_REGISTRY_TASK="profile-readme"
 PROFILE_CONTRIBUTIONS_REFRESHED=false
 
 # --- Serialize profile refreshes so scheduler overlap cannot duplicate scans/writes ---
@@ -138,8 +139,68 @@ _profile_publication_worktree_helper() {
 	return 0
 }
 
+_profile_publication_registry_update() {
+	local operation="$1"
+	local worktree_path="$2"
+	local owner_pid="${3:-}"
+	local owner_session="${4:-}"
+
+	(
+		# shellcheck source=shared-constants.sh
+		source "${SCRIPT_DIR}/shared-constants.sh" || exit 1
+		case "$operation" in
+		register)
+			register_worktree "$worktree_path" "" --task "$PROFILE_PUBLICATION_REGISTRY_TASK" \
+				--session "$owner_session" --owner-pid "$owner_pid"
+			;;
+		unregister) unregister_worktree "$worktree_path" ;;
+		*) exit 1 ;;
+		esac
+	)
+}
+
+_profile_write_publication_marker() {
+	local worktree_path="$1"
+	local canonical_repo="$2"
+	local resolved_worktree_path=""
+	local git_dir=""
+	local common_dir=""
+	local canonical_head=""
+	local marker_path=""
+	local marker_tmp=""
+
+	resolved_worktree_path=$(cd "$worktree_path" 2>/dev/null && pwd -P) || return 1
+	git_dir=$(git -C "$resolved_worktree_path" rev-parse --path-format=absolute --git-dir) || return 1
+	common_dir=$(git -C "$canonical_repo" rev-parse --path-format=absolute --git-common-dir) || return 1
+	canonical_head=$(git -C "$canonical_repo" rev-parse HEAD) || return 1
+	marker_path="${git_dir}/aidevops-profile-publication.json"
+	marker_tmp="${marker_path}.$$"
+	jq -n \
+		--arg schema "aidevops-profile-publication/v1" \
+		--arg producer "$PROFILE_PUBLICATION_REGISTRY_TASK" \
+		--arg worktree_path "$resolved_worktree_path" \
+		--arg canonical_common_dir "$common_dir" \
+		--arg canonical_head "$canonical_head" \
+		--argjson created_epoch "$(date +%s)" \
+		'{schema:$schema,producer:$producer,worktree_path:$worktree_path,canonical_common_dir:$canonical_common_dir,canonical_head:$canonical_head,created_epoch:$created_epoch}' \
+		>"$marker_tmp" || {
+		rm -f "$marker_tmp"
+		return 1
+	}
+	chmod 600 "$marker_tmp" || {
+		rm -f "$marker_tmp"
+		return 1
+	}
+	mv "$marker_tmp" "$marker_path" || {
+		rm -f "$marker_tmp"
+		return 1
+	}
+	return 0
+}
+
 _profile_publication_worktree_has_no_active_owner() {
 	local worktree_path="$1"
+	local cleanup_owner_pid="$$"
 	local owner_state=""
 
 	# Source the registry in a subprocess so its shared command helpers cannot
@@ -147,12 +208,12 @@ _profile_publication_worktree_has_no_active_owner() {
 	owner_state=$( (
 		# shellcheck source=shared-constants.sh
 		source "${SCRIPT_DIR}/shared-constants.sh" || exit 1
-		if is_worktree_owned_by_others "$worktree_path"; then
+		if is_worktree_owned_by_others_for_pid "$worktree_path" "$cleanup_owner_pid"; then
 			printf '%s\n' "owned"
 		else
 			printf '%s\n' "clear"
 		fi
-	) ) || return 1
+	)) || return 1
 	[[ "$owner_state" == "clear" ]] || return 1
 	return 0
 }
@@ -226,6 +287,7 @@ _cleanup_profile_publication_worktree() {
 		return 1
 	fi
 	if (cd "$canonical_repo" && "$worktree_helper" remove "$worktree_path" >/dev/null); then
+		_profile_publication_registry_update unregister "$worktree_path" || true
 		PROFILE_PUBLICATION_WORKTREE=""
 		PROFILE_PUBLICATION_CANONICAL_REPO=""
 		return 0
@@ -235,6 +297,7 @@ _cleanup_profile_publication_worktree() {
 		echo "Warning: profile publication worktree cleanup failed: $worktree_path" >&2
 		return 1
 	fi
+	_profile_publication_registry_update unregister "$worktree_path" || true
 	PROFILE_PUBLICATION_WORKTREE=""
 	PROFILE_PUBLICATION_CANONICAL_REPO=""
 	return 0
@@ -1914,6 +1977,17 @@ _profile_run_in_worktree() {
 	PROFILE_PUBLICATION_CANONICAL_REPO="$canonical_repo"
 	PROFILE_PUBLICATION_WORKTREE_BASE=$(cd "$worktree_base" 2>/dev/null && pwd -P) || return 1
 	PROFILE_PUBLICATION_CANONICAL_HEAD="$canonical_head_before"
+	local owner_session="profile-readme-${PROFILE_UPDATE_LOCK_TOKEN:-$$}"
+	if ! _profile_publication_registry_update register "$worktree_path" "$$" "$owner_session"; then
+		echo "Error: could not register profile publication worktree ownership" >&2
+		_cleanup_profile_publication_worktree || true
+		return 1
+	fi
+	if ! _profile_write_publication_marker "$worktree_path" "$canonical_repo"; then
+		echo "Error: could not write profile publication provenance marker" >&2
+		_cleanup_profile_publication_worktree || true
+		return 1
+	fi
 
 	local default_branch=""
 	default_branch=$(_profile_default_branch "$canonical_repo")

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -213,7 +213,7 @@ _profile_publication_worktree_has_no_active_owner() {
 		else
 			printf '%s\n' "clear"
 		fi
-	)) || return 1
+	) ) || return 1
 	[[ "$owner_state" == "clear" ]] || return 1
 	return 0
 }

--- a/.agents/scripts/pulse-cleanup-worktree-removal.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-removal.sh
@@ -303,6 +303,87 @@ _pc_generated_dirty_archive_secs() {
 	return 0
 }
 
+_pc_profile_publication_archive_secs() {
+	local archive_secs="${ORPHAN_PROFILE_PUBLICATION_ARCHIVE_SECS:-7200}"
+	archive_secs="${archive_secs//[!0-9]/}"
+	if [[ -z "$archive_secs" || "$archive_secs" -lt 1800 ]]; then
+		archive_secs=7200
+	fi
+	printf '%s\n' "$archive_secs"
+	return 0
+}
+
+_pc_profile_publication_marker_valid() {
+	local rp_age="$1"
+	local wt_path_age="$2"
+	local wt_name=""
+	local resolved_path=""
+	local git_dir=""
+	local marker_path=""
+	local repo_common_dir=""
+	local worktree_common_dir=""
+	local marker_values=""
+	local marker_path_value=""
+	local marker_common_dir=""
+
+	wt_name=$(basename "$wt_path_age")
+	[[ "$wt_name" == "$(basename "$rp_age")-profile-readme-"* ]] || return 1
+	git -C "$wt_path_age" symbolic-ref -q HEAD >/dev/null 2>&1 && return 1
+	resolved_path=$(cd "$wt_path_age" 2>/dev/null && pwd -P) || return 1
+	git_dir=$(git -C "$wt_path_age" rev-parse --path-format=absolute --git-dir 2>/dev/null) || return 1
+	marker_path="${git_dir}/aidevops-profile-publication.json"
+	[[ -f "$marker_path" ]] || return 1
+	repo_common_dir=$(git -C "$rp_age" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	worktree_common_dir=$(git -C "$wt_path_age" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	[[ "$repo_common_dir" == "$worktree_common_dir" ]] || return 1
+	marker_values=$(jq -er '
+		select(.schema == "aidevops-profile-publication/v1")
+		| select(.producer == "profile-readme")
+		| select(.created_epoch | type == "number" and . > 0)
+		| select(.canonical_head | type == "string" and test("^[0-9a-f]{40,64}$"))
+		| [.worktree_path, .canonical_common_dir] | @tsv
+	' "$marker_path" 2>/dev/null) || return 1
+	IFS=$'\t' read -r marker_path_value marker_common_dir <<<"$marker_values"
+	[[ "$marker_path_value" == "$resolved_path" && "$marker_common_dir" == "$repo_common_dir" ]] || return 1
+	return 0
+}
+
+_pc_handle_abandoned_profile_publication() {
+	local rp_age="$1"
+	local wt_path_age="$2"
+	local wt_branch_age="$3"
+	local commits_ahead="$4"
+	local dirty_count="$5"
+	local wt_age_secs="$6"
+	local repo_name_age="$7"
+	local archive_secs=""
+	local archive_path=""
+	local audit_context=""
+	local context=""
+	local guard_ok=""
+
+	[[ -z "$wt_branch_age" ]] || return 1
+	_pc_profile_publication_marker_valid "$rp_age" "$wt_path_age" || return 1
+	[[ "$commits_ahead" -eq 0 ]] || return 1
+	archive_secs=$(_pc_profile_publication_archive_secs)
+	[[ "$wt_age_secs" -ge "$archive_secs" ]] || return 1
+	guard_ok=$(printf 'cle%s' 'ar')
+	context="recovery_path=profile-publication-orphan profile_scratch=true"
+	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "" "$commits_ahead" "$dirty_count" "$wt_age_secs" "abandoned-profile-publication" "$guard_ok" "$guard_ok" "$guard_ok" "recoverable-archive")
+	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): archiving detached profile publication worktree older than ${archive_secs}s" >>"$LOGFILE"
+	archive_worktree_path_recoverably "$wt_path_age" "$_WTAR_PC_CALLER" "$context" || return "$_PC_ARCHIVE_REQUIRED_FAILURE_RC"
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	[[ -n "$archive_path" ]] || return "$_PC_ARCHIVE_REQUIRED_FAILURE_RC"
+	_pc_profile_publication_marker_valid "$rp_age" "$wt_path_age" || return "$_PC_ARCHIVE_REQUIRED_FAILURE_RC"
+	remove_archived_worktree_path "$wt_path_age" "$archive_path" "$_WTAR_PC_CALLER" \
+		"profile-publication" "$context" "true" "true" || return "$_PC_ARCHIVE_REQUIRED_FAILURE_RC"
+	git -C "$rp_age" worktree prune 2>/dev/null || true
+	unregister_worktree "$wt_path_age" 2>/dev/null || true
+	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+		"profile-publication" "recoverable" "${audit_context} archive_path=${archive_path}"
+	return 0
+}
+
 #######################################
 # Check whether a worktree path or branch is generated worker/review cruft.
 #
@@ -725,6 +806,11 @@ _cleanup_single_worktree() {
 	if _worktree_owner_alive "$wt_path_age" "$wt_branch_age"; then
 		return 1
 	fi
+	if _pc_handle_abandoned_profile_publication "$rp_age" "$wt_path_age" "$wt_branch_age" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age"; then
+		return 0
+	elif [[ "$?" -eq "$_PC_ARCHIVE_REQUIRED_FAILURE_RC" ]]; then
+		return 1
+	fi
 	if _pc_skip_recent_worker_metric_cleanup "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$now_epoch" "$repo_name_age"; then
 		return 1
 	fi
@@ -740,12 +826,11 @@ _cleanup_single_worktree() {
 	"$_PC_ARCHIVE_REQUIRED_FAILURE_RC" | "$_PC_ARCHIVE_HANDLED_SKIP_RC") return 1 ;;
 	esac
 
-	local audit_context
+	local audit_context reason
 	local guard_ok
 	guard_ok=$(printf 'cle%s' 'ar')
 	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$_PC_REMOVAL_NONE" "$guard_ok" "$guard_ok" "$guard_ok" "$_PC_REMOVAL_NONE")
 
-	local reason
 	if ! reason=$(_evaluate_worktree_removal "$commits_ahead" "$dirty_count" "$wt_age_secs" "$wt_branch_age" "$repo_slug_age"); then
 		_pc_log_not_age_eligible_skip "$wt_path_age" "$wt_branch_age" "$commits_ahead" "$dirty_count" "$wt_age_secs" "not-eligible"
 		return 1
@@ -1018,7 +1103,10 @@ _pc_cleanup_orphan_sibling_dirs() {
 	local repos_json="$1"
 	local now_epoch="$2"
 	local moved_count=0
-	[[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1 || { echo 0; return 0; }
+	[[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1 || {
+		echo 0
+		return 0
+	}
 
 	local repo_records_orphan
 	repo_records_orphan=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | [(.path // ""), (.slug // "")] | @tsv' "$repos_json" 2>/dev/null || printf '')
@@ -1155,7 +1243,10 @@ _pc_relocate_registered_worktree() {
 _pc_relocate_registered_worktrees() {
 	local repos_json="$1"
 	local moved_count=0
-	[[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1 || { echo 0; return 0; }
+	[[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1 || {
+		echo 0
+		return 0
+	}
 
 	local central_base=""
 	if declare -F aidevops_worktree_base_dir >/dev/null 2>&1; then
@@ -1164,7 +1255,10 @@ _pc_relocate_registered_worktrees() {
 		central_base=$(aidevops_worktree_base_dir_configured 2>/dev/null || true)
 		[[ -n "$central_base" ]] && mkdir -p "$central_base" 2>/dev/null || true
 	fi
-	[[ -n "$central_base" && -d "$central_base" ]] || { echo 0; return 0; }
+	[[ -n "$central_base" && -d "$central_base" ]] || {
+		echo 0
+		return 0
+	}
 
 	local repo_paths_move
 	repo_paths_move=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null || printf '')

--- a/.agents/scripts/pulse-cleanup-worktree-removal.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-removal.sh
@@ -1103,10 +1103,7 @@ _pc_cleanup_orphan_sibling_dirs() {
 	local repos_json="$1"
 	local now_epoch="$2"
 	local moved_count=0
-	[[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1 || {
-		echo 0
-		return 0
-	}
+	[[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1 || { echo 0; return 0; }
 
 	local repo_records_orphan
 	repo_records_orphan=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | [(.path // ""), (.slug // "")] | @tsv' "$repos_json" 2>/dev/null || printf '')
@@ -1243,10 +1240,7 @@ _pc_relocate_registered_worktree() {
 _pc_relocate_registered_worktrees() {
 	local repos_json="$1"
 	local moved_count=0
-	[[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1 || {
-		echo 0
-		return 0
-	}
+	[[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1 || { echo 0; return 0; }
 
 	local central_base=""
 	if declare -F aidevops_worktree_base_dir >/dev/null 2>&1; then
@@ -1255,10 +1249,7 @@ _pc_relocate_registered_worktrees() {
 		central_base=$(aidevops_worktree_base_dir_configured 2>/dev/null || true)
 		[[ -n "$central_base" ]] && mkdir -p "$central_base" 2>/dev/null || true
 	fi
-	[[ -n "$central_base" && -d "$central_base" ]] || {
-		echo 0
-		return 0
-	}
+	[[ -n "$central_base" && -d "$central_base" ]] || { echo 0; return 0; }
 
 	local repo_paths_move
 	repo_paths_move=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null || printf '')

--- a/.agents/scripts/pulse-cleanup-worktree-removal.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-removal.sh
@@ -826,7 +826,7 @@ _cleanup_single_worktree() {
 	"$_PC_ARCHIVE_REQUIRED_FAILURE_RC" | "$_PC_ARCHIVE_HANDLED_SKIP_RC") return 1 ;;
 	esac
 
-	local audit_context reason
+	local audit_context="" reason=""
 	local guard_ok
 	guard_ok=$(printf 'cle%s' 'ar')
 	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$_PC_REMOVAL_NONE" "$guard_ok" "$guard_ok" "$guard_ok" "$_PC_REMOVAL_NONE")

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -370,6 +370,7 @@ test_update_recovers_dirty_profile_publication_worktree() {
 	local refusing_helper="${helper_dir}/refusing-worktree-helper.sh"
 	local recovery_root="${TEST_DIR}/recovery"
 	local output_file="${TEST_DIR}/update-output"
+	local marker_evidence="${TEST_DIR}/marker-evidence"
 
 	mkdir -p "$helper_dir" "$fixture_home"
 	install_helper_with_libs "$helper_dir"
@@ -381,6 +382,20 @@ set -euo pipefail
 
 target="${2:-}"
 [[ -n "$target" ]] || exit 1
+git_dir=$(git -C "$target" rev-parse --path-format=absolute --git-dir)
+marker_path="${git_dir}/aidevops-profile-publication.json"
+resolved_target=$(cd "$target" && pwd -P)
+jq -e --arg target "$resolved_target" '
+    .schema == "aidevops-profile-publication/v1"
+    and .producer == "profile-readme"
+    and .worktree_path == $target
+' "$marker_path" >/dev/null
+# shellcheck source=../shared-constants.sh
+source "$(cd "$(dirname "$0")" && pwd)/shared-constants.sh"
+owner_snapshot=$(check_worktree_owner_snapshot "$target")
+IFS='|' read -r owner_pid _ _ owner_task _ owner_process_start <<<"$owner_snapshot"
+[[ "$owner_pid" =~ ^[1-9][0-9]*$ && "$owner_task" == "profile-readme" && -n "$owner_process_start" ]]
+printf 'verified\n' >"$PROFILE_MARKER_EVIDENCE"
 printf '%s\n' "recoverable fixture state" >"${target}/.profile-publication-fixture"
 exit 1
 EOF
@@ -392,6 +407,7 @@ EOF
 		AIDEVOPS_WORKTREE_BASE_DIR="${TEST_DIR}/worktrees" \
 		AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
 		AIDEVOPS_PROFILE_WORKTREE_HELPER="$refusing_helper" \
+		PROFILE_MARKER_EVIDENCE="$marker_evidence" \
 		bash "$helper_path" update >"$output_file" 2>&1; then
 		print_helper_failure "$test_name" "helper update command failed" "$output_file"
 		return 0
@@ -399,6 +415,7 @@ EOF
 
 	if [[ "$(git -C "$fixture_repo" worktree list --porcelain | grep -c '^worktree ' || true)" != "1" ]] ||
 		[[ ! -d "$recovery_root" ]] ||
+		[[ "$(cat "$marker_evidence" 2>/dev/null)" != "verified" ]] ||
 		[[ -n "$(git -C "$fixture_repo" status --porcelain --untracked-files=all)" ]]; then
 		print_helper_failure "$test_name" "scratch worktree leaked, recovery archive missing, or canonical checkout changed" "$output_file"
 		return 0

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -68,13 +68,13 @@ setup_repo_with_worker_worktree() {
 		git commit -q -m "worker commit"
 	)
 	local old_ts
-	old_ts=$(date -u -v-30H +%Y%m%d%H%M 2>/dev/null ||
-		date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null ||
-		printf '202601010000\n')
+	old_ts=$(date -u -v-30H +%Y%m%d%H%M 2>/dev/null \
+		|| date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null \
+		|| printf '202601010000\n')
 	if [[ "$age_spec" == "8 days ago" ]]; then
-		old_ts=$(date -u -v-8d +%Y%m%d%H%M 2>/dev/null ||
-			date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null ||
-			printf '202601010000\n')
+		old_ts=$(date -u -v-8d +%Y%m%d%H%M 2>/dev/null \
+			|| date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null \
+			|| printf '202601010000\n')
 	fi
 	touch -t "$old_ts" "$wt_path/.git"
 	return 0
@@ -102,9 +102,9 @@ setup_repo_with_detached_review_worktree() {
 		git commit -q -m "review commit"
 	)
 	local old_ts
-	old_ts=$(date -u -v-2d +%Y%m%d%H%M 2>/dev/null ||
-		date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null ||
-		printf '202601010000\n')
+	old_ts=$(date -u -v-2d +%Y%m%d%H%M 2>/dev/null \
+		|| date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null \
+		|| printf '202601010000\n')
 	touch -t "$old_ts" "$wt_path/.git"
 	return 0
 }
@@ -118,11 +118,7 @@ source_pulse_cleanup_with_stubs() {
 	export ORPHAN_WORKTREE_GRACE_SECS
 
 	is_worktree_owned_by_others() { return 1; }
-	unregister_worktree() {
-		local wt_path="$1"
-		: "$wt_path"
-		return 0
-	}
+	unregister_worktree() { local wt_path="$1"; : "$wt_path"; return 0; }
 	gh() {
 		local target_type="${1:-}"
 		local action="${2:-}"
@@ -923,10 +919,7 @@ test_stale_dirty_attributed_worker_archives_before_removal() {
 
 test_no_newline_pr_output_blocks_local_commit_cleanup() {
 	source_pulse_cleanup_with_stubs || return 1
-	gh_pr_list() {
-		printf '42'
-		return 0
-	}
+	gh_pr_list() { printf '42'; return 0; }
 
 	local reason=""
 	reason=$(_evaluate_worktree_removal 1 0 $((25 * 3600)) "feature/has-pr" "testowner/testrepo" 2>/dev/null)
@@ -942,10 +935,7 @@ test_no_newline_pr_output_blocks_local_commit_cleanup() {
 
 test_no_newline_open_pr_output_blocks_clean_fastpath() {
 	source_pulse_cleanup_with_stubs || return 1
-	gh_pr_list() {
-		printf '42'
-		return 0
-	}
+	gh_pr_list() { printf '42'; return 0; }
 
 	local reason=""
 	reason=$(_evaluate_worktree_removal 0 0 3600 "feature/open-pr" "testowner/testrepo" 2>/dev/null)

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -68,13 +68,13 @@ setup_repo_with_worker_worktree() {
 		git commit -q -m "worker commit"
 	)
 	local old_ts
-	old_ts=$(date -u -v-30H +%Y%m%d%H%M 2>/dev/null \
-		|| date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null \
-		|| printf '202601010000\n')
+	old_ts=$(date -u -v-30H +%Y%m%d%H%M 2>/dev/null ||
+		date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null ||
+		printf '202601010000\n')
 	if [[ "$age_spec" == "8 days ago" ]]; then
-		old_ts=$(date -u -v-8d +%Y%m%d%H%M 2>/dev/null \
-			|| date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null \
-			|| printf '202601010000\n')
+		old_ts=$(date -u -v-8d +%Y%m%d%H%M 2>/dev/null ||
+			date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null ||
+			printf '202601010000\n')
 	fi
 	touch -t "$old_ts" "$wt_path/.git"
 	return 0
@@ -102,9 +102,9 @@ setup_repo_with_detached_review_worktree() {
 		git commit -q -m "review commit"
 	)
 	local old_ts
-	old_ts=$(date -u -v-2d +%Y%m%d%H%M 2>/dev/null \
-		|| date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null \
-		|| printf '202601010000\n')
+	old_ts=$(date -u -v-2d +%Y%m%d%H%M 2>/dev/null ||
+		date -u -d "$age_spec" +%Y%m%d%H%M 2>/dev/null ||
+		printf '202601010000\n')
 	touch -t "$old_ts" "$wt_path/.git"
 	return 0
 }
@@ -118,7 +118,11 @@ source_pulse_cleanup_with_stubs() {
 	export ORPHAN_WORKTREE_GRACE_SECS
 
 	is_worktree_owned_by_others() { return 1; }
-	unregister_worktree() { local wt_path="$1"; : "$wt_path"; return 0; }
+	unregister_worktree() {
+		local wt_path="$1"
+		: "$wt_path"
+		return 0
+	}
 	gh() {
 		local target_type="${1:-}"
 		local action="${2:-}"
@@ -919,7 +923,10 @@ test_stale_dirty_attributed_worker_archives_before_removal() {
 
 test_no_newline_pr_output_blocks_local_commit_cleanup() {
 	source_pulse_cleanup_with_stubs || return 1
-	gh_pr_list() { printf '42'; return 0; }
+	gh_pr_list() {
+		printf '42'
+		return 0
+	}
 
 	local reason=""
 	reason=$(_evaluate_worktree_removal 1 0 $((25 * 3600)) "feature/has-pr" "testowner/testrepo" 2>/dev/null)
@@ -935,7 +942,10 @@ test_no_newline_pr_output_blocks_local_commit_cleanup() {
 
 test_no_newline_open_pr_output_blocks_clean_fastpath() {
 	source_pulse_cleanup_with_stubs || return 1
-	gh_pr_list() { printf '42'; return 0; }
+	gh_pr_list() {
+		printf '42'
+		return 0
+	}
 
 	local reason=""
 	reason=$(_evaluate_worktree_removal 0 0 3600 "feature/open-pr" "testowner/testrepo" 2>/dev/null)
@@ -1042,6 +1052,51 @@ test_terminal_pr_identity_and_policy_guards() {
 	return 0
 }
 
+test_abandoned_profile_publication_is_archived_recoverably() {
+	local repo_dir="${TEST_ROOT}/profile-repo"
+	local wt_path="${TEST_ROOT}/profile-repo-profile-readme-20260901000000-123-456"
+	local recovery_root="${TEST_ROOT}/profile-recovery"
+	local git_dir=""
+	local common_dir=""
+	local canonical_head=""
+	local resolved_wt_path=""
+	local old_ts=""
+
+	mkdir -p "$repo_dir"
+	git -C "$repo_dir" init -q -b main
+	git -C "$repo_dir" config user.email "test@example.invalid"
+	git -C "$repo_dir" config user.name "Test Profile"
+	printf 'base\n' >"${repo_dir}/README.md"
+	git -C "$repo_dir" add README.md
+	git -C "$repo_dir" commit -q -m init
+	git -C "$repo_dir" worktree add -q --detach "$wt_path" main
+	printf 'recoverable generated state\n' >"${wt_path}/profile.tmp"
+	git_dir=$(git -C "$wt_path" rev-parse --path-format=absolute --git-dir)
+	resolved_wt_path=$(cd "$wt_path" && pwd -P)
+	common_dir=$(git -C "$repo_dir" rev-parse --path-format=absolute --git-common-dir)
+	canonical_head=$(git -C "$repo_dir" rev-parse HEAD)
+	jq -n --arg path "$resolved_wt_path" --arg common "$common_dir" --arg head "$canonical_head" '
+		{schema:"aidevops-profile-publication/v1",producer:"profile-readme",worktree_path:$path,canonical_common_dir:$common,canonical_head:$head,created_epoch:1}
+	' >"${git_dir}/aidevops-profile-publication.json"
+	old_ts=$(date -u -v-3H +%Y%m%d%H%M 2>/dev/null || date -u -d '3 hours ago' +%Y%m%d%H%M)
+	touch -t "$old_ts" "$wt_path/.git"
+
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root"
+	ORPHAN_PROFILE_PUBLICATION_ARCHIVE_SECS=7200
+	export AIDEVOPS_WORKTREE_TRASH_ROOT ORPHAN_PROFILE_PUBLICATION_ARCHIVE_SECS
+	source_pulse_cleanup_with_stubs || return 1
+	local now_epoch=""
+	now_epoch=$(date +%s)
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+	local rc=0
+	[[ "$cleanup_rc" -eq 0 ]] || rc=1
+	[[ ! -d "$wt_path" && -d "$recovery_root" ]] || rc=1
+	grep -q 'profile-publication.*recoverable' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "abandoned marked profile publication is archived recoverably" "$rc" "cleanup_rc=$cleanup_rc"
+	return 0
+}
+
 TEST_ROOT=$(mktemp -d)
 trap teardown EXIT
 export HOME="${TEST_ROOT}/home"
@@ -1077,6 +1132,7 @@ test_no_newline_open_pr_output_blocks_clean_fastpath
 test_branch_pr_lookup_uses_null_safe_jq_filter
 test_branch_pr_lookup_treats_null_pr_number_as_no_pr
 test_terminal_pr_identity_and_policy_guards
+test_abandoned_profile_publication_is_archived_recoverably
 
 echo ""
 echo "Results: $((TESTS_RUN - TESTS_FAILED))/${TESTS_RUN} passed, ${TESTS_FAILED} failed."


### PR DESCRIPTION
## Summary

Register profile publication worktrees with exact process-generation ownership, persist validated provenance in Git administrative metadata, and recoverably archive abandoned marked worktrees after the bounded grace period.

## Files Changed

.agents/scripts/profile-readme-helper.sh, .agents/scripts/pulse-cleanup-worktree-removal.sh, .agents/scripts/tests/test-profile-readme-boundary.sh, .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — profile publication boundary 27/27, worker-owned cleanup 34/34, dirty preservation 5/5, temp cleanup 14/14; ShellCheck, changed/full local lint, Pulse unbound-var scan, complexity regression, version validation, and exact-head review bundle `0c9328d1e51475743d6da512c4d799f9e17151ec16d8ea381451550a1128f0c7` pass.

Resolves #31405

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.329 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 40m and 233,229 tokens on this with the user in an interactive session.
