### PR TITLE
GH#31523: improve SEO GEO entity evidence and experiment guidance

### DIFF
--- a/.agents/seo/ai-hallucination-defense.md
+++ b/.agents/seo/ai-hallucination-defense.md
@@ -31,6 +31,12 @@ Prevent misinformation by fixing contradictions and weakly-supported claims in s
 4. **Remove ambiguity** — rewrite unclear references (pronouns, implied subjects, outdated qualifiers); keep policy/offer language explicit; normalize terminology across product, support, and legal pages
 5. **Re-test representative prompts** — ask question sets likely to trigger past confusion; confirm generated answers align with canonical facts; record residual drift for follow-up
 
+For corpus-level identity or apparent cross-domain consensus, load
+`entity-evidence-audit.md` before accepting corroboration. Distinguish product,
+publisher, and person identities; record source ownership and claim derivation.
+Repeated owned or syndicated claims are not independent verification. Use
+`seo-geo-experiment-design.md` for repeatable prompt conditions and causal limits.
+
 ## Risk Signals
 
 - Conflicting numeric values between key pages

--- a/.agents/seo/ai-search-kpi-template.md
+++ b/.agents/seo/ai-search-kpi-template.md
@@ -14,6 +14,15 @@ target, and evidence for each material change.
 - Scope (domain/pages):
 - Intent clusters:
 - Competitor set:
+- Engine/product, model/version (or unknown), retrieval mode, locale, language:
+- Prompt cohort/variants, branded versus unbranded, session conditions:
+- Capture dates, sample size, completed/failed requests, evidence source IDs:
+
+Keep one snapshot per engine/mode/cohort. Define every rate's numerator,
+denominator, and observation window; show counts alongside percentages. Unknown
+or unobservable values are unavailable, not zero. Failed requests are not valid
+negative answers; report them separately. Follow `seo-geo-experiment-design.md`
+for controlled re-tests and `entity-evidence-audit.md` for source independence.
 
 ## KPI Snapshot
 
@@ -22,12 +31,25 @@ target, and evidence for each material change.
 | Grounding eligibility rate (%) | | | | | |
 | Fan-out coverage (high-priority branches, %) | | | | | |
 | Criteria coverage strong (%) | | | | | |
-| Selection rate (cited/retrieved, %) | | | | | |
+| Selection rate (cited/retrieved, %; only with observed retrieval denominator) | | | | | |
 | Snippet fitness pass rate (%) | | | | | |
 | Critical contradiction count | | | | | |
 | Autonomous discovery success (%) | | | | | |
 | Citation confidence (avg) | | | | | |
 | Citation stability (variance) | | | | | |
+| Crawl/index eligibility (audited URLs; not proof of retrieval) | | | | | |
+| Observed search visibility (query set, rank/source, and date) | | | | | |
+| Accurate entity/category recognition (valid answers, n/N) | | | | | |
+| Citation frequency (valid answers citing target, n/N) | | | | | |
+| Independent supporting sources (ownership and derivation deduplicated) | | | | | |
+| Unbranded recommendation frequency (valid answers, n/N) | | | | | |
+| Qualified referral sessions / conversions (attribution limits) | | | | | |
+
+Recognition requires an accurate identity/category association, not a name match;
+recommendation requires an actual recommendation, not any mention. Preserve answer
+captures for coding decisions. Citation does not prove endorsement or verification.
+Do not derive a retrieval denominator from the citation list. These outcomes need
+not follow a linear sequence and should not be collapsed into one authority score.
 
 ## Diagnostic Evidence
 
@@ -49,3 +71,8 @@ target, and evidence for each material change.
 - Intents to re-test:
 - Pages changed since last run:
 - Expected movement:
+- Hypothesis, primary outcome, predeclared threshold:
+- Comparison group/period, intervention revision and deployment time:
+- Sampling/review window, observed recrawl/index timing, confounders:
+- Null/negative results, uncertainty, commercial-query validation:
+- Decision (retain/revise/stop/inconclusive), rollback owner:

--- a/.agents/seo/entity-evidence-audit.md
+++ b/.agents/seo/entity-evidence-audit.md
@@ -1,0 +1,89 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2026 Marcus Quinn -->
+
+# Entity, Evidence, and Internal-Link Audit
+
+Use before recommending corpus expansion, entity markup, or multiple publishing
+domains. This reference supports `geo-strategy.md` and
+`ai-hallucination-defense.md`; it does not replace technical crawling, schema
+validation, or keyword research. Query → topic → entity is a planning model,
+not a disclosed search-engine algorithm.
+
+## Entity register
+
+Map priority user questions to concepts, entities, existing pages, and evidence.
+For each entity, record:
+
+| Field | Required evidence |
+|-------|-------------------|
+| Identity | Entity ID, type, canonical name, legitimate aliases, authoritative identity page |
+| Relationships | Explicit subject → relationship → object, such as product → published by → organisation |
+| Support | Source IDs and sections supporting each relationship; unsupported relationships remain flagged |
+| Coverage | Relevant page URLs, visible text, structured-data references, and external profiles |
+| Integrity | Contradictions, ambiguous references, fact owner, verification date, and recheck path |
+
+Keep products, organisations, people, categories, and capabilities distinct.
+Normalise facts and identity, not every sentence: titles, headings, anchors, FAQs,
+and biographies should serve their own reader intent rather than repeat an entity
+chain mechanically. Check for misleading superlatives and category assignments.
+
+Structured data describes visible, accurate content; it does not certify authority.
+Use a stable `@id` for each actual entity, with separate IDs for its product,
+publisher, and people. Use `sameAs` only for identity-equivalent references, not
+favourable articles or related concepts. Shared ownership does not make every page
+canonical to the brand homepage: citation links and HTML canonical signals serve
+different purposes. Validate markup with `schema-validator.md`; FAQ visibility
+does not by itself establish rich-result eligibility or GEO benefit.
+
+## Evidence independence
+
+Use the provenance fields in `llm-visibility-source-accrual.md`. Evaluate both
+publisher independence and claim derivation; these are separate questions.
+
+- Group commonly owned properties and syndicated/copied material before counting
+  corroborating sources. Eight owned domains are not eight independent endorsements.
+- An independent publisher quoting a vendor claim establishes that it was quoted,
+  not that the publisher verified it. Record the underlying source and method.
+- Owned documentation can substantiate product behaviour; ownership does not make
+  it useless. It cannot independently establish category leadership.
+- Record unknown ownership or derivation as unknown, not independent. Link each
+  material claim to its evidence and distinguish observed, verified, inferred,
+  benchmark, and unsupported claims using `conversational-search-intent.md`.
+- Prefer reproducible product proof and original research: dated datasets,
+  sampling, method, limitations, and appropriate privacy safeguards. Never invent
+  scans, founders, credentials, product packages, reviews, or third-party mentions.
+
+## Internal-link graph
+
+Start with an existing crawl (`site-crawler.md` or `screaming-frog.md`) and record
+its scope, date, rendering mode, and known gaps. Compare crawled URLs with sitemaps
+or another available URL inventory; a link-only crawl cannot reveal every orphan.
+
+Inspect orphan candidates, click depth, contextual incoming links to priority
+pages, anchor relevance/repetition, duplicate intent, and links through redirects
+or to noncanonical/nonindexable destinations. Distinguish navigational boilerplate
+from contextual links. Verify important destinations and canonical/index status
+before recommending changes.
+
+Give each supporting page a distinct user purpose, useful explanation, or evidence
+asset. Link where the relationship helps the reader; do not prescribe a fixed
+number of supporting pages or force every page to link to a money page. A
+crawl-derived internal PageRank calculation is an optional model of the observed
+graph, not Google's PageRank or a ranking forecast. Record its assumptions and
+crawl coverage; more pages do not automatically create more authority.
+
+## Publishing decision and handoff
+
+Prefer improving the primary site's documentation, comparisons, research, and
+glossary before creating domains. A separate property needs a distinct audience
+or publishing purpose, ownership disclosure, original value, and maintenance
+capacity. Exact-match wording is not a reliable ranking advantage. Reject networks
+whose main purpose is doorway coverage, manipulative links, or manufactured
+consensus; review current search spam policies before any network experiment.
+
+Deliver an entity register, claim/provenance ledger, and prioritised graph findings.
+Each finding needs affected URLs, source IDs, user/business value, proposed change,
+owner, confidence, and verification. Use `seo-geo-experiment-design.md` for causal
+hypotheses and `ai-search-kpi-template.md` for observed outcomes. Ranking,
+recognition, corroboration, and recommendation are separate outcomes, not a
+guaranteed linear progression.

--- a/.agents/seo/geo-strategy.md
+++ b/.agents/seo/geo-strategy.md
@@ -18,7 +18,7 @@ tools:
 
 # GEO Strategy
 
-Increase citation likelihood in AI search by matching decision criteria with verifiable page content on pages that already rank. Ranking is prerequisite — unranked pages cannot be consistently cited. Optimize for deterministic retrieval signals, not daily answer volatility.
+Improve AI-search discovery and citation opportunities with verifiable, criteria-matching content. Conventional search visibility can help discovery, but ranking is neither a universal prerequisite nor a guarantee of AI citation. Verify retrieval and citation separately for each engine and mode; do not optimise around one day's answer volatility.
 
 **Inputs:** intent ledger, core query set, top landing pages, page types, competitor set, proof assets (certifications, policies, prices, case evidence)
 **Outputs:** criteria matrix, source-ID evidence ledger, page-type gap map, weighted implementation plan, per-engine report lines
@@ -30,9 +30,10 @@ Increase citation likelihood in AI search by matching decision criteria with ver
 - Normalize observed and proposed queries with `conversational-search-intent.md`;
   retain source IDs, user job, constraints, grounding hypothesis, and confidence
 - Select 5-20 intents that influence revenue or lead quality; map each to an existing target page
-- Exclude intents without a realistic ranking path
+- Prioritise intents with a plausible discovery path; record conventional search, direct fetch, or other observed retrieval routes rather than excluding pages solely on rank
 - Classify by grounding likelihood to avoid optimizing non-retrieval prompts
 - Classify each target as PDP, category, homepage, article, local, SaaS feature, pricing, comparison, glossary, use-case, or research/report before scoring tactics
+- Before corpus expansion, entity markup, or multi-domain recommendations, use `entity-evidence-audit.md` to audit identity, evidence independence, and internal links
 
 ### 2) Extract decision criteria
 
@@ -57,6 +58,7 @@ Increase citation likelihood in AI search by matching decision criteria with ver
 - Monitor citations directionally, not as the only success metric
 - Report AIO, Gemini, ChatGPT, AI Mode, and Perplexity on separate per-engine lines; never aggregate AI Share of Voice without the underlying engine-level evidence
 - Re-run criteria extraction monthly or after major model shifts
+- Before testing causal claims, use `seo-geo-experiment-design.md`; separate recognition, corroboration, and unbranded recommendation from ranking and citation
 
 ## Anti-Patterns
 
@@ -75,16 +77,16 @@ Increase citation likelihood in AI search by matching decision criteria with ver
 - Prefer additive edits to existing pages before creating net-new pages
 - Weight tactics with `seo-audit-skill/aeo-geo-patterns/04-page-type-tactic-matrix.md` before proposing copy, schema, FAQ, comparison, or proof work
 - Keep key pages accessible to major AI/search crawlers
-- One topic per URL; titles, H1s, and headings must include category terms, feature type, year, and pricing where applicable
+- Give each URL a distinct primary intent; use accurate category/feature language and include year or pricing only when useful and maintained, not as a repeated entity formula
 - Keep pricing, feature lists, and comparison data in crawlable HTML — not behind JS rendering or gated forms
-- AI models use `site:yourdomain.com [category] features [year]` patterns to extract detail from known-relevant domains
+- Search-enabled systems may use site-restricted category/feature queries; record exposed query traces before attributing a particular query pattern to an engine
 
 ### Review platform parity
 
-AI models query G2, Capterra, and TrustRadius as a validation stage after extracting brand-site claims:
+Review platforms such as G2, Capterra, and TrustRadius can supply relevant evidence; their use is engine-, query-, and category-dependent, not a universal validation stage:
 
 - Maintain complete profiles with the same canonical facts (pricing, features, integrations) as the primary site
-- Consistent product naming across platforms; wrong category = invisible to model queries
+- Keep product naming consistent and categories accurate; assess actual discovery gaps rather than declaring an incorrectly categorised product invisible
 - Respond to reviews — AI models may extract vendor responses as support quality evidence
 - Monitor profiles quarterly; add TrustRadius, PeerSpot, or vertical-specific sites where G2/Capterra coverage is thin
 

--- a/.agents/seo/llm-visibility-source-accrual.md
+++ b/.agents/seo/llm-visibility-source-accrual.md
@@ -21,6 +21,14 @@ For each source, record:
 | Supported claims | Which report claims the source supports. |
 | Trust level | Verified, partial, inferred, or missing. |
 | Recheck path | Command, routine, or manual step to refresh the source. |
+| Publisher/ownership | Publisher, known ownership group, evidence for grouping, or unknown. |
+| Commercial relationship | Owned, paid, partner, editorial, or unknown; record disclosure evidence. |
+| Derivation | Original source ID, syndicated/copied/quoted relationship, or unknown. |
+| Claim substantiation | Independent verification, first-party proof, repetition only, or unknown; supporting method/section. |
+
+Before counting corroboration, use `entity-evidence-audit.md` to group ownership
+and derivation separately. Domain count is not independent-source count; an
+independent publisher repeating a vendor claim has not necessarily verified it.
 
 ## Source Families
 

--- a/.agents/seo/seo-geo-experiment-design.md
+++ b/.agents/seo/seo-geo-experiment-design.md
@@ -1,0 +1,78 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2026 Marcus Quinn -->
+
+# SEO/GEO Experiment Design
+
+Use when testing entity wording, contextual links, topical expansion, markup, or
+external mentions. This is a measurement reference for `geo-strategy.md`, not
+authority to publish, purchase domains, pay for placements, or conduct outreach.
+Placement-specific disclosure rules remain in
+`youtube-description-link-acquisition.md`.
+
+## Pre-register the decision
+
+Before changing a page, record:
+
+| Field | Required record |
+|-------|-----------------|
+| Hypothesis | One intervention, expected mechanism (labelled hypothesis), primary outcome, and decision threshold |
+| Scope | Query/intent cohort, audience, locale, target URLs, owner, and business relevance |
+| Baseline | Dated observations, index status, available crawl evidence, rankings, and relevant conversions |
+| Comparison | Comparable untreated pages/queries or an untreated period; differences and limitations |
+| Intervention | Exact changed URLs/content/links, deployment time, and revision identifier |
+| Sampling | Prompt variants, repeats per variant, measurement dates, review window, and stop/rollback rule |
+| Confounders | Concurrent site work, indexing latency, competitors, seasonality, model/search updates, and instrumentation changes |
+
+Change one factor where practical. If changes are bundled, report the bundle's
+association rather than attributing movement to one ingredient. Define the sample
+and review window before seeing results; avoid stopping at the first favourable
+answer. Low-volume or invented queries can be useful pilots, but neither low
+competition nor low noise follows from volume alone. Pilot success needs a second
+test on relevant buyer queries before commercial generalisation.
+
+## Capture each engine and mode separately
+
+Record engine/product, model/version where exposed (otherwise unknown), date/time,
+locale, language, exact prompt, session/history conditions, personalisation where
+known, and live-search/retrieval mode. Use fresh sessions for baseline comparisons
+unless conversation history is an intentional variable. Separate branded prompts
+from unbranded discovery and recommendation prompts; do not seed the target brand
+into a purported unaided recommendation test.
+
+Preserve answer captures, visible cited URLs, accessible query/tool traces, and
+failures with source IDs. Keep AIO, AI Mode, Gemini, ChatGPT, Claude, Perplexity, or
+other tested products on separate lines. A model answering without live search is
+not the same measurement as its search-enabled mode. A newly repeated claim in a
+retrieved answer does not demonstrate training-data inclusion or permanent learning.
+
+Distinguish crawl/index eligibility, observed search rank, accurate recognition,
+citation, independent corroboration, unbranded recommendation, and qualified
+traffic/conversion. None guarantees the next. Conventional ranking is neither a
+universal prerequisite nor a guarantee of AI citation. A citation shows source
+selection, not necessarily claim verification or endorsement.
+
+## Analyse without inventing observability
+
+- Report counts and denominators, sample size, dates, failures, and missing data.
+  Keep failed requests separate from valid answers without a mention/citation;
+  show completion coverage to expose selection bias.
+- Retrieval candidate sets are often hidden. Mark cited/retrieved selection rate
+  unavailable unless both numerator and denominator are observed over the same
+  scope. A visible citation list is not the retrieval denominator.
+- Compare repeated baseline and post-change observations with the comparison
+  group. Report variation and uncertainty; justify statistical methods and avoid
+  treating repeated answers as independent users or independent sources.
+- Record observed recrawl/index timing when available. Minutes-to-hours movement
+  or a 24-hour snapshot is not a universal response window, durable improvement,
+  or proof of causality. An inconclusive window stays inconclusive.
+- Preserve null, negative, and contradictory results alongside gains. Distinguish
+  correlation from causation and do not infer proprietary algorithm weights.
+
+## Decision and verification
+
+Use `ai-search-kpi-template.md` for baseline/current/delta and evidence. Report
+retain, revise, stop, or inconclusive against the predeclared threshold; include
+business outcomes where measurable, costs, limitations, next review date, and
+rollback owner. Retest promising pilot findings on representative competitive
+queries. A methodological walkthrough validates the experiment plan, not the
+claimed SEO/GEO effectiveness of an intervention.


### PR DESCRIPTION
## Summary

Add entity-evidence-audit.md and seo-geo-experiment-design.md under .agents/seo; connect geo-strategy.md and ai-hallucination-defense.md; extend llm-visibility-source-accrual.md and ai-search-kpi-template.md. Distinguish owned repetition from corroboration, audit internal links, and correct universal ranking/retrieval claims.

## Files Changed

.agents/seo/ai-hallucination-defense.md, .agents/seo/ai-search-kpi-template.md, .agents/seo/entity-evidence-audit.md, .agents/seo/geo-strategy.md, .agents/seo/llm-visibility-source-accrual.md, .agents/seo/seo-geo-experiment-design.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Changed-file linters passed (six Markdown files); whitespace and secret checks passed. Direct closeout review clean: bundle 01364899e4bfe00abaf38a53fe351a65edb2b69cb7fec7e5fa92dbf89379e52c. Inspected seo-geo.md to geo-strategy.md routing and walked through owned-network, hidden-denominator, unbranded-prompt, and unranked-citation scenarios. Documentation assessment only, not proof of live SEO uplift.

Resolves #31523


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 15m and 103,957 tokens on this with the user in an interactive session.