### PR TITLE
GH#31479: resume pinned snapshots with legacy authorization

### DIFF
--- a/.agents/reference/release-lane-coordination.md
+++ b/.agents/reference/release-lane-coordination.md
@@ -105,12 +105,29 @@ new session publication authority. Do not report background progress without
 an observed executor or current recovery evidence. A resumed legacy transaction
 does not gain automatic-recovery eligibility merely by acquiring new metadata.
 
+### Legacy authorization on a pinned snapshot (GH#31479)
+
+An authorized same-source retry may encounter an implicit singleton authorization
+record from before snapshot support. When the lane is pinned, reserved, tagless
+and nonterminal with no legacy recovery transaction, capture verifies the complete
+snapshot and requires the old immutable source set to be a compatible subset.
+It binds the complete manifest through the publisher CAS before migrating the
+local authorization, retaining the previous authorization in its existing recovery
+audit record. If local persistence fails, retry the same command: the identical
+lane-bound snapshot resumes without rollback or selecting a newer main tip.
+
+Current explicit `--expected-sources` remains an exact assertion; it is never
+silently widened. Conflicting source SHAs, stale owner tokens, mismatched pins,
+publication state and uncertain reads fail closed. This migration changes neither
+signed tags nor an established snapshot range and adds no publication authority.
+
 ## Verification
 
 Run from the repository root:
 
 ```bash
 bash .agents/scripts/tests/test-release-snapshot-helper.sh
+bash .agents/scripts/tests/test-release-snapshot-migration.sh
 bash .agents/scripts/tests/test-release-lane-reservation.sh
 bash .agents/scripts/tests/test-release-lane.sh
 python3 .agents/scripts/tests/test-release-lane-owner.py

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -96,6 +96,8 @@ source "${SCRIPT_DIR}/release-lane-helper.sh"
 source "${SCRIPT_DIR}/full-loop-release-reconcile.sh"
 # shellcheck source=./full-loop-release-aggregate-recovery.sh
 source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+# shellcheck source=./full-loop-release-snapshot-migration.sh
+source "${SCRIPT_DIR}/full-loop-release-snapshot-migration.sh"
 
 _FULL_LOOP_RESOLVED_SOURCE_JSON=""
 _FULL_LOOP_RESOLVED_SOURCE_PR=""
@@ -130,7 +132,8 @@ _full_loop_capture_release_authorization() {
 		.expected_sources | sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")
 	' <<<"$authorization_json") || return 1
 	if [[ "$(jq -r '.mode // ""' <<<"$authorization_json")" == "snapshot" ]]; then
-		release_lane_bind_snapshot "$repo" "$source_pr" "$authorization_json" || return 1
+		_full_loop_bind_snapshot_authorization "$repo" "$source_pr" "$authorization_json" \
+			"$_FULL_LOOP_RESOLVED_EXPECTED_SOURCES" || return 1
 	fi
 	_full_loop_persist_release_authorization "$repo" "$source_pr" "$_FULL_LOOP_RESOLVED_EXPECTED_SOURCES"
 	return $?
@@ -589,7 +592,10 @@ _full_loop_release_start_new() {
 	_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=false
 	_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION=false
 	_full_loop_release_guard_competing_lane "$repo" "$source_pr" || return $?
-	if persisted_expected=$(_full_loop_read_release_authorization "$repo" "$source_pr"); then
+	# A snapshot retry must not turn an implicit legacy subset into a new exact
+	# CLI assertion. The verified capture migrates compatible prior evidence.
+	if persisted_expected=$(_full_loop_read_release_authorization "$repo" "$source_pr") &&
+		! _full_loop_snapshot_retry_eligible "$repo" "$source_pr"; then
 		_full_loop_release_resolve_persisted_intent "$repo" "$source_pr" "$expected_sources" \
 			"$persisted_expected" "$release_type" || return $?
 		expected_sources="$_FULL_LOOP_RESERVED_RECOVERY_EXPECTED"

--- a/.agents/scripts/full-loop-release-snapshot-migration.sh
+++ b/.agents/scripts/full-loop-release-snapshot-migration.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# Reserved snapshot authorization migration; sourced by the release entry point.
+
+_full_loop_snapshot_retry_eligible() {
+	local repo="$1"
+	local source_pr="$2"
+	release_lane_read "$repo" || return 1
+	jq -e --argjson pr "$source_pr" '
+		.active == true and .source_pr == $pr and .phase == "reserved"
+		and .tag == null and .terminal_receipt == null
+		and (.snapshot_sha | type == "string" and test("^[0-9a-f]{40}$"))
+		and (.snapshot_base | type == "string" and test("^[0-9a-f]{40}$"))
+		and .prepublication_recovery == null and .aggregate_recovery == null
+		and .aggregate_successor == null and .reserved_authorization_refresh == null
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null
+	return $?
+}
+
+_full_loop_snapshot_previous_matches_lane() {
+	local previous="$1"
+	local expected="$2"
+	local intent=""
+	local previous_json=""
+	intent=$(release_authorization_intent_json "$(jq -r '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON")") || return 1
+	previous_json=$(release_authorization_manifest_json "$previous") || return 1
+	jq -e --argjson intent "$intent" --argjson previous "$previous_json" --arg expected "$expected" '
+		(.snapshot_manifest_bound == true and .expected_sources == $expected)
+		or (.snapshot_manifest_bound != true
+			and ($intent | map(.pr) | sort) == ($previous | map(.pr) | sort)
+			and all($intent[]; . as $entry | any($previous[];
+				.pr == $entry.pr and ($entry.merge == null or .merge == $entry.merge))))
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null
+	return $?
+}
+
+#aidevops:trust-boundary
+# The caller already verifies the complete immutable snapshot and any explicit
+# current CLI assertion. Widen only a compatible prior pre-publication record;
+# CAS-bind the lane first and retain its pin across failed local persistence.
+_full_loop_bind_snapshot_authorization() {
+	local repo="$1"
+	local source_pr="$2"
+	local source_json="$3"
+	local expected="$4"
+	local previous=""
+	local read_rc=0
+	previous=$(_full_loop_read_release_authorization "$repo" "$source_pr") || read_rc=$?
+	case "$read_rc" in 0 | 2) ;; *) return 1 ;; esac
+	if [[ "$read_rc" -eq 0 && "$previous" != "$expected" ]]; then
+		_full_loop_snapshot_retry_eligible "$repo" "$source_pr" || return 1
+		release_authorization_subset "$previous" "$expected" || return 1
+		_full_loop_snapshot_previous_matches_lane "$previous" "$expected" || return 1
+		release_lane_bind_snapshot "$repo" "$source_pr" "$source_json" || return 1
+		_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" "$previous" "$expected" || return 1
+		printf 'Migrated compatible reserved authorization to the verified pinned snapshot for PR #%s\n' "$source_pr"
+		return 0
+	fi
+	release_lane_bind_snapshot "$repo" "$source_pr" "$source_json"
+	return $?
+}

--- a/.agents/scripts/tests/test-release-snapshot-migration.sh
+++ b/.agents/scripts/tests/test-release-snapshot-migration.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# Real capture/bind/persistence helpers with an offline verified-resolver fixture.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+# shellcheck source=../full-loop-release-helper.sh
+source "$SCRIPT_DIR/full-loop-release-helper.sh" help >/dev/null
+
+FIRST=1111111111111111111111111111111111111111
+SNAPSHOT=2222222222222222222222222222222222222222
+BASE=0000000000000000000000000000000000000000
+CASE_NUMBER=0
+STATE='{}'
+WRITES=0
+READ_FAIL=0
+BIND_FAIL=0
+export SOURCE_JSON
+SOURCE_JSON=$(jq -cn --arg first "$FIRST" --arg sha "$SNAPSHOT" --arg base "$BASE" \
+	'{mode:"snapshot",requested_pr:41,source_pr:42,source_merge:$sha,snapshot_base:$base,
+	expected_sources:[{pr:41,merge:$first},{pr:42,merge:$sha}]}')
+cat >"$ROOT/resolver.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$SOURCE_JSON"
+EOF
+
+release_lane_read() {
+	[[ "$READ_FAIL" == 0 ]] || return 1
+	_AIDEVOPS_RELEASE_LANE_JSON="$STATE"
+	_AIDEVOPS_RELEASE_LANE_HEAD="$FIRST"
+	return 0
+}
+_release_lane_write() {
+	[[ "$BIND_FAIL" == 0 && "$3" == "$FIRST" ]] || return 1
+	WRITES=$((WRITES + 1))
+	STATE="$2"
+	_AIDEVOPS_RELEASE_LANE_JSON="$STATE"
+	return 0
+}
+reset_case() {
+	CASE_NUMBER=$((CASE_NUMBER + 1))
+	export AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$ROOT/receipts-$CASE_NUMBER"
+	WRITES=0 READ_FAIL=0 BIND_FAIL=0
+	_AIDEVOPS_RELEASE_LANE_TOKEN=fixture
+	STATE=$(jq -cn --arg sha "$SNAPSHOT" --arg base "$BASE" \
+		'{schema_version:1,repository:"test/repo",active:true,source_pr:41,phase:"reserved",
+		tag:null,terminal_receipt:null,snapshot_sha:$sha,snapshot_base:$base,
+		expected_sources:"41",operation_token:"fixture"}')
+	_full_loop_persist_release_authorization test/repo 41 "41@$FIRST"
+	return $?
+}
+capture_snapshot() {
+	_full_loop_capture_release_authorization test/repo 41 "$ROOT" "$ROOT/resolver.sh" "${1:-}"
+	return $?
+}
+refuse_capture() {
+	local name="$1"
+	local before="$STATE"
+	if capture_snapshot "${2:-}" >/dev/null 2>&1; then
+		printf 'FAIL: accepted %s\n' "$name"
+		exit 1
+	fi
+	[[ "$STATE" == "$before" && "$WRITES" == 0 ]] || exit 1
+	[[ "$(_full_loop_read_release_authorization test/repo 41)" == "41@$FIRST" ]] || exit 1
+	printf 'PASS: rejects %s before mutation\n' "$name"
+	return 0
+}
+
+reset_case
+capture_snapshot
+[[ "$(_full_loop_read_release_authorization test/repo 41)" == "41@$FIRST,42@$SNAPSHOT" ]]
+_full_loop_read_release_authorization_recovery_snapshot test/repo 41 | jq -e '.expected_sources | length == 1' >/dev/null
+capture_snapshot
+printf 'PASS: implicit legacy subset expands lane-first with prior evidence and replay\n'
+
+reset_case
+refuse_capture 'explicit incomplete CLI assertion' 41
+reset_case
+refuse_capture 'explicit conflicting merge assertion' "41@$SNAPSHOT,42@$SNAPSHOT"
+original_source="$SOURCE_JSON"
+for change in '.expected_sources |= map(select(.pr != 41))' '.expected_sources[0].merge="3333333333333333333333333333333333333333"'; do
+	reset_case
+	SOURCE_JSON=$(jq -c "$change" <<<"$original_source")
+	refuse_capture 'missing or conflicting prior source'
+done
+SOURCE_JSON="$original_source"
+for change in '.phase="preparing"' '.tag="v1.2.3"' '.terminal_receipt="failed"' '.prepublication_recovery={}' '.aggregate_recovery={}' '.aggregate_successor={}' '.reserved_authorization_refresh={}' '.source_pr=99' '.snapshot_sha="3333333333333333333333333333333333333333"' '.expected_sources="99"' '.expected_sources="41@3333333333333333333333333333333333333333"'; do
+	reset_case
+	STATE=$(jq -c "$change" <<<"$STATE")
+	refuse_capture "$change"
+done
+reset_case
+READ_FAIL=1
+refuse_capture 'unavailable publisher lane'
+reset_case
+BIND_FAIL=1
+refuse_capture 'CAS conflict'
+reset_case
+_AIDEVOPS_RELEASE_LANE_TOKEN=other-owner
+refuse_capture 'stale ownership token'
+
+reset_case
+original_writer=$(declare -f _full_loop_write_release_authorization_record)
+_full_loop_write_release_authorization_record() { return 1; }
+if capture_snapshot; then exit 1; fi
+jq -e '.snapshot_manifest_bound == true' <<<"$STATE" >/dev/null
+[[ "$(_full_loop_read_release_authorization test/repo 41)" == "41@$FIRST" ]]
+eval "$original_writer"
+capture_snapshot
+[[ "$(_full_loop_read_release_authorization test/repo 41)" == "41@$FIRST,42@$SNAPSHOT" ]]
+printf 'PASS: interrupted local persistence resumes the identical lane-bound snapshot\n'
+
+reset_case
+_full_loop_release_guard_competing_lane() { return 0; }
+_full_loop_release_guard_existing() {
+	[[ "$3" == "$EXPECTED_ARGUMENT" ]]
+	return $?
+}
+EXPECTED_ARGUMENT=""
+_full_loop_release_start_new test/repo 41 patch incremental ""
+EXPECTED_ARGUMENT="41,42"
+_full_loop_release_start_new test/repo 41 patch incremental "41,42"
+printf 'PASS: start preserves explicit assertions without promoting an implicit legacy subset\n'


### PR DESCRIPTION
## Summary

Preserve explicit current source assertions while migrating compatible implicit legacy subsets to the verified pinned snapshot. Bind the full manifest through the existing publisher CAS before local authorization persistence, retain prior audit evidence, and resume partial writes without rollback or snapshot widening.

## Files Changed

.agents/reference/release-lane-coordination.md, .agents/scripts/full-loop-release-helper.sh, .agents/scripts/full-loop-release-snapshot-migration.sh, .agents/scripts/tests/test-release-snapshot-migration.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — High-risk runtime-verified release authorization boundary: 21 focused migration/rejection assertions; existing test-full-loop-release-helper.sh and test-release-snapshot-helper.sh pass including signed local fixture publication. ShellCheck, formatting, Markdown, secret scan and changed-file regression gates pass. Independent security closeout ACCEPT. Local bundle e071d95e66da6c7d97c7dbd1350d519cd73fdb8c01ed66a48bc5603b1fb59e28.

Resolves #31479


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.330 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 2h 27m and 887,905 tokens on this with the user in an interactive session.