### PR TITLE
fix: extend SimpleX approval timeout to 12 hours

### DIFF
--- a/.agents/scripts/simplex-bot/README.md
+++ b/.agents/scripts/simplex-bot/README.md
@@ -37,9 +37,15 @@ The bot loads config from three sources (highest priority first):
   "autoAcceptFiles": false,
   "autoJoinGroups": false,
   "logLevel": "info",
+  "execApproval": {
+    "approvalTimeoutMs": 43200000
+  },
   "sessionIdleTimeout": 300
 }
 ```
+
+Pending command approvals remain valid for 12 hours by default. Override
+`execApproval.approvalTimeoutMs` with a duration in milliseconds when needed.
 
 ### Environment Variables
 

--- a/.agents/scripts/simplex-bot/src/approval.test.ts
+++ b/.agents/scripts/simplex-bot/src/approval.test.ts
@@ -155,16 +155,12 @@ describe("ApprovalManager", () => {
 
   describe("timeout", () => {
     test("expires request after timeout and notifies requester", async () => {
-      mock.timers.enable({ apis: ["setTimeout"] });
-
       const replyMock = mock(async (_text: string): Promise<void> => {});
       const shortTimeout = new ApprovalManager({ approvalTimeoutMs: 100 });
       const req = shortTimeout.createRequest("docker ps", 1, "alice", replyMock);
 
       try {
-        mock.timers.tick(101);
-        await Promise.resolve();
-        await Promise.resolve();
+        await new Promise((resolve) => setTimeout(resolve, 200));
 
         // Request should be expired and cleaned up
         expect(shortTimeout.getRequest(req.id)).toBeUndefined();
@@ -177,7 +173,6 @@ describe("ApprovalManager", () => {
         expect(callArg).toContain(req.id);
       } finally {
         shortTimeout.shutdown();
-        mock.timers.reset();
       }
     });
   });
@@ -200,6 +195,11 @@ describe("ApprovalManager", () => {
   // ===========================================================================
 
   describe("custom config", () => {
+    test("defaults to a 12-hour approval window", () => {
+      expect(DEFAULT_EXEC_APPROVAL_CONFIG.approvalTimeoutMs).toBe(12 * 60 * 60 * 1000);
+      expect(manager.formatTimeout()).toBe("12h");
+    });
+
     test("custom allowlist overrides defaults", () => {
       const custom = new ApprovalManager({
         allowlist: ["git status", "git log"],
@@ -225,6 +225,9 @@ describe("ApprovalManager", () => {
 
       const m3 = new ApprovalManager({ approvalTimeoutMs: 120_000 });
       expect(m3.formatTimeout()).toBe("2m");
+
+      const m4 = new ApprovalManager({ approvalTimeoutMs: 12 * 60 * 60 * 1000 });
+      expect(m4.formatTimeout()).toBe("12h");
     });
   });
 });

--- a/.agents/scripts/simplex-bot/src/approval.ts
+++ b/.agents/scripts/simplex-bot/src/approval.ts
@@ -167,6 +167,10 @@ export class ApprovalManager {
   /** Format the approval timeout as a human-readable string */
   formatTimeout(): string {
     const seconds = Math.round(this.config.approvalTimeoutMs / 1000);
+    if (seconds >= 60 * 60) {
+      const hours = Math.round(seconds / (60 * 60));
+      return `${hours}h`;
+    }
     if (seconds >= 60) {
       const minutes = Math.round(seconds / 60);
       return `${minutes}m`;

--- a/.agents/scripts/simplex-bot/src/types.ts
+++ b/.agents/scripts/simplex-bot/src/types.ts
@@ -283,7 +283,7 @@ export interface ExecApprovalConfig {
   allowlist: string[];
   /** Commands that are always rejected (e.g., "rm -rf", "shutdown") */
   blocklist: string[];
-  /** Timeout in ms before a pending approval is auto-rejected (default: 60000) */
+  /** Timeout in ms before a pending approval is auto-rejected (default: 12 hours) */
   approvalTimeoutMs: number;
   /** Whether to require approval for commands not in allowlist or blocklist (default: true) */
   requireApprovalByDefault: boolean;
@@ -305,7 +305,7 @@ export const DEFAULT_EXEC_APPROVAL_CONFIG: ExecApprovalConfig = {
     "> /dev/",
     ":(){ :|:& };:",
   ],
-  approvalTimeoutMs: 60_000,
+  approvalTimeoutMs: 12 * 60 * 60 * 1000,
   requireApprovalByDefault: true,
 };
 


### PR DESCRIPTION
## Summary

- extend the default SimpleX remote-command approval window from 60 seconds to 12 hours
- display hour-scale approval windows as hours in chat prompts
- document the configurable millisecond override and repair the Bun-compatible expiry test

## Runtime Testing

- `bun test` — 85 pass, 0 fail
- `bun run typecheck` — pass
- `.agents/scripts/linters-local.sh --changed` — pass
- `git diff --check` — pass

## Decisions

- retain the existing `approvalTimeoutMs` configuration key and partial override behavior
- keep timeout-to-reject semantics unchanged

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 9m and 69,394 tokens on this with the user in an interactive session.
