### PR TITLE
GH#31489: preserve open PR progress

### DIFF
--- a/.agents/scripts/pulse_check_progress.py
+++ b/.agents/scripts/pulse_check_progress.py
@@ -48,9 +48,14 @@ def pr_progress_age(slug, number, now, run_gh):
     if not isinstance(number, int) or number <= 0:
         return None
     pr = run_gh(["gh", "pr", "view", str(number), "--repo", slug,
-                 "--json", "createdAt,commits,statusCheckRollup"])
+                 "--json", "createdAt,commits,statusCheckRollup,state"])
     if not isinstance(pr, dict):
         return None
+    # A linked open PR is an owned durable checkpoint. Its age may warrant
+    # review elsewhere, but it must not cause the queue scanner to recommend a
+    # replacement dispatch or stale-owner recovery.
+    if pr.get("state") == "OPEN":
+        return 0
     ages = [age for value in pr_progress_times(pr) if (age := age_at(value, now)) is not None]
     return min(ages) if ages else None
 

--- a/.agents/scripts/tests/test-pr-checkpoint-revision.py
+++ b/.agents/scripts/tests/test-pr-checkpoint-revision.py
@@ -241,6 +241,26 @@ class ProgressTests(unittest.TestCase):
         queue._run_gh_json = lambda args: None
         self.assertIsNone(queue._durable_progress_age("owner/repo", issue, now))
 
+    def test_open_linked_pr_preserves_owned_progress(self):
+        now = dt.datetime.fromisoformat("2026-09-05T13:00:00+00:00")
+        issue = {"number": 123, "createdAt": "2026-09-05T10:00:00Z", "labels": []}
+
+        def run_gh(args):
+            if args[1:3] == ["api", "repos/owner/repo/issues/123/timeline?per_page=100"]:
+                return [{"event": "cross-referenced", "source": {"issue": {
+                    "number": 42, "pull_request": {"url": "https://example.invalid/pr/42"},
+                    "repository_url": "https://api.github.com/repos/owner/repo"}}}]
+            if args[1:3] == ["pr", "view"]:
+                return {"state": "OPEN", "createdAt": "2026-09-05T10:30:00Z",
+                        "commits": [], "statusCheckRollup": []}
+            return None
+
+        queue._run_gh_json = run_gh
+        aggregate = queue._empty_aggregate()
+        queue._count_durable_progress(aggregate, "owner/repo", issue, now)
+        self.assertEqual(aggregate["no_durable_progress_hour"], 0)
+        self.assertEqual(aggregate["oldest_durable_progress_age_min"], 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Treat linked open pull requests as owned durable progress in the pulse queue scanner.

## Files Changed

.agents/scripts/pulse_check_progress.py, .agents/scripts/tests/test-pr-checkpoint-revision.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-pulse-check-helper.sh; python3 .agents/scripts/tests/test-pr-checkpoint-revision.py; .agents/scripts/pulse-check-helper.sh --json no longer reports pulse-no-durable-progress-hour

Resolves #31489


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.332 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 8m and 120,413 tokens on this as a headless worker.