### PR TITLE
GH#31493: fix Pulse lifecycle and stale claim recovery

### DIFF
--- a/.agents/plugins/opencode-aidevops/package-lock.json
+++ b/.agents/plugins/opencode-aidevops/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
-        "@opencode-ai/plugin": "^1.18.25"
+        "@opencode-ai/plugin": "^1.18.29"
       },
       "peerDependencies": {
         "opencode-ai": ">=1.3.0"
@@ -113,13 +113,13 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.25.tgz",
-      "integrity": "sha512-Kb34zFqYosFNiMd1IuYiZGjX17z+18Srm7tHZMCz+uMVRTYNkEw1FTrfAK2FLbggwYdgzifGwKMNF1slLT8eLw==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.29.tgz",
+      "integrity": "sha512-IhF83EU4I/ASgWwvm0FIh1O3a8ZVuCLqPrCbmSHdSYq7GHxIYe773i6dHqcbrzCzvlG/lP2H+dyTQ+xPAwFpbw==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.25",
+        "@opencode-ai/sdk": "1.18.29",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.25",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.25.tgz",
-      "integrity": "sha512-GwgwhW+vE8FWSDw730SjzqNhsWXB0uJjbFOiqFkmM+USFuG13HuTlGe6SR2ixt+WXxoD6FV1hILWqsXyqej9hQ==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.29.tgz",
+      "integrity": "sha512-4CS+FoLPkymTlcga8jxivGDDb2AbWMIIl3b8+myoe2wtv/1ANYCErslgz1xy5hTVHymWE6CtVNKzRuPU0ED57A==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/.agents/plugins/opencode-aidevops/package.json
+++ b/.agents/plugins/opencode-aidevops/package.json
@@ -17,7 +17,7 @@
   "author": "Marcus Quinn",
   "license": "MIT",
   "opencode": {
-    "tracked_version": "1.18.25",
+    "tracked_version": "1.18.29",
     "repo": "anomalyco/opencode"
   },
   "peerDependencies": {
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0",
-    "@opencode-ai/plugin": "^1.18.25"
+    "@opencode-ai/plugin": "^1.18.29"
   }
 }

--- a/.agents/scripts/interactive-session-helper-scan.sh
+++ b/.agents/scripts/interactive-session-helper-scan.sh
@@ -368,9 +368,9 @@ _isc_scan_stampless_phase() {
 # scan-stale Phase 1 helper (t2414) — stamp-based stale claim detection.
 # -----------------------------------------------------------------------------
 # Iterates $CLAIM_STAMP_DIR. For each local-hostname stamp with a verifiably
-# dead PID and missing worktree: either auto-releases (when
-# auto_release_flag==1) or prints a report advisory. Live owners, existing
-# worktrees, lockdown labels, and unverifiable metadata fail closed.
+# dead PID and no recoverable worktree progress: either auto-releases (when
+# auto_release_flag==1) or prints a report advisory. Live owners, worktrees with
+# progress, lockdown labels, and unverifiable metadata fail closed.
 # Extracted from _isc_cmd_scan_stale to keep the coordinator under the
 # 100-line function cap (Complexity Analysis CI gate).
 #
@@ -379,6 +379,22 @@ _isc_scan_stampless_phase() {
 #   $2 stamp_limit       — max stamp files to examine; "0" means unbounded
 #
 # Exit: 0 always.
+_isc_worktree_has_recoverable_progress() {
+	local worktree="$1"
+	local status_output=""
+	local default_ref=""
+	local ahead_count=""
+	[[ -n "$worktree" && -d "$worktree" ]] || return 1
+	status_output=$(git -C "$worktree" status --porcelain 2>/dev/null) || return 2
+	[[ -z "$status_output" ]] || return 0
+	default_ref=$(git -C "$worktree" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) || return 2
+	[[ -n "$default_ref" ]] || return 2
+	ahead_count=$(git -C "$worktree" rev-list --count "${default_ref}..HEAD" 2>/dev/null) || return 2
+	[[ "$ahead_count" =~ ^[0-9]+$ ]] || return 2
+	[[ "$ahead_count" -gt 0 ]] && return 0
+	return 1
+}
+
 _isc_scan_dead_stamps_phase() {
 	local auto_release_flag="${1:-0}"
 	local stamp_limit="${2:-0}"
@@ -408,9 +424,6 @@ _isc_scan_dead_stamps_phase() {
 			# Only consider current-hostname stamps — cross-machine stamps
 			# can't have their PID verified and must not be surfaced as stale.
 			[[ "$hostname" == "$local_host" ]] || continue
-			# A surviving worktree may contain in-progress work even when the
-			# recorded process has exited. Preserve it for explicit recovery.
-			[[ -n "$worktree" && -d "$worktree" ]] && continue
 			# Missing owner metadata cannot prove that a claim is abandoned.
 			[[ "$pid" =~ ^[0-9]+$ ]] || continue
 
@@ -424,6 +437,11 @@ _isc_scan_dead_stamps_phase() {
 			fi
 
 			if [[ $pid_alive -eq 0 ]]; then
+				local progress_rc=0
+				_isc_worktree_has_recoverable_progress "$worktree" || progress_rc=$?
+				# Dirty/ahead work is a durable recovery checkpoint. Unknown Git
+				# state also fails closed rather than releasing possible work.
+				[[ "$progress_rc" -eq 0 || "$progress_rc" -eq 2 ]] && continue
 				if [[ "$auto_release_flag" == "1" ]]; then
 					local label_rc=0
 					_isc_has_label "$issue" "$slug" "no-auto-dispatch" || label_rc=$?
@@ -517,8 +535,14 @@ _isc_cmd_scan_stale() {
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-		--auto-release) auto_release_flag=1 ; shift ;;
-		--no-auto-release) auto_release_flag=0 ; shift ;;
+		--auto-release)
+			auto_release_flag=1
+			shift
+			;;
+		--no-auto-release)
+			auto_release_flag=0
+			shift
+			;;
 		*) shift ;;
 		esac
 	done

--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -84,12 +84,35 @@ unset _PULSE_BOOTSTRAP_SCRIPT_DIR _PULSE_RUNTIME_PIN_HELPER _PULSE_PINNED_ROOT _
 _PULSE_SCRIPT="${_PULSE_AGENTS_DIR}/scripts/pulse-wrapper.sh"
 _PULSE_LOG="${HOME}/.aidevops/logs/pulse-wrapper.log"
 
-# Process-match pattern for pgrep. The production default matches any
-# pulse-wrapper.sh script regardless of path. Tests may override this to
-# isolate mock pulses from the live user pulse (the mock's path is embedded
-# in the pattern). See tests/test-pulse-lifecycle-helper.sh.
-_PULSE_PATTERN="${AIDEVOPS_PULSE_PROCESS_PATTERN:-(^|/)pulse-wrapper\\.sh( |\$)}"
-_PULSE_MERGE_PATTERN="${AIDEVOPS_PULSE_MERGE_PROCESS_PATTERN:-(^|/)pulse-merge-routine\\.sh( |\$)}"
+# Process-match pattern for pgrep. Scope the production default to this user's
+# deployed or immutable runtime paths so another local user's Pulse cannot
+# satisfy lifecycle checks on a shared host. Tests may still provide an exact
+# override to isolate mock processes.
+_pulse_escape_ere() {
+	local _value="$1"
+	local _escaped=""
+	local _character=""
+	local _index=0
+	while [[ "$_index" -lt "${#_value}" ]]; do
+		_character="${_value:$_index:1}"
+		case "$_character" in
+		"\\" | "." | "[" | "]" | "^" | '$' | "*" | "+" | "?" | "{" | "}" | "|" | "(" | ")")
+			_escaped="${_escaped}\\${_character}"
+			;;
+		*) _escaped="${_escaped}${_character}" ;;
+		esac
+		_index=$((_index + 1))
+	done
+	printf '%s' "$_escaped"
+	return 0
+}
+_PULSE_DEPLOYED_ROOT=$(_pulse_escape_ere "${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}")
+_PULSE_ACTIVE_ROOT=$(_pulse_escape_ere "$_PULSE_AGENTS_DIR")
+_PULSE_BUNDLES_ROOT=$(_pulse_escape_ere "${AIDEVOPS_RUNTIME_BUNDLES_DIR:-${HOME}/.aidevops/runtime-bundles}")
+_PULSE_DEFAULT_PATTERN="(${_PULSE_DEPLOYED_ROOT}|${_PULSE_ACTIVE_ROOT}|${_PULSE_BUNDLES_ROOT}/[^/]+/agents)/scripts/pulse-wrapper\\.sh( |\$)"
+_PULSE_DEFAULT_MERGE_PATTERN="(${_PULSE_DEPLOYED_ROOT}|${_PULSE_ACTIVE_ROOT}|${_PULSE_BUNDLES_ROOT}/[^/]+/agents)/scripts/pulse-merge-routine\\.sh( |\$)"
+_PULSE_PATTERN="${AIDEVOPS_PULSE_PROCESS_PATTERN:-$_PULSE_DEFAULT_PATTERN}"
+_PULSE_MERGE_PATTERN="${AIDEVOPS_PULSE_MERGE_PROCESS_PATTERN:-$_PULSE_DEFAULT_MERGE_PATTERN}"
 
 # Timing
 _PULSE_RESTART_WAIT="${AIDEVOPS_PULSE_RESTART_WAIT:-3}"

--- a/.agents/scripts/pulse-watchdog-tick.sh
+++ b/.agents/scripts/pulse-watchdog-tick.sh
@@ -113,8 +113,14 @@ if ! _systemd_owns_pulse && [[ ! -x "$_LIFECYCLE_HELPER" ]]; then
 fi
 
 # Fast path: ask the owning scheduler before falling back to process discovery.
+# A systemd oneshot may report inactive after its launcher exits while the Pulse
+# process it started is still running. Confirm process liveness before declaring
+# that scheduler-owned Pulse dead and repeatedly trying to revive it.
 if _systemd_owns_pulse; then
 	if _systemd_pulse_alive; then
+		exit 0
+	fi
+	if [[ -x "$_LIFECYCLE_HELPER" ]] && "$_LIFECYCLE_HELPER" is-running >/dev/null 2>&1; then
 		exit 0
 	fi
 elif "$_LIFECYCLE_HELPER" is-running >/dev/null 2>&1; then

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -30,6 +30,7 @@
 #   18. Genuine unkillable snapshot PIDs fail closed with PID evidence
 #   19. Managed replacement requires a new active-bundle PID lease
 #   20. Launchd runtime proof handles prompt, delayed, wrong, and missing starts
+#   21. Default discovery ignores another local user's Pulse process
 #
 # No real pulse is touched. We use a unique mock filename and match pattern
 # on pulse-wrapper.sh which we control inside TEST_ROOT.
@@ -1358,6 +1359,53 @@ test_status_sidecar_only_reports_not_running() {
 	return 0
 }
 
+test_default_pattern_ignores_foreign_user_pulse() {
+	_kill_mocks
+	local foreign_root="${TEST_ROOT}-foreign-user"
+	mkdir -p "${foreign_root}/scripts"
+	cp "${TEST_ROOT}/scripts/pulse-wrapper.sh" "${foreign_root}/scripts/pulse-wrapper.sh"
+	cp "${TEST_ROOT}/scripts/pulse-merge-routine.sh" "${foreign_root}/scripts/pulse-merge-routine.sh"
+	chmod +x "${foreign_root}/scripts/pulse-wrapper.sh"
+	chmod +x "${foreign_root}/scripts/pulse-merge-routine.sh"
+	bash "${TEST_ROOT}/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
+	local current_pid=$!
+	bash "${foreign_root}/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
+	local foreign_pid=$!
+	bash "${TEST_ROOT}/scripts/pulse-merge-routine.sh" >/dev/null 2>&1 &
+	local current_merge_pid=$!
+	bash "${foreign_root}/scripts/pulse-merge-routine.sh" >/dev/null 2>&1 &
+	local foreign_merge_pid=$!
+	sleep 0.3
+
+	local out="" rc=0
+	out=$(env -u AIDEVOPS_PULSE_PROCESS_PATTERN AIDEVOPS_AGENTS_DIR="$TEST_ROOT" \
+		AIDEVOPS_RUNTIME_BUNDLES_DIR="${TEST_ROOT}/runtime-bundles" \
+		"$HELPER" status 2>&1) || rc=$?
+	_assert_eq "default pattern: current-user Pulse status exits 0" "0" "$rc"
+	if [[ "$out" == *"Pulse: running (1 instance)"* && "$out" == *"PID ${current_pid}"* && "$out" != *"PID ${foreign_pid}"* ]]; then
+		_print_result "default pattern: foreign-user Pulse is ignored" 1
+	else
+		_print_result "default pattern: foreign-user Pulse leaked into status (out=$out)" 0
+	fi
+	local merge_pids=""
+	# $1 intentionally expands in the child shell.
+	# shellcheck disable=SC2016
+	merge_pids=$(env -u AIDEVOPS_PULSE_MERGE_PROCESS_PATTERN \
+		AIDEVOPS_AGENTS_DIR="$TEST_ROOT" \
+		AIDEVOPS_RUNTIME_BUNDLES_DIR="${TEST_ROOT}/runtime-bundles" \
+		bash -c 'source "$1"; _pulse_merge_pids_raw' _ "$HELPER")
+	if [[ "$merge_pids" == *"${current_merge_pid}"* && "$merge_pids" != *"${foreign_merge_pid}"* ]]; then
+		_print_result "default pattern: foreign-user merge routine is ignored" 1
+	else
+		_print_result "default pattern: foreign-user merge routine leaked into discovery (pids=$merge_pids)" 0
+	fi
+
+	kill -KILL "$current_pid" "$foreign_pid" "$current_merge_pid" "$foreign_merge_pid" 2>/dev/null || true
+	wait "$current_pid" "$foreign_pid" "$current_merge_pid" "$foreign_merge_pid" 2>/dev/null || true
+	rm -rf "$foreign_root"
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Runner
 # -----------------------------------------------------------------------------
@@ -1408,6 +1456,7 @@ main() {
 	test_status_four_main_plus_sidecar_warns
 	test_is_running_returns_false_with_only_sidecar
 	test_status_sidecar_only_reports_not_running
+	test_default_pattern_ignores_foreign_user_pulse
 
 	echo ""
 	echo "----"

--- a/.agents/scripts/tests/test-pulse-watchdog-tick.sh
+++ b/.agents/scripts/tests/test-pulse-watchdog-tick.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# Regression tests for systemd-owned Pulse watchdog liveness.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+WATCHDOG="${SCRIPT_DIR}/../pulse-watchdog-tick.sh"
+TEST_ROOT=$(mktemp -d -t pulse-watchdog-tick.XXXXXX)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/home/.aidevops/logs" "${TEST_ROOT}/agents/scripts"
+SYSTEMCTL_LOG="${TEST_ROOT}/systemctl.log"
+LIFECYCLE_STATE="${TEST_ROOT}/lifecycle.state"
+
+cat >"${TEST_ROOT}/bin/systemctl" <<'SH'
+#!/usr/bin/env bash
+if [[ "$*" == *"--property=LoadState"* ]]; then
+	printf 'loaded\n'
+	exit 0
+fi
+if [[ "$*" == *"--property=ActiveState"* ]]; then
+	printf 'inactive\n'
+	exit 0
+fi
+if [[ "$*" == *" start "* ]]; then
+	printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+	exit 0
+fi
+exit 1
+SH
+chmod +x "${TEST_ROOT}/bin/systemctl"
+
+cat >"${TEST_ROOT}/agents/scripts/pulse-lifecycle-helper.sh" <<'SH'
+#!/usr/bin/env bash
+[[ "${1:-}" == "is-running" ]] || exit 2
+[[ "$(<"$LIFECYCLE_STATE")" == "running" ]]
+SH
+chmod +x "${TEST_ROOT}/agents/scripts/pulse-lifecycle-helper.sh"
+
+run_watchdog() {
+	PATH="${TEST_ROOT}/bin:${PATH}" \
+		HOME="${TEST_ROOT}/home" \
+		AIDEVOPS_AGENTS_DIR="${TEST_ROOT}/agents" \
+		AIDEVOPS_PULSE_WATCHDOG_GRACE=0 \
+		SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+		LIFECYCLE_STATE="$LIFECYCLE_STATE" \
+		"$WATCHDOG"
+}
+
+printf 'running\n' >"$LIFECYCLE_STATE"
+: >"$SYSTEMCTL_LOG"
+run_watchdog
+if [[ -s "$SYSTEMCTL_LOG" ]]; then
+	printf 'FAIL: inactive systemd unit revived despite live Pulse process\n' >&2
+	exit 1
+fi
+printf 'PASS: inactive systemd unit accepts live Pulse process evidence\n'
+
+printf 'stopped\n' >"$LIFECYCLE_STATE"
+: >"$SYSTEMCTL_LOG"
+run_watchdog
+if [[ ! -s "$SYSTEMCTL_LOG" ]]; then
+	printf 'FAIL: dead systemd-owned Pulse was not revived\n' >&2
+	exit 1
+fi
+printf 'PASS: dead systemd-owned Pulse is revived\n'

--- a/.agents/scripts/tests/test-scan-stale-auto-release.sh
+++ b/.agents/scripts/tests/test-scan-stale-auto-release.sh
@@ -5,7 +5,7 @@
 # test-scan-stale-auto-release.sh — stale interactive claim regression guard.
 #
 # Asserts that `_isc_cmd_scan_stale` Phase 1 auto-releases only verifiably dead
-# claims without a surviving worktree or no-auto-dispatch lockdown.
+# claims without recoverable worktree progress or a no-auto-dispatch lockdown.
 #
 # Background (GH#20012, t2414):
 #   scan-stale Phase 1 previously ONLY reported dead stamps, requiring N manual
@@ -44,6 +44,8 @@
 #   17. direct pulse reaper preserves a surviving worktree.
 #   18. direct pulse reaper enforces its per-cycle stamp cap.
 #   19. direct pulse reaper preserves stamps with invalid target metadata.
+#   20. direct pulse reaper releases a dead claim with a clean, unchanged worktree.
+#   21. direct pulse reaper preserves a dead claim with dirty worktree progress.
 #
 # Stub strategy: override `_isc_release_claim_by_stamp_path` as a shell function
 # after sourcing the helper to capture auto-release calls without real gh ops.
@@ -103,7 +105,7 @@ LOCAL_HOST=$(hostname 2>/dev/null || echo "unknown")
 
 # Write a stamp file with given PID and worktree path.
 write_stamp() {
-	local filename="$1"   # e.g. owner-repo-42.json
+	local filename="$1" # e.g. owner-repo-42.json
 	local s_pid="$2"
 	local s_worktree="$3"
 	local s_issue="${4:-42}"
@@ -124,11 +126,26 @@ write_stamp() {
 # =============================================================================
 # Source helper with stubs to suppress side-effects
 # =============================================================================
-print_info() { :; return 0; }
-print_warning() { :; return 0; }
-print_error() { :; return 0; }
-print_success() { :; return 0; }
-log_verbose() { :; return 0; }
+print_info() {
+	:
+	return 0
+}
+print_warning() {
+	:
+	return 0
+}
+print_error() {
+	:
+	return 0
+}
+print_success() {
+	:
+	return 0
+}
+log_verbose() {
+	:
+	return 0
+}
 export -f print_info print_warning print_error print_success log_verbose
 
 # Override WORKER_PROCESS_PATTERN so the test bash process matches when we
@@ -172,10 +189,16 @@ _isc_release_claim_by_stamp_path() {
 export -f _isc_release_claim_by_stamp_path
 
 # Phase 1a and Phase 2 are not under test here — suppress them.
-_isc_scan_stampless_phase() { :; return 0; }
+_isc_scan_stampless_phase() {
+	:
+	return 0
+}
 export -f _isc_scan_stampless_phase
 
-_isc_scan_closed_pr_orphans() { printf '0'; return 0; }
+_isc_scan_closed_pr_orphans() {
+	printf '0'
+	return 0
+}
 export -f _isc_scan_closed_pr_orphans
 
 # Override CLAIM_STAMP_DIR to the test sandbox.
@@ -434,7 +457,7 @@ write_stamp "owner-repo-111.json" "99999" "$EXISTING_WORKTREE" "111" "owner/repo
 
 REPORT_OUTPUT=$(_isc_cmd_scan_stale --no-auto-release 2>/dev/null || true)
 
-if [[ -f "${STAMP_DIR}/owner-repo-111.json" ]] && \
+if [[ -f "${STAMP_DIR}/owner-repo-111.json" ]] &&
 	[[ "$REPORT_OUTPUT" != *"#111 in owner/repo"* ]]; then
 	pass "report-only scan preserves and ignores an existing worktree"
 else
@@ -481,7 +504,10 @@ rm -f "${STAMP_DIR}/owner-repo-119.json"
 # =============================================================================
 # Test 15 — stamps bind to the durable runtime owner, not the helper shell
 # =============================================================================
-_resolve_worktree_owner_pid() { printf '4242'; return 0; }
+_resolve_worktree_owner_pid() {
+	printf '4242'
+	return 0
+}
 _compute_argv_hash() {
 	local pid="$1"
 	printf 'hash-%s' "$pid"
@@ -490,7 +516,7 @@ _compute_argv_hash() {
 CLAIM_STAMP_DIR="$STAMP_DIR"
 _isc_write_stamp "118" "owner/repo" "/nonexistent/path/118" "owner"
 DURABLE_STAMP="${STAMP_DIR}/owner-repo-118.json"
-if [[ "$(jq -r '.pid' "$DURABLE_STAMP")" == "4242" ]] && \
+if [[ "$(jq -r '.pid' "$DURABLE_STAMP")" == "4242" ]] &&
 	[[ "$(jq -r '.owner_argv_hash' "$DURABLE_STAMP")" == "hash-4242" ]]; then
 	pass "claim stamp records the durable runtime owner"
 else
@@ -531,8 +557,8 @@ rm -f "${STAMP_DIR}/outside-repos-121.json"
 write_stamp "a-repo-122.json" "99999" "/nonexistent/path/122" "122" "a/repo"
 write_stamp "b-repo-123.json" "99999" "/nonexistent/path/123" "123" "b/repo"
 AIDEVOPS_DEAD_STAMP_REAP_LIMIT=1 _isc_cmd_reap_dead_stamps >/dev/null 2>/dev/null || true
-if [[ ! -f "${STAMP_DIR}/a-repo-122.json" ]] && \
-	[[ -f "${STAMP_DIR}/b-repo-123.json" ]] && \
+if [[ ! -f "${STAMP_DIR}/a-repo-122.json" ]] &&
+	[[ -f "${STAMP_DIR}/b-repo-123.json" ]] &&
 	[[ "$(wc -l <"$RELEASE_LOG" | tr -d ' ')" -eq 1 ]]; then
 	pass "direct pulse reaper enforces its per-cycle stamp cap"
 else
@@ -547,14 +573,49 @@ rm -f "${STAMP_DIR}/a-repo-122.json" "${STAMP_DIR}/b-repo-123.json"
 write_stamp "invalid-issue.json" "99999" "/nonexistent/path/124" "0" "owner/repo"
 write_stamp "invalid-slug.json" "99999" "/nonexistent/path/125" "125" "owner/repo/extra"
 _isc_cmd_reap_dead_stamps >/dev/null 2>/dev/null || true
-if [[ -f "${STAMP_DIR}/invalid-issue.json" ]] && \
-	[[ -f "${STAMP_DIR}/invalid-slug.json" ]] && \
+if [[ -f "${STAMP_DIR}/invalid-issue.json" ]] &&
+	[[ -f "${STAMP_DIR}/invalid-slug.json" ]] &&
 	[[ ! -s "$RELEASE_LOG" ]]; then
 	pass "direct pulse reaper preserves stamps with invalid target metadata"
 else
 	fail "direct pulse reaper preserves stamps with invalid target metadata"
 fi
 rm -f "${STAMP_DIR}/invalid-issue.json" "${STAMP_DIR}/invalid-slug.json"
+
+# =============================================================================
+# Tests 20-21 — a surviving worktree blocks only when it contains progress
+# =============================================================================
+CLEAN_WORKTREE="${TMP}/clean-git-worktree"
+mkdir -p "$CLEAN_WORKTREE"
+git -C "$CLEAN_WORKTREE" init -q
+git -C "$CLEAN_WORKTREE" config user.name "Aidevops Test"
+git -C "$CLEAN_WORKTREE" config user.email "test@example.invalid"
+printf 'baseline\n' >"${CLEAN_WORKTREE}/baseline.txt"
+git -C "$CLEAN_WORKTREE" add baseline.txt
+git -C "$CLEAN_WORKTREE" commit -qm "baseline"
+git -C "$CLEAN_WORKTREE" branch -M main
+git -C "$CLEAN_WORKTREE" update-ref refs/remotes/origin/main HEAD
+git -C "$CLEAN_WORKTREE" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+
+: >"$RELEASE_LOG"
+write_stamp "outside-repos-126.json" "99999" "$CLEAN_WORKTREE" "126" "outside/repo"
+_isc_cmd_reap_dead_stamps >/dev/null 2>/dev/null || true
+if [[ ! -f "${STAMP_DIR}/outside-repos-126.json" ]] && [[ "$(wc -l <"$RELEASE_LOG" | tr -d ' ')" -eq 1 ]]; then
+	pass "direct pulse reaper releases dead claim with unchanged worktree"
+else
+	fail "direct pulse reaper releases dead claim with unchanged worktree"
+fi
+
+: >"$RELEASE_LOG"
+printf 'recoverable progress\n' >"${CLEAN_WORKTREE}/progress.txt"
+write_stamp "outside-repos-127.json" "99999" "$CLEAN_WORKTREE" "127" "outside/repo"
+_isc_cmd_reap_dead_stamps >/dev/null 2>/dev/null || true
+if [[ -f "${STAMP_DIR}/outside-repos-127.json" ]] && [[ ! -s "$RELEASE_LOG" ]]; then
+	pass "direct pulse reaper preserves dead claim with dirty worktree progress"
+else
+	fail "direct pulse reaper preserves dead claim with dirty worktree progress"
+fi
+rm -f "${STAMP_DIR}/outside-repos-127.json"
 
 # =============================================================================
 # Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- scope Pulse lifecycle discovery to the current user on shared hosts
+- avoid false systemd watchdog revivals while the Pulse process is alive
+- release dead interactive claims whose preserved worktrees contain no progress
+
+### Changed
+
+- track OpenCode compatibility through 1.18.29
+
 ## [3.32.335] - 2026-09-07
 
 ### Changed


### PR DESCRIPTION
## Summary

Scope Pulse process discovery to the current user's deployed/runtime-bundle paths, prevent false systemd watchdog revivals, release dead interactive claims when their worktrees contain no progress, and advance tested OpenCode compatibility to 1.18.29.

## Files Changed

.agents/plugins/opencode-aidevops/package-lock.json, .agents/plugins/opencode-aidevops/package.json, .agents/scripts/interactive-session-helper-scan.sh, .agents/scripts/pulse-lifecycle-helper.sh, .agents/scripts/pulse-watchdog-tick.sh, .agents/scripts/tests/test-pulse-lifecycle-helper.sh, .agents/scripts/tests/test-pulse-watchdog-tick.sh, .agents/scripts/tests/test-scan-stale-auto-release.sh, CHANGELOG.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: hermetic Pulse process, systemd watchdog, and dead-claim worktree scenarios passed; plugin-health, ShellCheck, changed-file lint, and diff checks passed; independent exact-worktree review found no P0-P2 defects.

Resolves #31493


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.335 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 27m and 228,888 tokens on this with the user in an interactive session.