### PR TITLE
GH#31407: reclaim verified detached profile archives

### DIFF
--- a/.agents/reference/storage-lifecycle-worktree-recovery.md
+++ b/.agents/reference/storage-lifecycle-worktree-recovery.md
@@ -80,8 +80,8 @@ expected allocated bytes, schema, and permanent-delete action. Earlier or
 tokenless plan versions are never upgraded into destructive authorization.
 
 Candidate status requires a valid complete archive, completed source removal,
-a clean tracked/untracked/user-ignored Git state, an exact merged commit, a
-closed linked task, no open pull request, no live Git
+a clean tracked/untracked/user-ignored Git state, an exact terminal commit, no
+open pull request, no live Git
 worktree/registry/claim/process reference, and exact readable sizing. Ignored,
 untracked directories with recognised regenerable-cache identities
 (`node_modules`, `.pnpm-store`, `.yarn/cache`, `.next/cache`, `.nuxt/cache`,
@@ -94,6 +94,16 @@ validation, or sizing is `unknown`. Identity and allocated bytes are read again
 immediately before an entry is emitted, so concurrent drift downgrades only
 that entry. Age, size, and OpenCode or Claude session history never prove
 reclaimability. Plan files grant no deletion authority by themselves.
+
+Branch-backed archives prove terminal state through an exact merged PR head and
+a closed linked task. Detached archives remain protected unless their v2
+producer identity matches the profile publication scratch-worktree contract.
+That narrow producer has no branch-keyed claim or linked task; it becomes
+eligible only when GitHub independently proves the archived HEAD is the merge
+base of the repository's current default-branch tip. A changed producer/context,
+unavailable API, non-ancestor commit, dirty archive, or live local reference
+still preserves the bucket. Other detached producers remain protected until
+they define an equally specific evidence contract.
 
 Automatic maintenance may reclaim those same approved cache roots from an
 otherwise protected mixed archive without deleting the archive. This narrower

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -483,21 +483,26 @@ test_detached_claim_does_not_invent_active_owner() {
 
 test_profile_publication_detached_evidence_is_exact_and_fail_closed() {
 	local identity='' evidence='' result='' disposition='' reason='' mode=''
+	local evidence_path="${TEST_DIR}/profile-evidence.json"
 	local rc=0
 	identity=$(jq -cn \
 		'{format:"aidevops-worktree-recovery-v2",archive_path:"/recovery/profile",source_path:"/worktrees/profile-readme",head:"abc123",branch:"detached",producer:"profile-readme-helper.sh",producer_context:"recovery_path=profile-publication-archive profile_scratch=true",source_removal_outcome:"removed"}') || rc=1
 
 	for mode in published unpublished unavailable; do
-		evidence=$(
+		if ! (
 			_worktree_recovery_plan_repo_slug() {
 				printf '%s\n' 'example/profile'
 				return 0
 			}
-			command() { [[ "$1" == '-v' && "$2" == 'gh' ]]; }
+			command() {
+				[[ "$1" == '-v' && "$2" == 'gh' ]]
+			}
 			gh() {
 				[[ "$mode" != 'unavailable' ]] || return 1
 				case "$2" in
-				'repos/example/profile') printf '%s\n' 'main' ;;
+				'repos/example/profile')
+					printf '%s\n' 'main'
+					;;
 				'repos/example/profile/compare/abc123...main')
 					if [[ "$mode" == 'published' ]]; then
 						printf 'ahead\tabc123\n'
@@ -509,8 +514,11 @@ test_profile_publication_detached_evidence_is_exact_and_fail_closed() {
 				esac
 				return 0
 			}
-			_worktree_recovery_plan_profile_publication_evidence_json "$identity"
-		) || rc=1
+			_worktree_recovery_plan_profile_publication_evidence_json "$identity" >"$evidence_path"
+		); then
+			rc=1
+		fi
+		evidence=$(<"$evidence_path") || rc=1
 		case "$mode" in
 		published)
 			printf '%s\n' "$evidence" | jq -e \
@@ -542,7 +550,7 @@ test_profile_publication_detached_evidence_is_exact_and_fail_closed() {
 	result=$(_worktree_recovery_plan_classification_json "$identity" \
 		"$(jq -cn --argjson external "$evidence" '{git:"clear",worktree:"clear",registry:"clear",claim:"not-applicable",process:"active",external:$external}')" true) || rc=1
 	[[ "$(printf '%s\n' "$result" | jq -r '.reasons[0]')" == 'active-process-reference' ]] || rc=1
-	evidence=$(
+	if ! (
 		_worktree_recovery_plan_git_state() { printf 'clear\n'; }
 		_worktree_recovery_plan_worktree_reference_state() { printf 'clear\n'; }
 		_worktree_recovery_plan_registry_state() { printf 'clear\n'; }
@@ -551,8 +559,11 @@ test_profile_publication_detached_evidence_is_exact_and_fail_closed() {
 		_worktree_recovery_plan_external_evidence_json() {
 			printf '%s\n' '{"commit":"published","open_pr":"clear","task":"not-applicable","issue_number":null,"repo":"example/profile","provenance":"profile-publication"}'
 		}
-		_worktree_recovery_plan_evidence_json "$identity"
-	) || rc=1
+		_worktree_recovery_plan_evidence_json "$identity" >"$evidence_path"
+	); then
+		rc=1
+	fi
+	evidence=$(<"$evidence_path") || rc=1
 	[[ "$(printf '%s\n' "$evidence" | jq -r '.claim')" == 'not-applicable' ]] || rc=1
 	[[ "$(printf '%s\n' "$evidence" | jq -r '.external.commit')" == 'published' ]] || rc=1
 	print_result "profile_publication_detached_evidence_is_exact_and_fail_closed" "$rc" \

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -481,6 +481,149 @@ test_detached_claim_does_not_invent_active_owner() {
 	return 0
 }
 
+test_profile_publication_detached_evidence_is_exact_and_fail_closed() {
+	local identity='' evidence='' result='' disposition='' reason='' mode=''
+	local rc=0
+	identity=$(jq -cn \
+		'{format:"aidevops-worktree-recovery-v2",archive_path:"/recovery/profile",source_path:"/worktrees/profile-readme",head:"abc123",branch:"detached",producer:"profile-readme-helper.sh",producer_context:"recovery_path=profile-publication-archive profile_scratch=true",source_removal_outcome:"removed"}') || rc=1
+
+	for mode in published unpublished unavailable; do
+		evidence=$(
+			_worktree_recovery_plan_repo_slug() {
+				printf '%s\n' 'example/profile'
+				return 0
+			}
+			command() { [[ "$1" == '-v' && "$2" == 'gh' ]]; }
+			gh() {
+				[[ "$mode" != 'unavailable' ]] || return 1
+				case "$2" in
+				'repos/example/profile') printf '%s\n' 'main' ;;
+				'repos/example/profile/compare/abc123...main')
+					if [[ "$mode" == 'published' ]]; then
+						printf 'ahead\tabc123\n'
+					else
+						printf 'diverged\tdef456\n'
+					fi
+					;;
+				*) return 1 ;;
+				esac
+				return 0
+			}
+			_worktree_recovery_plan_profile_publication_evidence_json "$identity"
+		) || rc=1
+		case "$mode" in
+		published)
+			printf '%s\n' "$evidence" | jq -e \
+				'.commit == "published" and .open_pr == "clear" and .task == "not-applicable" and .provenance == "profile-publication"' \
+				>/dev/null || rc=1
+			;;
+		unpublished)
+			[[ "$(printf '%s\n' "$evidence" | jq -r '.commit')" == 'unproven' ]] || rc=1
+			;;
+		unavailable)
+			[[ "$(printf '%s\n' "$evidence" | jq -r '.commit')" == "$WORKTREE_RECOVERY_UNAVAILABLE" ]] || rc=1
+			;;
+		esac
+		result=$(_worktree_recovery_plan_classification_json "$identity" \
+			"$(jq -cn --argjson external "$evidence" '{git:"clear",worktree:"clear",registry:"clear",claim:"not-applicable",process:"clear",external:$external}')" true) || rc=1
+		disposition=$(printf '%s\n' "$result" | jq -r '.disposition') || rc=1
+		reason=$(printf '%s\n' "$result" | jq -r '.reasons[0]') || rc=1
+		case "$mode" in
+		published) [[ "$disposition:$reason" == 'candidate:producer-published-detached-evidence-clear' ]] || rc=1 ;;
+		unpublished) [[ "$disposition:$reason" == 'protected:exact-commit-not-published' ]] || rc=1 ;;
+		unavailable) [[ "$disposition:$reason" == 'unknown:required-evidence-unavailable' ]] || rc=1 ;;
+		esac
+	done
+	evidence='{"commit":"published","open_pr":"clear","task":"not-applicable","issue_number":null,"repo":"example/profile","provenance":"profile-publication"}'
+	result=$(_worktree_recovery_plan_classification_json \
+		"$(printf '%s\n' "$identity" | jq -c '.producer_context = "malformed"')" \
+		"$(jq -cn --argjson external "$evidence" '{git:"clear",worktree:"clear",registry:"clear",claim:"not-applicable",process:"clear",external:$external}')" true) || rc=1
+	[[ "$(printf '%s\n' "$result" | jq -r '.reasons[0]')" == 'detached-or-unresolved-branch' ]] || rc=1
+	result=$(_worktree_recovery_plan_classification_json "$identity" \
+		"$(jq -cn --argjson external "$evidence" '{git:"clear",worktree:"clear",registry:"clear",claim:"not-applicable",process:"active",external:$external}')" true) || rc=1
+	[[ "$(printf '%s\n' "$result" | jq -r '.reasons[0]')" == 'active-process-reference' ]] || rc=1
+	evidence=$(
+		_worktree_recovery_plan_git_state() { printf 'clear\n'; }
+		_worktree_recovery_plan_worktree_reference_state() { printf 'clear\n'; }
+		_worktree_recovery_plan_registry_state() { printf 'clear\n'; }
+		_worktree_recovery_plan_claim_state() { printf 'not-applicable\n'; }
+		_worktree_recovery_plan_process_state() { printf 'clear\n'; }
+		_worktree_recovery_plan_external_evidence_json() {
+			printf '%s\n' '{"commit":"published","open_pr":"clear","task":"not-applicable","issue_number":null,"repo":"example/profile","provenance":"profile-publication"}'
+		}
+		_worktree_recovery_plan_evidence_json "$identity"
+	) || rc=1
+	[[ "$(printf '%s\n' "$evidence" | jq -r '.claim')" == 'not-applicable' ]] || rc=1
+	[[ "$(printf '%s\n' "$evidence" | jq -r '.external.commit')" == 'published' ]] || rc=1
+	print_result "profile_publication_detached_evidence_is_exact_and_fail_closed" "$rc" \
+		"Expected producer-bound publication proof while malformed, live, unavailable, or unpublished archives remain preserved"
+	return 0
+}
+
+test_profile_publication_detached_archive_plans_without_apply() {
+	local home_path="${TEST_DIR}/profile-plan-home"
+	local repo_path="${TEST_DIR}/profile-plan-repo"
+	local worktree_path="${TEST_DIR}/profile-plan-worktree"
+	local dirty_worktree_path="${TEST_DIR}/profile-plan-dirty-worktree"
+	local recovery_root="${home_path}/recovery"
+	local plan_path="${TEST_DIR}/profile-plan.json"
+	local archive_path='' dirty_archive_path='' rc=0
+
+	mkdir -p "$home_path" "$recovery_root" || rc=1
+	"$GIT_BIN" init -q -b main "$repo_path" || rc=1
+	"$GIT_BIN" -C "$repo_path" config user.email test@example.invalid || rc=1
+	"$GIT_BIN" -C "$repo_path" config user.name 'Aidevops Test' || rc=1
+	"$GIT_BIN" -C "$repo_path" config commit.gpgsign false || rc=1
+	printf 'profile\n' >"${repo_path}/README.md" || rc=1
+	"$GIT_BIN" -C "$repo_path" add README.md || rc=1
+	"$GIT_BIN" -C "$repo_path" commit -q -m init || rc=1
+	"$GIT_BIN" -C "$repo_path" remote add origin 'https://github.com/example/profile.git' || rc=1
+	"$GIT_BIN" -C "$repo_path" worktree add -q --detach "$worktree_path" HEAD || rc=1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
+		archive_worktree_path_recoverably "$worktree_path" 'profile-readme-helper.sh' \
+		'recovery_path=profile-publication-archive profile_scratch=true' || rc=1
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" remove_archived_worktree_path \
+		"$worktree_path" "$archive_path" 'profile-readme-helper.sh' 'profile-publication' \
+		'recovery_path=profile-publication-archive profile_scratch=true' 'true' 'true' || rc=1
+	"$GIT_BIN" -C "$repo_path" worktree add -q --detach "$dirty_worktree_path" HEAD || rc=1
+	printf 'unique unpublished data\n' >"${dirty_worktree_path}/unique.bin" || rc=1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
+		archive_worktree_path_recoverably "$dirty_worktree_path" 'profile-readme-helper.sh' \
+		'recovery_path=profile-publication-archive profile_scratch=true' || rc=1
+	dirty_archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" remove_archived_worktree_path \
+		"$dirty_worktree_path" "$dirty_archive_path" 'profile-readme-helper.sh' 'profile-publication' \
+		'recovery_path=profile-publication-archive profile_scratch=true' 'true' 'true' || rc=1
+	if ! (
+		_worktree_recovery_plan_worktree_reference_state() { printf 'clear\n'; }
+		_worktree_recovery_plan_registry_state() { printf 'clear\n'; }
+		_worktree_recovery_plan_process_state() { printf 'clear\n'; }
+		_worktree_recovery_plan_external_evidence_json() {
+			printf '%s\n' '{"commit":"published","open_pr":"clear","task":"not-applicable","issue_number":null,"repo":"example/profile","provenance":"profile-publication"}'
+		}
+		HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+			cmd_recovery plan --output "$plan_path" >/dev/null
+	); then
+		rc=1
+	fi
+	jq -e --arg archive "$archive_path" --arg dirty_archive "$dirty_archive_path" '
+		.candidate_count == 1 and .protected_count == 1 and .unknown_count == 0 and
+		(.entries[] | select(.archive_path == $archive) |
+			.identity.producer == "profile-readme-helper.sh" and
+			.identity.producer_context == "recovery_path=profile-publication-archive profile_scratch=true" and
+			.evidence.claim == "not-applicable" and
+			.reasons == ["producer-published-detached-evidence-clear"]) and
+		(.entries[] | select(.archive_path == $dirty_archive) |
+			.disposition == "protected" and .reasons == ["archive-worktree-dirty"])
+	' "$plan_path" >/dev/null || rc=1
+	[[ -d "$archive_path" && -d "$dirty_archive_path" &&
+		! -e "$worktree_path" && ! -e "$dirty_worktree_path" ]] || rc=1
+	print_result "profile_publication_detached_archive_plans_without_apply" "$rc" \
+		"Expected only the clean published archive to become a read-only candidate while unique unpublished data remains protected"
+	return 0
+}
+
 test_plan_output_refuses_unsafe_targets() {
 	local existing_path="${TEST_DIR}/existing-plan.json"
 	local symlink_path="${TEST_DIR}/symlink-plan.json"
@@ -2431,6 +2574,8 @@ run_all_tests() {
 	test_archive_pruning_preserves_tracked_codegraph_root
 	test_claim_state_uses_archive_repository
 	test_detached_claim_does_not_invent_active_owner
+	test_profile_publication_detached_evidence_is_exact_and_fail_closed
+	test_profile_publication_detached_archive_plans_without_apply
 	test_recovery_issue_attribution_uses_archived_source_path
 	test_unlinked_merged_pr_is_terminal_task_evidence
 	test_dirty_recovery_short_circuits_expensive_probes

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -16,9 +16,16 @@ WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN="unknown"
 WORKTREE_RECOVERY_PLAN_STATE_ACTIVE="active"
 WORKTREE_RECOVERY_PLAN_STATE_CLEAR="clear"
 WORKTREE_RECOVERY_PLAN_STATE_DIRTY="dirty"
+WORKTREE_RECOVERY_PLAN_STATE_NOT_APPLICABLE="not-applicable"
+WORKTREE_RECOVERY_PLAN_BRANCH_DETACHED="detached"
+WORKTREE_RECOVERY_PLAN_COMMIT_PUBLISHED="published"
+WORKTREE_RECOVERY_PLAN_COMMIT_UNPROVEN="unproven"
 WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT="exact"
 WORKTREE_RECOVERY_PLAN_JSON_NULL="null"
 WORKTREE_RECOVERY_PRODUCER="worktree-helper"
+WORKTREE_RECOVERY_PROFILE_PRODUCER="profile-readme-helper.sh"
+WORKTREE_RECOVERY_PROFILE_CONTEXT="recovery_path=profile-publication-archive profile_scratch=true"
+WORKTREE_RECOVERY_PROFILE_PROVENANCE="profile-publication"
 WORKTREE_RECOVERY_AUTOMATION_POLICY_SCHEMA="aidevops.worktree-recovery-automation-policy/v1"
 WORKTREE_RECOVERY_AUTOMATION_POLICY_ID="bounded-terminal-evidence-v1"
 
@@ -592,8 +599,8 @@ _worktree_recovery_plan_claim_state() {
 	branch=$(printf '%s\n' "$identity_json" | jq -r '.branch') || return 1
 	# Detached archives have no branch-keyed claim. Do not invent a live owner
 	# or report clear evidence: the classifier still protects detached identity.
-	if [[ "$branch" == "detached" ]]; then
-		printf '%s\n' 'not-applicable'
+	if [[ "$branch" == "$WORKTREE_RECOVERY_PLAN_BRANCH_DETACHED" ]]; then
+		printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_NOT_APPLICABLE"
 		return 0
 	fi
 	[[ "$branch" == refs/heads/* ]] || {
@@ -703,6 +710,64 @@ _worktree_recovery_plan_identity_issue_number() {
 	return 1
 }
 
+_worktree_recovery_plan_is_profile_publication() {
+	local identity_json="$1"
+	local format=""
+	local branch=""
+	local producer=""
+	local producer_context=""
+
+	format=$(printf '%s\n' "$identity_json" | jq -r '.format // ""') || return 1
+	branch=$(printf '%s\n' "$identity_json" | jq -r '.branch // ""') || return 1
+	producer=$(printf '%s\n' "$identity_json" | jq -r '.producer // ""') || return 1
+	producer_context=$(printf '%s\n' "$identity_json" | jq -r '.producer_context // ""') || return 1
+	[[ "$format" == "$_WT_RECOVERY_FORMAT_V2" && "$branch" == "$WORKTREE_RECOVERY_PLAN_BRANCH_DETACHED" &&
+		"$producer" == "$WORKTREE_RECOVERY_PROFILE_PRODUCER" &&
+		"$producer_context" == "$WORKTREE_RECOVERY_PROFILE_CONTEXT" ]]
+}
+
+_worktree_recovery_plan_profile_publication_evidence_json() {
+	local identity_json="$1"
+	local archive_path=""
+	local head=""
+	local repo_slug=""
+	local default_branch=""
+	local comparison=""
+	local comparison_status=""
+	local merge_base=""
+	local commit_state="$WORKTREE_RECOVERY_PLAN_COMMIT_UNPROVEN"
+
+	archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
+	head=$(printf '%s\n' "$identity_json" | jq -r '.head') || return 1
+	repo_slug=$(_worktree_recovery_plan_repo_slug "$archive_path") || {
+		jq -cn --arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
+			--arg provenance "$WORKTREE_RECOVERY_PROFILE_PROVENANCE" \
+			'{commit:$unavailable,open_pr:$unavailable,task:$unavailable,issue_number:null,repo:null,provenance:$provenance}'
+		return 0
+	}
+	if ! command -v gh >/dev/null 2>&1 ||
+		! default_branch=$(gh api "repos/${repo_slug}" --jq '.default_branch // empty' 2>/dev/null) ||
+		[[ -z "$default_branch" ]] ||
+		! comparison=$(gh api "repos/${repo_slug}/compare/${head}...${default_branch}" \
+			--jq '[.status, .merge_base_commit.sha] | @tsv' 2>/dev/null); then
+		jq -cn --arg repo "$repo_slug" --arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
+			--arg provenance "$WORKTREE_RECOVERY_PROFILE_PROVENANCE" \
+			'{commit:$unavailable,open_pr:$unavailable,task:$unavailable,issue_number:null,repo:$repo,provenance:$provenance}'
+		return 0
+	fi
+	IFS=$'\t' read -r comparison_status merge_base <<<"$comparison"
+	if [[ "$merge_base" == "$head" ]] &&
+		[[ "$comparison_status" == "ahead" || "$comparison_status" == "identical" ]]; then
+		commit_state="$WORKTREE_RECOVERY_PLAN_COMMIT_PUBLISHED"
+	fi
+	jq -cn --arg repo "$repo_slug" --arg commit "$commit_state" \
+		--arg clear "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" \
+		--arg task "$WORKTREE_RECOVERY_PLAN_STATE_NOT_APPLICABLE" \
+		--arg provenance "$WORKTREE_RECOVERY_PROFILE_PROVENANCE" \
+		'{commit:$commit,open_pr:$clear,task:$task,issue_number:null,repo:$repo,provenance:$provenance}'
+	return $?
+}
+
 _worktree_recovery_plan_external_evidence_json() {
 	local identity_json="$1"
 	local archive_path="" source_path="" branch_name="" head="" repo_slug=""
@@ -714,6 +779,17 @@ _worktree_recovery_plan_external_evidence_json() {
 	source_path=$(printf '%s\n' "$identity_json" | jq -r '.source_path') || return 1
 	branch=$(printf '%s\n' "$identity_json" | jq -r '.branch') || return 1
 	head=$(printf '%s\n' "$identity_json" | jq -r '.head') || return 1
+	if [[ "$branch" == "$WORKTREE_RECOVERY_PLAN_BRANCH_DETACHED" ]]; then
+		if _worktree_recovery_plan_is_profile_publication "$identity_json"; then
+			_worktree_recovery_plan_profile_publication_evidence_json "$identity_json"
+			return $?
+		fi
+		jq -cn --arg commit "$WORKTREE_RECOVERY_PLAN_COMMIT_UNPROVEN" \
+			--arg clear "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" \
+			--arg task "$WORKTREE_RECOVERY_PLAN_STATE_NOT_APPLICABLE" \
+			'{commit:$commit,open_pr:$clear,task:$task,issue_number:null,repo:null,provenance:"unsupported-detached-producer"}'
+		return 0
+	fi
 	branch_name="${branch#refs/heads/}"
 	repo_slug=$(_worktree_recovery_plan_repo_slug "$archive_path") || {
 		jq -cn --arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
@@ -805,9 +881,12 @@ _worktree_recovery_plan_evidence_json() {
 	fi
 	claim_state=$(_worktree_recovery_plan_claim_state "$identity_json") || return 1
 	if [[ "$claim_state" != "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ]]; then
-		_worktree_recovery_plan_partial_evidence_json \
-			"$git_state" "$worktree_state" "$registry_state" "$claim_state"
-		return $?
+		if [[ "$claim_state" != "$WORKTREE_RECOVERY_PLAN_STATE_NOT_APPLICABLE" ]] ||
+			! _worktree_recovery_plan_is_profile_publication "$identity_json"; then
+			_worktree_recovery_plan_partial_evidence_json \
+				"$git_state" "$worktree_state" "$registry_state" "$claim_state"
+			return $?
+		fi
 	fi
 	process_state=$(_worktree_recovery_plan_process_state "$identity_json") || return 1
 	if [[ "$process_state" != "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ]]; then
@@ -818,9 +897,11 @@ _worktree_recovery_plan_evidence_json() {
 	external_json=$(_worktree_recovery_plan_external_evidence_json "$identity_json") || return 1
 	printf '%s\n' "$external_json" | jq -e \
 		--arg clear "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" \
+		--arg published "$WORKTREE_RECOVERY_PLAN_COMMIT_PUBLISHED" \
+		--arg unproven "$WORKTREE_RECOVERY_PLAN_COMMIT_UNPROVEN" \
 		--arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" '
 		type == "object" and
-		(.commit | IN("merged","unproven",$unavailable)) and
+		(.commit | IN("merged",$published,$unproven,$unavailable)) and
 		(.open_pr | IN("active",$clear,$unavailable)) and
 		(.task | type == "string")
 	' >/dev/null 2>&1 || return 1
@@ -845,8 +926,19 @@ _worktree_recovery_plan_classification_json() {
 		--arg clear "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" \
 		--arg dirty "$WORKTREE_RECOVERY_PLAN_STATE_DIRTY" \
 		--arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
+		--arg profile_producer "$WORKTREE_RECOVERY_PROFILE_PRODUCER" \
+		--arg profile_context "$WORKTREE_RECOVERY_PROFILE_CONTEXT" \
+		--arg profile_provenance "$WORKTREE_RECOVERY_PROFILE_PROVENANCE" \
+		--arg published "$WORKTREE_RECOVERY_PLAN_COMMIT_PUBLISHED" \
+		--arg not_applicable "$WORKTREE_RECOVERY_PLAN_STATE_NOT_APPLICABLE" \
 		--argjson identity "$identity_json" --argjson evidence "$evidence_json" \
 		--argjson stable "$stable" '
+		def profile_publication:
+			$identity.format == "aidevops-worktree-recovery-v2" and
+			$identity.branch == "detached" and
+			$identity.producer == $profile_producer and
+			$identity.producer_context == $profile_context and
+			($evidence.external.provenance // "") == $profile_provenance;
 		if $stable != true then {disposition:$unknown,reasons:["identity-or-size-changed"]}
 		elif $evidence.git == $dirty then {disposition:$protected,reasons:["archive-worktree-dirty"]}
 		elif $evidence.worktree == $active then {disposition:$protected,reasons:["active-git-worktree-reference"]}
@@ -855,10 +947,19 @@ _worktree_recovery_plan_classification_json() {
 		elif $evidence.process == $active then {disposition:$protected,reasons:["active-process-reference"]}
 		elif $evidence.external.open_pr == $active then {disposition:$protected,reasons:["open-pull-request"]}
 		elif $identity.source_removal_outcome != "removed" then {disposition:$protected,reasons:["source-removal-not-complete"]}
-		elif ($identity.branch | startswith("refs/heads/") | not) then {disposition:$protected,reasons:["detached-or-unresolved-branch"]}
+		elif ($identity.branch | startswith("refs/heads/") | not) and (profile_publication | not)
+		then {disposition:$protected,reasons:["detached-or-unresolved-branch"]}
 		elif ([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.claim,$evidence.process,
 			$evidence.external.commit,$evidence.external.open_pr,$evidence.external.task ] | index($unavailable)) != null
 		then {disposition:$unknown,reasons:["required-evidence-unavailable"]}
+		elif profile_publication and $evidence.external.commit != $published
+		then {disposition:$protected,reasons:["exact-commit-not-published"]}
+		elif profile_publication and $evidence.external.task != $not_applicable
+		then {disposition:$unknown,reasons:["unrecognised-evidence-state"]}
+		elif profile_publication and
+			([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.process ] | all(. == $clear)) and
+			$evidence.claim == $not_applicable
+		then {disposition:$candidate,reasons:["producer-published-detached-evidence-clear"]}
 		elif $evidence.external.commit != "merged" then {disposition:$protected,reasons:["exact-commit-not-merged"]}
 		elif $evidence.external.task != "closed" then {disposition:$protected,reasons:["linked-task-not-closed"]}
 		elif ([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.claim,$evidence.process ] | all(. == $clear))

--- a/.agents/scripts/worktree-recovery-maintenance-helper.sh
+++ b/.agents/scripts/worktree-recovery-maintenance-helper.sh
@@ -275,7 +275,8 @@ _worktree_recovery_maintenance_zero_reason_counts_json() {
 		unrecognised_evidence_state:0,age_unavailable:0,archive_worktree_dirty:0,
 		active_git_worktree_reference:0,active_registry_owner:0,active_session_claim:0,
 		active_process_reference:0,open_pull_request:0,source_removal_not_complete:0,
-		detached_or_unresolved_branch:0,exact_commit_not_merged:0,linked_task_not_closed:0,
+		detached_or_unresolved_branch:0,exact_commit_not_merged:0,exact_commit_not_published:0,
+		linked_task_not_closed:0,
 		protected_other:0,retention_policy:0,selection_limit:0}'
 	return $?
 }
@@ -304,6 +305,7 @@ _worktree_recovery_maintenance_record_reason() {
 	source-removal-not-complete) safe_reason="source_removal_not_complete" ;;
 	detached-or-unresolved-branch) safe_reason="detached_or_unresolved_branch" ;;
 	exact-commit-not-merged) safe_reason="exact_commit_not_merged" ;;
+	exact-commit-not-published) safe_reason="exact_commit_not_published" ;;
 	linked-task-not-closed) safe_reason="linked_task_not_closed" ;;
 	retention-policy) safe_reason="retention_policy" ;;
 	selection-limit) safe_reason="selection_limit" ;;


### PR DESCRIPTION
## Summary

Allow only producer-authenticated detached profile publication archives with exact default-branch publication evidence to enter recovery cleanup plans; preserve all unsupported, dirty, live, unpublished, or unavailable cases.

## Files Changed

.agents/reference/storage-lifecycle-worktree-recovery.md, .agents/scripts/tests/test-worktree-recovery-lifecycle.sh, .agents/scripts/worktree-recovery-lifecycle-helper.sh, .agents/scripts/worktree-recovery-maintenance-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 51 recovery lifecycle tests pass; ShellCheck and changed-file linters pass; synthetic archive-to-plan flow preserves unique unpublished data; live GitHub compare semantics verified.

Resolves #31407


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.329 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 53m and 377,041 tokens on this with the user in an interactive session.