### PR TITLE
GH#31504: correct DataForSEO backlink exporter guidance

### DIFF
--- a/.agents/seo/backlink-checker.md
+++ b/.agents/seo/backlink-checker.md
@@ -23,7 +23,7 @@ tools:
 
 - **Purpose**: Monitor backlinks, detect lost/broken links, and flag expired referring domains for manual review
 - **Data Sources**: Authorized Ahrefs/DataForSEO exports and registry/registrar expiry evidence
-- **Helpers**: `scripts/seo-export-ahrefs.sh`, `scripts/seo-export-dataforseo.sh` (backlink data export)
+- **Helper**: `scripts/seo-export-ahrefs.sh` (backlink data export)
 
 **Workflow**: Export backlink profile -> Identify lost/broken links -> Verify expiry evidence -> Rank reclamation leads. For current auction inventory and local opportunity reports, use `seo/domain-opportunities.md`.
 
@@ -42,7 +42,9 @@ Ahrefs endpoints used:
 
 ### DataForSEO Backlinks API (Alternative)
 
-> See `scripts/seo-export-dataforseo.sh` for the export implementation.
+> No DataForSEO Backlinks exporter is currently included. The existing
+> `scripts/seo-export-dataforseo.sh` helper exports ranked-keyword data and must
+> not be used as a backlink inventory.
 
 DataForSEO endpoints:
 - `/v3/backlinks/backlinks/live` - Live backlink data


### PR DESCRIPTION
## Summary

Correct the backlink workflow so it no longer presents the ranked-keywords helper as a Backlinks exporter.

## Files Changed

.agents/seo/backlink-checker.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — DataForSEO helper help confirms ranked-keyword output; changed-file lint and Markdown checks pass; local review bundle 6fd23cfbc796504bf0f4a604a319e1d03e0c0d85c93ff3c21e2e456e2c40068a is clean.

Resolves #31504


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 33m and 155,749 tokens on this with the user in an interactive session.