### PR TITLE
GH#31502: fix worktree and pulse reliability

### DIFF
--- a/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
@@ -21,6 +21,7 @@ import {
   signalSupervisor,
   trimTerminalOperations,
 } from "./bounded-operation-runtime.mjs";
+import { resolveSessionOwnedWorktreeRoot } from "./gpt-image-worktree.mjs";
 
 const MAX_OPERATIONS = 24;
 const SUPERVISOR_PATH = fileURLToPath(new URL("./bounded-operation-supervisor.mjs", import.meta.url));
@@ -29,6 +30,8 @@ const SUPERVISOR_RUNTIME = "node";
 export class BoundedInteractiveOperationManager {
   constructor(options = {}) {
     this.projectRoot = realpathSync(options.projectRoot || process.cwd());
+    this.scriptsDir = options.scriptsDir;
+    this.worktreeResolver = options.resolveWorktreeRoot || resolveSessionOwnedWorktreeRoot;
     this.spawn = options.spawn || spawn;
     this.now = options.now || Date.now;
     this.makeID = options.makeID || (() => `op_${this.now()}_${randomBytes(6).toString("hex")}`);
@@ -41,10 +44,15 @@ export class BoundedInteractiveOperationManager {
     this.operations = new Map();
   }
 
-  resolveCwd(requested) {
+  async resolveCwd(requested, context) {
     const cwd = realpathSync(requested || this.projectRoot);
-    if (!withinRoot(cwd, this.projectRoot)) throw new Error("cwd must remain inside the active project root");
-    return cwd;
+    if (withinRoot(cwd, this.projectRoot)) return cwd;
+    const resolved = await this.worktreeResolver(cwd, this.projectRoot, context, {
+      allowStartupRoot: true,
+      scriptsDir: this.scriptsDir,
+      subject: "Operation",
+    });
+    return resolved.root;
   }
 
   trimTerminalOperations() {
@@ -99,7 +107,7 @@ export class BoundedInteractiveOperationManager {
     const operation = {
       id: this.makeID(),
       owner,
-      cwd: this.resolveCwd(args.cwd),
+      cwd: await this.resolveCwd(args.cwd, context),
       command: [...args.command],
       restorationCommand: args.restorationCommand ? [...args.restorationCommand] : null,
       budgetMs: boundedInteger(args.budgetMs, 15 * 60 * 1000, 10, 24 * 60 * 60 * 1000),

--- a/.agents/plugins/opencode-aidevops/gpt-image-worktree.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-worktree.mjs
@@ -32,8 +32,8 @@ async function gitWorktreeIdentity(root) {
   };
 }
 
-async function verifyRegisteredOwnership({ root, sessionID, scriptsDir }) {
-  if (!scriptsDir) throw new Error("Image worktree ownership verification is unavailable.");
+async function verifyRegisteredOwnership({ root, sessionID, scriptsDir, subject }) {
+  if (!scriptsDir) throw new Error(`${subject} worktree ownership verification is unavailable.`);
   try {
     const { stdout } = await execFileAsync(
       join(scriptsDir, "worktree-helper.sh"),
@@ -42,42 +42,51 @@ async function verifyRegisteredOwnership({ root, sessionID, scriptsDir }) {
     );
     if (stdout.trim() !== "VERIFIED") throw new Error("unexpected verification receipt");
   } catch {
-    throw new Error("Image workdir is not owned by the current OpenCode session.");
+    throw new Error(`${subject} workdir is not owned by the current OpenCode session.`);
   }
 }
 
-export async function resolveGptImageProjectRoot(requestedWorkdir, projectRoot, context, options = {}) {
+export async function resolveSessionOwnedWorktreeRoot(requestedWorkdir, projectRoot, context, options = {}) {
+  const subject = options.subject || "Requested";
   const startupRoot = await requireProjectRoot(projectRoot);
   if (requestedWorkdir === undefined) return { root: startupRoot, linked: false };
   if (typeof requestedWorkdir !== "string" || !isAbsolute(requestedWorkdir)) {
-    throw new Error("Image workdir must be an absolute linked-worktree path.");
+    throw new Error(`${subject} workdir must be an absolute linked-worktree path.`);
   }
 
   let requestedStats;
   try {
     requestedStats = await lstat(requestedWorkdir);
   } catch {
-    throw new Error("Image workdir is unavailable or unsafe.");
+    throw new Error(`${subject} workdir is unavailable or unsafe.`);
   }
   if (!requestedStats.isDirectory() || requestedStats.isSymbolicLink()) {
-    throw new Error("Image workdir is unavailable or unsafe.");
+    throw new Error(`${subject} workdir is unavailable or unsafe.`);
   }
   const root = await requireProjectRoot(requestedWorkdir);
+  if (options.allowStartupRoot && root === startupRoot) return { root, linked: false };
   const sessionID = String(context?.sessionID || "");
   if (!/^ses_[A-Za-z0-9_-]+$/.test(sessionID)) {
-    throw new Error("Image workdir requires a current OpenCode session identity.");
+    throw new Error(`${subject} workdir requires a current OpenCode session identity.`);
   }
 
   const startupIdentity = await gitWorktreeIdentity(await gitPath(startupRoot, "--show-toplevel"));
   const requestedIdentity = await gitWorktreeIdentity(root);
   if (startupIdentity.commonDir !== requestedIdentity.commonDir) {
-    throw new Error("Image workdir belongs to an unrelated Git repository.");
+    throw new Error(`${subject} workdir belongs to an unrelated Git repository.`);
   }
   if (requestedIdentity.gitDir === requestedIdentity.commonDir) {
-    throw new Error("Image workdir must be a linked Git worktree, not a canonical checkout.");
+    throw new Error(`${subject} workdir must be a linked Git worktree, not a canonical checkout.`);
   }
 
   const verifyOwnership = options.verifyWorktreeOwnership || verifyRegisteredOwnership;
-  await verifyOwnership({ root, sessionID, scriptsDir: options.scriptsDir });
+  await verifyOwnership({ root, sessionID, scriptsDir: options.scriptsDir, subject });
   return { root, linked: true };
+}
+
+export async function resolveGptImageProjectRoot(requestedWorkdir, projectRoot, context, options = {}) {
+  return resolveSessionOwnedWorktreeRoot(requestedWorkdir, projectRoot, context, {
+    ...options,
+    subject: "Image",
+  });
 }

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -386,6 +386,7 @@ export async function AidevopsPlugin({ directory, client }) {
   // global OAuth fetch wrapper from an earlier OpenCode workspace.
   const boundedOperationManager = new BoundedInteractiveOperationManager({
     projectRoot: directory,
+    scriptsDir: SCRIPTS_DIR,
     recordOutput: createOutputSandboxRecorder(join(SCRIPTS_DIR, "output-sandbox-helper.sh")),
   });
   process.once("exit", () => boundedOperationManager.dispose());

--- a/.agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs
@@ -3,7 +3,7 @@
 
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, describe, test } from "node:test";
@@ -96,6 +96,29 @@ describe("bounded interactive operations", () => {
     assert.equal(result.command_execution, "observed");
     assert.match(result.supervisor_runtime, /^node v\d+\./);
     assert.equal(JSON.stringify(result).includes("phase-one"), false);
+  });
+
+  test("an outside cwd requires a session-owned worktree resolution before spawn", async () => {
+    const linked = mkdtempSync(join(tmpdir(), "aidevops-bounded-linked-"));
+    let resolution;
+    const instance = manager({
+      resolveWorktreeRoot: async (requested, projectRoot, context, options) => {
+        resolution = { requested, projectRoot, context, options };
+        return { root: linked, linked: true };
+      },
+    });
+    const started = await instance.start({
+      command: [process.execPath, "-e", "process.exit(0)"],
+      cwd: linked,
+      budgetMs: 1000,
+    }, owner);
+    assert.equal((await terminal(instance, started.operation_id)).state, "succeeded");
+    assert.equal(resolution.requested, realpathSync(linked));
+    assert.equal(resolution.projectRoot, realpathSync(root));
+    assert.equal(resolution.context, owner);
+    assert.equal(resolution.options.subject, "Operation");
+    assert.equal(resolution.options.allowStartupRoot, true);
+    rmSync(linked, { recursive: true, force: true });
   });
 
   test("failure, timeout, and scoped cancellation cannot appear as success", async () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs
@@ -21,6 +21,7 @@ import {
 } from "../../../scripts/worker-blocker-reconcile.mjs";
 
 const LOGGER_PATH = fileURLToPath(new URL("../../../scripts/worker-blocker-log.mjs", import.meta.url));
+const CLI_PATH = fileURLToPath(new URL("../../../scripts/worker-blocker-cli.mjs", import.meta.url));
 
 function appendInSubprocess(logPath, event) {
   return new Promise((resolve, reject) => {
@@ -270,6 +271,31 @@ test("resolve-session CLI appends a terminal event for a null-issue identity", (
   assert.equal(terminal.session_key, "routine-r005");
   assert.equal(terminal.request_id, "request-cli");
   assert.equal(terminal.blocking, false);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("worker-blocker CLI runs directly and rejects unknown commands", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-blocker-direct-cli-"));
+  const logPath = join(root, "events.jsonl");
+  assert.equal(appendWorkerBlockerEvent({
+    event: "permission_request_captured",
+    reason: "permission_required",
+    issue_number: 701,
+    repo_slug: "owner/repo",
+    session_key: "issue-701",
+  }, { logPath }), true);
+
+  const listed = spawnSync(process.execPath, [
+    CLI_PATH,
+    "list-active-issues",
+    "--log-file", logPath,
+    "--repo-slug", "owner/repo",
+  ], { encoding: "utf8" });
+  assert.equal(listed.status, 0);
+  assert.equal(listed.stdout.trim(), "701");
+
+  const invalid = spawnSync(process.execPath, [CLI_PATH, "unknown-command"], { encoding: "utf8" });
+  assert.equal(invalid.status, 2);
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -224,6 +224,7 @@ export function createTools(scriptsDir, run, options = {}) {
   if (options.sessionOrigin === "triage") return {};
   const boundedOperationManager = options.boundedOperationManager || new BoundedInteractiveOperationManager({
     projectRoot: options.projectRoot || process.cwd(),
+    scriptsDir,
     recordOutput: createOutputSandboxRecorder(join(scriptsDir, "output-sandbox-helper.sh")),
   });
 

--- a/.agents/scripts/gh-transport-controls.sh
+++ b/.agents/scripts/gh-transport-controls.sh
@@ -70,7 +70,7 @@ _gh_transport_run_rest() {
 	command -v python3 >/dev/null 2>&1 || return 125
 	local temp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
 	local metadata="" error_file="" start_ms="" end_ms="" elapsed="" rc=0
-	local status="" resource="" remaining="" reset="" retry_after="" cost="" attempted="" pool="" response="" outcome=success
+	local status="" resource="" remaining="" reset="" retry_after="" cost="" attempted="" deferred_by="" pool="" response="" outcome=success
 	mkdir -p "$temp_dir" || return 75
 	metadata=$(mktemp "${temp_dir}/gh-transport-meta.XXXXXX") || return 75
 	error_file=$(mktemp "${temp_dir}/gh-transport-error.XXXXXX") || {
@@ -79,6 +79,18 @@ _gh_transport_run_rest() {
 	}
 	start_ms=$(_gh_now_ms)
 	python3 "${_GHGT_DIR}/gh-transport-governor.py" "$metadata" "$executable" "$@" 2>"$error_file" || rc=$?
+	attempted=$(jq -r '.attempted // false' "$metadata" 2>/dev/null) || attempted=false
+	deferred_by=$(jq -r '.deferred_by // ""' "$metadata" 2>/dev/null) || deferred_by=""
+	if [[ "$rc" -eq 75 && "$attempted" != true && "$deferred_by" == "local_admission" ]]; then
+		local retry_delay="${AIDEVOPS_GH_LOCAL_ADMISSION_RETRY_DELAY_SECONDS:-1}"
+		[[ "$retry_delay" =~ ^[0-5]([.][0-9]+)?$ ]] || retry_delay=1
+		command cat "$error_file" >&2
+		printf '[gh-transport] retrying one request that local admission proved was not attempted\n' >&2
+		sleep "$retry_delay"
+		: >"$error_file"
+		rc=0
+		python3 "${_GHGT_DIR}/gh-transport-governor.py" "$metadata" "$executable" "$@" 2>"$error_file" || rc=$?
+	fi
 	end_ms=$(_gh_now_ms)
 	command cat "$error_file" >&2
 	attempted=$(jq -r '.attempted // false' "$metadata" 2>/dev/null) || attempted=false

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -230,12 +230,13 @@ _isc_normalize_owned_pr() {
 	_isc_can_manage_issue_state "$slug" "$user" || return 1
 	metadata=$(_isc_read_claim_metadata "$issue" "$slug") || return 1
 	jq -e --arg user "$user" '
-		.state == "OPEN" and ([.assignees[].login] == [$user]) and
-		([.labels[].name] | index("status:in-review") != null)
+		.state == "OPEN" and ([.assignees[].login] == [$user])
 	' <<<"$metadata" >/dev/null || return 1
 	prs=$(gh pr list --repo "$slug" --head "$branch" --state open \
 		--json number,isCrossRepository,closingIssuesReferences 2>/dev/null) || return 1
 	[[ "$(jq 'length' <<<"$prs")" == 0 ]] && return 0
+	jq -e '([.labels[].name] | index("status:in-review") != null)' \
+		<<<"$metadata" >/dev/null || return 1
 	pr=$(jq -er --argjson issue "$issue" '
 		select(length == 1) | .[0] | select(.isCrossRepository == false) |
 		select([.closingIssuesReferences[].number] == [$issue]) | .number

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1227,11 +1227,28 @@ _dispatch_permission_history_requires_grant() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local events_json="" labeled_count="" verification=""
+	local attempts="${AIDEVOPS_PERMISSION_HISTORY_ATTEMPTS:-2}"
+	local retry_delay="${AIDEVOPS_PERMISSION_HISTORY_RETRY_DELAY:-1}"
+	local attempt=1
 	_DISPATCH_PERMISSION_VERIFY_RESULT=""
-	events_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/events?per_page=100" --paginate --slurp 2>/dev/null) || {
+	[[ "$attempts" =~ ^[1-9][0-9]*$ ]] || attempts=2
+	[[ "$attempts" -le 3 ]] || attempts=3
+	[[ "$retry_delay" =~ ^[0-9]+$ ]] || retry_delay=1
+	[[ "$retry_delay" -le 5 ]] || retry_delay=1
+	while [[ "$attempt" -le "$attempts" ]]; do
+		if events_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/events?per_page=100" --paginate --slurp 2>/dev/null); then
+			break
+		fi
+		events_json=""
+		if [[ "$attempt" -lt "$attempts" ]]; then
+			sleep "$retry_delay"
+		fi
+		attempt=$((attempt + 1))
+	done
+	if [[ -z "$events_json" ]]; then
 		_DISPATCH_PERMISSION_VERIFY_RESULT="API_ERROR"
 		return 0
-	}
+	fi
 	labeled_count=$(jq '[.[][]? | select(.event == "labeled" and .label.name == "needs-maintainer-permissions")] | length' <<<"$events_json" 2>/dev/null) || {
 		_DISPATCH_PERMISSION_VERIFY_RESULT="API_ERROR"
 		return 0

--- a/.agents/scripts/pulse-prefetch-workers.sh
+++ b/.agents/scripts/pulse-prefetch-workers.sh
@@ -26,8 +26,18 @@ _prefetch_batch_refresh() {
 	if [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" != "1" || ! -x "$_batch_helper" ]]; then
 		return 0
 	fi
-	local _batch_output
-	_batch_output=$("$_batch_helper" refresh 2>/dev/null) || true
+	local _batch_output="" _batch_rc=0
+	local _batch_timeout="${PULSE_BATCH_PREFETCH_TIMEOUT_SECONDS:-180}"
+	[[ "$_batch_timeout" =~ ^[1-9][0-9]*$ ]] || _batch_timeout=180
+	if declare -F run_cmd_with_timeout >/dev/null 2>&1; then
+		_batch_output=$(run_cmd_with_timeout "$_batch_timeout" "$_batch_helper" refresh 2>/dev/null) || _batch_rc=$?
+	else
+		_batch_output=$("$_batch_helper" refresh 2>/dev/null) || _batch_rc=$?
+	fi
+	if [[ "$_batch_rc" -eq 124 ]]; then
+		printf '[pulse-wrapper] prefetch_batch_refresh timed out after %ss (non-fatal)\n' \
+			"$_batch_timeout" >>"${LOGFILE:-/dev/null}" 2>/dev/null || true
+	fi
 	# Parse counters for health instrumentation (t2830: also parses tickle counters)
 	local _batch_search_calls=0 _batch_cache_writes=0
 	local _tickle_fresh=0 _tickle_stale=0

--- a/.agents/scripts/pulse-prefetch-workers.sh
+++ b/.agents/scripts/pulse-prefetch-workers.sh
@@ -29,11 +29,12 @@ _prefetch_batch_refresh() {
 	local _batch_output="" _batch_rc=0
 	local _batch_timeout="${PULSE_BATCH_PREFETCH_TIMEOUT_SECONDS:-180}"
 	[[ "$_batch_timeout" =~ ^[1-9][0-9]*$ ]] || _batch_timeout=180
-	if declare -F run_cmd_with_timeout >/dev/null 2>&1; then
-		_batch_output=$(run_cmd_with_timeout "$_batch_timeout" "$_batch_helper" refresh 2>/dev/null) || _batch_rc=$?
-	else
-		_batch_output=$("$_batch_helper" refresh 2>/dev/null) || _batch_rc=$?
+	if ! declare -F run_cmd_with_timeout >/dev/null 2>&1; then
+		printf '[pulse-wrapper] prefetch_batch_refresh skipped: timeout helper unavailable (non-fatal)\n' \
+			>>"${LOGFILE:-/dev/null}" 2>/dev/null || true
+		return 0
 	fi
+	_batch_output=$(run_cmd_with_timeout "$_batch_timeout" "$_batch_helper" refresh 2>/dev/null) || _batch_rc=$?
 	if [[ "$_batch_rc" -eq 124 ]]; then
 		printf '[pulse-wrapper] prefetch_batch_refresh timed out after %ss (non-fatal)\n' \
 			"$_batch_timeout" >>"${LOGFILE:-/dev/null}" 2>/dev/null || true

--- a/.agents/scripts/shared-gh-secondary-cooldown.sh
+++ b/.agents/scripts/shared-gh-secondary-cooldown.sh
@@ -790,6 +790,7 @@ _gh_secondary_cooldown_status() {
 
 _gh_secondary_cooldown_header_expires_at() {
 	local response_text="$1"
+	local body_classification="${2:-}"
 	local now=""
 	local retry_after=""
 	local reset_at=""
@@ -800,11 +801,16 @@ _gh_secondary_cooldown_header_expires_at() {
 		printf '%s' $((now + retry_after))
 		return 0
 	fi
-	reset_at="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-reset")"
-	if [[ "$reset_at" =~ ^[0-9]+$ && "$reset_at" -gt "$now" ]]; then
-		printf '%s' "$reset_at"
-		return 0
-	fi
+	case "$body_classification" in
+	secondary-rate-limit | abuse-detection) ;;
+	*)
+		reset_at="$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-reset")"
+		if [[ "$reset_at" =~ ^[0-9]+$ && "$reset_at" -gt "$now" ]]; then
+			printf '%s' "$reset_at"
+			return 0
+		fi
+		;;
+	esac
 	printf '%s' $((now + AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS))
 	return 0
 }
@@ -873,7 +879,7 @@ _gh_secondary_cooldown_record_response_if_needed() {
 			_gh_secondary_cooldown_record_event "diagnostic-only" "github-api-forbidden-status-403" "status-403-diagnostic-only" "$response_text" "$method_arg" "$endpoint_arg" "$query_shape_arg" "$operation_arg" "$wrapper_arg" "$pulse_stage_arg"
 			return 0
 		fi
-		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text")"
+		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text" "$body_classification")"
 		if [[ -z "$retry_after" ]] && ! [[ "$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-reset")" =~ ^[0-9]+$ ]]; then
 			expires_at="$(_gh_secondary_cooldown_rest_reset_at "$endpoint_arg" || printf '%s' "$expires_at")"
 		fi
@@ -881,7 +887,7 @@ _gh_secondary_cooldown_record_response_if_needed() {
 		return 0
 		;;
 	429)
-		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text")"
+		expires_at="$(_gh_secondary_cooldown_header_expires_at "$response_text" "$body_classification")"
 		if [[ -z "$retry_after" ]] && ! [[ "$(_gh_secondary_cooldown_header_value "$response_text" "x-ratelimit-reset")" =~ ^[0-9]+$ ]]; then
 			expires_at="$(_gh_secondary_cooldown_rest_reset_at "$endpoint_arg" || printf '%s' "$expires_at")"
 		fi

--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -68,6 +68,14 @@ WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DB:-${WORKTREE_REGISTRY_DIR}/worktree-
 WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES="${WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES:-60}"
 _WORKTREE_REGISTRY_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
 
+_wt_sqlite3() {
+	local timeout_ms="${AIDEVOPS_WORKTREE_REGISTRY_BUSY_TIMEOUT_MS:-5000}"
+	[[ "$timeout_ms" =~ ^[0-9]+$ ]] || timeout_ms=5000
+	[[ "$timeout_ms" -le 60000 ]] || timeout_ms=60000
+	command sqlite3 -cmd ".timeout ${timeout_ms}" "$@"
+	return $?
+}
+
 # Get the command name (basename) for a given PID.
 # Returns empty string if the PID does not exist or info is unavailable.
 # Arguments:
@@ -334,7 +342,7 @@ _wt_registry_lookup_path() {
 			printf '%s' "$stored_path"
 			return 0
 		fi
-	done < <(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT worktree_path FROM worktree_owners;" 2>/dev/null || true)
+	done < <(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT worktree_path FROM worktree_owners;" 2>/dev/null || true)
 
 	printf '%s' "$normalized"
 	return 0
@@ -361,7 +369,7 @@ _wt_path_is_canonical() {
 _wt_delete_owner_row() {
 	local wt_path="$1"
 	[[ -f "$WORKTREE_REGISTRY_DB" ]] || return 0
-	sqlite3 "$WORKTREE_REGISTRY_DB" \
+	_wt_sqlite3 "$WORKTREE_REGISTRY_DB" \
 		"DELETE FROM worktree_owners WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';" \
 		2>/dev/null || return 1
 	return 0
@@ -370,7 +378,7 @@ _wt_delete_owner_row() {
 # Initialize the registry database
 _init_registry_db() {
 	mkdir -p "$WORKTREE_REGISTRY_DIR" 2>/dev/null || true
-	sqlite3 "$WORKTREE_REGISTRY_DB" "
+	_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         CREATE TABLE IF NOT EXISTS worktree_owners (
             worktree_path TEXT PRIMARY KEY,
             branch        TEXT,
@@ -386,41 +394,41 @@ _init_registry_db() {
     " 2>/dev/null || true
 
 	local has_dead_seen_column
-	has_dead_seen_column=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	has_dead_seen_column=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         SELECT 1 FROM pragma_table_info('worktree_owners')
         WHERE name = 'owner_dead_seen_at';
     " 2>/dev/null || echo "")
 	if [[ -z "$has_dead_seen_column" ]]; then
-		sqlite3 "$WORKTREE_REGISTRY_DB" "
+		_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
             ALTER TABLE worktree_owners
             ADD COLUMN owner_dead_seen_at TEXT DEFAULT '';
         " 2>/dev/null || true
 	fi
 
 	local has_owner_comm_column
-	has_owner_comm_column=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	has_owner_comm_column=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         SELECT 1 FROM pragma_table_info('worktree_owners')
         WHERE name = 'owner_comm';
     " 2>/dev/null || echo "")
 	if [[ -z "$has_owner_comm_column" ]]; then
-		sqlite3 "$WORKTREE_REGISTRY_DB" "
+		_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
             ALTER TABLE worktree_owners
             ADD COLUMN owner_comm TEXT DEFAULT '';
 		" 2>/dev/null || true
 	fi
 
 	local has_owner_process_start_column
-	has_owner_process_start_column=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	has_owner_process_start_column=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         SELECT 1 FROM pragma_table_info('worktree_owners')
         WHERE name = 'owner_process_start';
     " 2>/dev/null || echo "")
 	if [[ -z "$has_owner_process_start_column" ]]; then
-		sqlite3 "$WORKTREE_REGISTRY_DB" "
+		_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
             ALTER TABLE worktree_owners
             ADD COLUMN owner_process_start TEXT DEFAULT '';
 		" 2>/dev/null || return 1
 	fi
-	has_owner_process_start_column=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	has_owner_process_start_column=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         SELECT 1 FROM pragma_table_info('worktree_owners')
         WHERE name = 'owner_process_start';
     " 2>/dev/null) || return 1
@@ -505,7 +513,7 @@ register_worktree() {
 		  '$(_wt_sql_escape "$owner_process_start")',
 		  '');
     "
-	} | sqlite3 "$WORKTREE_REGISTRY_DB" 2>/dev/null || return 1
+	} | _wt_sqlite3 "$WORKTREE_REGISTRY_DB" 2>/dev/null || return 1
 	return 0
 }
 
@@ -872,7 +880,7 @@ unregister_worktree() {
 	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 0
 	wt_path=$(_wt_registry_lookup_path "$wt_path")
 
-	sqlite3 "$WORKTREE_REGISTRY_DB" "
+	_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         DELETE FROM worktree_owners
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
     " 2>/dev/null || true
@@ -931,7 +939,7 @@ unregister_worktree_if_owner_pid() {
 	wt_path=$(_wt_registry_lookup_path "$wt_path") || return 1
 
 	local changed="0"
-	changed=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	changed=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
 		DELETE FROM worktree_owners
 		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
 		  AND owner_pid = ${expected_owner_pid};
@@ -958,7 +966,7 @@ unregister_worktree_if_owner_contract() {
 	command -v sqlite3 >/dev/null 2>&1 || return 1
 	[[ -f "$WORKTREE_REGISTRY_DB" ]] || return 1
 	wt_path=$(_wt_registry_lookup_path "$wt_path") || return 1
-	changed=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	changed=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
 		DELETE FROM worktree_owners
 		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
 		  AND owner_pid = ${expected_owner_pid}
@@ -988,7 +996,7 @@ worktree_has_exact_owner_contract() {
 	command -v sqlite3 >/dev/null 2>&1 || return 1
 	[[ -f "$WORKTREE_REGISTRY_DB" ]] || return 1
 	wt_path=$(_wt_registry_lookup_path "$wt_path") || return 1
-	exact_match=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	exact_match=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
 		SELECT 1
 		FROM worktree_owners
 		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
@@ -1015,7 +1023,7 @@ check_worktree_owner_snapshot() {
 	wt_path=$(_wt_registry_lookup_path "$wt_path")
 
 	local owner_info
-	owner_info=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
+	owner_info=$(_wt_sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
         SELECT owner_pid, owner_session, owner_batch, task_id, created_at,
                COALESCE(owner_process_start, '')
         FROM worktree_owners
@@ -1057,7 +1065,7 @@ worktree_owner_dead_seen_at() {
 	wt_path=$(_wt_registry_lookup_path "$wt_path")
 
 	local dead_seen_at
-	dead_seen_at=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	dead_seen_at=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         SELECT COALESCE(owner_dead_seen_at, '')
         FROM worktree_owners
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
@@ -1078,7 +1086,7 @@ _wt_owner_dead_cooldown_minutes() {
 _wt_mark_owner_dead_seen() {
 	local wt_path="$1"
 
-	sqlite3 "$WORKTREE_REGISTRY_DB" "
+	_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         UPDATE worktree_owners
         SET owner_dead_seen_at = CASE
             WHEN COALESCE(owner_dead_seen_at, '') = '' THEN strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
@@ -1095,7 +1103,7 @@ _wt_owner_dead_cooldown_expired() {
 	cooldown_minutes=$(_wt_owner_dead_cooldown_minutes)
 
 	local expired
-	expired=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	expired=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         SELECT CASE
             WHEN COALESCE(owner_dead_seen_at, '') != ''
              AND datetime(replace(replace(owner_dead_seen_at, 'T', ' '), 'Z', ''), '+${cooldown_minutes} minutes') <= datetime('now')
@@ -1130,7 +1138,7 @@ PY
 _wt_owner_comm_for_path() {
 	local wt_path="$1"
 	local owner_comm
-	owner_comm=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	owner_comm=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         SELECT COALESCE(owner_comm, '')
         FROM worktree_owners
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
@@ -1145,7 +1153,7 @@ _wt_owner_generation_contract_for_path() {
 	local wt_path="$1"
 	local separator=$'\x1f'
 	local owner_contract=""
-	owner_contract=$(sqlite3 -separator "$separator" "$WORKTREE_REGISTRY_DB" "
+	owner_contract=$(_wt_sqlite3 -separator "$separator" "$WORKTREE_REGISTRY_DB" "
         SELECT owner_pid, COALESCE(owner_process_start, ''), COALESCE(created_at, '')
         FROM worktree_owners
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
@@ -1164,7 +1172,7 @@ _wt_unregister_owner_if_generation_matches() {
 	local changed="0"
 
 	[[ "$expected_owner_pid" =~ ^[0-9]+$ && -n "$expected_created_at" ]] || return 1
-	changed=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	changed=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         DELETE FROM worktree_owners
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
           AND owner_pid = ${expected_owner_pid}
@@ -1236,7 +1244,7 @@ _wt_legacy_dispatch_precreate_systemd_owner_expired() {
 	registered_comm=$(_wt_owner_comm_for_path "$wt_path")
 	[[ "$current_comm" == "systemd" && "$registered_comm" == "systemd" ]] || return 1
 
-	expired=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	expired=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         SELECT CASE
             WHEN owner_pid = ${owner_pid}
              AND COALESCE(owner_process_start, '') = ''
@@ -1317,7 +1325,7 @@ _wt_is_worktree_owned_by_others_for_resolved_pid() {
 		return 0
 	fi
 
-	sqlite3 "$WORKTREE_REGISTRY_DB" "
+	_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         UPDATE worktree_owners
         SET owner_dead_seen_at = ''
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
@@ -1378,7 +1386,7 @@ _wt_registry_delete_paths_batch() {
 			printf "DELETE FROM worktree_owners WHERE worktree_path = '%s';\n" "$escaped_wt_path"
 		done <<<"$stale_entries"
 		printf 'COMMIT;\n'
-	} | sqlite3 "$WORKTREE_REGISTRY_DB" >/dev/null 2>&1 || return 1
+	} | _wt_sqlite3 "$WORKTREE_REGISTRY_DB" >/dev/null 2>&1 || return 1
 	return 0
 }
 
@@ -1434,7 +1442,7 @@ _wt_registry_reconcile_existing_owners() {
 
 	local separator=$'\x1f'
 	local entries=""
-	entries=$(sqlite3 -separator "$separator" "$WORKTREE_REGISTRY_DB" "
+	entries=$(_wt_sqlite3 -separator "$separator" "$WORKTREE_REGISTRY_DB" "
         SELECT worktree_path, owner_pid
         FROM worktree_owners
         ORDER BY CASE WHEN COALESCE(owner_dead_seen_at, '') = '' THEN 1 ELSE 0 END,
@@ -1469,7 +1477,7 @@ prune_worktree_registry() {
 	# First, delete entries with ANSI escape codes (corrupted entries)
 	# These often have newlines and break normal parsing
 	local ansi_count
-	ansi_count=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	ansi_count=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         DELETE FROM worktree_owners 
         WHERE worktree_path LIKE '%'||char(27)||'%' 
            OR worktree_path LIKE '%[0;%'
@@ -1481,7 +1489,7 @@ prune_worktree_registry() {
 
 	# Next, delete test artifacts in temp directories
 	local temp_count
-	temp_count=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	temp_count=$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "
         DELETE FROM worktree_owners 
         WHERE worktree_path LIKE '/tmp/%' 
            OR worktree_path LIKE '/var/folders/%';
@@ -1494,7 +1502,7 @@ prune_worktree_registry() {
 	# one sqlite transaction; the old path called unregister_worktree once per row,
 	# which made large stale backlogs exceed common assistant/tool timeouts.
 	local entries
-	entries=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
+	entries=$(_wt_sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
         SELECT worktree_path, owner_pid FROM worktree_owners;
     " 2>/dev/null || echo "")
 

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -365,6 +365,20 @@ test_header_parsers_ignore_response_body() {
 	return 1
 }
 
+test_explicit_secondary_ignores_primary_resource_reset() {
+	reset_case
+	local now="" response_text="" expiry=""
+	now="$(_gh_secondary_cooldown_now)"
+	response_text=$(printf 'HTTP/2 403\r\nX-RateLimit-Resource: search\r\nX-RateLimit-Remaining: 27\r\nX-RateLimit-Reset: %s\r\n\r\n' "$((now + 56))")
+	expiry="$(_gh_secondary_cooldown_header_expires_at "$response_text" "secondary-rate-limit")"
+	if [[ "$expiry" -eq $((now + AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS)) ]]; then
+		printf 'PASS explicit secondary response ignores primary resource reset\n'
+		return 0
+	fi
+	printf 'FAIL explicit secondary response used primary reset: expiry=%s now=%s\n' "$expiry" "$now"
+	return 1
+}
+
 test_timeout_temp_cleanup_when_out_mktemp_fails() {
 	reset_case
 	local leaked_file="${TMP_HOME}/leaked.err"
@@ -558,6 +572,7 @@ test_override_allows_audited_call
 test_default_path_without_home_is_user_scoped
 test_no_jq_fallback_escapes_json_strings
 test_header_parsers_ignore_response_body
+test_explicit_secondary_ignores_primary_resource_reset
 test_timeout_temp_cleanup_when_out_mktemp_fails
 test_event_trim_enforces_bytes_below_line_cap
 test_boot_ramp_defers_after_per_minute_budget

--- a/.agents/scripts/tests/test-gh-shim-transport-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-transport-cases.sh
@@ -109,6 +109,37 @@ fi
 # adapter must never take that route away from an explicitly metered window.
 # shellcheck source=/dev/null
 source "${TMP}/scripts/gh-transport-controls.sh"
+
+_governor_count_file="${TMP}/governor/calls"
+printf '0\n' >"$_governor_count_file"
+python3() {
+	if [[ "${1:-}" == *gh-transport-governor.py ]]; then
+		local governor_calls=""
+		governor_calls=$(<"$_governor_count_file")
+		governor_calls=$((governor_calls + 1))
+		printf '%s\n' "$governor_calls" >"$_governor_count_file"
+		local metadata="$2"
+		if [[ "$governor_calls" -eq 1 ]]; then
+			printf '{"attempted":false,"deferred_by":"local_admission","retry_at":1}\n' >"$metadata"
+			return 75
+		fi
+		printf '{"attempted":true,"status":200,"resource":"core","remaining":4999,"reset":%s,"retry_after":null,"cost":1}\n' "$_governor_reset" >"$metadata"
+		printf '{"fixture":true}\n'
+		return 0
+	fi
+	command python3 "$@"
+}
+_governor_rc=0
+_governor_output=$(AIDEVOPS_GH_LOCAL_ADMISSION_RETRY_DELAY_SECONDS=0 \
+	_gh_transport_run_rest "${TMP}/bin/gh" rest gh_api_rest 0 api user 2>/dev/null) || _governor_rc=$?
+unset -f python3
+_governor_calls=$(<"$_governor_count_file")
+if [[ "$_governor_calls" -eq 2 && "$_governor_output" == '{"fixture":true}' ]]; then
+	_pass "local admission deferral retries once only after attempted=false evidence"
+else
+	_fail "local admission deferral was not retried safely (rc=${_governor_rc} calls=${_governor_calls} output=${_governor_output:-<empty>})"
+fi
+
 _governor_rc=0
 AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 _gh_transport_run_rest \
 	"${TMP}/bin/gh" rest gh_api_rest 0 api user >/dev/null 2>/dev/null || _governor_rc=$?

--- a/.agents/scripts/tests/test-permission-grant-verification.sh
+++ b/.agents/scripts/tests/test-permission-grant-verification.sh
@@ -77,6 +77,20 @@ cat >"${TEST_ROOT}/bin/gh" <<'STUB'
 set -euo pipefail
 args="$*"
 if [[ "$args" == *"/events?"* ]]; then
+	printf 'event\n' >>"$PERMISSION_GH_CALLS_FILE"
+	call_count=$(wc -l <"$PERMISSION_GH_CALLS_FILE" | tr -d ' ')
+	case "${PERMISSION_GH_MODE:-success}" in
+	events-fail-first)
+		[[ "$call_count" -gt 1 ]] || exit 75
+		;;
+	events-always-fail)
+		exit 75
+		;;
+	events-malformed)
+		printf '{malformed\n'
+		exit 0
+		;;
+	esac
   command cat "$PERMISSION_EVENTS_FILE"
 else
   command cat "$PERMISSION_COMMENTS_FILE"
@@ -86,6 +100,8 @@ chmod +x "${TEST_ROOT}/bin/gh"
 export PATH="${TEST_ROOT}/bin:${PATH}"
 export PERMISSION_COMMENTS_FILE="$comments_file"
 export PERMISSION_EVENTS_FILE="$events_file"
+export PERMISSION_GH_CALLS_FILE="${TEST_ROOT}/gh-calls"
+export AIDEVOPS_PERMISSION_HISTORY_RETRY_DELAY=0
 
 verification=$(cmd_verify_permissions issue 123 owner/repo)
 [[ "$verification" == "VERIFIED" ]] || {
@@ -95,6 +111,33 @@ verification=$(cmd_verify_permissions issue 123 owner/repo)
 
 # shellcheck source=../pulse-dispatch-core.sh
 source "${SCRIPT_DIR}/pulse-dispatch-core.sh"
+
+: >"$PERMISSION_GH_CALLS_FILE"
+export PERMISSION_GH_MODE="events-fail-first"
+if _dispatch_permission_history_requires_grant 123 owner/repo; then
+	printf 'dispatch remained blocked after a transient permission-history failure: %s\n' "${_DISPATCH_PERMISSION_VERIFY_RESULT:-}" >&2
+	exit 1
+fi
+[[ "$_DISPATCH_PERMISSION_VERIFY_RESULT" == "VERIFIED" ]]
+[[ "$(wc -l <"$PERMISSION_GH_CALLS_FILE" | tr -d ' ')" == "2" ]]
+
+: >"$PERMISSION_GH_CALLS_FILE"
+export PERMISSION_GH_MODE="events-always-fail"
+if ! _dispatch_permission_history_requires_grant 123 owner/repo; then
+	printf 'dispatch was allowed after repeated permission-history failures\n' >&2
+	exit 1
+fi
+[[ "$_DISPATCH_PERMISSION_VERIFY_RESULT" == "API_ERROR" ]]
+[[ "$(wc -l <"$PERMISSION_GH_CALLS_FILE" | tr -d ' ')" == "2" ]]
+
+export PERMISSION_GH_MODE="events-malformed"
+if ! _dispatch_permission_history_requires_grant 123 owner/repo; then
+	printf 'dispatch was allowed after malformed permission-history data\n' >&2
+	exit 1
+fi
+[[ "$_DISPATCH_PERMISSION_VERIFY_RESULT" == "API_ERROR" ]]
+
+export PERMISSION_GH_MODE="success"
 if _dispatch_permission_history_requires_grant 123 owner/repo; then
 	printf 'dispatch remained blocked despite a matching valid grant: %s\n' "${_DISPATCH_PERMISSION_VERIFY_RESULT:-}" >&2
 	exit 1

--- a/.agents/scripts/tests/test-pulse-batch-refresh-timeout.sh
+++ b/.agents/scripts/tests/test-pulse-batch-refresh-timeout.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT=$(mktemp -d)
+PREFETCH_PARENT_PID_FILE="${TEST_ROOT}/parent.pid"
+PREFETCH_CHILD_PID_FILE="${TEST_ROOT}/child.pid"
+export PREFETCH_PARENT_PID_FILE PREFETCH_CHILD_PID_FILE
+export LOGFILE="${TEST_ROOT}/pulse.log"
+
+cleanup() {
+	local pid=""
+	for pid_file in "$PREFETCH_PARENT_PID_FILE" "$PREFETCH_CHILD_PID_FILE"; do
+		if [[ -f "$pid_file" ]]; then
+			pid=$(<"$pid_file")
+			[[ -n "$pid" ]] && kill -9 "$pid" >/dev/null 2>&1 || true
+		fi
+	done
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+cat >"${TEST_ROOT}/pulse-batch-prefetch-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$$" >"$PREFETCH_PARENT_PID_FILE"
+sleep 300 &
+child_pid=$!
+printf '%s\n' "$child_pid" >"$PREFETCH_CHILD_PID_FILE"
+wait "$child_pid"
+STUB
+chmod +x "${TEST_ROOT}/pulse-batch-prefetch-helper.sh"
+
+# shellcheck source=../worker-lifecycle-common.sh
+source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+# shellcheck source=../pulse-watchdog.sh
+source "${SCRIPTS_DIR}/pulse-watchdog.sh"
+SCRIPT_DIR="$TEST_ROOT"
+# shellcheck source=../pulse-prefetch-workers.sh
+source "${SCRIPTS_DIR}/pulse-prefetch-workers.sh"
+
+export PULSE_BATCH_PREFETCH_TIMEOUT_SECONDS=1
+started_at=$SECONDS
+_prefetch_batch_refresh
+elapsed=$((SECONDS - started_at))
+[[ "$elapsed" -le 5 ]] || {
+	printf 'batch refresh exceeded its bounded timeout: %ss\n' "$elapsed" >&2
+	exit 1
+}
+[[ -s "$PREFETCH_PARENT_PID_FILE" && -s "$PREFETCH_CHILD_PID_FILE" ]]
+parent_pid=$(<"$PREFETCH_PARENT_PID_FILE")
+child_pid=$(<"$PREFETCH_CHILD_PID_FILE")
+if kill -0 "$parent_pid" 2>/dev/null || kill -0 "$child_pid" 2>/dev/null; then
+	printf 'batch refresh timeout left a descendant alive: parent=%s child=%s\n' "$parent_pid" "$child_pid" >&2
+	exit 1
+fi
+grep -q 'prefetch_batch_refresh timed out after 1s' "$LOGFILE"
+
+printf 'pulse batch refresh timeout test passed\n'

--- a/.agents/scripts/tests/test-pulse-batch-refresh-timeout.sh
+++ b/.agents/scripts/tests/test-pulse-batch-refresh-timeout.sh
@@ -59,4 +59,10 @@ if kill -0 "$parent_pid" 2>/dev/null || kill -0 "$child_pid" 2>/dev/null; then
 fi
 grep -q 'prefetch_batch_refresh timed out after 1s' "$LOGFILE"
 
+unset -f run_cmd_with_timeout
+rm -f "$PREFETCH_PARENT_PID_FILE" "$PREFETCH_CHILD_PID_FILE"
+_prefetch_batch_refresh
+[[ ! -e "$PREFETCH_PARENT_PID_FILE" && ! -e "$PREFETCH_CHILD_PID_FILE" ]]
+grep -q 'prefetch_batch_refresh skipped: timeout helper unavailable' "$LOGFILE"
+
 printf 'pulse batch refresh timeout test passed\n'

--- a/.agents/scripts/tests/test-worktree-registry-session-claim.sh
+++ b/.agents/scripts/tests/test-worktree-registry-session-claim.sh
@@ -18,10 +18,12 @@ TESTS_RUN=0
 TESTS_FAILED=0
 OWNER_PID=""
 CLAIM_PID=""
+LOCK_PID=""
 
 cleanup() {
 	[[ -n "$OWNER_PID" ]] && kill "$OWNER_PID" >/dev/null 2>&1 || true
 	[[ -n "$CLAIM_PID" ]] && kill "$CLAIM_PID" >/dev/null 2>&1 || true
+	[[ -n "$LOCK_PID" ]] && kill "$LOCK_PID" >/dev/null 2>&1 || true
 	wait "$OWNER_PID" "$CLAIM_PID" 2>/dev/null || true
 	rm -rf "$TEST_ROOT"
 	return 0
@@ -107,6 +109,43 @@ test_registry_owner_verification_command() {
 		rc=1
 	fi
 	print_result "registry command verifies exact live session owner" "$rc"
+	return 0
+}
+
+test_registry_sqlite_contention_is_bounded() {
+	reset_registry
+	_init_registry_db || {
+		print_result "registry SQLite contention waits boundedly" 1
+		return 0
+	}
+	local lock_sql="${TEST_ROOT}/hold-registry-lock.sql"
+	printf '%s\n' \
+		'BEGIN EXCLUSIVE;' \
+		"INSERT OR REPLACE INTO worktree_owners (worktree_path, branch, owner_pid) VALUES ('/tmp/lock-holder', 'lock-holder', 1);" \
+		'.shell sleep 2' \
+		'COMMIT;' >"$lock_sql"
+	command sqlite3 "$WORKTREE_REGISTRY_DB" <"$lock_sql" &
+	LOCK_PID=$!
+	sleep 1
+
+	local rc=0 started_at=$SECONDS elapsed=0
+	if AIDEVOPS_WORKTREE_REGISTRY_BUSY_TIMEOUT_MS=100 \
+		_wt_sqlite3 "$WORKTREE_REGISTRY_DB" \
+		"INSERT OR REPLACE INTO worktree_owners (worktree_path, branch, owner_pid) VALUES ('/tmp/bounded-writer', 'bounded-writer', 2);" \
+		>/dev/null 2>&1; then
+		rc=1
+	fi
+	elapsed=$((SECONDS - started_at))
+	[[ "$elapsed" -lt 2 ]] || rc=1
+	wait "$LOCK_PID" || rc=1
+	LOCK_PID=""
+
+	AIDEVOPS_WORKTREE_REGISTRY_BUSY_TIMEOUT_MS=1000 \
+		_wt_sqlite3 "$WORKTREE_REGISTRY_DB" \
+		"INSERT OR REPLACE INTO worktree_owners (worktree_path, branch, owner_pid) VALUES ('/tmp/bounded-writer', 'bounded-writer', 2);" \
+		>/dev/null 2>&1 || rc=1
+	[[ "$(_wt_sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT COUNT(*) FROM worktree_owners WHERE worktree_path = '/tmp/bounded-writer';")" == "1" ]] || rc=1
+	print_result "registry SQLite contention waits boundedly" "$rc"
 	return 0
 }
 
@@ -508,6 +547,7 @@ test_owner_writers_fail_when_process_generation_is_unavailable() {
 
 main() {
 	start_live_pids
+	test_registry_sqlite_contention_is_bounded
 	test_registry_owner_verification_command
 	test_same_opencode_session_rolls_owner_pid
 	test_parameterized_claim_preserves_metacharacters

--- a/.agents/scripts/worker-blocker-cli.mjs
+++ b/.agents/scripts/worker-blocker-cli.mjs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
+import { pathToFileURL } from "node:url";
+
 import { appendWorkerBlockerEvent } from "./worker-blocker-log.mjs";
 import {
   listActiveWorkerBlockerIssues,
@@ -60,4 +62,8 @@ export function runWorkerBlockerCli(argv = process.argv.slice(2)) {
   if (!handler) return 2;
   const { event, options } = parseCliArguments(args);
   return handler(event, options);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = runWorkerBlockerCli();
 }


### PR DESCRIPTION
## Summary

Harden session-owned worktree routing, interactive claim normalization, direct CLI execution, GitHub admission/cooldown recovery, permission verification, bounded batch prefetch, and concurrent SQLite registry access. Resolves #31501. Resolves #31500. Resolves #31498. Resolves #31497. Resolves #31495. Resolves #31492. Resolves #31491.

## Files Changed

.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs, .agents/plugins/opencode-aidevops/gpt-image-worktree.mjs, .agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs, .agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs, .agents/plugins/opencode-aidevops/tools.mjs, .agents/scripts/gh-transport-controls.sh, .agents/scripts/interactive-session-helper.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/pulse-prefetch-workers.sh, .agents/scripts/shared-gh-secondary-cooldown.sh, .agents/scripts/shared-worktree-registry.sh, .agents/scripts/tests/test-gh-secondary-cooldown.sh, .agents/scripts/tests/test-gh-shim-transport-cases.sh, .agents/scripts/tests/test-permission-grant-verification.sh, .agents/scripts/tests/test-pulse-batch-refresh-timeout.sh, .agents/scripts/tests/test-worktree-registry-session-claim.sh, .agents/scripts/worker-blocker-cli.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 29 Node tests; 48 interactive-claim tests; 17 registry tests; permission, prefetch, cooldown, and 162 gh-shim tests; changed-file linters and ShellCheck

Resolves #31502


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 2h 45m and 602,765 tokens on this with the user in an interactive session.