### PR TITLE
GH#31513: keep daily sweep cadence independent of stall runs

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -818,7 +818,7 @@ _should_run_llm_supervisor() {
 	local now_epoch
 	now_epoch=$(date +%s)
 
-	# 1. Daily sweep: run when the last successful LLM completion is stale.
+	# 1. Daily sweep: only a successful daily sweep advances its cadence.
 	# last_llm_run_epoch remains as the legacy success timestamp for older installs;
 	# last_llm_attempt_epoch is separate so failed runs do not suppress retries for
 	# a full daily interval.
@@ -829,7 +829,17 @@ _should_run_llm_supervisor() {
 	fi
 	last_llm_attempt_epoch=$(_pulse_read_epoch_file "${PULSE_DIR}/last_llm_attempt_epoch")
 
-	local llm_age=$((now_epoch - last_llm_success_epoch))
+	local last_daily_epoch="" last_success_mode=""
+	last_daily_epoch=$(_pulse_read_epoch_file "${PULSE_DIR}/last_daily_sweep_success_epoch")
+	if [[ "$last_daily_epoch" -eq 0 && -f "${PULSE_DIR}/last_llm_success_mode" ]]; then
+		IFS= read -r last_success_mode <"${PULSE_DIR}/last_llm_success_mode" || true
+		# Migrate only positively identified daily completion evidence. A recent
+		# stall/first-run success must not postpone an unobserved daily sweep.
+		if [[ "$last_success_mode" == "daily_sweep" ]]; then
+			last_daily_epoch="$last_llm_success_epoch"
+		fi
+	fi
+	local llm_age=$((now_epoch - last_daily_epoch))
 	if [[ "$llm_age" -ge "$PULSE_LLM_DAILY_INTERVAL" ]]; then
 		if _pulse_llm_failure_cooldown_active "$now_epoch" "$last_llm_success_epoch" "$last_llm_attempt_epoch"; then
 			return 1

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -32,6 +32,7 @@
 # Include guard
 [[ -n "${_PULSE_WRAPPER_CYCLE_LIB_LOADED:-}" ]] && return 0
 _PULSE_WRAPPER_CYCLE_LIB_LOADED=1
+_PULSE_CYCLE_DAILY_MODE="daily_sweep"
 
 # Defensive SCRIPT_DIR fallback (matches issue-sync-lib.sh pattern)
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -229,7 +230,7 @@ run_pulse() {
 	# causing "Argument list too long" on every pulse invocation. The agent
 	# reads the file via its Read tool instead. See: #4257
 	local pulse_command="/pulse"
-	if [[ "$trigger_mode" == "daily_sweep" ]]; then
+	if [[ "$trigger_mode" == "$_PULSE_CYCLE_DAILY_MODE" ]]; then
 		pulse_command="/pulse-sweep"
 	fi
 	local prompt
@@ -318,6 +319,9 @@ _pulse_record_llm_success() {
 	# Keep the legacy file as successful-completion state for older helpers.
 	printf '%s\n' "$success_epoch" >"${PULSE_DIR}/last_llm_run_epoch" 2>/dev/null || return 1
 	printf '%s\n' "$trigger_mode" >"${PULSE_DIR}/last_llm_success_mode" 2>/dev/null || true
+	if [[ "$trigger_mode" == "$_PULSE_CYCLE_DAILY_MODE" ]]; then
+		printf '%s\n' "$success_epoch" >"${PULSE_DIR}/last_daily_sweep_success_epoch" 2>/dev/null || return 1
+	fi
 	echo "[pulse-wrapper] LLM supervisor completed successfully (trigger=${trigger_mode}, epoch=${success_epoch})" >>"$LOGFILE"
 	return 0
 }
@@ -343,7 +347,7 @@ _pulse_maybe_run_llm_supervisor() {
 			llm_trigger_mode=$(cat "${PULSE_DIR}/llm_trigger_mode" 2>/dev/null) || llm_trigger_mode="stall"
 		fi
 		if [[ "${PULSE_FORCE_LLM:-0}" == "1" && "$llm_trigger_mode" == "stall" ]]; then
-			llm_trigger_mode="daily_sweep"
+			llm_trigger_mode="$_PULSE_CYCLE_DAILY_MODE"
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-pulse-sigpipe-llm-state.sh
+++ b/.agents/scripts/tests/test-pulse-sigpipe-llm-state.sh
@@ -72,4 +72,38 @@ _pulse_record_llm_failure "daily_sweep" "7"
 _pulse_record_llm_success "daily_sweep"
 [[ -f "${PULSE_DIR}/last_llm_success_epoch" && -f "${PULSE_DIR}/last_llm_run_epoch" ]] || fail "success timestamps missing"
 
+now_epoch=$(date +%s)
+daily_epoch=$((now_epoch - 1000))
+printf '%s\n' "$daily_epoch" >"${PULSE_DIR}/last_daily_sweep_success_epoch"
+printf '%s 0 0\n' "$now_epoch" >"${PULSE_DIR}/backlog_snapshot.txt"
+_pulse_record_llm_success "stall"
+_should_run_llm_supervisor || fail "successful stall run postponed an overdue daily sweep"
+[[ "$(<"${PULSE_DIR}/llm_trigger_mode")" == daily_sweep ]] || fail "overdue sweep did not select daily mode"
+[[ "$(<"${PULSE_DIR}/last_daily_sweep_success_epoch")" == "$daily_epoch" ]] || fail "stall changed daily completion evidence"
+_pulse_record_llm_success "first_run"
+[[ "$(<"${PULSE_DIR}/last_daily_sweep_success_epoch")" == "$daily_epoch" ]] || fail "first-run changed daily completion evidence"
+_pulse_record_llm_failure "daily_sweep" 7
+[[ "$(<"${PULSE_DIR}/last_daily_sweep_success_epoch")" == "$daily_epoch" ]] || fail "failed daily sweep advanced completion evidence"
+mv "${PULSE_DIR}/last_llm_success_epoch" "${PULSE_DIR}/saved-success"
+mkdir "${PULSE_DIR}/last_llm_success_epoch"
+if _pulse_record_llm_success "daily_sweep" 2>/dev/null; then
+	fail "generic success write failure was ignored"
+fi
+[[ "$(<"${PULSE_DIR}/last_daily_sweep_success_epoch")" == "$daily_epoch" ]] || fail "partial state write advanced daily cadence"
+rmdir "${PULSE_DIR}/last_llm_success_epoch"
+mv "${PULSE_DIR}/saved-success" "${PULSE_DIR}/last_llm_success_epoch"
+_pulse_record_llm_success "daily_sweep"
+[[ "$(<"${PULSE_DIR}/last_daily_sweep_success_epoch")" -ge "$now_epoch" ]] || fail "successful daily sweep did not advance its own clock"
+if _should_run_llm_supervisor; then
+	fail "recent daily success triggered another sweep with unchanged fresh backlog"
+fi
+
+# Migration may reuse a positively identified daily completion, not a stall.
+rm -f "${PULSE_DIR}/last_daily_sweep_success_epoch"
+if _should_run_llm_supervisor; then
+	fail "known legacy daily completion was ignored"
+fi
+_pulse_record_llm_success "stall"
+_should_run_llm_supervisor || fail "legacy stall completion suppressed first independently tracked daily sweep"
+
 printf 'PASS pulse SIGPIPE and LLM state regressions\n'


### PR DESCRIPTION
## Summary

Separate daily-only completion time from generic LLM success timestamps in pulse-dispatch-engine.sh and pulse-wrapper-cycle.sh; extend the existing SIGPIPE/LLM-state regression harness.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-wrapper-cycle.sh, .agents/scripts/tests/test-pulse-sigpipe-llm-state.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified red/green: old selector postponed overdue daily sweep after successful stall; fixed selector selects daily. Cadence, migration, failure cooldown and partial-write tests pass. All 52 characterization checks, ShellCheck and local quality gates pass. Independent final review clean after addressing partial-write ordering.

Resolves #31513


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 1d 13h and 3,877,979 tokens on this with the user in an interactive session.