### PR TITLE
GH#31505: bound rejected worker dependency provisioning attempts

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -535,7 +535,7 @@ _dlw_restore_worktree_deps() {
 	# missing node_modules. Only check top-level and one level deep —
 	# deeper nesting is unlikely and find is expensive.
 	local _pkg_dir=""
-	local _restored=0
+	local _attempted=0
 	local _max_dirs="${WORKTREE_NODE_MODULES_RESTORE_MAX_DIRS:-2}"
 	local _restore_root="${WORKTREE_NODE_MODULES_RESTORE_ROOT_ENABLED:-auto}"
 	# Share the controller's bounded, identity-checked copy implementation.
@@ -550,7 +550,7 @@ _dlw_restore_worktree_deps() {
 	fi
 	[[ "$_max_dirs" =~ ^[0-9]+$ ]] || _max_dirs=2
 	while IFS= read -r _pkg_dir; do
-		if ((_restored >= _max_dirs)); then
+		if ((_attempted >= _max_dirs)); then
 			break
 		fi
 		local _dir=""
@@ -566,9 +566,10 @@ _dlw_restore_worktree_deps() {
 		local _src_nm="${repo_path}${_rel_dir}/node_modules"
 		local _dst_nm="${worktree_path}${_rel_dir}/node_modules"
 		if [[ -d "$_src_nm" && ! -d "$_dst_nm" ]]; then
-			if _provision_worktree_node_modules "$worktree_path" "$repo_path" "${_rel_dir#/}" >>"$LOGFILE" 2>&1; then
-				_restored=$((_restored + 1))
-			else
+			# Rejections also spend preparation time and must not exhaust the
+			# prelaunch lease by retrying every package in a large worktree.
+			_attempted=$((_attempted + 1))
+			if ! _provision_worktree_node_modules "$worktree_path" "$repo_path" "${_rel_dir#/}" >>"$LOGFILE" 2>&1; then
 				echo "[dispatch_with_dedup] Dependency provisioning unavailable; no external permission granted" >>"$LOGFILE"
 			fi
 		fi

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
@@ -76,6 +76,38 @@ if [[ -e "${wt_dir}/node_modules/.bin" || -L "${wt_dir}/node_modules/.bin" ]]; t
 	fail "dispatcher-created canonical node_modules .bin link was not removed"
 fi
 
+# Rejected provisioning must consume the same directory budget as success.
+# Keep the real restore loop and lock; replace only the protected copy boundary.
+(
+	restore_repo="${TEST_TMP}/restore-repo"
+	restore_wt="${TEST_TMP}/restore-worktree"
+	for package in one two three four; do
+		mkdir -p "${restore_repo}/${package}/node_modules" "${restore_wt}/${package}"
+		printf '{}\n' >"${restore_wt}/${package}/package.json"
+	done
+	_provision_worktree_node_modules() {
+		restore_calls=$((restore_calls + 1))
+		case "$restore_mode" in
+		success) return 0 ;;
+		mixed) [[ "$restore_calls" -eq 1 ]] && return 0 ;;
+		esac
+		return 1
+	}
+	for restore_mode in rejected mixed success; do
+		for restore_limit in 0 1 2 invalid; do
+			restore_calls=0
+			expected_calls="$restore_limit"
+			[[ "$restore_limit" == invalid ]] && expected_calls=2
+			LOGFILE="${TEST_TMP}/restore.log" AIDEVOPS_WORKSPACE_DIR="$TEST_TMP" \
+				WORKTREE_NODE_MODULES_RESTORE_MAX_DIRS="$restore_limit" \
+				_dlw_restore_worktree_deps "$restore_wt" "$restore_repo" || fail "restore failed instead of continuing safely"
+			[[ "$restore_calls" -eq "$expected_calls" ]] || fail "${restore_mode} restore attempted ${restore_calls} directories with budget ${restore_limit}; expected ${expected_calls}"
+			[[ ! -d "$(_dlw_node_modules_restore_lock_dir)" ]] || fail "restore left its lock behind"
+		done
+	done
+) || exit 1
+printf 'PASS: rejected, mixed and successful provisioning respect directory attempt budgets\n'
+
 if ! declare -F _dlw_append_node_tool_env >/dev/null 2>&1; then
 	fail "worker launch does not provide a local command path for canonical Node tools"
 fi


### PR DESCRIPTION
## Summary

Count every eligible dependency provisioning attempt against the existing directory budget, including rejected copies. Files: pulse-dispatch-worker-launch.sh and its launch-lock regression harness.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified red/green: budget=1 previously attempted four rejected directories, now one. Twelve budget scenarios pass; launch-lock suite, 17 dirty-worktree/lease cases, 19 warm-start checks, ShellCheck and local quality gates pass. Independent standard-tier review clean. Live post-release throughput verification pending.

Resolves #31505


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.332 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 1d 12h and 3,752,703 tokens on this with the user in an interactive session.