### PR TITLE
GH#31508: classify stale queue progress ownership

### DIFF
--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -68,6 +68,8 @@ def _empty_aggregate() -> dict[str, int]:
         "excluded_persistent_dashboard": 0,
         "available_old": 0,
         "no_durable_progress_hour": 0,
+        "no_durable_progress_owned": 0,
+        "no_durable_progress_unowned": 0,
         "oldest_issue_age_min": 0,
         "oldest_durable_progress_age_min": 0,
         "durable_progress_unknown": 0,
@@ -128,11 +130,20 @@ def _durable_progress_age(slug: str, issue: dict[str, Any], now: dt.datetime) ->
 
 
 def _count_durable_progress(aggregate: dict[str, int], slug: str,
-                            issue: dict[str, Any], now: dt.datetime) -> None:
+                             issue: dict[str, Any], now: dt.datetime) -> None:
+    no_progress_before = aggregate["no_durable_progress_hour"]
     context = progress_scan.ProgressContext(slug, _run_gh_json,
-                                            lambda probe: _dependency_diagnostic(slug, probe),
-                                            PERSISTENT_DASHBOARD_LABELS)
+                                             lambda probe: _dependency_diagnostic(slug, probe),
+                                             PERSISTENT_DASHBOARD_LABELS)
     progress_scan.count_progress(aggregate, issue, now, context)
+    if aggregate["no_durable_progress_hour"] == no_progress_before:
+        return
+    labels = _issue_labels(issue)
+    owned = bool(issue.get("assignees")) or bool(
+        labels & {"status:claimed", "status:in-progress", "status:in-review", "status:queued"}
+    )
+    key = "no_durable_progress_owned" if owned else "no_durable_progress_unowned"
+    aggregate[key] += 1
 
 
 def _load_repos(repos_json: pathlib.Path) -> tuple[list[dict[str, Any]], str]:

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -304,11 +304,13 @@ end) as $max_workers |
         "Issues need owned progress assessment after at least one hour";
         [
           ("issues=" + ($queue.aggregate.no_durable_progress_hour | tostring)),
+          ("owned_without_durable_progress=" + (($queue.aggregate.no_durable_progress_owned // 0) | tostring)),
+          ("unowned_without_durable_progress=" + (($queue.aggregate.no_durable_progress_unowned // 0) | tostring)),
           ("oldest_issue_age_minutes=" + ($queue.aggregate.oldest_issue_age_min | tostring)),
           ("oldest_durable_progress_age_minutes=" + ($queue.aggregate.oldest_durable_progress_age_min | tostring)),
           "clock=creation_linked_pr_commits_terminal_checks_not_comments"
         ];
-        "Freshly inspect the affected registered queue and choose one evidence-backed recovery per unchanged target: continue its live owner, route a released approved draft through dispatch-approved, or send a bounded scope-revision request to the authorised brief owner. Preserve ownership and external waits. Do not create replacement PRs, redispatch unchanged blockers, or post repeated age/status comments; retain the action in the existing recovery receipt.";
+        "Freshly inspect the affected registered queue and choose one evidence-backed recovery per unchanged target. Start with owned targets (assignee or active lifecycle label) and continue only a verified live owner; for unowned targets, route only a released approved draft through dispatch-approved. Send a bounded scope-revision request to the authorised brief owner when neither path applies. Preserve ownership and external waits. Do not create replacement PRs, redispatch unchanged blockers, or post repeated age/status comments; retain the action in the existing recovery receipt.";
         true
       )
     else empty end,

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -285,11 +285,11 @@ if [[ "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "shortfall" || "${PULSE_CHECK_QUEUE_FI
   if [[ " $* " == *"private/repo-one"* ]]; then
     cat <<'JSON'
 [
-  {"number":11,"title":"private eligible","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
-  {"number":12,"title":"private assigned","updatedAt":"2000-01-01T00:00:00Z","assignees":[{"login":"worker"}],"labels":[{"name":"auto-dispatch"},{"name":"status:queued"},{"name":"tier:standard"}]},
-  {"number":13,"title":"private nmr","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:thinking"},{"name":"needs-maintainer-review"}]},
-  {"number":14,"title":"private malformed","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]},
-  {"number":15,"title":"private active review","updatedAt":"2000-01-01T00:00:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"auto-dispatch"},{"name":"status:in-review"},{"name":"tier:standard"}]}
+  {"number":11,"title":"private eligible","createdAt":"2000-01-01T00:00:00Z","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
+  {"number":12,"title":"private assigned","createdAt":"2000-01-01T00:00:00Z","updatedAt":"2000-01-01T00:00:00Z","assignees":[{"login":"worker"}],"labels":[{"name":"auto-dispatch"},{"name":"status:queued"},{"name":"tier:standard"}]},
+  {"number":13,"title":"private nmr","createdAt":"2000-01-01T00:00:00Z","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:thinking"},{"name":"needs-maintainer-review"}]},
+  {"number":14,"title":"private malformed","createdAt":"2000-01-01T00:00:00Z","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]},
+  {"number":15,"title":"private active review","createdAt":"2000-01-01T00:00:00Z","updatedAt":"2000-01-01T00:00:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"auto-dispatch"},{"name":"status:in-review"},{"name":"tier:standard"}]}
 ]
 JSON
   else
@@ -593,13 +593,16 @@ chmod +x "${TEST_ROOT}/current-state-shortfall.sh"
 SHORTFALL_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=shortfall" \
 	"PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-shortfall.sh" "$HELPER" json 2>&1)
 SHORTFALL_IDS=$(printf '%s' "$SHORTFALL_OUT" | jq -r '[.findings[].id] | sort | join(",")')
-assert_eq "active workers do not hide eligible queue shortfall" "auto-dispatch-missing-tier-labels,pulse-eligible-queue-under-target,pulse-inactive-nmr-holds" "$SHORTFALL_IDS"
+assert_eq "active workers do not hide eligible queue shortfall" "auto-dispatch-missing-tier-labels,pulse-eligible-queue-under-target,pulse-inactive-nmr-holds,pulse-no-durable-progress-hour" "$SHORTFALL_IDS"
 assert_eq "queue shortfall remains a maintainer advisory" "medium" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.findings[] | select(.id == "pulse-eligible-queue-under-target") | .severity')"
 assert_eq "queue shortfall does not auto-file a non-actionable issue" "false" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.findings[] | select(.id == "pulse-eligible-queue-under-target") | .autofile')"
 assert_eq "shortfall fixture has one eligible issue" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.eligible_available_unassigned')"
 assert_eq "shortfall fixture distinguishes assigned work" "2" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.assigned_in_flight')"
 assert_eq "shortfall fixture distinguishes held work" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.blocked_explicit_hold')"
 assert_eq "active review ownership is not an explicit hold" "2" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.blocked_labels')"
+assert_eq "durable-progress finding distinguishes owned targets" "2" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.no_durable_progress_owned')"
+assert_eq "durable-progress finding distinguishes unowned targets" "2" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.no_durable_progress_unowned')"
+assert_contains "durable-progress recovery prioritizes verified ownership" "owned_without_durable_progress=2" "$SHORTFALL_OUT"
 assert_contains "shortfall evidence does not claim assignment proves liveness" "assigned_or_in_flight=2" "$SHORTFALL_OUT"
 assert_contains "NMR advisory names updatedAt inactivity basis" "issue_updatedAt_not_label_application_time" "$SHORTFALL_OUT"
 assert_eq "inactive NMR holds remain visible" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '[.findings[] | select(.id == "pulse-inactive-nmr-holds")] | length')"


### PR DESCRIPTION
## Summary

Classified durable-progress findings into owned and unowned queue targets so recovery starts with verified owners.

## Files Changed

.agents/scripts/pulse-check-queue-scan.py, .agents/scripts/pulse-check-report.jq, .agents/scripts/tests/test-pulse-check-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-pulse-check-helper.sh; shellcheck .agents/scripts/tests/test-pulse-check-helper.sh; python3 -m py_compile .agents/scripts/pulse-check-queue-scan.py .agents/scripts/pulse_check_progress.py

Resolves #31508


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 10m and 140,384 tokens on this as a headless worker.
