### PR TITLE
GH#31487: recover stalled Pulse runtime safely

### DIFF
--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -121,8 +121,10 @@ _runtime_freshness_json() {
 	local active_manifest_file="${AIDEVOPS_ACTIVE_RUNTIME_MANIFEST_FILE:-${HOME}/.aidevops/agents/.bundle-manifest}"
 	local stamp_file="${AIDEVOPS_DEPLOYED_SHA_FILE:-${HOME}/.aidevops/.deployed-sha}"
 	local update_state_file="${AIDEVOPS_AUTO_UPDATE_STATE_FILE:-${HOME}/.aidevops/cache/auto-update-state.json}"
+	local recovery_state_file="${AIDEVOPS_PULSE_RUNTIME_RECOVERY_STATE_FILE:-${HOME}/.aidevops/cache/pulse-runtime-recovery.json}"
 	local upstream_ref="${AIDEVOPS_RUNTIME_UPSTREAM_REF:-}"
 	local canonical_sha="" upstream_sha="" deployed_sha=""
+	local recovery_state="{}"
 	local auto_update_status="$UNKNOWN_STATUS" auto_update_at="" deployment_relation=""
 	local status="$UNKNOWN_STATUS" action="Verify the canonical checkout and active runtime bundle"
 	local canonical_dirty=false canonical_on_main=false canonical_behind=false
@@ -141,6 +143,11 @@ _runtime_freshness_json() {
 	if [[ -r "$update_state_file" ]]; then
 		auto_update_status=$(jq -r --arg unknown "$UNKNOWN_STATUS" '.last_status // $unknown' "$update_state_file" 2>/dev/null || printf '%s' "$UNKNOWN_STATUS")
 		auto_update_at=$(jq -r '.last_timestamp // ""' "$update_state_file" 2>/dev/null || true)
+	fi
+	if [[ -r "$recovery_state_file" ]]; then
+		recovery_state=$(jq -c --arg unknown "$UNKNOWN_STATUS" 'if .schema == "aidevops-pulse-runtime-recovery/v1" then {
+			status:(.status // $unknown), reason:(.reason // $unknown), recorded_at:(.recorded_at // null)
+		} else {} end' "$recovery_state_file" 2>/dev/null || printf '{}')
 	fi
 	if ! git -C "$repo_path" diff --quiet 2>/dev/null || ! git -C "$repo_path" diff --cached --quiet 2>/dev/null; then
 		canonical_dirty=true
@@ -192,6 +199,7 @@ _runtime_freshness_json() {
 		--arg status "$status" --arg action "$action" --arg upstream_ref "$upstream_ref" \
 		--arg canonical_sha "$canonical_sha" --arg upstream_sha "$upstream_sha" --arg deployed_sha "$deployed_sha" \
 		--arg auto_status "$auto_update_status" --arg auto_at "$auto_update_at" \
+		--argjson recovery "$recovery_state" \
 		--argjson stale "$stale" --argjson dirty "$canonical_dirty" \
 		--argjson canonical_on_main "$canonical_on_main" --argjson canonical_behind "$canonical_behind" \
 		--argjson canonical_ahead "$canonical_ahead" --argjson canonical_diverged "$canonical_diverged" \
@@ -202,6 +210,7 @@ _runtime_freshness_json() {
 			upstream_ref:$upstream_ref, canonical_sha:$canonical_sha,
 			upstream_sha:$upstream_sha, deployed_sha:$deployed_sha,
 			auto_update_status:$auto_status, auto_update_at:$auto_at,
+			recovery:$recovery,
 			operator_action:$action
 		}'
 	return 0
@@ -315,6 +324,10 @@ _runtime_record_state_overlay() {
 
 _current_active_worker_processes() {
 	local active_worker_processes=""
+	if [[ "${AIDEVOPS_ACTIVE_WORKER_PROCESSES_OVERRIDE:-}" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$AIDEVOPS_ACTIVE_WORKER_PROCESSES_OVERRIDE"
+		return 0
+	fi
 	if [[ -f "${SCRIPT_DIR}/worker-lifecycle-common.sh" ]]; then
 		# Keep worker process discovery in the shell lifecycle helper so Python
 		# static-analysis checks do not flag a subprocess bridge for this metric.

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -400,6 +400,98 @@ def build_current_state_guardrails(counter_hits, pre_launch_blockers, gauge_valu
     }
 
 
+def blocker_category(reason):
+    value = str(reason or '').lower()
+    if any(token in value for token in ('github', 'graphql', 'rest_', 'snapshot', 'enumeration', 'lookup_unavailable')):
+        return 'github_read_incomplete'
+    if any(token in value for token in ('dependency', 'blocked_by', 'prerequisite')):
+        return 'dependency_state'
+    if any(token in value for token in ('assign', 'claim', 'owner', 'lease')):
+        return 'assignment_ownership'
+    if any(token in value for token in ('label', 'status', 'auto_dispatch', 'dispatchable', 'eligible')):
+        return 'queue_labels'
+    return 'admission_failure'
+
+
+def build_zero_worker_underutilization(active_workers, worker_terminal_events, cycle_state,
+                                       pre_launch_blockers, gauge_values):
+    threshold_raw = os.environ.get('AIDEVOPS_ZERO_WORKER_MIN_CYCLES', '3')
+    threshold = int(threshold_raw) if threshold_raw.isdigit() and int(threshold_raw) > 0 else 3
+    available = gauge_values.get('pulse_dispatch_guardrail_available_slots')
+    available = int(available) if isinstance(available, (int, float)) else None
+    no_progress = ((cycle_state.get('progress') or {}).get('consecutive_no_progress_cycles')
+                   if cycle_state.get('availability') == 'available' else 0)
+    no_progress = no_progress if isinstance(no_progress, int) else 0
+    categories = {name: 0 for name in (
+        'queue_labels', 'dependency_state', 'assignment_ownership',
+        'admission_failure', 'github_read_incomplete',
+    )}
+    for reason, count in pre_launch_blockers.items():
+        categories[blocker_category(reason)] += count
+    prolonged = no_progress >= threshold
+    free_capacity = available is not None and available > 0
+    zero_delivery = active_workers == 0 and worker_terminal_events == 0
+    return {
+        'actionable': bool(free_capacity and zero_delivery and prolonged),
+        'available_slots': available,
+        'zero_delivery': zero_delivery,
+        'consecutive_no_progress_cycles': no_progress,
+        'minimum_cycles': threshold,
+        'classifications': categories,
+        'github_read_complete': categories['github_read_incomplete'] == 0,
+    }
+
+
+def build_permission_evidence(path):
+    latest = {}
+    retained_records = 0
+    try:
+        for line in recent_lines(path, 2000):
+            try:
+                item = json.loads(line)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if item.get('schema') != 'aidevops-worker-blocker/v1':
+                continue
+            retained_records += 1
+            key = (item.get('repo_slug'), item.get('issue_number'),
+                   item.get('session_key'), item.get('request_id'))
+            if float(item.get('ts') or 0) >= float(latest.get(key, {}).get('ts') or 0):
+                latest[key] = item
+    except OSError:
+        pass
+    current = [item for item in latest.values()
+               if item.get('blocking') is True and item.get('status') == 'blocked'
+               and item.get('event') in {'permission_awaiting_approval', 'permission_request_persistence_failed'}]
+    historical = [item for item in latest.values() if item not in current]
+    return {
+        'retained_records': retained_records,
+        'distinct_requests': len(latest),
+        'proven_current_blockers': len(current),
+        'historical_or_reconciled': len(historical),
+        'current_reason_counts': dict(Counter(str(item.get('reason') or 'unknown') for item in current)),
+    }
+
+
+def build_resource_recovery_evidence(lines, worker_metrics):
+    direct_reasons = Counter()
+    for line in lines:
+        if '[lifecycle] worker_killed ' not in line or ' reason=' not in line:
+            continue
+        reason = line.split(' reason=', 1)[1].split(' ', 1)[0]
+        direct_reasons[reason] += 1
+    for item in worker_metrics:
+        result = str(item.get('result') or '')
+        if result in {'watchdog_stall_killed', 'watchdog_stall_continue'}:
+            direct_reasons[result] += 1
+    return {
+        'direct_evidence_count': sum(direct_reasons.values()),
+        'reason_counts': dict(direct_reasons),
+        'unattributed_service_kills': 0,
+        'attribution_policy': 'process lifecycle and worker metric evidence only',
+    }
+
+
 stage_records = []
 for line in recent_lines(os.path.join(log_dir, 'dispatch-stages.tsv')):
     record = parse_stage(line)
@@ -620,6 +712,13 @@ if os.path.isdir(review_thread_state_dir):
 objective_reconciliation = build_objective_reconciliation(
     os.environ.get('AIDEVOPS_OBJECTIVE_STATE_FILE', '')
 )
+zero_worker_underutilization = build_zero_worker_underutilization(
+    active_worker_processes, len(worker_metrics), cycle_state, pre_launch_blockers, gauge_values
+)
+permission_evidence = build_permission_evidence(
+    os.environ.get('AIDEVOPS_WORKER_BLOCKER_LOG_FILE', os.path.join(log_dir, 'worker-progress-blockers.jsonl'))
+)
+resource_recovery = build_resource_recovery_evidence(wrapper_log_lines, worker_metrics)
 
 result = {
     'window_seconds': window_s,
@@ -676,6 +775,9 @@ result = {
     'cycle_state': cycle_state,
     'review_thread_attention': review_thread_attention,
     'objective_reconciliation': objective_reconciliation,
+    'zero_worker_underutilization': zero_worker_underutilization,
+    'permission_evidence': permission_evidence,
+    'resource_recovery': resource_recovery,
 }
 
 runtime_state = {
@@ -703,6 +805,9 @@ runtime_state = {
     'resource_context': result['resource_context'],
     'review_thread_attention_count': len(review_thread_attention),
     'objective_reconciliation': objective_reconciliation,
+    'zero_worker_underutilization': zero_worker_underutilization,
+    'permission_evidence': permission_evidence,
+    'resource_recovery': resource_recovery,
     'window_seconds': window_s,
     'worker_outcomes': result['worker_outcomes'],
     'worker_result_counts': dict(metric_class_counts),
@@ -743,6 +848,9 @@ else:
     print(f'- Review-thread maintainer attention: {json.dumps(review_thread_attention, sort_keys=True)}')
     print(f'- Objectives without next action: {objective_reconciliation["objectives_without_next_action"]}')
     print(f'- Oldest unverified assumption: {json.dumps(objective_reconciliation["oldest_unverified_assumption"], sort_keys=True)}')
+    print(f'- Zero-worker under-utilization: {json.dumps(zero_worker_underutilization, sort_keys=True)}')
+    print(f'- Permission evidence: {json.dumps(permission_evidence, sort_keys=True)}')
+    print(f'- Resource recovery evidence: {json.dumps(resource_recovery, sort_keys=True)}')
     print(f'- Worker worktrees: {result["worker_worktrees"]}')
     if wrapper_activity:
         print('- Recent wrapper activity:')

--- a/.agents/scripts/pulse-runtime-recovery.sh
+++ b/.agents/scripts/pulse-runtime-recovery.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+# Bootstrap-time repair for a deployed Pulse bundle that is behind a clean,
+# exact canonical main checkout. This file is sourced before Pulse acquires its
+# runtime lease, allowing setup's atomic bundle transition to proceed safely.
+
+[[ -n "${_AIDEVOPS_PULSE_RUNTIME_RECOVERY_LOADED:-}" ]] && return 0
+_AIDEVOPS_PULSE_RUNTIME_RECOVERY_LOADED=1
+PULSE_RUNTIME_RECOVERY_BLOCKED_STATUS="blocked"
+
+_pulse_runtime_recovery_record() {
+	local status="$1"
+	local reason="$2"
+	local canonical_sha="${3:-}"
+	local deployed_sha="${4:-}"
+	local state_file="${AIDEVOPS_PULSE_RUNTIME_RECOVERY_STATE_FILE:-${HOME}/.aidevops/cache/pulse-runtime-recovery.json}"
+	local state_dir="${state_file%/*}"
+	local temporary="${state_file}.$$"
+	local recorded_epoch=""
+	recorded_epoch=$(date +%s)
+
+	mkdir -p "$state_dir" 2>/dev/null || return 0
+	if command -v jq >/dev/null 2>&1; then
+		jq -n --arg status "$status" --arg reason "$reason" \
+			--arg canonical "$canonical_sha" --arg deployed "$deployed_sha" \
+			--arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+			--argjson epoch "$recorded_epoch" \
+			'{schema:"aidevops-pulse-runtime-recovery/v1",status:$status,reason:$reason,canonical_sha:$canonical,deployed_sha:$deployed,recorded_at:$at,recorded_epoch:$epoch}' \
+			>"$temporary" 2>/dev/null && mv "$temporary" "$state_file"
+	else
+		printf 'status=%s\nreason=%s\ncanonical_sha=%s\ndeployed_sha=%s\nrecorded_epoch=%s\n' \
+			"$status" "$reason" "$canonical_sha" "$deployed_sha" "$recorded_epoch" >"$temporary" 2>/dev/null && mv "$temporary" "$state_file"
+	fi
+	rm -f "$temporary" 2>/dev/null || true
+	return 0
+}
+
+_pulse_runtime_recovery_last_attempt_epoch() {
+	local state_file="${AIDEVOPS_PULSE_RUNTIME_RECOVERY_STATE_FILE:-${HOME}/.aidevops/cache/pulse-runtime-recovery.json}"
+	[[ -f "$state_file" ]] || {
+		printf '0\n'
+		return 0
+	}
+	if command -v jq >/dev/null 2>&1; then
+		local recorded="" recorded_epoch=""
+		recorded_epoch=$(jq -r '.recorded_epoch // 0' "$state_file" 2>/dev/null || true)
+		if [[ "$recorded_epoch" =~ ^[0-9]+$ && "$recorded_epoch" -gt 0 ]]; then
+			printf '%s\n' "$recorded_epoch"
+			return 0
+		fi
+		recorded=$(jq -r '.recorded_at // ""' "$state_file" 2>/dev/null || true)
+		if [[ -n "$recorded" ]]; then
+			date -j -f '%Y-%m-%dT%H:%M:%SZ' "$recorded" +%s 2>/dev/null || date -d "$recorded" +%s 2>/dev/null || printf '0\n'
+			return 0
+		fi
+	fi
+	local key="" value=""
+	while IFS='=' read -r key value; do
+		if [[ "$key" == "recorded_epoch" && "$value" =~ ^[0-9]+$ ]]; then
+			printf '%s\n' "$value"
+			return 0
+		fi
+	done <"$state_file"
+	printf '0\n'
+	return 0
+}
+
+_pulse_runtime_recovery_run_setup() {
+	local setup_script="$1"
+	local timeout_seconds="${AIDEVOPS_PULSE_RUNTIME_RECOVERY_TIMEOUT_SECONDS:-240}"
+	[[ "$timeout_seconds" =~ ^[1-9][0-9]*$ ]] || timeout_seconds=240
+
+	if command -v timeout >/dev/null 2>&1; then
+		env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR AIDEVOPS_NON_INTERACTIVE=true \
+			timeout --signal=TERM --kill-after=15 "$timeout_seconds" bash "$setup_script" --stage ai-session
+		return $?
+	fi
+	if command -v gtimeout >/dev/null 2>&1; then
+		env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR AIDEVOPS_NON_INTERACTIVE=true \
+			gtimeout --signal=TERM --kill-after=15 "$timeout_seconds" bash "$setup_script" --stage ai-session
+		return $?
+	fi
+
+	# macOS ships Perl even when GNU timeout is unavailable. alarm bounds the
+	# setup owner; setup's own EXIT cleanup handles any interrupted transition.
+	# Perl source is intentionally single-quoted.
+	# shellcheck disable=SC2016
+	env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR AIDEVOPS_NON_INTERACTIVE=true \
+		perl -e '$timeout=shift; $SIG{ALRM}=sub{kill "TERM", $$; exit 124}; alarm $timeout; exec @ARGV' \
+		"$timeout_seconds" bash "$setup_script" --stage ai-session
+	return $?
+}
+
+_pulse_runtime_recovery_acquire_lock() {
+	local lock_dir="$1"
+	local owner_pid="" lock_mtime="0" now="" grace="${AIDEVOPS_PULSE_RUNTIME_RECOVERY_OWNERLESS_GRACE_SECONDS:-300}"
+	mkdir -p "${lock_dir%/*}" 2>/dev/null || return 1
+	if mkdir "$lock_dir" 2>/dev/null; then
+		printf '%s\n' "$$" >"${lock_dir}/pid" 2>/dev/null || {
+			rmdir "$lock_dir" 2>/dev/null || true
+			return 1
+		}
+		return 0
+	fi
+	if [[ -r "${lock_dir}/pid" ]]; then
+		IFS= read -r owner_pid <"${lock_dir}/pid" || owner_pid=""
+	fi
+	if [[ "$owner_pid" =~ ^[0-9]+$ ]] && kill -0 "$owner_pid" 2>/dev/null; then
+		return 1
+	fi
+	if [[ -z "$owner_pid" || ! "$owner_pid" =~ ^[0-9]+$ ]]; then
+		[[ "$grace" =~ ^[0-9]+$ ]] || grace=300
+		if declare -F _file_mtime_epoch >/dev/null 2>&1; then
+			lock_mtime=$(_file_mtime_epoch "$lock_dir" 2>/dev/null || printf '0')
+		fi
+		now=$(date +%s)
+		[[ "$lock_mtime" =~ ^[0-9]+$ ]] || lock_mtime=0
+		((now - lock_mtime >= grace)) || return 1
+	fi
+	rm -f "${lock_dir}/pid" 2>/dev/null || return 1
+	rmdir "$lock_dir" 2>/dev/null || return 1
+	if mkdir "$lock_dir" 2>/dev/null; then
+		printf '%s\n' "$$" >"${lock_dir}/pid" 2>/dev/null || {
+			rmdir "$lock_dir" 2>/dev/null || true
+			return 1
+		}
+		return 0
+	fi
+	return 1
+}
+
+pulse_runtime_recover_if_safe() {
+	[[ "${AIDEVOPS_PULSE_RUNTIME_RECOVERY_ENABLED:-1}" == "1" ]] || return 0
+	[[ "${AIDEVOPS_PULSE_RUNTIME_RECOVERY_ACTIVE:-0}" != "1" ]] || return 0
+	case " ${*:-} " in
+	*" --self-check "* | *" --dry-run "* | *" --canary "*) return 0 ;;
+	esac
+
+	local repo_path="${AIDEVOPS_REPO_PATH:-${HOME}/Git/aidevops}"
+	local stamp_file="${AIDEVOPS_DEPLOYED_SHA_FILE:-${HOME}/.aidevops/.deployed-sha}"
+	local setup_script="${repo_path}/setup.sh"
+	local canonical_sha="" upstream_sha="" deployed_sha="" branch="" last_attempt="0"
+	local now="" cooldown="${AIDEVOPS_PULSE_RUNTIME_RECOVERY_COOLDOWN_SECONDS:-3600}"
+	local lock_dir="${AIDEVOPS_PULSE_RUNTIME_RECOVERY_LOCK_DIR:-${HOME}/.aidevops/cache/pulse-runtime-recovery.lock.d}"
+
+	[[ -d "${repo_path}/.git" || -f "${repo_path}/.git" ]] || return 0
+	[[ -r "$setup_script" && -r "$stamp_file" ]] || return 0
+	canonical_sha=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null || true)
+	upstream_sha=$(git -C "$repo_path" rev-parse refs/remotes/origin/main 2>/dev/null || true)
+	IFS= read -r deployed_sha <"$stamp_file" || deployed_sha=""
+	deployed_sha="${deployed_sha//[[:space:]]/}"
+	[[ "$canonical_sha" =~ ^[0-9a-fA-F]{7,64}$ && "$deployed_sha" =~ ^[0-9a-fA-F]{7,64}$ ]] || return 0
+	[[ "$canonical_sha" != "$deployed_sha" ]] || return 0
+
+	branch=$(git -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+	if [[ "$branch" != "main" ]]; then
+		_pulse_runtime_recovery_record "$PULSE_RUNTIME_RECOVERY_BLOCKED_STATUS" "canonical_non_main" "$canonical_sha" "$deployed_sha"
+		return 0
+	fi
+	if [[ ! "$upstream_sha" =~ ^[0-9a-fA-F]{7,64}$ || "$canonical_sha" != "$upstream_sha" ]]; then
+		_pulse_runtime_recovery_record "$PULSE_RUNTIME_RECOVERY_BLOCKED_STATUS" "canonical_not_exact_origin_main" "$canonical_sha" "$deployed_sha"
+		return 0
+	fi
+	if ! git -C "$repo_path" diff --quiet 2>/dev/null || ! git -C "$repo_path" diff --cached --quiet 2>/dev/null; then
+		_pulse_runtime_recovery_record "$PULSE_RUNTIME_RECOVERY_BLOCKED_STATUS" "canonical_dirty" "$canonical_sha" "$deployed_sha"
+		return 0
+	fi
+	if ! git -C "$repo_path" merge-base --is-ancestor "$deployed_sha" "$canonical_sha" 2>/dev/null; then
+		_pulse_runtime_recovery_record "$PULSE_RUNTIME_RECOVERY_BLOCKED_STATUS" "deployment_not_ancestor" "$canonical_sha" "$deployed_sha"
+		return 0
+	fi
+	if ! git -C "$repo_path" diff --name-only "$deployed_sha" "$canonical_sha" -- \
+		.agents/scripts/ .agents/agents/ .agents/workflows/ .agents/prompts/ .agents/hooks/ setup.sh aidevops.sh 2>/dev/null | grep -q .; then
+		return 0
+	fi
+
+	[[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=3600
+	now=$(date +%s)
+	last_attempt=$(_pulse_runtime_recovery_last_attempt_epoch)
+	[[ "$last_attempt" =~ ^[0-9]+$ ]] || last_attempt=0
+	if ((now - last_attempt < cooldown)); then
+		return 0
+	fi
+	if ! _pulse_runtime_recovery_acquire_lock "$lock_dir"; then
+		_pulse_runtime_recovery_record "deferred" "recovery_already_running" "$canonical_sha" "$deployed_sha"
+		return 0
+	fi
+	trap 'rm -f "${lock_dir:-}/pid" 2>/dev/null || true; rmdir "${lock_dir:-}" 2>/dev/null || true' RETURN
+	_pulse_runtime_recovery_record "attempting" "safe_canonical_deployment" "$canonical_sha" "$deployed_sha"
+
+	local setup_rc=0
+	AIDEVOPS_PULSE_RUNTIME_RECOVERY_ACTIVE=1 _pulse_runtime_recovery_run_setup "$setup_script" || setup_rc=$?
+	if [[ "$setup_rc" -ne 0 ]]; then
+		_pulse_runtime_recovery_record "$PULSE_RUNTIME_RECOVERY_BLOCKED_STATUS" "setup_failed_exit_${setup_rc}" "$canonical_sha" "$deployed_sha"
+		return 0
+	fi
+	local activated_sha=""
+	IFS= read -r activated_sha <"$stamp_file" || activated_sha=""
+	activated_sha="${activated_sha//[[:space:]]/}"
+	if [[ "$activated_sha" != "$canonical_sha" ]]; then
+		_pulse_runtime_recovery_record "$PULSE_RUNTIME_RECOVERY_BLOCKED_STATUS" "activation_not_converged" "$canonical_sha" "$activated_sha"
+		return 0
+	fi
+	_pulse_runtime_recovery_record "recovered" "activated_canonical_runtime" "$canonical_sha" "$deployed_sha"
+	if [[ "${AIDEVOPS_PULSE_RUNTIME_RECOVERY_NO_REEXEC:-0}" != "1" && -x "${HOME}/.aidevops/agents/scripts/pulse-wrapper.sh" ]]; then
+		rm -f "${lock_dir}/pid" 2>/dev/null || true
+		rmdir "$lock_dir" 2>/dev/null || true
+		export AIDEVOPS_PULSE_RUNTIME_RECOVERY_ACTIVE=1
+		exec "${HOME}/.aidevops/agents/scripts/pulse-wrapper.sh" "$@"
+	fi
+	return 0
+}

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -216,6 +216,12 @@ if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" && -r "${_pw_bootstrap_script_dir}/pulse
 	unset _pw_pin_rc
 fi
 source "${_pw_bootstrap_script_dir}/portable-stat.sh"
+# Bootstrap recovery must run before the runtime lease is acquired. A clean,
+# exact canonical main checkout may atomically activate its newer runtime;
+# unsafe states are recorded once and Pulse continues on the current bundle.
+# shellcheck source=./pulse-runtime-recovery.sh
+source "${_pw_bootstrap_script_dir}/pulse-runtime-recovery.sh"
+pulse_runtime_recover_if_safe "$@"
 # shellcheck source=./runtime-bundle-lease.sh
 source "${_pw_bootstrap_script_dir}/runtime-bundle-lease.sh"
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -46,7 +46,10 @@ json.dump({
         'dispatch_candidate_failed_reason_dedup_active_claim': [now],
         'dispatch_candidate_failed_reason_graphql_circuit_breaker': [now],
     },
-    'gauges': {'graphql_remaining': {'value': 1234, 'ts': now}},
+    'gauges': {
+        'graphql_remaining': {'value': 1234, 'ts': now},
+        'pulse_dispatch_guardrail_available_slots': {'value': 2, 'ts': now},
+    },
 }, open(os.path.join(root, 'pulse-stats.json'), 'w'))
 json.dump({
     '_meta': {'total_calls': 42},
@@ -99,10 +102,22 @@ json.dump({
 }, open(os.path.join(root, 'objective-reconciliation.json'), 'w'))
 open(os.path.join(root, 'pulse-wrapper.log'), 'w').write(
     '[pulse] useful activity\n'
+    f'[lifecycle] worker_killed pid=123 reason=process_guard_node trigger_age=60s session=pulse ts={iso}\n'
     'ERROR Refusing reconciliation: HEAD is not exact origin/develop SHA private-sha\n'
     '[pulse-canonical-recovery] diagnostic-only canonical state: /private/path (state=uncommitted)\n'
     '[pulse-canonical-recovery] advisory filed locally: /private/path/canonical-recovery-repo.advisory\n'
     'PR opened #2\nPR merged #2\nissue closed #1\nInstance lock acquired\n'
+)
+blocker = {
+    'schema': 'aidevops-worker-blocker/v1', 'ts': now - 10,
+    'event': 'permission_awaiting_approval', 'status': 'blocked', 'reason': 'permission_required',
+    'blocking': True, 'repo_slug': 'owner/repo', 'issue_number': 7,
+    'session_key': 'issue-7', 'request_id': 'perm-current',
+}
+historical = dict(blocker, ts=now - 20, issue_number=8, session_key='issue-8', request_id='perm-old')
+reconciled = dict(historical, ts=now - 5, event='issue_terminal_reconciled', status='resolved', blocking=False)
+open(os.path.join(root, 'worker-progress-blockers.jsonl'), 'w').write(
+    json.dumps(historical) + '\n' + json.dumps(reconciled) + '\n' + json.dumps(blocker) + '\n'
 )
 state_dir = os.path.join(root, 'review-thread-state')
 os.makedirs(state_dir, exist_ok=True)
@@ -204,6 +219,14 @@ jq -e '.objective_reconciliation.oldest_unverified_assumption.number == 41' "$js
 jq -e '.canonical_reconciliation.refusal_count == 1' "$json_output" >/dev/null
 jq -e '.canonical_reconciliation.classification == "dirty_or_uncommitted"' "$json_output" >/dev/null
 jq -e '.canonical_reconciliation.canonical_recovery_advisory_observed == true' "$json_output" >/dev/null
+jq -e '.zero_worker_underutilization.actionable == false' "$json_output" >/dev/null
+jq -e '.zero_worker_underutilization.available_slots == 2' "$json_output" >/dev/null
+jq -e '.zero_worker_underutilization.classifications.assignment_ownership == 1' "$json_output" >/dev/null
+jq -e '.permission_evidence.retained_records == 3' "$json_output" >/dev/null
+jq -e '.permission_evidence.proven_current_blockers == 1' "$json_output" >/dev/null
+jq -e '.permission_evidence.historical_or_reconciled == 1' "$json_output" >/dev/null
+jq -e '.resource_recovery.direct_evidence_count == 2' "$json_output" >/dev/null
+jq -e '.resource_recovery.reason_counts.process_guard_node == 1' "$json_output" >/dev/null
 if grep -Eq '/private/path|develop SHA|private-sha' "$json_output"; then
 	printf 'FAIL canonical reconciliation projection exposes raw diagnostic context\n' >&2
 	exit 1
@@ -230,6 +253,9 @@ assert 'def build_graphql_budget' in implementation_source
 assert 'def build_current_state_guardrails' in implementation_source
 assert 'def build_objective_reconciliation' in implementation_source
 assert 'def build_cycle_state' in implementation_source
+assert 'def build_zero_worker_underutilization' in implementation_source
+assert 'def build_permission_evidence' in implementation_source
+assert 'def build_resource_recovery_evidence' in implementation_source
 assert "graphql_budget_status = (" not in implementation_source
 assert 'import subprocess' not in implementation_source
 assert 'subprocess.check_output' not in implementation_source
@@ -271,5 +297,36 @@ inconsistent_cycle_json="$TMP_DIR/inconsistent-cycle-state.json"
 "$HELPER" --log-dir "$missing_dir" --repo-path "$PWD" --window 15m --json >"$inconsistent_cycle_json"
 jq -e '.cycle_state.availability == "malformed" and .cycle_state.reason == "cycle-state-contract"' \
 	"$inconsistent_cycle_json" >/dev/null
+
+zero_dir="$TMP_DIR/zero-worker"
+mkdir -p "$zero_dir"
+python3 - "$zero_dir" <<'PY'
+import json, os, sys, time
+root = sys.argv[1]
+now = time.time()
+iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(now))
+json.dump({
+    'counters': {
+        'dispatch_candidate_failed_reason_missing_auto_dispatch_label': [now],
+        'dispatch_candidate_failed_reason_blocked_by_dependency': [now],
+        'dispatch_candidate_failed_reason_dedup_active_claim': [now],
+        'dispatch_candidate_failed_reason_admission_validation': [now],
+        'dispatch_candidate_failed_reason_candidate_enumeration_unavailable': [now],
+    },
+    'gauges': {'pulse_dispatch_guardrail_available_slots': {'value': 2, 'ts': now}},
+}, open(os.path.join(root, 'pulse-stats.json'), 'w'))
+json.dump({'cycle_state': {
+    'schema': 'aidevops.pulse-cycle-state/v1', 'cycle_id': 'zero-1',
+    'phase': 'completed', 'outcome': 'idle', 'heartbeat_at': iso,
+    'progress': {'last_at': None, 'kinds': [], 'consecutive_no_progress_cycles': 5},
+    'blocker': {'kind': 'none', 'fingerprint': None, 'consecutive_same_cycles': 0},
+}}, open(os.path.join(root, 'pulse-health.json'), 'w'))
+PY
+zero_json="$TMP_DIR/zero-worker.json"
+AIDEVOPS_ACTIVE_WORKER_PROCESSES_OVERRIDE=0 AIDEVOPS_ZERO_WORKER_MIN_CYCLES=3 \
+	"$HELPER" --log-dir "$zero_dir" --repo-path "$PWD" --window 15m --json >"$zero_json"
+jq -e '.zero_worker_underutilization.actionable == true' "$zero_json" >/dev/null
+jq -e '.zero_worker_underutilization.github_read_complete == false' "$zero_json" >/dev/null
+jq -e '.zero_worker_underutilization.classifications == {"admission_failure":1,"assignment_ownership":1,"dependency_state":1,"github_read_incomplete":1,"queue_labels":1}' "$zero_json" >/dev/null
 
 printf 'PASS pulse-current-state-helper\n'

--- a/.agents/scripts/tests/test-pulse-runtime-recovery.sh
+++ b/.agents/scripts/tests/test-pulse-runtime-recovery.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+# shellcheck source=../pulse-runtime-recovery.sh
+source "${REPO_ROOT}/.agents/scripts/pulse-runtime-recovery.sh"
+
+TEST_ROOT=""
+TESTS_RUN=0
+
+cleanup() {
+	[[ -z "$TEST_ROOT" ]] || rm -rf "$TEST_ROOT"
+}
+
+fail() {
+	printf 'FAIL: %s\n' "$1" >&2
+	exit 1
+}
+
+assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	[[ "$actual" == "$expected" ]] || fail "${message}: expected=${expected} actual=${actual}"
+	printf 'PASS: %s\n' "$message"
+}
+
+new_fixture() {
+	local name="$1"
+	local root="${TEST_ROOT}/${name}"
+	local repo="${root}/repo"
+	local remote="${root}/origin.git"
+	local home="${root}/home"
+	mkdir -p "${repo}/.agents/scripts" "${home}/.aidevops/cache"
+	git init -q --bare -b main "$remote"
+	git init -q -b main "$repo"
+	git -C "$repo" config user.name Test
+	git -C "$repo" config user.email test@example.invalid
+	cat >"${repo}/setup.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+repo_dir="$(cd "$(dirname "$0")" && pwd)"
+git -C "$repo_dir" rev-parse HEAD >"$AIDEVOPS_DEPLOYED_SHA_FILE"
+SH
+	chmod +x "${repo}/setup.sh"
+	printf 'old\n' >"${repo}/.agents/scripts/runtime.sh"
+	git -C "$repo" add setup.sh .agents/scripts/runtime.sh
+	git -C "$repo" commit -qm base
+	git -C "$repo" remote add origin "$remote"
+	git -C "$repo" push -qu origin main
+	git -C "$repo" rev-parse HEAD >"${root}/base.sha"
+	printf 'new\n' >"${repo}/.agents/scripts/runtime.sh"
+	git -C "$repo" commit -qam runtime-change
+	git -C "$repo" push -qu origin main
+	printf '%s\n' "$repo" >"${root}/repo.path"
+	printf '%s\n' "$home" >"${root}/home.path"
+}
+
+run_recovery() {
+	local fixture="$1"
+	local repo="" home="" base_sha=""
+	IFS= read -r repo <"${fixture}/repo.path"
+	IFS= read -r home <"${fixture}/home.path"
+	IFS= read -r base_sha <"${fixture}/base.sha"
+	mkdir -p "${home}/.aidevops"
+	printf '%s\n' "$base_sha" >"${home}/.aidevops/.deployed-sha"
+	HOME="$home" \
+		AIDEVOPS_REPO_PATH="$repo" \
+		AIDEVOPS_DEPLOYED_SHA_FILE="${home}/.aidevops/.deployed-sha" \
+		AIDEVOPS_PULSE_RUNTIME_RECOVERY_STATE_FILE="${fixture}/state.json" \
+		AIDEVOPS_PULSE_RUNTIME_RECOVERY_LOCK_DIR="${fixture}/recovery.lock.d" \
+		AIDEVOPS_PULSE_RUNTIME_RECOVERY_COOLDOWN_SECONDS=0 \
+		AIDEVOPS_PULSE_RUNTIME_RECOVERY_NO_REEXEC=1 \
+		pulse_runtime_recover_if_safe
+}
+
+test_safe_runtime_recovery() {
+	local fixture="${TEST_ROOT}/safe"
+	local repo="" canonical_sha="" deployed_sha=""
+	new_fixture safe
+	run_recovery "$fixture"
+	IFS= read -r repo <"${fixture}/repo.path"
+	canonical_sha=$(git -C "$repo" rev-parse HEAD)
+	IFS= read -r deployed_sha <"${fixture}/home/.aidevops/.deployed-sha"
+	assert_eq "$canonical_sha" "$deployed_sha" "safe stale runtime activates canonical HEAD"
+	assert_eq "recovered" "$(jq -r '.status' "${fixture}/state.json")" "successful recovery is recorded"
+}
+
+test_dirty_canonical_is_preserved() {
+	local fixture="${TEST_ROOT}/dirty"
+	local repo="" base_sha="" deployed_sha=""
+	new_fixture dirty
+	IFS= read -r repo <"${fixture}/repo.path"
+	printf 'dirty\n' >>"${repo}/.agents/scripts/runtime.sh"
+	run_recovery "$fixture"
+	IFS= read -r base_sha <"${fixture}/base.sha"
+	IFS= read -r deployed_sha <"${fixture}/home/.aidevops/.deployed-sha"
+	assert_eq "$base_sha" "$deployed_sha" "dirty canonical checkout is not deployed"
+	assert_eq "canonical_dirty" "$(jq -r '.reason' "${fixture}/state.json")" "dirty block records an exact reason"
+}
+
+test_non_exact_main_is_preserved() {
+	local fixture="${TEST_ROOT}/ahead"
+	local repo="" base_sha="" deployed_sha=""
+	new_fixture ahead
+	IFS= read -r repo <"${fixture}/repo.path"
+	printf 'local ahead\n' >>"${repo}/.agents/scripts/runtime.sh"
+	git -C "$repo" commit -qam local-ahead
+	run_recovery "$fixture"
+	IFS= read -r base_sha <"${fixture}/base.sha"
+	IFS= read -r deployed_sha <"${fixture}/home/.aidevops/.deployed-sha"
+	assert_eq "$base_sha" "$deployed_sha" "local-ahead main is not deployed"
+	assert_eq "canonical_not_exact_origin_main" "$(jq -r '.reason' "${fixture}/state.json")" "non-exact main records a safe recovery action"
+}
+
+test_key_value_cooldown_state() {
+	local state_file="${TEST_ROOT}/fallback-state"
+	local expected="" actual=""
+	expected=$(date +%s)
+	printf 'status=blocked\nrecorded_epoch=%s\n' "$expected" >"$state_file"
+	actual=$(AIDEVOPS_PULSE_RUNTIME_RECOVERY_STATE_FILE="$state_file" _pulse_runtime_recovery_last_attempt_epoch)
+	assert_eq "$expected" "$actual" "key-value fallback retains cooldown epoch"
+}
+
+test_dead_owner_lock_is_reclaimed() {
+	local fixture="${TEST_ROOT}/stale-lock"
+	new_fixture stale-lock
+	mkdir "${fixture}/recovery.lock.d"
+	printf '99999999\n' >"${fixture}/recovery.lock.d/pid"
+	run_recovery "$fixture"
+	assert_eq "recovered" "$(jq -r '.status' "${fixture}/state.json")" "dead recovery owner does not strand the runtime"
+	[[ ! -e "${fixture}/recovery.lock.d" ]] || fail "reclaimed recovery lock remains after completion"
+}
+
+main() {
+	TEST_ROOT=$(mktemp -d)
+	trap cleanup EXIT
+	test_safe_runtime_recovery
+	test_dirty_canonical_is_preserved
+	test_non_exact_main_is_preserved
+	test_key_value_cooldown_state
+	test_dead_owner_lock_is_reclaimed
+	printf 'Results: %s checks passed\n' "$TESTS_RUN"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Automatically activate a stale Pulse runtime only from clean exact origin/main with bounded setup, cooldown, and stale-lock recovery. Add prolonged zero-worker classifications, direct resource evidence, and current-versus-historical permission projections.

## Files Changed

.agents/scripts/pulse-current-state-helper.sh, .agents/scripts/pulse-current-state.py, .agents/scripts/pulse-runtime-recovery.sh, .agents/scripts/pulse-wrapper.sh, .agents/scripts/tests/test-pulse-current-state-helper.sh, .agents/scripts/tests/test-pulse-runtime-recovery.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused Pulse recovery/current-state/deployment/atomic-bundle tests passed (78 assertions); .agents/scripts/linters-local.sh --changed passed; independent closeout review found no blocking issues

Resolves #31487


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.332 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 27m and 210,237 tokens on this as a headless worker.
