### PR TITLE
GH#31533: fix: preserve protected-main release descendants

### DIFF
--- a/.agents/reference/release-lane-coordination.md
+++ b/.agents/reference/release-lane-coordination.md
@@ -141,6 +141,14 @@ silently widened. Conflicting source SHAs, stale owner tokens, mismatched pins,
 publication state and uncertain reads fail closed. This migration changes neither
 signed tags nor an established snapshot range and adds no publication authority.
 
+Post-release runtime convergence preserves a changed-tree descendant of the
+immutable release commit only when its full manifest SHA exactly equals the
+freshly fetched protected `main` tip and the existing bundle verifier proves the
+deployed files, sentinel and deployment stamp match that commit. This covers a
+protected release merge that combines the pinned release with later ordinary
+merges without downgrading the active runtime. A stale descendant, fetch failure,
+concurrent replacement or unrelated history remains a hard failure.
+
 ## Verification
 
 Run from the repository root:

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -347,6 +347,18 @@ create_fake_repo() {
 	return 0
 }
 
+configure_local_aidevops_remote() {
+	local repo_path="$1"
+	local repo_name="${repo_path##*/}"
+	local remote_path="$TEST_DIR/remotes/$repo_name/marcusquinn/aidevops.git"
+
+	mkdir -p "${remote_path%/*}"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git init --bare -q "$remote_path"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" remote set-url origin "$remote_path"
+	printf '%s\n' "$remote_path"
+	return 0
+}
+
 prepare_active_release_preservation() {
 	local repo_path="$1"
 	local topology="$2"
@@ -758,19 +770,60 @@ test_release_sync_accepts_validated_same_tree_descendant() {
 	return 0
 }
 
-test_release_sync_rejects_changed_tree_descendant() {
+test_release_sync_accepts_changed_tree_protected_main_descendant() {
 	local repo_path
+	local remote_path=""
+	local active_sha=""
 	local output=""
-	repo_path=$(create_fake_repo "release-changed-tree-descendant" "https://github.com/marcusquinn/aidevops.git")
-	prepare_active_release_preservation "$repo_path" changed-tree >/dev/null
+	repo_path=$(create_fake_repo "release-changed-tree-protected-main" "https://github.com/marcusquinn/aidevops.git")
+	remote_path=$(configure_local_aidevops_remote "$repo_path") || {
+		print_result "release sync accepts a changed-tree protected-main descendant" 1 "Could not prepare local protected remote"
+		return 0
+	}
+	active_sha=$(prepare_active_release_preservation "$repo_path" changed-tree)
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" push -q "$remote_path" "$active_sha:refs/heads/main"
+	: >"$TEST_DIR/sync.log"
+
+	if output=$(invoke_release_sync "$repo_path" 2>&1) &&
+		[[ ! -s "$TEST_DIR/sync.log" ]] &&
+		[[ "$output" == *"preservation merge ${active_sha:0:12}"* ]] &&
+		[[ "$output" == *"verified no-op"* ]]; then
+		print_result "release sync accepts an exact-verified changed-tree protected-main descendant" 0
+	else
+		print_result "release sync accepts an exact-verified changed-tree protected-main descendant" 1 "$output"
+	fi
+	return 0
+}
+
+test_release_sync_rejects_changed_tree_non_tip_descendant() {
+	local repo_path
+	local remote_path=""
+	local release_sha=""
+	local active_sha=""
+	local protected_main=""
+	local output=""
+	repo_path=$(create_fake_repo "release-changed-tree-non-tip" "https://github.com/marcusquinn/aidevops.git")
+	remote_path=$(configure_local_aidevops_remote "$repo_path") || {
+		print_result "release sync rejects a changed-tree non-tip descendant" 1 "Could not prepare local protected remote"
+		return 0
+	}
+	release_sha=$(PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" rev-parse HEAD)
+	active_sha=$(prepare_active_release_preservation "$repo_path" changed-tree)
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" checkout -q --detach "$active_sha"
+	printf 'new protected-main change\n' >"$repo_path/new-protected-change.txt"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" add new-protected-change.txt
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" commit -qm "advance protected main"
+	protected_main=$(PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" rev-parse HEAD)
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" push -q "$remote_path" "$protected_main:refs/heads/main"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" checkout -q --detach "$release_sha"
 	: >"$TEST_DIR/sync.log"
 
 	if output=$(invoke_release_sync "$repo_path" 2>&1); then
-		print_result "release sync rejects a changed-tree preservation descendant" 1 "Changed-tree descendant was reported as converged"
-	elif [[ "$output" == *"tree differs from release"* && ! -s "$TEST_DIR/sync.log" ]]; then
-		print_result "release sync rejects a changed-tree preservation descendant" 0
+		print_result "release sync rejects a changed-tree non-tip descendant" 1 "Non-tip descendant was reported as converged"
+	elif [[ "$output" == *"changed tree does not match protected main"* && ! -s "$TEST_DIR/sync.log" ]]; then
+		print_result "release sync rejects a changed-tree non-tip descendant" 0
 	else
-		print_result "release sync rejects a changed-tree preservation descendant" 1 "Missing fail-closed changed-tree evidence: $output"
+		print_result "release sync rejects a changed-tree non-tip descendant" 1 "Missing fail-closed protected-main evidence: $output"
 	fi
 	return 0
 }
@@ -981,7 +1034,8 @@ main() {
 	test_release_sync_rejects_stale_sentinel
 	test_release_sync_deploys_validated_active_ancestor
 	test_release_sync_accepts_validated_same_tree_descendant
-	test_release_sync_rejects_changed_tree_descendant
+	test_release_sync_accepts_changed_tree_protected_main_descendant
+	test_release_sync_rejects_changed_tree_non_tip_descendant
 	test_release_sync_rejects_unrelated_active_commit
 	test_release_sync_recovers_verified_squash_integration
 	test_release_sync_rejects_incomplete_squash_evidence

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -769,6 +769,38 @@ _verify_release_deployment_source_unchanged() {
 	return 0
 }
 
+_verify_release_descendant_active_source() {
+	local sync_repo_root="$1"
+	local release_sha="$2"
+	local active_sha="$3"
+	local release_tree=""
+	local active_tree=""
+	local protected_main=""
+
+	release_tree=$(git -C "$sync_repo_root" rev-parse "${release_sha}^{tree}" 2>/dev/null) || {
+		print_error "Post-release deployment gate cannot resolve the release tree"
+		return 1
+	}
+	active_tree=$(git -C "$sync_repo_root" rev-parse "${active_sha}^{tree}" 2>/dev/null) || {
+		print_error "Post-release deployment gate cannot resolve the active bundle tree"
+		return 1
+	}
+	[[ "$release_tree" != "$active_tree" ]] || return 0
+	if ! git -C "$sync_repo_root" fetch origin main --quiet; then
+		print_error "Post-release deployment gate cannot refresh protected main for active descendant verification"
+		return 1
+	fi
+	protected_main=$(git -C "$sync_repo_root" rev-parse "origin/main^{commit}" 2>/dev/null) || {
+		print_error "Post-release deployment gate cannot resolve protected main for active descendant verification"
+		return 1
+	}
+	if [[ "$active_sha" != "$protected_main" ]]; then
+		print_error "Post-release deployment gate rejected active descendant ${active_sha:0:12}: changed tree does not match protected main ${protected_main:0:12}"
+		return 1
+	fi
+	return 0
+}
+
 _verify_active_release_preservation_merge() {
 	local sync_repo_root="$1"
 	local release_sha="$2"
@@ -778,8 +810,6 @@ _verify_active_release_preservation_merge() {
 	local manifest_status=""
 	local manifest_sha=""
 	local active_sha=""
-	local release_tree=""
-	local active_tree=""
 	local verify_base=""
 	local verify_root=""
 	local verify_repo=""
@@ -816,19 +846,8 @@ _verify_active_release_preservation_merge() {
 			print_error "Post-release deployment gate rejected active source ${active_sha:0:12}: it is neither ancestry-related nor a lane-authorized squash-integrated source"
 			return 1
 		fi
-	else
-		release_tree=$(git -C "$sync_repo_root" rev-parse "${release_sha}^{tree}" 2>/dev/null) || {
-			print_error "Post-release deployment gate cannot resolve the release tree"
-			return 1
-		}
-		active_tree=$(git -C "$sync_repo_root" rev-parse "${active_sha}^{tree}" 2>/dev/null) || {
-			print_error "Post-release deployment gate cannot resolve the active bundle tree"
-			return 1
-		}
-		if [[ "$release_tree" != "$active_tree" ]]; then
-			print_error "Post-release deployment gate rejected active descendant ${active_sha:0:12}: its tree differs from release ${release_sha:0:12}"
-			return 1
-		fi
+	elif ! _verify_release_descendant_active_source "$sync_repo_root" "$release_sha" "$active_sha"; then
+		return 1
 	fi
 
 	verify_base="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"


### PR DESCRIPTION
## Summary

Implementation for issue #31533.

## Files Changed

.agents/reference/release-lane-coordination.md, .agents/scripts/tests/test-agent-auto-sync.sh, .agents/scripts/version-manager-release.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #31533


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.333 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 6h 5m and 1,658,419 tokens on this with the user in an interactive session.