### PR TITLE
GH#31515: fix: recover dead preparing release lanes

### DIFF
--- a/.agents/reference/release-lane-coordination.md
+++ b/.agents/reference/release-lane-coordination.md
@@ -97,8 +97,16 @@ Competing release starts use the same bounded recovery for eligible reservations
 ordinary merge guards do not read or mutate publisher ownership. Status remains read-only.
 
 Age alone never unlocks a lane. Live/recent reservations, legacy/foreign owners,
-preparing/publication phases and aggregation recovery are not automatically
-released. For a reservation without a recorded tag, tag-based `reconcile` may
+publication phases and aggregation recovery are not automatically released. A
+stale `preparing` lane is resumable only by the exact same authorized source and
+increment when the local executor is verifiably dead, its deterministic detached
+worktree remains isolated at the pinned snapshot, no release process survives,
+the persisted source manifest still matches, and the intended tag, protected
+release branch, GitHub release, npm version, and Homebrew version are all proven
+absent. The publisher rotates the operation token through the lane compare-and-swap,
+retains durable `preparing_recovery` evidence, and restarts from a fresh copy of
+the pinned commit; lookup uncertainty or any existing artifact refuses recovery.
+For a reservation without a recorded tag, tag-based `reconcile` may
 have nothing to resume: the authorized release owner must restart the same
 source with its original increment and persisted intent. This does not grant a
 new session publication authority. Do not report background progress without

--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -26,6 +26,7 @@ _FULL_LOOP_AGGREGATE_COMMIT_PHASE="aggregate-publication-committing"
 _FULL_LOOP_FAILED_PREPUBLICATION_PHASE="reconcile-required"
 _FULL_LOOP_AGGREGATE_RECOVERY_TAG_REF_PREFIX="refs/tags/"
 _FULL_LOOP_AGGREGATE_RECOVERY_MAIN_BRANCH="main"
+_FULL_LOOP_RECOVERY_STATE_ABSENT="absent"
 
 _full_loop_recovery_http_status() {
 	local endpoint="$1"
@@ -645,6 +646,93 @@ _full_loop_recovery_prepare_prepublication_source() {
 	case "$resolved_mode" in direct | aggregate) ;; *) return 1 ;; esac
 	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$_FULL_LOOP_RESOLVED_EXPECTED_SOURCES"
 	return 0
+}
+
+_full_loop_recovery_process_uses_path() {
+	local release_path="$1"
+	local processes=""
+	processes=$(ps -axo command= 2>/dev/null) || return 2
+	[[ "$processes" != *"$release_path"* ]]
+	return $?
+}
+
+# A preparing release runs entirely in an isolated detached worktree until its
+# signed tag is pushed. A dead attempt can restart from the immutable snapshot
+# only after both that worktree and all remote publication precursors are proven
+# inert. Lookup failures are unknown and fail closed.
+#aidevops:trust-boundary
+_full_loop_recovery_dead_preparing() {
+	local repo="$1"
+	local source_pr="$2"
+	local expected_sources="$3"
+	local release_type="$4"
+	local lane_sources=""
+	local persisted_sources=""
+	local snapshot=""
+	local base_tag=""
+	local attempted_tag=""
+	local attempted_version=""
+	local owner_pid=""
+	local release_path=""
+	local worktree_head=""
+	local worktree_version=""
+	local remote_refs=""
+	local recovery_evidence=""
+	local process_rc=0
+	local permission=""
+	local lane_read_rc=0
+	release_lane_read "$repo" || lane_read_rc=$?
+	case "$lane_read_rc" in
+	0) ;;
+	2) return 2 ;;
+	*) return 1 ;;
+	esac
+	jq -e --argjson source_pr "$source_pr" --arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_PREPARING" \
+		'.active == true and .source_pr == $source_pr and .phase == $preparing' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 2
+	lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	persisted_sources=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	[[ "$expected_sources" == "$lane_sources" && "$persisted_sources" == "$lane_sources" ]] || return 1
+	snapshot=$(jq -er '.snapshot_sha | select(test("^[0-9a-f]{40}$"))' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	base_tag=$(jq -er '.snapshot_base_tag | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	attempted_tag=$(_full_loop_release_expected_tag_at_commit "$snapshot" "$release_type") || return 1
+	attempted_version="${attempted_tag#v}"
+	owner_pid=$(jq -er '.executor.pid | select(type == "number" and . > 0 and floor == .)' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	release_path=$(jq -r '.preparation.worktree // ""' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	if [[ -z "$release_path" ]]; then
+		release_path="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}/aidevops-release-${source_pr}-${owner_pid}"
+	fi
+	case "$release_path" in
+	"${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"/aidevops-release-"${source_pr}"-*) ;;
+	*) return 1 ;;
+	esac
+	[[ -d "$release_path" ]] || return 1
+	worktree_head=$(git -C "$release_path" rev-parse HEAD 2>/dev/null) || return 1
+	[[ "$worktree_head" == "$snapshot" ]] || return 1
+	! git -C "$release_path" symbolic-ref -q HEAD >/dev/null 2>&1 || return 1
+	! git -C "$release_path" show-ref --verify --quiet "refs/tags/${attempted_tag}" || return 1
+	worktree_version=$(tr -d '[:space:]' <"$release_path/VERSION") || return 1
+	[[ "v${worktree_version}" == "$base_tag" || "$worktree_version" == "$attempted_version" ]] || return 1
+	_full_loop_recovery_process_uses_path "$release_path" || process_rc=$?
+	[[ "$process_rc" -eq 0 ]] || return 1
+	permission=$(gh api "repos/${repo}" \
+		--jq '.permissions.push == true or .permissions.maintain == true or .permissions.admin == true' 2>/dev/null) || return 1
+	[[ "$permission" == "true" ]] || return 1
+	_full_loop_recovery_verify_channels_absent "$repo" "$attempted_tag" || return 1
+	remote_refs=$(git -C "$REPO_ROOT" ls-remote --heads origin \
+		"refs/heads/chore/release-${attempted_tag}-provenance") || return 1
+	[[ -z "$remote_refs" ]] || return 1
+	recovery_evidence=$(jq -cn --arg tag "$attempted_tag" --arg expected "$lane_sources" \
+		--arg head "$worktree_head" --arg path "$release_path" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+		--arg absent "$_FULL_LOOP_RECOVERY_STATE_ABSENT" \
+		'{type:"preparing-recovery/v1",attempted_tag:$tag,expected_sources:$expected,
+		worktree:$path,worktree_head:$head,worktree_state:"isolated",surviving_process:$absent,
+		remote_tag:$absent,github_release:$absent,npm:$absent,homebrew:$absent,
+		protected_branch:$absent,checked_at:$now}') || return 1
+	release_lane_recover_dead_preparing "$repo" "$source_pr" "$lane_sources" "$attempted_tag" "$recovery_evidence"
+	return $?
 }
 
 _full_loop_recovery_resolve_lane_authorization() {

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -589,6 +589,7 @@ _full_loop_release_start_new() {
 	local expected_sources="$5"
 	local existing_state_rc=0
 	local persisted_expected=""
+	local preparing_recovery_rc=0
 	_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=false
 	_FULL_LOOP_RESERVED_RECOVERY_FAILED_PREPUBLICATION=false
 	_full_loop_release_guard_competing_lane "$repo" "$source_pr" || return $?
@@ -605,6 +606,15 @@ _full_loop_release_start_new() {
 	0) return 0 ;;
 	2) ;;
 	*) return "$existing_state_rc" ;;
+	esac
+	_full_loop_recovery_dead_preparing "$repo" "$source_pr" "$expected_sources" "$release_type" || preparing_recovery_rc=$?
+	case "$preparing_recovery_rc" in
+	0)
+		_full_loop_release_run_new "$repo" "$source_pr" "$release_type" "$deployment_scope" "$expected_sources"
+		return $?
+		;;
+	2) ;;
+	*) return "$preparing_recovery_rc" ;;
 	esac
 	if [[ "$_FULL_LOOP_RESERVED_RECOVERY_COMPLETED" == "$_FULL_LOOP_RELEASE_BOOL_TRUE" ]]; then
 		_full_loop_release_run_new "$repo" "$source_pr" "$release_type" "$deployment_scope" "$expected_sources"

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -25,6 +25,8 @@ _AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATE_COMMIT="aggregate-publication-committing"
 _AIDEVOPS_RELEASE_LANE_PHASE_RESERVED_REFRESH="reserved-authorization-refresh"
 _AIDEVOPS_RELEASE_LANE_PHASE_RECONCILE_REQUIRED="reconcile-required"
 _AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING="aggregation-successor-preparing"
+_AIDEVOPS_RELEASE_LANE_PHASE_PREPARING="preparing"
+_AIDEVOPS_RELEASE_LANE_STATE_ABSENT="absent"
 
 _AIDEVOPS_RELEASE_LANE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=release-lane-liveness.sh
@@ -167,6 +169,87 @@ _release_lane_stale_prepublication() {
 	[[ "$updated_epoch" =~ ^[0-9]+$ && "$now_epoch" =~ ^[0-9]+$ && "$now_epoch" -ge "$updated_epoch" ]] || return 1
 	[[ $((now_epoch - updated_epoch)) -ge "$stale_after" ]]
 	return $?
+}
+
+# Reclaiming a preparing lane is intentionally a separate contract from stale
+# reservation recovery. The caller must first prove that the isolated release
+# worktree and every remote publication precursor are absent or inert.
+#aidevops:trust-boundary
+release_lane_recover_dead_preparing() {
+	local repo="$1"
+	local source_pr="$2"
+	local expected_sources="$3"
+	local attempted_tag="$4"
+	local recovery_evidence="$5"
+	local operation_token=""
+	local state_json=""
+	local updated_at=""
+	local updated_epoch=""
+	local now_epoch=""
+	local stale_after="${AIDEVOPS_RELEASE_LANE_STALE_SECONDS:-$_AIDEVOPS_RELEASE_LANE_STALE_PREPUBLICATION_SECONDS}"
+	[[ "$source_pr" =~ ^[0-9]+$ && -n "$expected_sources" ]] || return 1
+	[[ "$attempted_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	[[ "$stale_after" =~ ^[0-9]+$ && "$stale_after" -gt 0 ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg expected "$expected_sources" \
+		--arg attempted_tag "$attempted_tag" --arg contract "fenced-prepublication/v1" \
+		--arg sha_pattern '^[0-9a-f]{40}$' --arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_PREPARING" '
+		.active == true and .source_pr == $source_pr and .phase == $preparing
+		and .reservation_contract == $contract and .expected_sources == $expected
+		and .tag == null and .terminal_receipt == null
+		and (.snapshot_manifest_bound == true)
+		and (.snapshot_sha | test($sha_pattern)) and (.snapshot_base | test($sha_pattern))
+		and (.snapshot_base_object | test($sha_pattern))
+		and (.snapshot_base_tag | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))
+		and ((.preparing_recovery // null) == null
+			or (.preparing_recovery.attempted_tag == $attempted_tag
+				and .preparing_recovery.evidence.expected_sources == $expected))
+		and (.prepublication_recovery // null) == null
+		and (.aggregate_recovery // null) == null
+		and (.aggregate_successor // null) == null
+		and (.reserved_authorization_refresh // null) == null
+		and ($attempted_tag | length) > 0
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 3
+	[[ "$(_release_lane_executor_observe "$_AIDEVOPS_RELEASE_LANE_JSON" | jq -r '.state')" == "dead" ]] || return 3
+	updated_at=$(jq -r '.updated_at // ""' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	updated_epoch=$(date -u -d "$updated_at" +%s 2>/dev/null ||
+		date -u -jf '%Y-%m-%dT%H:%M:%SZ' "$updated_at" +%s 2>/dev/null || true)
+	now_epoch=$(date +%s 2>/dev/null || true)
+	[[ "$updated_epoch" =~ ^[0-9]+$ && "$now_epoch" =~ ^[0-9]+$ && "$now_epoch" -ge "$updated_epoch" ]] || return 3
+	[[ $((now_epoch - updated_epoch)) -ge "$stale_after" ]] || return 3
+	jq -e --arg tag "$attempted_tag" --arg expected "$expected_sources" --arg sha_pattern '^[0-9a-f]{40}$' \
+		--arg absent "$_AIDEVOPS_RELEASE_LANE_STATE_ABSENT" '
+		.type == "preparing-recovery/v1" and .attempted_tag == $tag
+		and .expected_sources == $expected and .remote_tag == $absent
+		and .github_release == $absent and .protected_branch == $absent
+		and .npm == $absent and .homebrew == $absent
+		and .surviving_process == $absent and .worktree_state == "isolated"
+		and (.worktree_head | test($sha_pattern))
+		and (.checked_at | type) == "string" and (.checked_at | length) > 0
+	' <<<"$recovery_evidence" >/dev/null || return 1
+	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(openssl rand -hex 16 2>/dev/null)" || return 1
+	state_json=$(jq -c --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \
+		--arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_PREPARING" \
+		--arg token "$operation_token" --arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" --arg tag "$attempted_tag" \
+		--argjson evidence "$recovery_evidence" --argjson executor "$(_release_lane_executor_capture || printf 'null')" '
+		.updated_at as $previous_updated_at | .executor as $previous_executor
+		| (.preparing_recovery // null) as $existing_recovery
+		| .phase=$reserved | .operation_token=$token | .owner=$owner | .updated_at=$now
+		| .executor=$executor
+		| .preparing_recovery=(if $existing_recovery == null then
+			{previous_phase:$preparing,previous_updated_at:$previous_updated_at,
+			 previous_executor:$previous_executor,attempted_tag:$tag,recovered_at:$now,evidence:$evidence}
+		  else $existing_recovery
+			| .revalidations=((.revalidations // []) +
+				[{previous_updated_at:$previous_updated_at,previous_executor:$previous_executor,
+				  recovered_at:$now,evidence:$evidence}]) end)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
+	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
+	_AIDEVOPS_RELEASE_LANE_RESULT="$_AIDEVOPS_RELEASE_LANE_RESULT_ACQUIRED"
+	printf 'Recovered dead tagless preparing lane for PR #%s at %s\n' "$source_pr" "$attempted_tag"
+	return 0
 }
 
 _release_lane_reclaim_same_source() {
@@ -322,9 +405,10 @@ release_lane_begin_aggregate_successor() {
 	state_json=$(jq -c --argjson stale "$stale_pr" --arg base "$base_sha" \
 		--arg expected "$expected_sources" --arg branch "$branch_name" --arg token "$operation_token" \
 		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
-		--arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING" --argjson previous "$previous_state" '
+		--arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING" \
+		--arg status_preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_PREPARING" --argjson previous "$previous_state" '
 		.phase=$preparing | .operation_token=$token | .updated_at=$now
-		| .aggregate_successor={status:"preparing",stale_pr:$stale,base_sha:$base,
+		| .aggregate_successor={status:$status_preparing,stale_pr:$stale,base_sha:$base,
 			expected_sources:$expected,branch:$branch,previous_state:$previous}
 	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
@@ -851,7 +935,8 @@ release_lane_update() {
 	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
 		'.active == true and .source_pr == $source_pr and .operation_token == $token' \
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
-	state_json=$(jq -c --arg phase "$phase" --arg tag "$tag_name" --arg preparing "preparing" \
+	state_json=$(jq -c --arg phase "$phase" --arg tag "$tag_name" \
+		--arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_PREPARING" \
 		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
 		.phase=$phase | .tag=(if $tag == "" then .tag else $tag end) | .updated_at=$now
 		| if $phase == $preparing then del(.prepublication_recovery) else . end

--- a/.agents/scripts/release-lane-liveness.sh
+++ b/.agents/scripts/release-lane-liveness.sh
@@ -35,6 +35,9 @@ release_lane_liveness_report() {
 			printf 'Release owner: resume with existing publication authority using aidevops release patch %s (or the originally authorized increment).\n' "$source_pr"
 			printf 'Live, recent, legacy, or foreign ownership cannot be automatically released; unknown is not an active executor.\n'
 		fi
+	elif jq -e '.active == true and .phase == "preparing" and .tag == null' <<<"$state_json" >/dev/null &&
+		[[ "$(jq -r '.state' <<<"$observation")" == "dead" ]]; then
+		printf 'Preparing owner is dead before a tag was recorded. Rerun the exact authorized release command; fenced recovery will first verify the isolated worktree, source authorization, and every publication channel.\n'
 	else
 		printf 'Inspect/resume publication: aidevops release reconcile %s\n' "$source_pr"
 	fi

--- a/.agents/scripts/tests/test-release-dead-preparing-recovery.sh
+++ b/.agents/scripts/tests/test-release-dead-preparing-recovery.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="$TEST_ROOT/home"
+export AIDEVOPS_WORKTREE_BASE_DIR="$TEST_ROOT/worktrees"
+mkdir -p "$HOME" "$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42"
+printf '1.2.4\n' >"$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42/VERSION"
+
+# shellcheck source=../release-lane-helper.sh
+source "$SCRIPT_DIR/release-lane-helper.sh"
+# shellcheck source=../full-loop-release-aggregate-recovery.sh
+source "$SCRIPT_DIR/full-loop-release-aggregate-recovery.sh"
+
+REPO_ROOT="$TEST_ROOT/repo"
+mkdir -p "$REPO_ROOT"
+SNAPSHOT=2222222222222222222222222222222222222222
+EXPECTED='101@1111111111111111111111111111111111111111'
+BASE_STATE='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101@1111111111111111111111111111111111111111","phase":"preparing","tag":null,"owner":"process-42","operation_token":"token-old","updated_at":"2020-01-01T00:00:00Z","terminal_receipt":null,"reservation_contract":"fenced-prepublication/v1","executor":{"host_id":"local","pid":42,"started_at":"old"},"snapshot_sha":"2222222222222222222222222222222222222222","snapshot_base":"1111111111111111111111111111111111111111","snapshot_base_tag":"v1.2.3","snapshot_base_object":"3333333333333333333333333333333333333333","snapshot_manifest_bound":true}'
+STATE="$BASE_STATE"
+AUTHORIZATION="$EXPECTED"
+CHANNELS_ABSENT=true
+SURVIVING_PROCESS=false
+PROTECTED_BRANCH=false
+PERMISSION=true
+LANE_ABSENT=false
+RECOVERY_CALLS=0
+CAPTURED_EVIDENCE=""
+
+release_lane_read() {
+	[[ "$LANE_ABSENT" == "false" ]] || return 2
+	_AIDEVOPS_RELEASE_LANE_JSON="$STATE"
+	_AIDEVOPS_RELEASE_LANE_HEAD=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	return 0
+}
+
+_full_loop_read_release_authorization() {
+	printf '%s\n' "$AUTHORIZATION"
+	return 0
+}
+
+_full_loop_release_expected_tag_at_commit() {
+	[[ "$1" == "$SNAPSHOT" && "$2" == "patch" ]] || return 1
+	printf 'v1.2.4\n'
+	return 0
+}
+
+_full_loop_recovery_verify_channels_absent() {
+	[[ "$1" == "test/repo" && "$2" == "v1.2.4" && "$CHANNELS_ABSENT" == "true" ]]
+	return $?
+}
+
+_full_loop_recovery_process_uses_path() {
+	[[ "$SURVIVING_PROCESS" == "false" ]]
+	return $?
+}
+
+git() {
+	local args="$*"
+	case "$args" in
+	*"rev-parse HEAD"*) printf '%s\n' "$SNAPSHOT" ;;
+	*"symbolic-ref -q HEAD"*) return 1 ;;
+	*"show-ref --verify --quiet refs/tags/v1.2.4"*) return 1 ;;
+	*"ls-remote --heads origin refs/heads/chore/release-v1.2.4-provenance"*)
+		[[ "$PROTECTED_BRANCH" == "false" ]] && return 0
+		printf '%s\t%s\n' 4444444444444444444444444444444444444444 refs/heads/chore/release-v1.2.4-provenance
+		;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+release_lane_recover_dead_preparing() {
+	[[ "$1" == "test/repo" && "$2" == "101" && "$3" == "$EXPECTED" && "$4" == "v1.2.4" ]] || return 1
+	RECOVERY_CALLS=$((RECOVERY_CALLS + 1))
+	CAPTURED_EVIDENCE="$5"
+	return 0
+}
+
+gh() {
+	[[ "$*" == 'api repos/test/repo --jq '* ]] || return 1
+	printf '%s\n' "$PERMISSION"
+	return 0
+}
+
+reset_fixture() {
+	STATE="$BASE_STATE"
+	AUTHORIZATION="$EXPECTED"
+	CHANNELS_ABSENT=true
+	SURVIVING_PROCESS=false
+	PROTECTED_BRANCH=false
+	PERMISSION=true
+	LANE_ABSENT=false
+	RECOVERY_CALLS=0
+	CAPTURED_EVIDENCE=""
+	printf '1.2.4\n' >"$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42/VERSION"
+	return 0
+}
+
+reset_fixture
+_full_loop_recovery_dead_preparing test/repo 101 "$EXPECTED" patch >/dev/null
+[[ "$RECOVERY_CALLS" -eq 1 ]] || exit 1
+jq -e '.attempted_tag == "v1.2.4" and .worktree_state == "isolated"
+	and .remote_tag == "absent" and .github_release == "absent"
+	and .npm == "absent" and .homebrew == "absent" and .protected_branch == "absent"' \
+	<<<"$CAPTURED_EVIDENCE" >/dev/null
+printf 'PASS dead preparing recovery proves isolated worktree and absent channels before one CAS\n'
+
+reset_fixture
+LANE_ABSENT=true
+absent_rc=0
+_full_loop_recovery_dead_preparing test/repo 101 "$EXPECTED" patch >/dev/null 2>&1 || absent_rc=$?
+[[ "$absent_rc" -eq 2 && "$RECOVERY_CALLS" -eq 0 ]] || exit 1
+printf 'PASS absent lane falls through to the ordinary release path\n'
+
+for refusal in authorization channels process permission branch version; do
+	reset_fixture
+	case "$refusal" in
+	authorization) AUTHORIZATION='101@9999999999999999999999999999999999999999' ;;
+	channels) CHANNELS_ABSENT=false ;;
+	process) SURVIVING_PROCESS=true ;;
+	permission) PERMISSION=false ;;
+	branch) PROTECTED_BRANCH=true ;;
+	version) printf '1.2.5\n' >"$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42/VERSION" ;;
+	esac
+	if _full_loop_recovery_dead_preparing test/repo 101 "$EXPECTED" patch >/dev/null 2>&1; then
+		printf 'FAIL unsafe %s state was recovered\n' "$refusal" >&2
+		exit 1
+	fi
+	[[ "$RECOVERY_CALLS" -eq 0 ]] || exit 1
+done
+printf 'PASS preparing recovery refuses authorization, channel, process, branch, and worktree uncertainty\n'

--- a/.agents/scripts/tests/test-release-lane-liveness.sh
+++ b/.agents/scripts/tests/test-release-lane-liveness.sh
@@ -78,6 +78,12 @@ STATE=$(jq -c --arg recent "$RECENT" '.updated_at=$recent' <<<"$BASE")
 AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 refused 'caller cannot shorten five-minute recovery grace'
 STATE="$BASE"
 
+STATE=$(jq -c '.phase="preparing"' <<<"$BASE")
+report=$(release_lane_liveness_report "$STATE")
+[[ "$report" == *"Rerun the exact authorized release command"* ]] || exit 1
+printf 'PASS dead tagless preparing status routes through fenced same-command recovery\n'
+STATE="$BASE"
+
 AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo release_lane_merge_guard test/repo 202 main feature/ordinary
 [[ "$WRITES" == 0 ]] || exit 1
 release_lane_recover_reservation test/repo 101

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -620,6 +620,82 @@ run_aggregate_successor_transaction_test() {
 	return $?
 }
 
+run_dead_preparing_recovery_test() (
+	local expected='101@1111111111111111111111111111111111111111'
+	local old_token="token-old"
+	local written=""
+	local evidence='{"type":"preparing-recovery/v1","attempted_tag":"v1.2.4","expected_sources":"101@1111111111111111111111111111111111111111","worktree_head":"2222222222222222222222222222222222222222","worktree_state":"isolated","surviving_process":"absent","remote_tag":"absent","github_release":"absent","npm":"absent","homebrew":"absent","protected_branch":"absent","checked_at":"2026-09-07T18:00:00Z"}'
+	local state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101@1111111111111111111111111111111111111111","phase":"preparing","tag":null,"owner":"process-42","operation_token":"token-old","updated_at":"2020-01-01T00:00:00Z","terminal_receipt":null,"reservation_contract":"fenced-prepublication/v1","executor":{"host_id":"local","pid":42,"started_at":"old"},"snapshot_sha":"2222222222222222222222222222222222222222","snapshot_base":"1111111111111111111111111111111111111111","snapshot_base_tag":"v1.2.3","snapshot_base_object":"3333333333333333333333333333333333333333","snapshot_manifest_bound":true}'
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$state"
+		_AIDEVOPS_RELEASE_LANE_HEAD="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		return 0
+	}
+	_release_lane_executor_observe() { printf '{"state":"dead","reason":"process-absent"}\n'; }
+	_release_lane_executor_capture() { printf '{"host_id":"local","pid":99,"started_at":"new"}\n'; }
+	_release_lane_write() {
+		[[ "$1" == "test/repo" && "$3" == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ]] || return 1
+		written="$2"
+		state="$2"
+		return 0
+	}
+	AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null || return 1
+	jq -e --arg old "$old_token" '
+		.phase == "reserved" and .active == true and .tag == null
+		and .operation_token != $old and .executor.pid == 99
+		and .preparing_recovery.previous_phase == "preparing"
+		and .preparing_recovery.previous_executor.pid == 42
+		and .preparing_recovery.attempted_tag == "v1.2.4"
+		and .preparing_recovery.evidence.remote_tag == "absent"
+	' <<<"$written" >/dev/null
+	state=$(jq -c '.phase="preparing" | .updated_at="2020-01-01T00:00:00Z"
+		| .executor={host_id:"local",pid:77,started_at:"retry"}' <<<"$state") || return 1
+	AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null || return 1
+	jq -e '.phase == "reserved" and (.preparing_recovery.revalidations | length) == 1
+		and .preparing_recovery.revalidations[0].previous_executor.pid == 77' <<<"$written" >/dev/null
+)
+
+run_dead_preparing_refusal_test() (
+	local expected='101@1111111111111111111111111111111111111111'
+	local evidence='{"type":"preparing-recovery/v1","attempted_tag":"v1.2.4","expected_sources":"101@1111111111111111111111111111111111111111","worktree_head":"2222222222222222222222222222222222222222","worktree_state":"isolated","surviving_process":"absent","remote_tag":"absent","github_release":"absent","npm":"absent","homebrew":"absent","protected_branch":"absent","checked_at":"2026-09-07T18:00:00Z"}'
+	local base='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101@1111111111111111111111111111111111111111","phase":"preparing","tag":null,"owner":"process-42","operation_token":"token-old","updated_at":"2020-01-01T00:00:00Z","terminal_receipt":null,"reservation_contract":"fenced-prepublication/v1","executor":{"host_id":"local","pid":42,"started_at":"old"},"snapshot_sha":"2222222222222222222222222222222222222222","snapshot_base":"1111111111111111111111111111111111111111","snapshot_base_tag":"v1.2.3","snapshot_base_object":"3333333333333333333333333333333333333333","snapshot_manifest_bound":true}'
+	local state=""
+	local executor_state="dead"
+	local write_rc=0
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$state"
+		_AIDEVOPS_RELEASE_LANE_HEAD="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		return 0
+	}
+	_release_lane_executor_observe() { printf '{"state":"%s"}\n' "$executor_state"; }
+	_release_lane_executor_capture() { printf '{"host_id":"local","pid":99,"started_at":"new"}\n'; }
+	_release_lane_write() { return "$write_rc"; }
+	for executor_state in live foreign unknown; do
+		state="$base"
+		if AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+			release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null 2>&1; then
+			return 1
+		fi
+	done
+	executor_state="dead"
+	for transform in '.tag="v1.2.4"' '.terminal_receipt="published"' '.phase="remote-publication"' '.preparing_recovery={}' '.snapshot_manifest_bound=false' '.expected_sources="101"'; do
+		state=$(jq -c "$transform" <<<"$base") || return 1
+		if AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+			release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null 2>&1; then
+			return 1
+		fi
+	done
+	state="$base"
+	write_rc=2
+	if AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null 2>&1; then
+		return 1
+	fi
+	return 0
+)
+
 if run_competing_source_test; then assert_result 'competing source receives active lane and reconcile action' true; else assert_result 'competing source receives active lane and reconcile action' false; fi
 if run_same_source_adoption_test; then assert_result 'same source adopts durable lane without another bump' true; else assert_result 'same source adopts durable lane without another bump' false; fi
 if run_terminal_lane_reacquire_test; then assert_result 'terminal lane can be atomically reserved by a later source' true; else assert_result 'terminal lane can be atomically reserved by a later source' false; fi
@@ -636,6 +712,8 @@ if run_reserved_aggregate_authorization_test; then assert_result 'reserved aggre
 if run_failed_prepublication_reopen_test; then assert_result 'verified failed pre-publication lane recovery rotates ownership and rejects unsafe states' true; else assert_result 'verified failed pre-publication lane recovery rotates ownership and rejects unsafe states' false; fi
 if run_failed_prepublication_resume_guard_test; then assert_result 'recovered pre-publication markers revalidate fenced refreshes and clear only at preparing' true; else assert_result 'recovered pre-publication markers revalidate fenced refreshes and clear only at preparing' false; fi
 if run_aggregate_successor_transaction_test; then assert_result 'successor aggregation retries converge through one lane CAS transaction' true; else assert_result 'successor aggregation retries converge through one lane CAS transaction' false; fi
+if run_dead_preparing_recovery_test; then assert_result 'dead tagless preparing recovery rotates ownership and preserves repeated recovery evidence' true; else assert_result 'dead tagless preparing recovery rotates ownership and preserves repeated recovery evidence' false; fi
+if run_dead_preparing_refusal_test; then assert_result 'preparing recovery refuses live, foreign, unknown, published, mismatched, and raced lanes' true; else assert_result 'preparing recovery refuses live, foreign, unknown, published, mismatched, and raced lanes' false; fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary

Resume the exact authorized release after a dead tagless preparing executor only when the pinned worktree, persisted source manifest, write authority, intended tag, protected branch, GitHub release, npm version, and Homebrew state are all verified safe. Rotate lane ownership through CAS and retain repeatable recovery evidence.

## Files Changed

.agents/reference/release-lane-coordination.md, .agents/scripts/full-loop-release-aggregate-recovery.sh, .agents/scripts/full-loop-release-helper.sh, .agents/scripts/release-lane-helper.sh, .agents/scripts/release-lane-liveness.sh, .agents/scripts/tests/test-release-dead-preparing-recovery.sh, .agents/scripts/tests/test-release-lane-liveness.sh, .agents/scripts/tests/test-release-lane.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Release lane, liveness, dead-preparing, full-loop helper, aggregate recovery, reconcile, and reservation suites passed; ShellCheck and linters-local.sh --changed passed.

Resolves #31515


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 4h 2m and 1,052,251 tokens on this with the user in an interactive session.