### PR TITLE
GH#31509: recover durable raw PR creation

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -1053,5 +1053,9 @@ _shim_ensure_requested_managed_labels_for_create || true
 # comment/edit) — these all use the GraphQL endpoint.
 _transport_caller=$(_shim_caller_label "${1:-}" "${2:-}")
 gh_record_call graphql "$_transport_caller" 2>/dev/null || true
+if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "pr:create" ]]; then
+	_shim_run_pr_create_transport "$REAL_GH" graphql "$_transport_caller" 0 "${_modified_args[@]}"
+	exit $?
+fi
 _shim_run_transport "$REAL_GH" graphql "$_transport_caller" 0 "${_modified_args[@]}"
 exit $?

--- a/.agents/scripts/gh-write-policy-lib.sh
+++ b/.agents/scripts/gh-write-policy-lib.sh
@@ -14,6 +14,9 @@ _GH_WRITE_POLICY_LIB_LOADED=1
 _SHIM_ORIGIN_INTERACTIVE_LABEL="origin:interactive"
 _SHIM_ISSUE_FIRST_SCOPE_EXTERNAL="external"
 _SHIM_MANAGED_LABEL_SET=""
+_SHIM_REPO_WRITE_CACHE_SLUG=""
+_SHIM_REPO_WRITE_CACHE_RESULT=""
+_SHIM_PR_CREATE_PARTIAL_RC=78
 
 if [[ -z "${_SHIM_DIR:-}" ]]; then
 	_gh_write_policy_path="${BASH_SOURCE[0]%/*}"
@@ -764,9 +767,118 @@ _shim_normalize_pr_create_origin() {
 	if _shim_is_headless_automation; then
 		origin_label="origin:worker"
 	fi
+	local repo_slug=""
+	repo_slug=$(_shim_target_repo_slug "${_modified_args[@]}" 2>/dev/null || true)
+	if [[ -z "$repo_slug" ]] || ! _shim_authenticated_actor_has_repo_write "$repo_slug"; then
+		printf '[aidevops][gh-shim][INFO] Upstream write authority is unavailable; deferring automatic %s provenance to repository triage.\n' \
+			"$origin_label" >&2
+		return 0
+	fi
 	_SHIM_MANAGED_LABEL_SET="origin"
 	_modified_args+=(--label "$origin_label")
 	return 0
+}
+
+_shim_pr_create_get_head() {
+	local args=("$@")
+	local idx=0
+	local arg=""
+	while [[ $idx -lt ${#args[@]} ]]; do
+		arg="${args[$idx]}"
+		case "$arg" in
+		--head)
+			printf '%s\n' "${args[idx + 1]:-}"
+			return 0
+			;;
+		--head=*)
+			printf '%s\n' "${arg#--head=}"
+			return 0
+			;;
+		esac
+		idx=$((idx + 1))
+	done
+	return 1
+}
+
+_shim_pr_create_validate_url() {
+	local url="$1"
+	local repo_slug="$2"
+	if [[ "$url" =~ ^https://[^/]+/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/pull/([0-9]+)$ ]] &&
+		[[ "${BASH_REMATCH[1]}" == "$repo_slug" ]]; then
+		printf '%s\n' "$url"
+		return 0
+	fi
+	return 1
+}
+
+_shim_pr_create_url_from_output() {
+	local output_file="$1"
+	local repo_slug="$2"
+	local line=""
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if _shim_pr_create_validate_url "$line" "$repo_slug"; then
+			return 0
+		fi
+	done <"$output_file"
+	return 1
+}
+
+_shim_pr_create_recover_exact_url() {
+	local repo_slug="$1"
+	shift
+	local head_ref=""
+	local response=""
+	local recovered_url=""
+	head_ref=$(_shim_pr_create_get_head "$@" 2>/dev/null || true)
+	[[ "$head_ref" =~ ^[A-Za-z0-9_.-]+:[A-Za-z0-9._/-]+$ ]] || return 1
+	response=$(_shim_run_transport "$REAL_GH" rest gh_pr_create_recovery 0 \
+		api "/repos/${repo_slug}/pulls" --method GET -f state=open \
+		-f "head=${head_ref}" -f per_page=5 2>/dev/null) || return 1
+	recovered_url=$(printf '%s\n' "$response" | jq -r --arg repo "$repo_slug" --arg head "$head_ref" \
+		'[.[] | select(.state == "open" and .head.label == $head and .base.repo.full_name == $repo)] | if length == 1 then .[0].html_url // empty else empty end' \
+		2>/dev/null || true)
+	_shim_pr_create_validate_url "$recovered_url" "$repo_slug"
+	return $?
+}
+
+_shim_run_pr_create_transport() {
+	local binary="$1"
+	local path="$2"
+	local caller="$3"
+	local retry="$4"
+	shift 4
+	local repo_slug=""
+	local stdout_file=""
+	local stderr_file=""
+	local rc=0
+	local durable_url=""
+	local output_has_url=0
+	repo_slug=$(_shim_target_repo_slug "$@" 2>/dev/null || true)
+	stdout_file=$(mktemp -t aidevops-gh-pr-create-out.XXXXXX 2>/dev/null || true)
+	stderr_file=$(mktemp -t aidevops-gh-pr-create-err.XXXXXX 2>/dev/null || true)
+	if [[ -z "$repo_slug" || -z "$stdout_file" || -z "$stderr_file" ]]; then
+		[[ -z "$stdout_file" ]] || rm -f "$stdout_file"
+		[[ -z "$stderr_file" ]] || rm -f "$stderr_file"
+		_shim_run_transport "$binary" "$path" "$caller" "$retry" "$@"
+		return $?
+	fi
+	_shim_run_transport "$binary" "$path" "$caller" "$retry" "$@" \
+		>"$stdout_file" 2>"$stderr_file" || rc=$?
+	durable_url=$(_shim_pr_create_url_from_output "$stdout_file" "$repo_slug" 2>/dev/null || true)
+	[[ -z "$durable_url" ]] || output_has_url=1
+	cat "$stdout_file"
+	cat "$stderr_file" >&2
+	if [[ $rc -ne 0 && -z "$durable_url" ]]; then
+		durable_url=$(_shim_pr_create_recover_exact_url "$repo_slug" "$@" 2>/dev/null || true)
+	fi
+	rm -f "$stdout_file" "$stderr_file"
+	if [[ $rc -ne 0 && -n "$durable_url" ]]; then
+		[[ $output_has_url -eq 1 ]] || printf '%s\n' "$durable_url"
+		printf '[aidevops][gh-shim][PARTIAL] Durable PR %s exists after a create-time mutation failure; not retrying creation.\n' \
+			"$durable_url" >&2
+		return "$_SHIM_PR_CREATE_PARTIAL_RC"
+	fi
+	return "$rc"
 }
 
 _shim_pr_create_get_title() {
@@ -1012,16 +1124,29 @@ _shim_authenticated_actor_has_repo_write() {
 	local current_user=""
 	local permission=""
 	[[ -n "$repo_slug" && "$repo_slug" == */* ]] || return 1
+	if [[ "$_SHIM_REPO_WRITE_CACHE_SLUG" == "$repo_slug" ]]; then
+		[[ "$_SHIM_REPO_WRITE_CACHE_RESULT" == "write" ]]
+		return $?
+	fi
 	#aidevops:trust-boundary -- exemption requires live GitHub identity and permission.
 	current_user=$(_shim_run_transport "$REAL_GH" rest gh_api_user 0 \
 		api user --jq '.login // empty' 2>/dev/null) || current_user=""
-	[[ -n "$current_user" && "$current_user" =~ ^[A-Za-z0-9-]+$ ]] || return 1
+	if [[ -z "$current_user" || ! "$current_user" =~ ^[A-Za-z0-9-]+$ ]]; then
+		_SHIM_REPO_WRITE_CACHE_SLUG="$repo_slug"
+		_SHIM_REPO_WRITE_CACHE_RESULT="unavailable"
+		return 1
+	fi
 	permission=$(_shim_run_transport "$REAL_GH" rest gh_api_collaborator_permission 0 \
 		api "/repos/${repo_slug}/collaborators/${current_user}/permission" \
 		--jq '.permission // .role_name // empty' 2>/dev/null) || permission=""
+	_SHIM_REPO_WRITE_CACHE_SLUG="$repo_slug"
 	case "$permission" in
-	admin | maintain | write) return 0 ;;
+	admin | maintain | write)
+		_SHIM_REPO_WRITE_CACHE_RESULT="write"
+		return 0
+		;;
 	esac
+	_SHIM_REPO_WRITE_CACHE_RESULT="unavailable"
 	return 1
 }
 

--- a/.agents/scripts/tests/test-gh-shim-core-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-core-cases.sh
@@ -271,6 +271,74 @@ else
 fi
 
 _reset_log
+pr_partial_url="https://github.com/owner/repo/pull/31503"
+pr_partial_output=""
+pr_partial_rc=0
+pr_partial_output=$(STUB_GH_PERMISSION=read STUB_PR_CREATE_EXIT_CODE=1 \
+	STUB_PR_CREATE_STDOUT="$pr_partial_url" \
+	STUB_PR_CREATE_STDERR='pull request update failed: GraphQL: permission denied (updatePullRequest)' \
+	"$SHIM_RUN" pr create --repo owner/repo --head contributor:feature/raw-partial \
+	--title "partial" --body "For #31509" 2>"$TMP/pr-create-partial.err") || pr_partial_rc=$?
+argv=$(_read_argv)
+pr_partial_create_calls=$(grep -c $'^pr\tcreate$' "$STUB_GH_CALL_LOG" || true)
+if [[ "$pr_partial_rc" -eq 78 && "$pr_partial_output" == "$pr_partial_url" ]] &&
+	[[ "$argv" != *"origin:interactive"* && "$pr_partial_create_calls" -eq 1 ]] &&
+	grep -q '\[aidevops\]\[gh-shim\]\[PARTIAL\].*not retrying creation' "$TMP/pr-create-partial.err"; then
+	_pass "external raw pr create preserves durable URL and reports stable partial success"
+else
+	_fail "external raw pr create partial-success recovery" \
+		"rc=${pr_partial_rc} output=${pr_partial_output} argv=${argv} err=$(cat "$TMP/pr-create-partial.err")"
+fi
+
+_reset_log
+pr_recovered_url="https://github.com/owner/repo/pull/31509"
+pr_recovered_output=""
+pr_recovered_rc=0
+pr_recovery_fixture="$TMP/pr-recovery.json"
+printf '%s\n' '[{"number":31509,"state":"open","html_url":"https://github.com/owner/repo/pull/31509","head":{"label":"contributor:feature/recover"},"base":{"repo":{"full_name":"owner/repo"}}}]' \
+	>"$pr_recovery_fixture"
+export STUB_REST_PULLS_FILE="$pr_recovery_fixture"
+pr_recovered_output=$(STUB_GH_PERMISSION=read STUB_PR_CREATE_EXIT_CODE=1 \
+	STUB_PR_CREATE_STDERR='pull request update failed' \
+	"$SHIM_RUN" pr create --repo owner/repo --head contributor:feature/recover \
+	--title "recover" --body "For #31509" 2>"$TMP/pr-create-recover.err") || pr_recovered_rc=$?
+if [[ "$pr_recovered_rc" -eq 78 && "$pr_recovered_output" == "$pr_recovered_url" ]] &&
+	grep -Fq 'head=contributor:feature/recover' "$STUB_GH_LOG"; then
+	_pass "raw pr create recovers one exact upstream and qualified-head identity"
+else
+	_fail "raw pr create exact identity recovery" \
+		"rc=${pr_recovered_rc} output=${pr_recovered_output} calls=$(cat "$STUB_GH_CALL_LOG")"
+fi
+
+_reset_log
+printf '%s\n' '[{"number":31510,"state":"open","html_url":"https://github.com/owner/repo/pull/31510","head":{"label":"other:feature/recover"},"base":{"repo":{"full_name":"owner/repo"}}}]' \
+	>"$pr_recovery_fixture"
+export STUB_REST_PULLS_FILE="$pr_recovery_fixture"
+pr_wrong_head_rc=0
+STUB_GH_PERMISSION_FAIL=1 STUB_PR_CREATE_EXIT_CODE=41 \
+	"$SHIM_RUN" pr create --repo owner/repo --head contributor:feature/recover \
+	--title "wrong head" --body "For #31509" >/dev/null 2>"$TMP/pr-create-wrong-head.err" || pr_wrong_head_rc=$?
+if [[ "$pr_wrong_head_rc" -eq 41 ]] &&
+	! grep -q '\[aidevops\]\[gh-shim\]\[PARTIAL\]' "$TMP/pr-create-wrong-head.err"; then
+	_pass "raw pr create rejects wrong-fork identity and unavailable authority"
+else
+	_fail "raw pr create wrong-fork recovery guard" "rc=${pr_wrong_head_rc} err=$(cat "$TMP/pr-create-wrong-head.err")"
+fi
+
+_reset_log
+pr_lookup_failure_rc=0
+STUB_GH_PERMISSION=read STUB_PR_CREATE_EXIT_CODE=42 STUB_REST_READ_FAIL=1 \
+	"$SHIM_RUN" pr create --repo owner/repo --head contributor:feature/recover \
+	--title "lookup failure" --body "For #31509" >/dev/null 2>"$TMP/pr-create-lookup-failure.err" || pr_lookup_failure_rc=$?
+if [[ "$pr_lookup_failure_rc" -eq 42 ]] &&
+	! grep -q '\[aidevops\]\[gh-shim\]\[PARTIAL\]' "$TMP/pr-create-lookup-failure.err"; then
+	_pass "raw pr create preserves failure when durable identity lookup is unavailable"
+else
+	_fail "raw pr create unavailable identity guard" \
+		"rc=${pr_lookup_failure_rc} err=$(cat "$TMP/pr-create-lookup-failure.err")"
+fi
+
+_reset_log
 AIDEVOPS_HEADLESS=1 AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE=owner/repo \
 	"$SHIM_RUN" pr create --repo owner/repo --title "worker" --body "For #25901" 2>/dev/null
 argv=$(_read_argv)

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -82,7 +82,7 @@ if [[ "$1" == "api" && "$2" == "user" ]]; then
 fi
 if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/collaborators/[^/]+/permission$ ]]; then
 	[[ "${STUB_GH_PERMISSION_FAIL:-0}" != "1" ]] || exit 44
-	printf '%s\n' "${STUB_GH_PERMISSION:-none}"
+	printf '%s\n' "${STUB_GH_PERMISSION:-write}"
 	exit 0
 fi
 if [[ "$1" == "auth" && "$2" == "token" ]]; then
@@ -91,6 +91,11 @@ if [[ "$1" == "auth" && "$2" == "token" ]]; then
 fi
 if [[ -n "${STUB_GH_CALL_LOG:-}" ]]; then
 	printf '%s\t%s\n' "${1:-}" "${2:-}" >>"$STUB_GH_CALL_LOG"
+fi
+if [[ "$1" == "pr" && "$2" == "create" && -n "${STUB_PR_CREATE_EXIT_CODE:-}" ]]; then
+	[[ -z "${STUB_PR_CREATE_STDOUT:-}" ]] || printf '%s\n' "$STUB_PR_CREATE_STDOUT"
+	[[ -z "${STUB_PR_CREATE_STDERR:-}" ]] || printf '%s\n' "$STUB_PR_CREATE_STDERR" >&2
+	exit "$STUB_PR_CREATE_EXIT_CODE"
 fi
 if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/labels\?per_page=100$ ]]; then
 	[[ "${STUB_MANAGED_LABEL_INVENTORY_FAIL:-0}" != "1" ]] || exit 42
@@ -205,7 +210,7 @@ if [[ "${STUB_REST_READ_FAIL:-0}" == "1" && "$1" == "api" && \
 	"$2" =~ ^/repos/[^/]+/[^/]+/(issues|pulls)(\?|/|$) ]]; then
 	exit "${STUB_REST_READ_EXIT_CODE:-42}"
 fi
-if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/pulls\? ]]; then
+if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/pulls(\?|$) ]]; then
 	jq_filter=""
 	i=3
 	while [[ $i -le $# ]]; do
@@ -216,7 +221,11 @@ if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/pulls\? ]]; then
 		fi
 		i=$((i + 1))
 	done
-	fixture='[{"number":22337,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22337"},{"number":22343,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22343"}]'
+	if [[ -n "${STUB_REST_PULLS_FILE:-}" ]]; then
+		fixture=$(<"$STUB_REST_PULLS_FILE")
+	else
+		fixture='[{"number":22337,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22337"},{"number":22343,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22343"}]'
+	fi
 	if [[ "$2" == *"head=owner%3Afeature%2Fauto-20260502-135611-gh22289"* ]]; then
 		fixture='[{"number":22337,"state":"open","merged_at":null,"html_url":"https://github.com/owner/repo/pull/22337"}]'
 	fi
@@ -350,6 +359,10 @@ _reset_log() {
 	unset STUB_MANAGED_LABEL_CREATE_FAIL
 	unset STUB_GH_PERMISSION
 	unset STUB_GH_PERMISSION_FAIL
+	unset STUB_PR_CREATE_EXIT_CODE
+	unset STUB_PR_CREATE_STDOUT
+	unset STUB_PR_CREATE_STDERR
+	unset STUB_REST_PULLS_FILE
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Make raw gh PR creation authority-aware and preserve exact durable PR identity when a post-create mutation fails, without retrying creation.

## Files Changed

.agents/scripts/gh, .agents/scripts/gh-write-policy-lib.sh, .agents/scripts/tests/test-gh-shim-core-cases.sh, .agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Hermetic gh shim suite passes 166 tests; ShellCheck passes all four changed shell files; changed-file lint and git diff checks pass; local review bundle 6a624f2275fd9b75ef83e46015a3598a68a66cc533515aa82bdada711646d17d is clean.

Resolves #31509


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 1h 16m and 241,726 tokens on this with the user in an interactive session.