### PR TITLE
GH#31482: reject unsafe Ollama summary URL schemes

### DIFF
--- a/.agents/scripts/email_md_summary.py
+++ b/.agents/scripts/email_md_summary.py
@@ -12,6 +12,7 @@ import json
 import subprocess
 import urllib.request
 import urllib.error
+import urllib.parse
 from pathlib import Path
 
 # Word count threshold: emails with <= this many words use heuristic summary
@@ -28,6 +29,19 @@ ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 
 # Anthropic model for summarisation (cheapest tier)
 ANTHROPIC_MODEL = 'claude-haiku-4-20250414'
+
+
+def _validated_ollama_api_url():
+    """Return the configured Ollama HTTP(S) URL, or None when it is unsafe."""
+    try:
+        parsed = urllib.parse.urlsplit(OLLAMA_API_URL)
+        hostname = parsed.hostname
+    except (TypeError, ValueError):
+        return None
+
+    if parsed.scheme.lower() not in {'http', 'https'} or not hostname:
+        return None
+    return OLLAMA_API_URL
 
 
 def strip_markdown(text):
@@ -136,14 +150,20 @@ def _summarise_with_ollama(plain_text, subject):
         'options': {'temperature': 0.3, 'num_predict': 100}
     }).encode('utf-8')
 
+    api_url = _validated_ollama_api_url()
+    if not api_url:
+        return None
+
     req = urllib.request.Request(
-        OLLAMA_API_URL,
+        api_url,
         data=payload,
         headers={'Content-Type': 'application/json'},
         method='POST'
     )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        # _validated_ollama_api_url restricts this configurable target to an
+        # HTTP(S) URL with an authority before the request is constructed.
+        with urllib.request.urlopen(req, timeout=30) as resp:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected,python_urlopen_rule-urllib-urlopen
             data = json.loads(resp.read().decode('utf-8'))
             summary = data.get('response', '').strip()
             if summary:

--- a/.agents/scripts/email_md_summary.py
+++ b/.agents/scripts/email_md_summary.py
@@ -163,7 +163,7 @@ def _summarise_with_ollama(plain_text, subject):
     try:
         # _validated_ollama_api_url restricts this configurable target to an
         # HTTP(S) URL with an authority before the request is constructed.
-        with urllib.request.urlopen(req, timeout=30) as resp:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected,python_urlopen_rule-urllib-urlopen
+        with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310 nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected,python_urlopen_rule-urllib-urlopen
             data = json.loads(resp.read().decode('utf-8'))
             summary = data.get('response', '').strip()
             if summary:

--- a/tests/test_email_md_summary.py
+++ b/tests/test_email_md_summary.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Tests for the email-to-Markdown summary transport boundary."""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS_DIR = Path(__file__).parent.parent / ".agents" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import email_md_summary  # noqa: E402
+
+
+class TestOllamaApiUrlValidation(unittest.TestCase):
+    """Keep configurable Ollama requests on network URL schemes."""
+
+    def test_accepts_http_and_https_urls_with_authorities(self):
+        for url in (
+            "http://localhost:11434/api/generate",
+            "https://ollama.example.test/api/generate",
+        ):
+            with self.subTest(url=url), mock.patch.object(
+                email_md_summary, "OLLAMA_API_URL", url
+            ):
+                self.assertEqual(email_md_summary._validated_ollama_api_url(), url)
+
+    def test_rejects_non_network_and_malformed_urls(self):
+        for url in (
+            "file:///etc/passwd",
+            "localhost:11434/api/generate",
+            "http:///api/generate",
+            "http://[invalid",
+        ):
+            with self.subTest(url=url), mock.patch.object(
+                email_md_summary, "OLLAMA_API_URL", url
+            ):
+                self.assertIsNone(email_md_summary._validated_ollama_api_url())
+
+    def test_invalid_url_uses_existing_non_fatal_fallback(self):
+        with mock.patch.object(
+            email_md_summary, "OLLAMA_API_URL", "file:///etc/passwd"
+        ):
+            with mock.patch.object(email_md_summary.urllib.request, "urlopen") as urlopen:
+                self.assertIsNone(
+                    email_md_summary._summarise_with_ollama("Body", "Subject")
+                )
+                urlopen.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Validate the configurable Ollama endpoint before urllib request construction, reject non-HTTP and malformed targets through the existing non-fatal fallback, and add focused regression coverage.

## Files Changed

.agents/scripts/email_md_summary.py, tests/test_email_md_summary.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: 3 focused unittest cases pass; compileall passes for both changed Python files; linters-local.sh --changed passes; independent security closeout review found no material defect (bundle 38678af322652b5645384a2dd55bcb9897fd4c14cfe9f7024e0a1ab4b1f13187).

Resolves #31482


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.330 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 21m and 178,059 tokens on this with the user in an interactive session.