### PR TITLE
GH#31468: Limit prefetch fallback to failed repositories

### DIFF
--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -780,13 +780,17 @@ _conditional_rest_refresh_slug() {
 _conditional_rest_per_slug() {
 	local kind="$1"
 	local slugs="${2:-}"
+	# Bash 3.2 output parameter, scoped by each owner/collection caller.
+	_CONDITIONAL_REST_FAILED_SLUGS=""
 	[[ -n "$slugs" ]] || return 1
-	local slug="" failures=0
+	local slug=""
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
-		_conditional_rest_refresh_slug "$kind" "$slug" || failures=$((failures + 1))
+		if ! _conditional_rest_refresh_slug "$kind" "$slug"; then
+			_CONDITIONAL_REST_FAILED_SLUGS="${_CONDITIONAL_REST_FAILED_SLUGS:+${_CONDITIONAL_REST_FAILED_SLUGS},}${slug}"
+		fi
 	done < <(tr ',' '\n' <<< "$slugs")
-	[[ "$failures" -eq 0 ]] || return 1
+	[[ -z "$_CONDITIONAL_REST_FAILED_SLUGS" ]] || return 1
 	return 0
 }
 
@@ -887,10 +891,12 @@ _refresh_owner_issues() {
 	local owner="$1"
 	local slugs="${2:-}"
 	local graphql_remaining="${3:-}"
+	local _CONDITIONAL_REST_FAILED_SLUGS=""
 	if _conditional_rest_per_slug issues "$slugs"; then
 		_log "conditional REST issues complete for owner=${owner} — skipped search"
 		return 0
 	fi
+	slugs="$_CONDITIONAL_REST_FAILED_SLUGS"
 	if _search_should_route_to_rest "$graphql_remaining"; then
 		_route_owner_search_to_rest issues "$owner" "$slugs"
 		return 0
@@ -954,10 +960,12 @@ _refresh_owner_prs() {
 	local owner="$1"
 	local slugs="${2:-}"
 	local graphql_remaining="${3:-}"
+	local _CONDITIONAL_REST_FAILED_SLUGS=""
 	if _conditional_rest_per_slug prs "$slugs"; then
 		_log "conditional REST prs complete for owner=${owner} — skipped search"
 		return 0
 	fi
+	slugs="$_CONDITIONAL_REST_FAILED_SLUGS"
 	if _search_should_route_to_rest "$graphql_remaining"; then
 		_route_owner_search_to_rest prs "$owner" "$slugs"
 		return 0

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -80,7 +80,11 @@ if [[ "\$1" == "api" ]]; then
     printf 'HTTP/2 304\\r\\netag: "etag-v1"\\r\\n\\r\\n'
     exit 1
   fi
-  if [[ "$mode" == "changed" ]]; then
+  if [[ "$mode" == "mixed" && "\$*" == *'repos/owner/failing/'* ]]; then
+    printf 'HTTP/2 500\\r\\n\\r\\n{}'
+    exit 1
+  fi
+  if [[ "$mode" == "changed" || "$mode" == "mixed" ]]; then
     if [[ "\$*" == *'/pulls?state=open'* ]]; then
       printf 'HTTP/2 200\\r\\netag: "etag-pr-v2"\\r\\n\\r\\n[{"number":7,"title":"PR","updated_at":"2026-05-02T00:00:00Z","user":{"login":"dev"},"head":{"sha":"abc","ref":"branch"}}]'
       exit 0
@@ -786,6 +790,26 @@ SH
 	return 0
 }
 
+test_partial_failure_keeps_successful_snapshots() {
+	setup_env
+	printf '%s\n' '{"initialized_repos":[{"slug":"owner/repo","pulse":true},{"slug":"owner/failing","pulse":true}],"git_parent_dirs":[]}' >"$REPOS_JSON"
+	write_gh_stub mixed
+	"$HELPER" refresh >/dev/null 2>&1 || true
+	local successful_calls=0 failed_calls=0
+	successful_calls=$(grep -c 'repos/owner/repo/' "$TEST_ROOT/gh-calls.log" || true)
+	failed_calls=$(grep -c 'repos/owner/failing/' "$TEST_ROOT/gh-calls.log" || true)
+	if [[ "$successful_calls" -eq 2 && "$failed_calls" -eq 4 ]] &&
+		jq -e '.source == "conditional-rest" and .complete == true' "$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json" >/dev/null &&
+		jq -e '.source == "conditional-rest" and .complete == true' "$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json" >/dev/null; then
+		print_result "partial issues and PR failure retries only failed repositories" 0
+	else
+		print_result "partial issues and PR failure retries only failed repositories (successful=${successful_calls}, failed=${failed_calls})" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_partial_failure_keeps_successful_snapshots
 test_unchanged_repo_uses_304_cache
 test_changed_repo_refreshes_cache
 test_bodyless_transport_rows_are_rejected


### PR DESCRIPTION
## Summary

Keep the failed conditional-refresh slug set local to each owner and collection, and restrict subsequent REST fallback to that set. Successful conditional snapshots are not redundantly fetched. Quota, pacing, auth, invalidation, pagination and opt-in owner-search policies are unchanged. Independent review found no material defect; local review bundle 4e699c21cb8627036dfc32c017cffb2bc0fd34694270dc0f5a7541bcbfe6be16.

## Files Changed

.agents/scripts/pulse-batch-prefetch-helper.sh, .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: existing mocked CLI conditional REST suite passed all 28 cases. Red/green mixed-result test reduced successful-repository requests from 4 to 2, with 4 failed-repository requests retained across issues and PRs. Successful snapshots stay complete. ShellCheck and local quality gates passed. This is fixture evidence, not a live throughput claim.

Resolves #31468


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.330 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 1d and 2,648,480 tokens on this with the user in an interactive session.