### PR TITLE
GH#31298: evaluate verified user and economic value (t18412)

### DIFF
--- a/.agents/reference/value-evaluation.md
+++ b/.agents/reference/value-evaluation.md
@@ -1,0 +1,111 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2026 Marcus Quinn -->
+
+# Value evaluation
+
+Evaluate aidevops profiles by verified user value, not by task, token, or cache
+counts alone. This bounded protocol reuses existing immutable evidence, records
+missing evidence, and does not create another telemetry database.
+
+## Measures
+
+Every report states the unit, source, coverage, and confidence for each measure.
+`null` means unknown; it never means zero.
+
+| Measure | Unit | Required evidence |
+| --- | --- | --- |
+| Verified outcome | Boolean plus verifier identity | Independent product/task verifier and retained source digest |
+| User active time | Seconds | Direct bounded observation or user-provided measurement |
+| User interruptions | Count | Requests requiring otherwise avoidable user attention |
+| User corrections | Count | Corrections needed to obtain the accepted outcome |
+| Elapsed delivery | Seconds | Stable start and terminal timestamps for the complete workflow |
+| Recurring work eliminated | Named recurrence and estimated occurrences | Reusable artifact plus observed or explicitly modelled baseline |
+| Maintenance effort | Seconds per stated period | Repairs, updates, and review attributable to the capability |
+| Monetary benefit | Currency and period | Observed change or labelled model with assumptions |
+| Actual paid charges | Currency | Provider/cloud invoice or account-owned metering |
+| Fixed subscription cost | Currency and period | Subscription record and stated allocation method |
+| Allowance consumption | Provider-native units | Account-owned usage evidence |
+| Hypothetical API cost | Currency | Versioned price model, labelled as an estimate |
+
+Machine duration, requests, tokens, compactions, and estimated API prices are
+supporting diagnostics. They do not establish user time, benefit, or actual cost.
+
+## Protocol
+
+1. Select a small matrix containing a short task, longer systems work, and a
+   non-code information workflow. State the installed profile and required
+   capability before each run.
+2. Define the accepted outcome and independent verifier before execution. Never
+   use model self-report, token use, or process exit alone as outcome evidence.
+3. Match model, provider, limits, tools, task input, and verifier. Alternate order
+   and repeat cells where affordable; otherwise mark the sample limitation.
+4. Keep attempts immutable. Retain failures, timeouts, interruptions, partial
+   usage, and missing measurements; do not select the best retry.
+5. Record user-active time separately from machine and elapsed time. Count
+   interruptions and corrections only when their definitions are observable.
+6. Separate actual charges, fixed subscriptions, allowance consumption, and
+   hypothetical API-price estimates. Unknown cost is not free usage.
+7. Record reusable output and maintenance only where evidence ties them to future
+   work. State recurrence and attribution assumptions.
+8. Compare matched cells only. Profile, runtime, and provider differences remain
+   visible and prevent unsupported causal claims.
+
+Raw prompts, account identifiers, OAuth material, invoices, and private logs stay
+outside Git. Repo evidence contains only redacted measures, configuration identity,
+verifier references, coverage, confidence, and source digests.
+
+## Representative matrix
+
+| Workflow | Intended outcome | Profiles | Minimum verifier | Current evidence |
+| --- | --- | --- | --- | --- |
+| Short terminal task | Correct repository change | Stock and aidevops | Task verifier | One matched trial per cell |
+| Longer systems work | Accepted multi-step change through lifecycle | Installed and focused/lighter | Tests, review, and merged outcome | Not yet measured |
+| Non-code information work | Accepted decision-ready artifact | Domain-primary and lighter delegated | Human acceptance plus factual/source checks | Not yet measured |
+
+The unmeasured rows are protocol commitments, not failed or zero-value results.
+No outreach, financial mutation, purchase, or production deployment is authorised
+merely to fill a report cell.
+
+## Initial bounded report: 2026-09-05 pilot
+
+Source: `.agents/tools/ai-assistants/frontier-harness-pilot.json`, six immutable
+`terminal-bench/regex-log` cells, one trial per cell, GPT-6 Astra through a local
+ChatGPT OAuth relay, OpenCode 1.18.29, and Harbor 0.22.0. Source result, event, and
+manifest SHA-256 digests are retained per cell.
+
+| Finding | Evidence | Coverage/confidence |
+| --- | --- | --- |
+| Normal stock outcome | Verifier pass; 131.040 agent seconds | Measured, one trial; limited |
+| Normal aidevops outcome | Verifier pass; 187.772 agent seconds | Measured, one trial; limited |
+| Calibrated 18,432-context outcomes | Both variants passed after two compactions | Measured, one trial each; limited |
+| Infeasible 16,384-context outcomes | Both variants timed out and were retained | Measured failures; configuration not comparative |
+| User active time, interruptions, and corrections | No source measurement | Unknown |
+| Elapsed delivery and recurring work eliminated | No complete workflow baseline | Unknown |
+| Maintenance effort and monetary benefit | No attributable source evidence | Unknown |
+| Actual charges, subscription allocation, and allowance use | OAuth route recorded; account economics absent | Unknown |
+| Hypothetical API cost | Harbor estimate is not an actual charge | Excluded from actual-spend conclusions |
+
+The normal aidevops cell used more agent time and completed input tokens on this
+single short task. That is observed overhead, not evidence of lower user value.
+The pilot does not cover longer systems work or non-code information workflows,
+does not measure human attention or money, and cannot support broad superiority
+or a 100x claim.
+
+## Report contract
+
+`frontier-harness-report.mjs --run` keeps schema-1 consumers compatible and adds a
+`value_metrics` object. The independent verifier supplies `verified_outcome`.
+Unmeasured attention, elapsed-delivery, recurrence, maintenance, and economic
+fields are `null` with explicit coverage. Existing agent/setup duration and usage
+fields remain supporting metrics outside this value object.
+
+The next information gap is user-attention evidence for accepted longer systems
+and non-code outcomes—not another token-only sweep.
+
+## Verification
+
+```bash
+node --test .agents/scripts/tests/test-frontier-harness.mjs
+node --test .agents/scripts/tests/test-model-replay-benchmark.mjs
+.agents/scripts/linters-local.sh --changed
+```

--- a/.agents/scripts/frontier-harness-report.mjs
+++ b/.agents/scripts/frontier-harness-report.mjs
@@ -80,6 +80,32 @@ export function summarize(records) {
   };
 }
 
+function valueMetrics(verifiedOutcome = null) {
+  const measured = verifiedOutcome === null ? "unmeasured" : "measured";
+  return {
+    verified_outcome: verifiedOutcome,
+    user_active_seconds: null,
+    user_interruptions: null,
+    user_corrections: null,
+    elapsed_delivery_seconds: null,
+    recurring_work_eliminated: null,
+    maintenance_seconds: null,
+    actual_paid_charges_usd: null,
+    fixed_subscription_cost_usd: null,
+    allowance_consumption: null,
+    hypothetical_api_cost_usd: null,
+    coverage: {
+      verified_outcome: measured,
+      user_attention: "unmeasured",
+      elapsed_delivery: "unmeasured",
+      recurring_work: "unmeasured",
+      maintenance: "unmeasured",
+      money: "unmeasured",
+    },
+    confidence: verifiedOutcome === null ? "unknown" : "limited",
+  };
+}
+
 function validateRunEvidence(manifest, records, telemetry) {
   if (telemetry.profile !== manifest.profile || !records.some((r) => r.type === "config.applied")
     || (manifest.profile !== "stock" && !(records[0].framework_tool_count > 0))) {
@@ -163,6 +189,7 @@ export function summarizeRun(root) {
     return Number.isFinite(ms) && ms >= 0 ? Math.round(ms) / 1000 : null;
   };
   const digest = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
+  const verdict = runVerdict(manifest, trial, calibrationStatus(manifest, telemetry));
   return {
     profile: manifest.profile, model: manifest.model,
     framework_commit: manifest.framework_commit, opencode_version: manifest.opencode_version,
@@ -171,9 +198,10 @@ export function summarizeRun(root) {
     source_manifest_sha256: digest(join(root, "manifest.json")),
     billing: manifest.inference_route, leaderboard_comparable: false,
     experimental_context_limit: manifest.experimental_context_limit ?? null,
-    ...runVerdict(manifest, trial, calibrationStatus(manifest, telemetry)),
+    ...verdict,
     agent_seconds: duration(trial.agent_execution), setup_seconds: duration(trial.agent_setup),
     ...transportUsage(manifest),
+    value_metrics: valueMetrics(verdict.verifier_reward === null ? null : verdict.task_passed),
     telemetry,
   };
 }

--- a/.agents/scripts/tests/test-frontier-harness.mjs
+++ b/.agents/scripts/tests/test-frontier-harness.mjs
@@ -188,6 +188,12 @@ test("run report joins verifier evidence, detects overridden output and preserve
     saveEvents();
     const report = summarizeRun(root);
     assert.equal(report.comparison_valid, true);
+    assert.equal(report.value_metrics.verified_outcome, true);
+    assert.equal(report.value_metrics.user_active_seconds, null);
+    assert.equal(report.value_metrics.actual_paid_charges_usd, null);
+    assert.equal(report.value_metrics.coverage.verified_outcome, "measured");
+    assert.equal(report.value_metrics.coverage.user_attention, "unmeasured");
+    assert.equal(report.value_metrics.confidence, "limited");
     assert.equal(report.telemetry.summary_output_tokens, 3);
     assert.equal(report.telemetry.calibration.applied[0].capacity.usable_input, 14336);
     assert.equal(report.upstream_usage_complete, false);
@@ -211,9 +217,15 @@ test("run report joins verifier evidence, detects overridden output and preserve
     saveEvents();
     assert.equal(summarizeRun(root).comparison_valid, false);
     assert.equal(summarizeRun(root).verifier_reward, 1, "never rewrite the verifier verdict");
+    result.verifier_result = { rewards: {} };
+    json(join(trialDir, "result.json"), result);
+    assert.equal(summarizeRun(root).value_metrics.verified_outcome, null);
+    assert.equal(summarizeRun(root).value_metrics.confidence, "unknown");
+    result.verifier_result = { rewards: { reward: 1 } };
     result.exception_info = { exception_type: "AgentTimeoutError" };
     json(join(trialDir, "result.json"), result);
     assert.equal(summarizeRun(root).task_passed, false);
+    assert.equal(summarizeRun(root).value_metrics.verified_outcome, false);
     assert.equal(summarizeRun(root).trial_exception, "AgentTimeoutError");
   } finally { rmSync(root, { recursive: true, force: true }); }
 });

--- a/.agents/tools/ai-assistants/frontier-harness-eval.md
+++ b/.agents/tools/ai-assistants/frontier-harness-eval.md
@@ -165,6 +165,11 @@ Source task commit: `2fd12b88aafdd04a52c298e3940bcb189f9766d6` from
 These are small-sample pilot observations, **not FrontierHarness leaderboard scores**.
 No Kimi K3/Fireworks run, full 30-task result, or statistical superiority claim exists.
 
+For outcome, attention, maintenance, and economic-value definitions—and the
+bounded initial report separating measured evidence from unknowns—see
+`reference/value-evaluation.md`. FrontierHarness run reports expose additive
+`value_metrics`; fields this pilot did not measure remain `null`, never zero.
+
 | Configuration | Verifier | Agent seconds | Completed upstream input tokens, including cache | Completed upstream output tokens | Completed compactions |
 | --- | --- | ---: | ---: | ---: | ---: |
 | Stock, normal context | Pass | 131.040 | 28,543 | 1,611 | 0 |


### PR DESCRIPTION
## Summary

Implementation for issue #31298.

## Files Changed

.agents/reference/value-evaluation.md, .agents/scripts/frontier-harness-report.mjs, .agents/scripts/tests/test-frontier-harness.mjs, .agents/tools/ai-assistants/frontier-harness-eval.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #31298


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.330 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 2h 3m and 702,478 tokens on this with the user in an interactive session.