### PR TITLE
GH#31521: fix: recover reclaimed fenced release lanes

### DIFF
--- a/.agents/reference/release-lane-coordination.md
+++ b/.agents/reference/release-lane-coordination.md
@@ -106,6 +106,18 @@ release branch, GitHub release, npm version, and Homebrew version are all proven
 absent. The publisher rotates the operation token through the lane compare-and-swap,
 retains durable `preparing_recovery` evidence, and restarts from a fresh copy of
 the pinned commit; lookup uncertainty or any existing artifact refuses recovery.
+Same-source reservation reclaim still removes automatic eligibility, but now
+records a `same-source-reclaim/v1` marker when it removes a modern fenced
+contract. For lanes reclaimed before that marker existed, recovery must verify
+the bounded authoritative release-lane history: every intervening file revision
+must remain active, tagless and pre-publication while retaining the immutable
+snapshot provenance back to a
+`fenced-prepublication/v1` ancestor. Missing, truncated, divergent or unreadable
+lineage fails closed. A pre-binding ancestor may retain only its compatible
+legacy source subset; once `snapshot_manifest_bound` is true, every revision must
+match the current exact manifest. Successful recovery restores the fenced
+contract and keeps the lineage proof in `reservation_contract_recovery` within
+the same lane CAS.
 For a reservation without a recorded tag, tag-based `reconcile` may
 have nothing to resume: the authorized release owner must restart the same
 source with its original increment and persisted intent. This does not grant a

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -411,12 +411,18 @@ _release_lane_reclaim_same_source() {
 	state_json=$(jq -c --argjson executor "$(_release_lane_executor_capture || printf 'null')" \
 		--arg contract "$_AIDEVOPS_RELEASE_LANE_RESERVATION_CONTRACT" \
 		--arg type "$_AIDEVOPS_RELEASE_LANE_RECLAIM_CONTRACT" --arg previous_head "$_AIDEVOPS_RELEASE_LANE_HEAD" \
+		--arg sha_pattern "$_AIDEVOPS_RELEASE_LANE_SHA_PATTERN" \
 		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
 		.executor as $previous_executor | (.reservation_contract // null) as $prior_contract
+		| (.reservation_contract_reclaim // null) as $existing_reclaim
 		| .executor=$executor
 		| if $prior_contract == $contract then
 			.reservation_contract_reclaim={type:$type,prior_contract:$prior_contract,
 				previous_head:$previous_head,previous_executor:$previous_executor,reclaimed_at:$now}
+		  elif ($existing_reclaim.type == $type
+			and $existing_reclaim.prior_contract == $contract
+			and ($existing_reclaim.previous_head | test($sha_pattern))) then
+			.reservation_contract_reclaim=$existing_reclaim
 		  else del(.reservation_contract_reclaim) end
 		| del(.reservation_contract)
 	' <<<"$state_json") || return 1

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -27,6 +27,11 @@ _AIDEVOPS_RELEASE_LANE_PHASE_RECONCILE_REQUIRED="reconcile-required"
 _AIDEVOPS_RELEASE_LANE_PHASE_SUCCESSOR_PREPARING="aggregation-successor-preparing"
 _AIDEVOPS_RELEASE_LANE_PHASE_PREPARING="preparing"
 _AIDEVOPS_RELEASE_LANE_STATE_ABSENT="absent"
+_AIDEVOPS_RELEASE_LANE_RESERVATION_CONTRACT="fenced-prepublication/v1"
+_AIDEVOPS_RELEASE_LANE_RECLAIM_CONTRACT="same-source-reclaim/v1"
+_AIDEVOPS_RELEASE_LANE_HISTORY_LIMIT=32
+_AIDEVOPS_RELEASE_LANE_SHA_PATTERN='^[0-9a-f]{40}$'
+_AIDEVOPS_RELEASE_LANE_TRUE="true"
 
 _AIDEVOPS_RELEASE_LANE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=release-lane-liveness.sh
@@ -171,6 +176,132 @@ _release_lane_stale_prepublication() {
 	return $?
 }
 
+_release_lane_history_heads() {
+	local repo="$1"
+	gh api --method GET "repos/${repo}/commits" -f "sha=${_AIDEVOPS_RELEASE_LANE_BRANCH}" \
+		-f "path=${_AIDEVOPS_RELEASE_LANE_FILE}" -f "per_page=${_AIDEVOPS_RELEASE_LANE_HISTORY_LIMIT}" \
+		--jq '.[].sha' 2>/dev/null
+	return $?
+}
+
+_release_lane_state_at_head() {
+	local repo="$1"
+	local head="$2"
+	[[ "$head" =~ ^[0-9a-f]{40}$ ]] || return 1
+	gh api "repos/${repo}/contents/${_AIDEVOPS_RELEASE_LANE_FILE}?ref=${head}" \
+		--jq '.content | @base64d' 2>/dev/null
+	return $?
+}
+
+_release_lane_reclaim_state_matches_current() {
+	local previous_state="$1"
+	local current_state="$2"
+	jq -e --argjson current "$current_state" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \
+		--arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_PREPARING" '
+		def entries($manifest):
+			$manifest | split(",") | map(select(length > 0) | split("@")
+				| {pr:.[0],merge:(.[1] // null)});
+		def compatible($old; $new):
+			(entries($old)) as $old_entries | (entries($new)) as $new_entries
+			| ($old_entries | length) > 0
+			and all($old_entries[]; . as $entry | any($new_entries[];
+				.pr == $entry.pr and ($entry.merge == null or .merge == $entry.merge)));
+		.active == true and (.phase == $reserved or .phase == $preparing)
+		and .repository == $current.repository and .source_pr == $current.source_pr
+		and ((.snapshot_manifest_bound == true and .expected_sources == $current.expected_sources)
+			or ((.snapshot_manifest_bound // false) != true
+				and compatible(.expected_sources; $current.expected_sources)))
+		and .snapshot_sha == $current.snapshot_sha and .snapshot_base == $current.snapshot_base
+		and .snapshot_base_tag == $current.snapshot_base_tag
+		and .snapshot_base_object == $current.snapshot_base_object
+		and .tag == null and .terminal_receipt == null
+		and (.prepublication_recovery // null) == null
+		and (.aggregate_recovery // null) == null
+		and (.aggregate_successor // null) == null
+		and (.reserved_authorization_refresh // null) == null
+	' <<<"$previous_state" >/dev/null
+	return $?
+}
+
+# Prove that a contract-less lane descends from the same fenced reservation.
+# Every file-changing revision between the current head and the fenced ancestor
+# must retain the immutable source/snapshot identity and remain pre-publication.
+#aidevops:trust-boundary
+_release_lane_find_reclaimed_contract_ancestor() {
+	local repo="$1"
+	local current_head="$2"
+	local current_state="$3"
+	local heads=""
+	local head=""
+	local state_json=""
+	local first=""
+	heads=$(_release_lane_history_heads "$repo") || return 1
+	[[ -n "$heads" ]] || return 1
+	while IFS= read -r head; do
+		[[ "$head" =~ ^[0-9a-f]{40}$ ]] || return 1
+		if [[ -z "$first" ]]; then
+			[[ "$head" == "$current_head" ]] || return 1
+			first="$head"
+			continue
+		fi
+		state_json=$(_release_lane_state_at_head "$repo" "$head") || return 1
+		_release_lane_reclaim_state_matches_current "$state_json" "$current_state" || return 1
+		if jq -e --arg contract "$_AIDEVOPS_RELEASE_LANE_RESERVATION_CONTRACT" \
+			'.reservation_contract == $contract' <<<"$state_json" >/dev/null; then
+			jq -cn --arg type "$_AIDEVOPS_RELEASE_LANE_RECLAIM_CONTRACT" \
+				--arg contract "$_AIDEVOPS_RELEASE_LANE_RESERVATION_CONTRACT" \
+				--arg ancestor "$head" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+				'{type:$type,prior_contract:$contract,ancestor_head:$ancestor,verified_at:$now}'
+			return $?
+		fi
+		jq -e '(.reservation_contract // null) == null' <<<"$state_json" >/dev/null || return 1
+	done <<<"$heads"
+	return 1
+}
+
+_release_lane_resolve_reclaim_evidence() {
+	local repo="$1"
+	local reclaim_head=""
+	local reclaim_state=""
+	if jq -e --arg contract "$_AIDEVOPS_RELEASE_LANE_RESERVATION_CONTRACT" \
+		'.reservation_contract == $contract' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null; then
+		printf 'null\n'
+		return 0
+	fi
+	if jq -e --arg type "$_AIDEVOPS_RELEASE_LANE_RECLAIM_CONTRACT" \
+		--arg contract "$_AIDEVOPS_RELEASE_LANE_RESERVATION_CONTRACT" \
+		--arg sha_pattern "$_AIDEVOPS_RELEASE_LANE_SHA_PATTERN" '
+		.reservation_contract_reclaim.type == $type
+		and .reservation_contract_reclaim.prior_contract == $contract
+		and (.reservation_contract_reclaim.previous_head | test($sha_pattern))
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null; then
+		reclaim_head=$(jq -r '.reservation_contract_reclaim.previous_head' \
+			<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+		reclaim_state=$(_release_lane_state_at_head "$repo" "$reclaim_head") || {
+			printf 'Preparing recovery refused: reclaim predecessor is unreadable\n' >&2
+			return 3
+		}
+		_release_lane_reclaim_state_matches_current "$reclaim_state" \
+			"$_AIDEVOPS_RELEASE_LANE_JSON" || {
+			printf 'Preparing recovery refused: reclaim predecessor provenance diverged\n' >&2
+			return 3
+		}
+		jq -e --arg contract "$_AIDEVOPS_RELEASE_LANE_RESERVATION_CONTRACT" \
+			'.reservation_contract == $contract' <<<"$reclaim_state" >/dev/null || {
+			printf 'Preparing recovery refused: reclaim predecessor was not fenced\n' >&2
+			return 3
+		}
+		jq -c '.reservation_contract_reclaim' <<<"$_AIDEVOPS_RELEASE_LANE_JSON"
+		return $?
+	fi
+	_release_lane_find_reclaimed_contract_ancestor "$repo" \
+		"$_AIDEVOPS_RELEASE_LANE_HEAD" "$_AIDEVOPS_RELEASE_LANE_JSON" || {
+		printf 'Preparing recovery refused: no verified fenced reservation lineage\n' >&2
+		return 3
+	}
+	return 0
+}
+
 # Reclaiming a preparing lane is intentionally a separate contract from stale
 # reservation recovery. The caller must first prove that the isolated release
 # worktree and every remote publication precursor are absent or inert.
@@ -186,16 +317,19 @@ release_lane_recover_dead_preparing() {
 	local updated_at=""
 	local updated_epoch=""
 	local now_epoch=""
+	local reclaim_evidence="null"
 	local stale_after="${AIDEVOPS_RELEASE_LANE_STALE_SECONDS:-$_AIDEVOPS_RELEASE_LANE_STALE_PREPUBLICATION_SECONDS}"
 	[[ "$source_pr" =~ ^[0-9]+$ && -n "$expected_sources" ]] || return 1
 	[[ "$attempted_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
 	[[ "$stale_after" =~ ^[0-9]+$ && "$stale_after" -gt 0 ]] || return 1
 	release_lane_read "$repo" || return 1
+	reclaim_evidence=$(_release_lane_resolve_reclaim_evidence "$repo") || return $?
 	jq -e --argjson source_pr "$source_pr" --arg expected "$expected_sources" \
-		--arg attempted_tag "$attempted_tag" --arg contract "fenced-prepublication/v1" \
+		--arg attempted_tag "$attempted_tag" --arg contract "$_AIDEVOPS_RELEASE_LANE_RESERVATION_CONTRACT" \
+		--argjson reclaim "$reclaim_evidence" \
 		--arg sha_pattern '^[0-9a-f]{40}$' --arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_PREPARING" '
 		.active == true and .source_pr == $source_pr and .phase == $preparing
-		and .reservation_contract == $contract and .expected_sources == $expected
+		and (.reservation_contract == $contract or $reclaim != null) and .expected_sources == $expected
 		and .tag == null and .terminal_receipt == null
 		and (.snapshot_manifest_bound == true)
 		and (.snapshot_sha | test($sha_pattern)) and (.snapshot_base | test($sha_pattern))
@@ -209,7 +343,10 @@ release_lane_recover_dead_preparing() {
 		and (.aggregate_successor // null) == null
 		and (.reserved_authorization_refresh // null) == null
 		and ($attempted_tag | length) > 0
-	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 3
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || {
+		printf 'Preparing recovery refused: lane state no longer matches the authorized recovery\n' >&2
+		return 3
+	}
 	[[ "$(_release_lane_executor_observe "$_AIDEVOPS_RELEASE_LANE_JSON" | jq -r '.state')" == "dead" ]] || return 3
 	updated_at=$(jq -r '.updated_at // ""' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	updated_epoch=$(date -u -d "$updated_at" +%s 2>/dev/null ||
@@ -232,11 +369,14 @@ release_lane_recover_dead_preparing() {
 		--arg preparing "$_AIDEVOPS_RELEASE_LANE_PHASE_PREPARING" \
 		--arg token "$operation_token" --arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" \
 		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" --arg tag "$attempted_tag" \
-		--argjson evidence "$recovery_evidence" --argjson executor "$(_release_lane_executor_capture || printf 'null')" '
+		--arg contract "$_AIDEVOPS_RELEASE_LANE_RESERVATION_CONTRACT" \
+		--argjson reclaim "$reclaim_evidence" --argjson evidence "$recovery_evidence" \
+		--argjson executor "$(_release_lane_executor_capture || printf 'null')" '
 		.updated_at as $previous_updated_at | .executor as $previous_executor
 		| (.preparing_recovery // null) as $existing_recovery
 		| .phase=$reserved | .operation_token=$token | .owner=$owner | .updated_at=$now
-		| .executor=$executor
+		| .executor=$executor | .reservation_contract=$contract
+		| if $reclaim == null then . else .reservation_contract_recovery=$reclaim end
 		| .preparing_recovery=(if $existing_recovery == null then
 			{previous_phase:$preparing,previous_updated_at:$previous_updated_at,
 			 previous_executor:$previous_executor,attempted_tag:$tag,recovered_at:$now,evidence:$evidence}
@@ -269,7 +409,17 @@ _release_lane_reclaim_same_source() {
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	# A resumed transaction may use older code: do not inherit auto-recovery eligibility.
 	state_json=$(jq -c --argjson executor "$(_release_lane_executor_capture || printf 'null')" \
-		'.executor=$executor | del(.reservation_contract)' <<<"$state_json") || return 1
+		--arg contract "$_AIDEVOPS_RELEASE_LANE_RESERVATION_CONTRACT" \
+		--arg type "$_AIDEVOPS_RELEASE_LANE_RECLAIM_CONTRACT" --arg previous_head "$_AIDEVOPS_RELEASE_LANE_HEAD" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
+		.executor as $previous_executor | (.reservation_contract // null) as $prior_contract
+		| .executor=$executor
+		| if $prior_contract == $contract then
+			.reservation_contract_reclaim={type:$type,prior_contract:$prior_contract,
+				previous_head:$previous_head,previous_executor:$previous_executor,reclaimed_at:$now}
+		  else del(.reservation_contract_reclaim) end
+		| del(.reservation_contract)
+	' <<<"$state_json") || return 1
 	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
 	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
 	_AIDEVOPS_RELEASE_LANE_RESULT="$_AIDEVOPS_RELEASE_LANE_RESULT_ACQUIRED"
@@ -330,7 +480,7 @@ release_lane_acquire() {
 		active=$(jq -r '.active' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 		active_pr=$(jq -r '.source_pr' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 		phase=$(jq -r '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
-		if [[ "$active" == "true" ]]; then
+		if [[ "$active" == "$_AIDEVOPS_RELEASE_LANE_TRUE" ]]; then
 			printf 'ACTIVE_RELEASE_LANE source_pr=%s phase=%s tag=%s\n' "$active_pr" "$phase" \
 				"$(jq -r '.tag // "pending"' <<<"$_AIDEVOPS_RELEASE_LANE_JSON")"
 			printf 'Inspect with: aidevops release status %s\n' "$active_pr"
@@ -998,11 +1148,11 @@ _release_lane_pr_is_metadata_only_aggregate() {
 	local files_count=""
 	command -v gh >/dev/null 2>&1 && command -v jq >/dev/null 2>&1 || return 1
 	pr_json=$(gh api "repos/${repo}/pulls/${pr_number}" 2>/dev/null) || return 1
-	jq -e --argjson pr "$pr_number" '
+	jq -e --argjson pr "$pr_number" --arg sha_pattern "$_AIDEVOPS_RELEASE_LANE_SHA_PATTERN" '
 		.state == "open" and .base.ref == "main"
 		and (.number == $pr)
-		and (.head.sha | test("^[0-9a-f]{40}$"))
-		and (.base.sha | test("^[0-9a-f]{40}$"))
+		and (.head.sha | test($sha_pattern))
+		and (.base.sha | test($sha_pattern))
 	' <<<"$pr_json" >/dev/null || return 1
 	body=$(jq -er '.body // ""' <<<"$pr_json") || return 1
 	identity_count=$(awk -v expected="Aidevops-Release-Aggregator-PR: ${pr_number}" \
@@ -1099,7 +1249,7 @@ release_lane_setup_guard() {
 		return 75
 		;;
 	esac
-	[[ "$(jq -r '.active' <<<"$_AIDEVOPS_RELEASE_LANE_JSON")" == "true" ]] || return 0
+	[[ "$(jq -r '.active' <<<"$_AIDEVOPS_RELEASE_LANE_JSON")" == "$_AIDEVOPS_RELEASE_LANE_TRUE" ]] || return 0
 	phase=$(jq -r '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	[[ "$phase" == "exact-tag-deployment" ]] || return 0
 	active_pr=$(jq -r '.source_pr' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -193,7 +193,7 @@ run_legacy_and_api_failure_test() (
 )
 
 run_default_stale_boundary_and_fencing_test() (
-	local original_state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"phase":"reserved","tag":null,"updated_at":"2020-01-01T00:00:00Z","operation_token":"token-old","terminal_receipt":null}'
+	local original_state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"phase":"reserved","tag":null,"updated_at":"2020-01-01T00:00:00Z","operation_token":"token-old","terminal_receipt":null,"reservation_contract":"fenced-prepublication/v1"}'
 	local state="$original_state"
 	local written=""
 	export AIDEVOPS_TEST_NOW_EPOCH=1000000299
@@ -230,6 +230,11 @@ run_default_stale_boundary_and_fencing_test() (
 	release_lane_acquire test/repo 101 101 >/dev/null || return 1
 	[[ "$_AIDEVOPS_RELEASE_LANE_RESULT" == "acquired" && "$(jq -r '.phase' <<<"$written")" == "reserved" &&
 	"$(jq -r '.operation_token' <<<"$written")" != "token-old" && "$writes" -eq 1 ]] || return 1
+	jq -e '.reservation_contract == null
+		and .reservation_contract_reclaim.type == "same-source-reclaim/v1"
+		and .reservation_contract_reclaim.prior_contract == "fenced-prepublication/v1"
+		and .reservation_contract_reclaim.previous_head == "1111111111111111111111111111111111111111"' \
+		<<<"$written" >/dev/null || return 1
 	_AIDEVOPS_RELEASE_LANE_TOKEN="token-old"
 	if release_lane_update test/repo 101 preparing; then
 		return 1
@@ -657,6 +662,84 @@ run_dead_preparing_recovery_test() (
 		and .preparing_recovery.revalidations[0].previous_executor.pid == 77' <<<"$written" >/dev/null
 )
 
+run_reclaimed_contract_recovery_test() (
+	local expected='101@1111111111111111111111111111111111111111'
+	local evidence='{"type":"preparing-recovery/v1","attempted_tag":"v1.2.4","expected_sources":"101@1111111111111111111111111111111111111111","worktree_head":"2222222222222222222222222222222222222222","worktree_state":"isolated","surviving_process":"absent","remote_tag":"absent","github_release":"absent","npm":"absent","homebrew":"absent","protected_branch":"absent","checked_at":"2026-09-07T18:00:00Z"}'
+	local base='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101@1111111111111111111111111111111111111111","phase":"preparing","tag":null,"owner":"process-42","operation_token":"token-old","updated_at":"2020-01-01T00:00:00Z","terminal_receipt":null,"executor":{"host_id":"local","pid":42,"started_at":"old"},"snapshot_sha":"2222222222222222222222222222222222222222","snapshot_base":"1111111111111111111111111111111111111111","snapshot_base_tag":"v1.2.3","snapshot_base_object":"3333333333333333333333333333333333333333","snapshot_manifest_bound":true}'
+	local ancestor=""
+	local state="$base"
+	local written=""
+	ancestor=$(jq -c '.phase="reserved" | .expected_sources="101"
+		| .reservation_contract="fenced-prepublication/v1"
+		| .snapshot_manifest_bound=null' <<<"$base") || return 1
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$state"
+		_AIDEVOPS_RELEASE_LANE_HEAD=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		return 0
+	}
+	_release_lane_history_heads() {
+		printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+	}
+	_release_lane_state_at_head() {
+		[[ "$2" == bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ||
+			"$2" == cccccccccccccccccccccccccccccccccccccccc ]] || return 1
+		printf '%s\n' "$ancestor"
+	}
+	_release_lane_executor_observe() { printf '{"state":"dead","reason":"process-absent"}\n'; }
+	_release_lane_executor_capture() { printf '{"host_id":"local","pid":99,"started_at":"new"}\n'; }
+	_release_lane_write() {
+		[[ "$1" == "test/repo" && "$3" == aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ]] || return 1
+		written="$2"
+		return 0
+	}
+	AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null || return 1
+	jq -e '
+		.phase == "reserved" and .reservation_contract == "fenced-prepublication/v1"
+		and .reservation_contract_recovery.type == "same-source-reclaim/v1"
+		and .reservation_contract_recovery.ancestor_head == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		and .preparing_recovery.attempted_tag == "v1.2.4"
+	' <<<"$written" >/dev/null || return 1
+	state=$(jq -c '.reservation_contract_reclaim={type:"same-source-reclaim/v1",
+		prior_contract:"fenced-prepublication/v1",previous_head:("c" * 40)}' <<<"$base") || return 1
+	AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null || return 1
+	jq -e '.reservation_contract == "fenced-prepublication/v1"
+		and .reservation_contract_recovery.type == "same-source-reclaim/v1"' <<<"$written" >/dev/null
+)
+
+run_reclaimed_contract_lineage_refusal_test() (
+	local expected='101@1111111111111111111111111111111111111111'
+	local evidence='{"type":"preparing-recovery/v1","attempted_tag":"v1.2.4","expected_sources":"101@1111111111111111111111111111111111111111","worktree_head":"2222222222222222222222222222222222222222","worktree_state":"isolated","surviving_process":"absent","remote_tag":"absent","github_release":"absent","npm":"absent","homebrew":"absent","protected_branch":"absent","checked_at":"2026-09-07T18:00:00Z"}'
+	local state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101@1111111111111111111111111111111111111111","phase":"preparing","tag":null,"owner":"process-42","operation_token":"token-old","updated_at":"2020-01-01T00:00:00Z","terminal_receipt":null,"executor":{"host_id":"local","pid":42,"started_at":"old"},"snapshot_sha":"2222222222222222222222222222222222222222","snapshot_base":"1111111111111111111111111111111111111111","snapshot_base_tag":"v1.2.3","snapshot_base_object":"3333333333333333333333333333333333333333","snapshot_manifest_bound":true}'
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$state"
+		_AIDEVOPS_RELEASE_LANE_HEAD=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		return 0
+	}
+	_release_lane_history_heads() { printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; }
+	if AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null 2>&1; then
+		return 1
+	fi
+	state=$(jq -c '.reservation_contract_reclaim={type:"unknown",prior_contract:"fenced-prepublication/v1",
+		previous_head:("c" * 40)}' <<<"$state") || return 1
+	if AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null 2>&1; then
+		return 1
+	fi
+	state=$(jq -c '.reservation_contract_reclaim={type:"same-source-reclaim/v1",
+		prior_contract:"fenced-prepublication/v1",previous_head:("c" * 40)}' <<<"$state") || return 1
+	_release_lane_state_at_head() {
+		jq -c '.snapshot_sha=("4" * 40) | .reservation_contract="fenced-prepublication/v1"' <<<"$state"
+	}
+	if AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null 2>&1; then
+		return 1
+	fi
+	return 0
+)
+
 run_dead_preparing_refusal_test() (
 	local expected='101@1111111111111111111111111111111111111111'
 	local evidence='{"type":"preparing-recovery/v1","attempted_tag":"v1.2.4","expected_sources":"101@1111111111111111111111111111111111111111","worktree_head":"2222222222222222222222222222222222222222","worktree_state":"isolated","surviving_process":"absent","remote_tag":"absent","github_release":"absent","npm":"absent","homebrew":"absent","protected_branch":"absent","checked_at":"2026-09-07T18:00:00Z"}'
@@ -672,6 +755,7 @@ run_dead_preparing_refusal_test() (
 	_release_lane_executor_observe() { printf '{"state":"%s"}\n' "$executor_state"; }
 	_release_lane_executor_capture() { printf '{"host_id":"local","pid":99,"started_at":"new"}\n'; }
 	_release_lane_write() { return "$write_rc"; }
+	_release_lane_history_heads() { return 1; }
 	for executor_state in live foreign unknown; do
 		state="$base"
 		if AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
@@ -713,6 +797,8 @@ if run_failed_prepublication_reopen_test; then assert_result 'verified failed pr
 if run_failed_prepublication_resume_guard_test; then assert_result 'recovered pre-publication markers revalidate fenced refreshes and clear only at preparing' true; else assert_result 'recovered pre-publication markers revalidate fenced refreshes and clear only at preparing' false; fi
 if run_aggregate_successor_transaction_test; then assert_result 'successor aggregation retries converge through one lane CAS transaction' true; else assert_result 'successor aggregation retries converge through one lane CAS transaction' false; fi
 if run_dead_preparing_recovery_test; then assert_result 'dead tagless preparing recovery rotates ownership and preserves repeated recovery evidence' true; else assert_result 'dead tagless preparing recovery rotates ownership and preserves repeated recovery evidence' false; fi
+if run_reclaimed_contract_recovery_test; then assert_result 'reclaimed fenced contract recovers through durable marker or verified immutable lineage' true; else assert_result 'reclaimed fenced contract recovers through durable marker or verified immutable lineage' false; fi
+if run_reclaimed_contract_lineage_refusal_test; then assert_result 'missing or unknown reclaim lineage remains fail closed' true; else assert_result 'missing or unknown reclaim lineage remains fail closed' false; fi
 if run_dead_preparing_refusal_test; then assert_result 'preparing recovery refuses live, foreign, unknown, published, mismatched, and raced lanes' true; else assert_result 'preparing recovery refuses live, foreign, unknown, published, mismatched, and raced lanes' false; fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -236,6 +236,14 @@ run_default_stale_boundary_and_fencing_test() (
 		and .reservation_contract_reclaim.previous_head == "1111111111111111111111111111111111111111"' \
 		<<<"$written" >/dev/null || return 1
 	_AIDEVOPS_RELEASE_LANE_TOKEN="token-old"
+	state=$(jq -c '.updated_at="2020-01-01T00:00:00Z"' <<<"$written") || return 1
+	_release_lane_executor_observe() { printf '{"state":"dead"}\n'; }
+	release_lane_acquire test/repo 101 101 >/dev/null || return 1
+	[[ "$writes" -eq 2 ]] || return 1
+	jq -e '.reservation_contract_reclaim.type == "same-source-reclaim/v1"
+		and .reservation_contract_reclaim.previous_head == "1111111111111111111111111111111111111111"' \
+		<<<"$written" >/dev/null || return 1
+	_AIDEVOPS_RELEASE_LANE_TOKEN="token-old"
 	if release_lane_update test/repo 101 preparing; then
 		return 1
 	fi


### PR DESCRIPTION
## Summary

- recover contract-less dead `preparing` lanes only when bounded authoritative history proves descent from the same fenced reservation
- permit the documented compatible legacy source subset only before manifest binding; require the exact manifest after binding
- persist auditable reclaim markers for future same-source retries and validate their fenced predecessor before use
- restore the fenced contract and lineage evidence atomically with the existing recovery CAS
- add actionable refusal diagnostics and regression coverage for success, missing lineage, unknown markers, provenance divergence, repeated reclaim, and CAS refusal

## Verification

- `bash .agents/scripts/tests/test-release-lane.sh` — 20/20 passed
- `bash .agents/scripts/tests/test-release-lane-liveness.sh` — passed
- `bash .agents/scripts/tests/test-release-dead-preparing-recovery.sh` — passed
- `bash .agents/scripts/tests/test-full-loop-release-helper.sh` — passed
- `bash .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh` — passed
- `bash .agents/scripts/tests/test-full-loop-release-reconcile.sh` — passed
- `bash .agents/scripts/tests/test-release-lane-reservation.sh` — passed
- `.agents/scripts/linters-local.sh --changed` — passed
- mutation-stubbed run against the live #31512 lane resolved fenced ancestor `5d5acd0a012954feeffe4653208db0a64cc217b3` and produced the expected atomic recovered state without changing remote state

Resolves #31521

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 5h 1m and 1,377,812 tokens on this with the user in an interactive session.