### PR TITLE
GH#31500: fix fresh interactive claim PR normalization

### DIFF
--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -230,12 +230,16 @@ _isc_normalize_owned_pr() {
 	_isc_can_manage_issue_state "$slug" "$user" || return 1
 	metadata=$(_isc_read_claim_metadata "$issue" "$slug") || return 1
 	jq -e --arg user "$user" '
-		.state == "OPEN" and ([.assignees[].login] == [$user]) and
-		([.labels[].name] | index("status:in-review") != null)
+		.state == "OPEN" and ([.assignees[].login] == [$user])
 	' <<<"$metadata" >/dev/null || return 1
 	prs=$(gh pr list --repo "$slug" --head "$branch" --state open \
 		--json number,isCrossRepository,closingIssuesReferences 2>/dev/null) || return 1
+	jq -e 'type == "array"' <<<"$prs" >/dev/null || return 1
+	# Fresh claims have no PR to normalize and correctly carry status:claimed.
+	# Keep the review-state requirement for mutations of an existing PR only.
 	[[ "$(jq 'length' <<<"$prs")" == 0 ]] && return 0
+	jq -e '[.labels[].name] | index("status:in-review") != null' \
+		<<<"$metadata" >/dev/null || return 1
 	pr=$(jq -er --argjson issue "$issue" '
 		select(length == 1) | .[0] | select(.isCrossRepository == false) |
 		select([.closingIssuesReferences[].number] == [$issue]) | .number

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -1326,6 +1326,76 @@ for closed_state in CLOSED closed; do
 done
 
 # =============================================================================
+# PR normalization must exercise an existing directory: missing fake worktrees
+# return before the fresh-claim regression path.
+# =============================================================================
+test_pr_normalization() (
+	local mode="$1"
+	local fixture_metadata='{"state":"OPEN","assignees":[{"login":"testuser"}],"labels":[{"name":"status:claimed"}]}'
+	local fixture_prs='[]'
+	local expected_rc=0 expected_edits=0 actual_rc=0
+	local edit_log="${TEST_ROOT}/normalize-${mode}.log"
+	: >"$edit_log"
+	case "$mode" in
+	fresh | refresh) ;;
+	closed) fixture_metadata='{"state":"CLOSED","assignees":[{"login":"testuser"}],"labels":[]}'; expected_rc=1 ;;
+	foreign) fixture_metadata='{"state":"OPEN","assignees":[{"login":"other"}],"labels":[]}'; expected_rc=1 ;;
+	denied | api-failure) expected_rc=1 ;;
+	malformed) fixture_prs='{}'; expected_rc=1 ;;
+	existing-claimed) fixture_prs='[{"number":42,"isCrossRepository":false,"closingIssuesReferences":[{"number":39}]}]'; expected_rc=1 ;;
+	existing-review | cross-repo | wrong-issue | drift)
+		fixture_metadata='{"state":"OPEN","assignees":[{"login":"testuser"}],"labels":[{"name":"status:in-review"}]}'
+		fixture_prs='[{"number":42,"isCrossRepository":false,"closingIssuesReferences":[{"number":39}]}]'
+		expected_edits=1
+		case "$mode" in
+		cross-repo) fixture_prs='[{"number":42,"isCrossRepository":true,"closingIssuesReferences":[{"number":39}]}]'; expected_rc=1; expected_edits=0 ;;
+		wrong-issue) fixture_prs='[{"number":42,"isCrossRepository":false,"closingIssuesReferences":[{"number":40}]}]'; expected_rc=1; expected_edits=0 ;;
+		drift) expected_rc=1; expected_edits=0 ;;
+		esac
+		;;
+	esac
+	_isc_validate_worktree_origin() { return 0; }
+	_isc_can_manage_issue_state() { [[ "$mode" != denied ]]; }
+	_isc_read_claim_metadata() {
+		if [[ "$mode" == drift && -f "${edit_log}.read" ]]; then
+			printf '%s\n' '{}'
+		else
+			printf '%s\n' "$fixture_metadata"
+		fi
+		: >"${edit_log}.read"
+		return 0
+	}
+	git() { printf '%s\n' 'feature/test'; return 0; }
+	gh() {
+		case "$1 $2" in
+		'pr list') [[ "$mode" != api-failure ]] || return 1; printf '%s\n' "$fixture_prs" ;;
+		'pr edit') printf '%s\n' "$*" >>"$edit_log" ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	if [[ "$mode" == refresh ]]; then
+		_isc_existing_stamp_worktree() { printf '%s\n' "$TEST_ROOT"; return 0; }
+		_isc_write_stamp() { return 0; }
+		_isc_refresh_existing_claim 39 testowner/testrepo "$TEST_ROOT" testuser 1 || actual_rc=$?
+	else
+		_isc_normalize_owned_pr 39 testowner/testrepo "$TEST_ROOT" testuser || actual_rc=$?
+	fi
+	[[ "$actual_rc" -eq "$expected_rc" ]] || return 1
+	if [[ "$expected_edits" -eq 0 ]]; then
+		[[ ! -s "$edit_log" ]] || return 1
+	else
+		[[ "$(wc -l <"$edit_log" | tr -d ' ')" == 1 ]] || return 1
+	fi
+	return 0
+)
+
+for normalization_case in fresh refresh closed foreign denied api-failure malformed existing-claimed existing-review cross-repo wrong-issue drift; do
+	test_pr_normalization "$normalization_case"
+	print_result "PR normalization: $normalization_case" "$?"
+done
+
+# =============================================================================
 # Summary
 # =============================================================================
 printf '\n'


### PR DESCRIPTION
## Summary

Fixes #31500

- Keep origin, maintainer authority, open issue, and sole-owner checks before PR lookup.
- Return success for a verified empty PR list before requiring `status:in-review`; fresh claims remain correctly claimed, not prematurely in review.
- Preserve existing-PR state, same-repository, exact issue linkage, and metadata freshness checks before any PR mutation. Reject non-array PR responses.
- Extend `.agents/scripts/tests/test-interactive-session-claim.sh` with an existing-directory regression matrix, including the real refresh-to-normalization path. Earlier fake nonexistent worktrees returned before this code.

## Type of change

- [x] Bug fix

## Runtime Testing

- [x] `runtime-verified` — shell helper paths exercised offline with stubbed GitHub transport; no live GitHub writes during tests.

| Check | Result |
|-------|--------|
| Claim regression suite | 60 tests passed |
| Interactive startup entrypoint suite | Passed |
| ShellCheck, both changed files | Passed, no warnings |
| Changed-file local lint | Passed; optional shfmt unavailable |
| git diff --check | Passed |

Negative cases cover closed issues, foreign assignment, denied authority, failed PR reads, malformed PR data, existing PR without review state, cross-repository PR, wrong issue linkage, and metadata drift. Positive cases cover no-PR normalization, linked-worktree claim refresh, and valid existing-PR normalization. The validator never relabels a fresh issue to evade the review-state check.

## Review evidence

Direct diff inspection found no additional in-scope defect. Local bundle SHA-256: `379bd91420d6eacb18a9ccad67dbb69cb1d6f3080709c1f40ac4ce956b8e628a` (prompt-injection scan clean). Upstream independent review remains requested before merge.

## Checklist

- [x] Linked issue reference included
- [x] Conventional commit
- [x] No new feature, dependency, configuration, deployment, or schema change
- [x] Scope follows the maintainer-approved resolution plan on the linked issue

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.332 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra
