### PR TITLE
GH#31516: preserve watchdog child failures

### DIFF
--- a/.agents/scripts/pulse-watchdog.sh
+++ b/.agents/scripts/pulse-watchdog.sh
@@ -553,6 +553,7 @@ _run_pulse_watchdog() {
 	local start_epoch="$2"
 	local effective_cold_start_timeout="$3"
 	local last_active_refill_epoch=0
+	local watchdog_stop_reason=""
 
 	# Idle detection state (t1398.3)
 	local idle_seconds=0
@@ -585,6 +586,7 @@ _run_pulse_watchdog() {
 
 		# Single kill block — avoids duplicating the kill+force-kill sequence.
 		if [[ -n "$kill_reason" ]]; then
+			watchdog_stop_reason="$kill_reason"
 			# t3056 / GH#21781: Classify kill reason for structured telemetry.
 			# t3060 / GH#21788: Setters in _watchdog_check_progress, _watchdog_check_idle,
 			# and _check_watchdog_conditions emit "<UPPER_CLASS>:<prose>". We extract
@@ -625,7 +627,12 @@ _run_pulse_watchdog() {
 		sleep 60
 	done
 
-	# Reap the process (may already be dead)
-	wait "$opencode_pid" 2>/dev/null || true
-	return 0
+	# Reap the process (may already be dead) and preserve its status. A watchdog
+	# stop is itself unsuccessful even when the terminated child races to exit 0.
+	local child_rc=0
+	wait "$opencode_pid" 2>/dev/null || child_rc=$?
+	if [[ -n "$watchdog_stop_reason" ]]; then
+		return 1
+	fi
+	return "$child_rc"
 }

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -259,8 +259,10 @@ run_pulse() {
 
 	echo "[pulse-wrapper] opencode PID: $opencode_pid" >>"$LOGFILE"
 
-	# Run the watchdog loop (checks stale/idle/progress, guards children)
-	_run_pulse_watchdog "$opencode_pid" "$start_epoch" "$effective_cold_start_timeout"
+	# Run the watchdog loop (checks stale/idle/progress, guards children) and
+	# retain the child/watchdog outcome for LLM completion accounting.
+	local pulse_rc=0
+	_run_pulse_watchdog "$opencode_pid" "$start_epoch" "$effective_cold_start_timeout" || pulse_rc=$?
 
 	# Write IDLE sentinel — never delete the PID file (GH#4324).
 	echo "IDLE:$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$PIDFILE"
@@ -268,8 +270,12 @@ run_pulse() {
 	local end_epoch
 	end_epoch=$(date +%s)
 	local duration=$((end_epoch - start_epoch))
-	echo "[pulse-wrapper] Pulse completed at $(date -u +%Y-%m-%dT%H:%M:%SZ) (ran ${duration}s)" >>"$LOGFILE"
-	return 0
+	if [[ "$pulse_rc" -eq 0 ]]; then
+		echo "[pulse-wrapper] Pulse completed at $(date -u +%Y-%m-%dT%H:%M:%SZ) (ran ${duration}s)" >>"$LOGFILE"
+	else
+		echo "[pulse-wrapper] Pulse failed at $(date -u +%Y-%m-%dT%H:%M:%SZ) (ran ${duration}s, rc=${pulse_rc})" >>"$LOGFILE"
+	fi
+	return "$pulse_rc"
 }
 
 # ---------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-pulse-sigpipe-llm-state.sh
+++ b/.agents/scripts/tests/test-pulse-sigpipe-llm-state.sh
@@ -24,6 +24,8 @@ source "${SCRIPT_DIR}/pulse-dispatch-engine.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-instance-lock.sh"
 # shellcheck source=/dev/null
+source "${SCRIPT_DIR}/pulse-watchdog.sh"
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-wrapper-cycle.sh"
 
 fail() {
@@ -105,5 +107,59 @@ if _should_run_llm_supervisor; then
 fi
 _pulse_record_llm_success "stall"
 _should_run_llm_supervisor || fail "legacy stall completion suppressed first independently tracked daily sweep"
+
+# Preserve direct child failure through the watchdog and actual run_pulse()
+# boundary, so _pulse_maybe_run_llm_supervisor never advances success state.
+PULSE_COLD_START_TIMEOUT=60
+PULSE_COLD_START_TIMEOUT_UNDERFILLED=60
+HEADLESS_RUNTIME_HELPER=false
+PIDFILE="${PULSE_DIR}/pulse.pid"
+STATE_FILE="${PULSE_DIR}/state.md"
+PULSE_MODEL=""
+( exit 7 ) &
+failed_child_pid=$!
+if _run_pulse_watchdog "$failed_child_pid" "$(date +%s)" "$PULSE_COLD_START_TIMEOUT"; then
+	fail "watchdog converted failed child exit to success"
+fi
+
+dead_pid=999987
+while ps -p "$dead_pid" >/dev/null 2>&1; do
+	dead_pid=$((dead_pid + 1))
+done
+if _run_pulse_watchdog "$dead_pid" "$(date +%s)" "$PULSE_COLD_START_TIMEOUT"; then
+	fail "watchdog converted unreapable child to success"
+fi
+
+_check_watchdog_conditions() {
+	printf '%s\n' "STOP_FLAG:test watchdog stop" "0" "0" "false" "0"
+	return 0
+}
+_kill_tree() {
+	kill "$1" 2>/dev/null || true
+	return 0
+}
+sleep 30 &
+watched_child_pid=$!
+if _run_pulse_watchdog "$watched_child_pid" "$(date +%s)" "$PULSE_COLD_START_TIMEOUT"; then
+	fail "watchdog stop returned success"
+fi
+unset -f _check_watchdog_conditions _kill_tree
+
+rm -f "${PULSE_DIR}/last_llm_success_epoch" "${PULSE_DIR}/last_llm_run_epoch" \
+	"${PULSE_DIR}/last_daily_sweep_success_epoch"
+PULSE_FORCE_LLM=1
+_compute_initial_underfill() {
+	printf '0\n0\n'
+	return 0
+}
+_run_early_exit_recycle_loop() {
+	return 0
+}
+_pulse_maybe_run_llm_supervisor || fail "failed supervisor run returned non-zero from cleanup wrapper"
+[[ ! -f "${PULSE_DIR}/last_llm_success_epoch" && ! -f "${PULSE_DIR}/last_llm_run_epoch" ]] || \
+	fail "failed run advanced generic success timestamps"
+[[ ! -f "${PULSE_DIR}/last_daily_sweep_success_epoch" ]] || fail "failed run advanced daily success timestamp"
+grep -q "LLM supervisor failed" "$LOGFILE" || fail "failed run was not recorded as a failure"
+grep -q '^IDLE:' "$PIDFILE" || fail "failed run did not preserve IDLE sentinel"
 
 printf 'PASS pulse SIGPIPE and LLM state regressions\n'


### PR DESCRIPTION
## Summary

Preserved nonzero child and watchdog-stop outcomes through pulse completion accounting.

## Files Changed

.agents/scripts/pulse-watchdog.sh, .agents/scripts/pulse-wrapper-cycle.sh, .agents/scripts/tests/test-pulse-sigpipe-llm-state.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-sigpipe-llm-state.sh; bash .agents/scripts/tests/test-watchdog-no-false-kill.sh; ShellCheck on changed files; .agents/scripts/linters-local.sh --changed

Resolves #31516


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 10m and 113,168 tokens on this as a headless worker.