### PR TITLE
GH#31536: harden runtime and dispatch recovery reliability

### DIFF
--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -103,6 +103,7 @@ duplicate_work_avoided: ${DUPLICATE_WORK_AVOIDED:-0}
 started_at: "${started_at}"
 updated_at: "${now}"
 pr_number: "${pr_number}"
+repository: "${REPOSITORY:-}"
 max_task_iterations: ${MAX_TASK_ITERATIONS:-$DEFAULT_MAX_TASK_ITERATIONS}
 max_preflight_iterations: ${MAX_PREFLIGHT_ITERATIONS:-$DEFAULT_MAX_PREFLIGHT_ITERATIONS}
 max_pr_iterations: ${MAX_PR_ITERATIONS:-$DEFAULT_MAX_PR_ITERATIONS}
@@ -171,6 +172,7 @@ load_state() {
 	STARTED_AT="unknown"
 	UPDATED_AT=""
 	PR_NUMBER=""
+	REPOSITORY=""
 	MAX_TASK_ITERATIONS="$DEFAULT_MAX_TASK_ITERATIONS"
 	MAX_PREFLIGHT_ITERATIONS="$DEFAULT_MAX_PREFLIGHT_ITERATIONS"
 	MAX_PR_ITERATIONS="$DEFAULT_MAX_PR_ITERATIONS"
@@ -199,7 +201,7 @@ load_state() {
 			MANUAL_RESUME_COUNT | REUSED_SUBAGENT_UNITS | DUPLICATE_WORK_AVOIDED | \
 			MAX_TASK_ITERATIONS | MAX_PREFLIGHT_ITERATIONS | \
 			MAX_PR_ITERATIONS | SKIP_PREFLIGHT | SKIP_POSTFLIGHT | SKIP_RUNTIME_TESTING | \
-			NO_AUTO_PR | NO_AUTO_DEPLOY | RELEASE_INTENT | RELEASE_TYPE | DEPLOYMENT_SCOPE | RELEASE_EXPECTED_SOURCES | RELEASE_STATUS | HEADLESS | PR_NUMBER)
+			NO_AUTO_PR | NO_AUTO_DEPLOY | RELEASE_INTENT | RELEASE_TYPE | DEPLOYMENT_SCOPE | RELEASE_EXPECTED_SOURCES | RELEASE_STATUS | HEADLESS | PR_NUMBER | REPOSITORY)
 			printf -v "$_key" '%s' "$_val"
 			;;
 		esac
@@ -1842,7 +1844,13 @@ cmd_status() {
 		fi
 	fi
 	if [[ "${PR_NUMBER:-}" =~ ^[0-9]+$ ]]; then
-		status_repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}" 2>/dev/null || true)
+		if [[ -n "${AIDEVOPS_FULL_LOOP_REPO:-}" ]]; then
+			status_repo=$(_full_loop_resolve_repo "$AIDEVOPS_FULL_LOOP_REPO" 2>/dev/null || true)
+		elif [[ "${REPOSITORY:-}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+			status_repo="$REPOSITORY"
+		else
+			status_repo=$(_full_loop_resolve_repo "" 2>/dev/null || true)
+		fi
 		if [[ -n "$status_repo" ]] && declare -F _full_loop_cleanup_receipt_path >/dev/null 2>&1; then
 			cleanup_receipt=$(_full_loop_cleanup_receipt_path "$status_repo" "$PR_NUMBER" 2>/dev/null || true)
 		fi
@@ -2053,6 +2061,11 @@ cmd_complete() {
 		fi
 	else
 		print_error "Cannot persist durable deferred-cleanup handoff without worktree and branch evidence"
+		return 1
+	fi
+	REPOSITORY="$repo"
+	if ! save_state "${CURRENT_PHASE:-complete}" "$SAVED_PROMPT" "$PR_NUMBER" "$STARTED_AT"; then
+		print_error "Cannot persist repository identity for deferred cleanup status"
 		return 1
 	fi
 	print_warning "LIFECYCLE_STATE=CLEANUP_DEFERRED worktree=${current_root}"

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -2040,26 +2040,7 @@ cmd_complete() {
 	if declare -F _resolve_worktree_owner_pid >/dev/null 2>&1; then
 		owner_pid=$(_resolve_worktree_owner_pid "" 2>/dev/null || printf '%s' "${PPID:-}")
 	fi
-	if [[ -n "$current_root" && -n "$current_branch" ]] && declare -F full_loop_write_cleanup_deferred >/dev/null 2>&1; then
-		receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$PR_NUMBER") || return 1
-		if [[ -f "$receipt_path" ]]; then
-			full_loop_finalize_cleanup_receipt "$repo" "$PR_NUMBER" \
-				"${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" "$current_root" "$current_branch" \
-				"$owner_pid" "$owner_session" || {
-				print_error "Cannot finalize durable deferred-cleanup handoff"
-				return 1
-			}
-		elif ! full_loop_write_cleanup_deferred "$repo" "$PR_NUMBER" "$current_root" "$current_branch" \
-			"$owner_pid" "$owner_session" "${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" >/dev/null; then
-			# A merge process may have created the receipt after the existence check.
-			full_loop_finalize_cleanup_receipt "$repo" "$PR_NUMBER" \
-				"${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" "$current_root" "$current_branch" \
-				"$owner_pid" "$owner_session" || {
-				print_error "Cannot persist durable deferred-cleanup handoff"
-				return 1
-			}
-		fi
-	else
+	if [[ -z "$current_root" || -z "$current_branch" ]] || ! declare -F full_loop_write_cleanup_deferred >/dev/null 2>&1; then
 		print_error "Cannot persist durable deferred-cleanup handoff without worktree and branch evidence"
 		return 1
 	fi
@@ -2067,6 +2048,24 @@ cmd_complete() {
 	if ! save_state "${CURRENT_PHASE:-complete}" "$SAVED_PROMPT" "$PR_NUMBER" "$STARTED_AT"; then
 		print_error "Cannot persist repository identity for deferred cleanup status"
 		return 1
+	fi
+	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$PR_NUMBER") || return 1
+	if [[ -f "$receipt_path" ]]; then
+		full_loop_finalize_cleanup_receipt "$repo" "$PR_NUMBER" \
+			"${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" "$current_root" "$current_branch" \
+			"$owner_pid" "$owner_session" || {
+			print_error "Cannot finalize durable deferred-cleanup handoff"
+			return 1
+		}
+	elif ! full_loop_write_cleanup_deferred "$repo" "$PR_NUMBER" "$current_root" "$current_branch" \
+		"$owner_pid" "$owner_session" "${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" >/dev/null; then
+		# A merge process may have created the receipt after the existence check.
+		full_loop_finalize_cleanup_receipt "$repo" "$PR_NUMBER" \
+			"${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" "$current_root" "$current_branch" \
+			"$owner_pid" "$owner_session" || {
+			print_error "Cannot persist durable deferred-cleanup handoff"
+			return 1
+		}
 	fi
 	print_warning "LIFECYCLE_STATE=CLEANUP_DEFERRED worktree=${current_root}"
 	print_info "Executor complete; guarded cleanup supervisor owns the remaining CLEANED transition"

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -2076,11 +2076,12 @@ cmd_complete() {
 _full_loop_resolve_repo() {
 	local repo_arg="${1:-}"
 	if [[ -n "$repo_arg" ]]; then
+		[[ "$repo_arg" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
 		printf '%s\n' "$repo_arg"
 		return 0
 	fi
 	repo_arg=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)
-	[[ -n "$repo_arg" ]] || return 1
+	[[ "$repo_arg" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
 	printf '%s\n' "$repo_arg"
 	return 0
 }

--- a/.agents/scripts/gh-transport-governor.py
+++ b/.agents/scripts/gh-transport-governor.py
@@ -246,10 +246,21 @@ def run(metadata: Path, executable: str, args: list[str]) -> int:
         retry = f" retry_at={exc.retry_at:.3f}" if exc.retry_at else ""
         print(f"[gh-transport] deferred: {exc}{retry}", file=sys.stderr)
         return 75
-    except (OSError, ValueError, sqlite3.Error):
+    except (OSError, ValueError, sqlite3.Error) as exc:
         # Metadata failure after execution is not permission to retry a
         # successful mutation. Keep the observed native status when available.
-        print("[gh-transport] safe REST transport state unavailable", file=sys.stderr)
+        failure = {"attempted": False, "deferred_by": "local_state", "reason": type(exc).__name__}
+        sqlite_name = getattr(exc, "sqlite_errorname", "")
+        if sqlite_name:
+            failure["sqlite_error"] = sqlite_name
+        if rc is None:
+            try:
+                metadata.write_text(json.dumps(failure), encoding="utf-8")
+            except OSError:
+                pass
+        detail = f"/{sqlite_name}" if sqlite_name else ""
+        print(f"[gh-transport] safe REST transport state unavailable: {type(exc).__name__}{detail}",
+              file=sys.stderr)
         return _exit_status(rc) if rc is not None else 75
     finally:
         _finish_budget(budget, reservation, resource, headers, started)

--- a/.agents/scripts/gh-transport-governor.py
+++ b/.agents/scripts/gh-transport-governor.py
@@ -249,10 +249,9 @@ def run(metadata: Path, executable: str, args: list[str]) -> int:
     except (OSError, ValueError, sqlite3.Error) as exc:
         # Metadata failure after execution is not permission to retry a
         # successful mutation. Keep the observed native status when available.
-        failure = {"attempted": False, "deferred_by": "local_state", "reason": type(exc).__name__}
-        sqlite_name = getattr(exc, "sqlite_errorname", "")
-        if sqlite_name:
-            failure["sqlite_error"] = sqlite_name
+        sqlite_name = getattr(exc, "sqlite_errorname", "") or None
+        failure = {"attempted": False, "deferred_by": "local_state", "reason": type(exc).__name__,
+                   "sqlite_error": sqlite_name}
         if rc is None:
             try:
                 metadata.write_text(json.dumps(failure), encoding="utf-8")

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -61,10 +61,10 @@ def credential_identity(executable: str, host: str) -> tuple[str, bool, dict[str
             token = "anonymous"
     authenticated = bool(token and token != "anonymous")
     environment = os.environ.copy()
-    if authenticated:
-        # Pin only the native child, not a long-lived wrapper or worker parent.
-        # The hashed identity and the request must use exactly the same token.
-        environment["GH_TOKEN"] = token
+    # Pin only the native child, not a long-lived wrapper or worker parent.
+    # Callers reject anonymous identity before execution; authenticated requests
+    # hash and execute with exactly the same token.
+    environment["GH_TOKEN"] = token
     return hashlib.sha256(f"{host}\0{token}".encode()).hexdigest(), authenticated, environment
 
 

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -144,8 +144,6 @@ class Budget:
         version = self.db.execute("PRAGMA user_version").fetchone()[0]
         if version == self.SCHEMA_VERSION:
             return
-        if version > self.SCHEMA_VERSION:
-            raise ValueError("transport state schema is newer than this runtime")
 
         # Schema migration is the exceptional write path. Give an existing
         # initializer a bounded opportunity to finish, then re-check under the

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -80,6 +80,36 @@ def process_birth(pid: int) -> str:
 
 
 class Budget:
+    SCHEMA_VERSION = 1
+    SCHEMA_STATEMENTS = (
+        """CREATE TABLE IF NOT EXISTS quota (
+            scope TEXT NOT NULL, resource TEXT NOT NULL,
+            remaining INTEGER NOT NULL, reset REAL NOT NULL,
+            observed REAL NOT NULL, blocked_until REAL NOT NULL DEFAULT 0,
+            quota_limit INTEGER NOT NULL,
+            PRIMARY KEY(scope, resource))""",
+        """CREATE TABLE IF NOT EXISTS reservation (
+            id TEXT PRIMARY KEY, scope TEXT NOT NULL, resource TEXT NOT NULL,
+            started REAL NOT NULL, pid INTEGER NOT NULL,
+            birth TEXT NOT NULL, credential TEXT NOT NULL,
+            uncertain INTEGER NOT NULL DEFAULT 0)""",
+        "CREATE TABLE IF NOT EXISTS binding (credential TEXT PRIMARY KEY, scope TEXT NOT NULL)",
+        "CREATE TABLE IF NOT EXISTS alias (scope TEXT PRIMARY KEY, target TEXT NOT NULL)",
+        """CREATE TABLE IF NOT EXISTS revalidation (
+            scope TEXT NOT NULL, resource TEXT NOT NULL, started REAL NOT NULL,
+            reservation_id TEXT NOT NULL,
+            PRIMARY KEY(scope, resource))""",
+        """CREATE TABLE IF NOT EXISTS admission_history (
+            scope TEXT NOT NULL, resource TEXT NOT NULL, started REAL NOT NULL)""",
+        "CREATE INDEX IF NOT EXISTS admission_history_scope ON admission_history(scope, resource, started)",
+        """CREATE TABLE IF NOT EXISTS pacing (
+            scope TEXT NOT NULL, resource TEXT NOT NULL, reset REAL NOT NULL,
+            retry_at REAL NOT NULL, remaining INTEGER NOT NULL,
+            PRIMARY KEY(scope, resource))""",
+        """CREATE TABLE IF NOT EXISTS reconciliation (
+            source TEXT PRIMARY KEY, owner TEXT NOT NULL, reconciled REAL NOT NULL)""",
+    )
+
     def __init__(self, directory: Path, scope: str, credential: str | None = None,
                  *, attributed: bool = False):
         private_directory(directory)
@@ -99,39 +129,44 @@ class Budget:
         self.credential = credential or scope
         self.attributed = False
         self.birth = process_birth(os.getpid())
-        self.db.executescript("""
-            CREATE TABLE IF NOT EXISTS quota (
-                scope TEXT NOT NULL, resource TEXT NOT NULL,
-                remaining INTEGER NOT NULL, reset REAL NOT NULL,
-                observed REAL NOT NULL, blocked_until REAL NOT NULL DEFAULT 0,
-                quota_limit INTEGER NOT NULL,
-                PRIMARY KEY(scope, resource));
-            CREATE TABLE IF NOT EXISTS reservation (
-                id TEXT PRIMARY KEY, scope TEXT NOT NULL, resource TEXT NOT NULL,
-                started REAL NOT NULL, pid INTEGER NOT NULL,
-                birth TEXT NOT NULL, credential TEXT NOT NULL,
-                uncertain INTEGER NOT NULL DEFAULT 0);
-            CREATE TABLE IF NOT EXISTS binding (credential TEXT PRIMARY KEY, scope TEXT NOT NULL);
-            CREATE TABLE IF NOT EXISTS alias (scope TEXT PRIMARY KEY, target TEXT NOT NULL);
-            CREATE TABLE IF NOT EXISTS revalidation (
-                scope TEXT NOT NULL, resource TEXT NOT NULL, started REAL NOT NULL,
-                reservation_id TEXT NOT NULL,
-                PRIMARY KEY(scope, resource));
-            CREATE TABLE IF NOT EXISTS admission_history (
-                scope TEXT NOT NULL, resource TEXT NOT NULL, started REAL NOT NULL);
-            CREATE INDEX IF NOT EXISTS admission_history_scope ON admission_history(scope, resource, started);
-            CREATE TABLE IF NOT EXISTS pacing (
-                scope TEXT NOT NULL, resource TEXT NOT NULL, reset REAL NOT NULL,
-                retry_at REAL NOT NULL, remaining INTEGER NOT NULL,
-                PRIMARY KEY(scope, resource));
-            CREATE TABLE IF NOT EXISTS reconciliation (
-                source TEXT PRIMARY KEY, owner TEXT NOT NULL, reconciled REAL NOT NULL);
-        """)
-        with self.transaction():
-            self._bind_scope()
+        try:
+            self._ensure_schema()
+            with self.transaction():
+                self._bind_scope()
+        except BaseException:
+            self.db.close()
+            raise
         # A configured owner is authoritative only after its requested scope is
         # canonical. A legacy owner->unresolved alias still needs reconciliation.
         self.attributed = attributed and self.scope == requested_scope
+
+    def _ensure_schema(self) -> None:
+        version = self.db.execute("PRAGMA user_version").fetchone()[0]
+        if version == self.SCHEMA_VERSION:
+            return
+        if version > self.SCHEMA_VERSION:
+            raise ValueError("transport state schema is newer than this runtime")
+
+        # Schema migration is the exceptional write path. Give an existing
+        # initializer a bounded opportunity to finish, then re-check under the
+        # same write lock so concurrent first opens do not replay every DDL.
+        self.db.execute("PRAGMA busy_timeout=10000")
+        try:
+            self.db.execute("BEGIN IMMEDIATE")
+            version = self.db.execute("PRAGMA user_version").fetchone()[0]
+            if version < self.SCHEMA_VERSION:
+                for statement in self.SCHEMA_STATEMENTS:
+                    self.db.execute(statement)
+                self.db.execute(f"PRAGMA user_version={self.SCHEMA_VERSION}")
+            elif version > self.SCHEMA_VERSION:
+                raise ValueError("transport state schema is newer than this runtime")
+            self.db.execute("COMMIT")
+        except BaseException:
+            if self.db.in_transaction:
+                self.db.execute("ROLLBACK")
+            raise
+        finally:
+            self.db.execute("PRAGMA busy_timeout=2000")
 
     def _root(self, scope: str) -> str:
         for _ in range(256):

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -22,7 +22,7 @@ from gh_transport_capacity import capacity_wait
 from gh_transport_identity import quota_owner
 from gh_transport_reconcile import reconcile_scope as _reconcile_scope
 from gh_transport_recovery import admission_status, mark_dead_reservations, probe_recovers, reserve_probe_allowed
-from gh_transport_schema import ensure_schema
+from gh_transport_schema import SCHEMA_VERSION, ensure_schema
 
 
 class Deferred(Exception):
@@ -170,6 +170,8 @@ class Budget:
     def transaction(self):
         self.db.execute("BEGIN IMMEDIATE")
         try:
+            if self.db.execute("PRAGMA user_version").fetchone()[0] != SCHEMA_VERSION:
+                raise ValueError("transport state schema changed after initialization")
             self.scope = self._root(self.scope)
             yield
             self.db.execute("COMMIT")

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -162,8 +162,7 @@ class Budget:
                 raise ValueError("transport state schema is newer than this runtime")
             self.db.execute("COMMIT")
         except BaseException:
-            if self.db.in_transaction:
-                self.db.execute("ROLLBACK")
+            self.db.rollback()
             raise
         finally:
             self.db.execute("PRAGMA busy_timeout=2000")

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -22,6 +22,7 @@ from gh_transport_capacity import capacity_wait
 from gh_transport_identity import quota_owner
 from gh_transport_reconcile import reconcile_scope as _reconcile_scope
 from gh_transport_recovery import admission_status, mark_dead_reservations, probe_recovers, reserve_probe_allowed
+from gh_transport_schema import ensure_schema
 
 
 class Deferred(Exception):
@@ -80,36 +81,6 @@ def process_birth(pid: int) -> str:
 
 
 class Budget:
-    SCHEMA_VERSION = 1
-    SCHEMA_STATEMENTS = (
-        """CREATE TABLE IF NOT EXISTS quota (
-            scope TEXT NOT NULL, resource TEXT NOT NULL,
-            remaining INTEGER NOT NULL, reset REAL NOT NULL,
-            observed REAL NOT NULL, blocked_until REAL NOT NULL DEFAULT 0,
-            quota_limit INTEGER NOT NULL,
-            PRIMARY KEY(scope, resource))""",
-        """CREATE TABLE IF NOT EXISTS reservation (
-            id TEXT PRIMARY KEY, scope TEXT NOT NULL, resource TEXT NOT NULL,
-            started REAL NOT NULL, pid INTEGER NOT NULL,
-            birth TEXT NOT NULL, credential TEXT NOT NULL,
-            uncertain INTEGER NOT NULL DEFAULT 0)""",
-        "CREATE TABLE IF NOT EXISTS binding (credential TEXT PRIMARY KEY, scope TEXT NOT NULL)",
-        "CREATE TABLE IF NOT EXISTS alias (scope TEXT PRIMARY KEY, target TEXT NOT NULL)",
-        """CREATE TABLE IF NOT EXISTS revalidation (
-            scope TEXT NOT NULL, resource TEXT NOT NULL, started REAL NOT NULL,
-            reservation_id TEXT NOT NULL,
-            PRIMARY KEY(scope, resource))""",
-        """CREATE TABLE IF NOT EXISTS admission_history (
-            scope TEXT NOT NULL, resource TEXT NOT NULL, started REAL NOT NULL)""",
-        "CREATE INDEX IF NOT EXISTS admission_history_scope ON admission_history(scope, resource, started)",
-        """CREATE TABLE IF NOT EXISTS pacing (
-            scope TEXT NOT NULL, resource TEXT NOT NULL, reset REAL NOT NULL,
-            retry_at REAL NOT NULL, remaining INTEGER NOT NULL,
-            PRIMARY KEY(scope, resource))""",
-        """CREATE TABLE IF NOT EXISTS reconciliation (
-            source TEXT PRIMARY KEY, owner TEXT NOT NULL, reconciled REAL NOT NULL)""",
-    )
-
     def __init__(self, directory: Path, scope: str, credential: str | None = None,
                  *, attributed: bool = False):
         private_directory(directory)
@@ -141,29 +112,7 @@ class Budget:
         self.attributed = attributed and self.scope == requested_scope
 
     def _ensure_schema(self) -> None:
-        version = self.db.execute("PRAGMA user_version").fetchone()[0]
-        if version == self.SCHEMA_VERSION:
-            return
-
-        # Schema migration is the exceptional write path. Give an existing
-        # initializer a bounded opportunity to finish, then re-check under the
-        # same write lock so concurrent first opens do not replay every DDL.
-        self.db.execute("PRAGMA busy_timeout=10000")
-        try:
-            self.db.execute("BEGIN IMMEDIATE")
-            version = self.db.execute("PRAGMA user_version").fetchone()[0]
-            if version < self.SCHEMA_VERSION:
-                for statement in self.SCHEMA_STATEMENTS:
-                    self.db.execute(statement)
-                self.db.execute(f"PRAGMA user_version={self.SCHEMA_VERSION}")
-            elif version > self.SCHEMA_VERSION:
-                raise ValueError("transport state schema is newer than this runtime")
-            self.db.execute("COMMIT")
-        except BaseException:
-            self.db.rollback()
-            raise
-        finally:
-            self.db.execute("PRAGMA busy_timeout=2000")
+        ensure_schema(self.db)
 
     def _root(self, scope: str) -> str:
         for _ in range(256):

--- a/.agents/scripts/gh_transport_schema.py
+++ b/.agents/scripts/gh_transport_schema.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Atomic schema initialization for local GitHub transport state."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+SCHEMA_VERSION = 1
+SCHEMA_STATEMENTS = (
+    """CREATE TABLE IF NOT EXISTS quota (
+        scope TEXT NOT NULL, resource TEXT NOT NULL,
+        remaining INTEGER NOT NULL, reset REAL NOT NULL,
+        observed REAL NOT NULL, blocked_until REAL NOT NULL DEFAULT 0,
+        quota_limit INTEGER NOT NULL,
+        PRIMARY KEY(scope, resource))""",
+    """CREATE TABLE IF NOT EXISTS reservation (
+        id TEXT PRIMARY KEY, scope TEXT NOT NULL, resource TEXT NOT NULL,
+        started REAL NOT NULL, pid INTEGER NOT NULL,
+        birth TEXT NOT NULL, credential TEXT NOT NULL,
+        uncertain INTEGER NOT NULL DEFAULT 0)""",
+    "CREATE TABLE IF NOT EXISTS binding (credential TEXT PRIMARY KEY, scope TEXT NOT NULL)",
+    "CREATE TABLE IF NOT EXISTS alias (scope TEXT PRIMARY KEY, target TEXT NOT NULL)",
+    """CREATE TABLE IF NOT EXISTS revalidation (
+        scope TEXT NOT NULL, resource TEXT NOT NULL, started REAL NOT NULL,
+        reservation_id TEXT NOT NULL,
+        PRIMARY KEY(scope, resource))""",
+    """CREATE TABLE IF NOT EXISTS admission_history (
+        scope TEXT NOT NULL, resource TEXT NOT NULL, started REAL NOT NULL)""",
+    "CREATE INDEX IF NOT EXISTS admission_history_scope ON admission_history(scope, resource, started)",
+    """CREATE TABLE IF NOT EXISTS pacing (
+        scope TEXT NOT NULL, resource TEXT NOT NULL, reset REAL NOT NULL,
+        retry_at REAL NOT NULL, remaining INTEGER NOT NULL,
+        PRIMARY KEY(scope, resource))""",
+    """CREATE TABLE IF NOT EXISTS reconciliation (
+        source TEXT PRIMARY KEY, owner TEXT NOT NULL, reconciled REAL NOT NULL)""",
+)
+
+
+def ensure_schema(db: sqlite3.Connection) -> None:
+    """Initialize or migrate schema once under a bounded write lock."""
+    version = db.execute("PRAGMA user_version").fetchone()[0]
+    if version == SCHEMA_VERSION:
+        return
+
+    db.execute("PRAGMA busy_timeout=10000")
+    try:
+        db.execute("BEGIN IMMEDIATE")
+        version = db.execute("PRAGMA user_version").fetchone()[0]
+        if version < SCHEMA_VERSION:
+            for statement in SCHEMA_STATEMENTS:
+                db.execute(statement)
+            db.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+        elif version > SCHEMA_VERSION:
+            raise ValueError("transport state schema is newer than this runtime")
+        db.execute("COMMIT")
+    except BaseException:
+        db.rollback()
+        raise
+    finally:
+        db.execute("PRAGMA busy_timeout=2000")

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -392,8 +392,10 @@ _post_launch_recovery_claim_released() {
 	local repo_slug="$2"
 	local self_login="$3"
 	local failure_reason="$4"
+	local claim_id="${5:-}"
+	local claim_nonce="${6:-}"
 
-	local body
+	local body claim_binding=""
 	local aidevops_version="$AIDEVOPS_UNKNOWN_VERSION" opencode_version="$AIDEVOPS_UNKNOWN_VERSION"
 	if declare -F aidevops_find_version >/dev/null 2>&1; then
 		aidevops_version=$(aidevops_find_version 2>/dev/null || printf '%s' "$AIDEVOPS_UNKNOWN_VERSION")
@@ -402,8 +404,11 @@ _post_launch_recovery_claim_released() {
 		opencode_version=$(_detect_opencode_version 2>/dev/null || printf '%s' "")
 		opencode_version="${opencode_version:-$AIDEVOPS_UNKNOWN_VERSION}"
 	fi
+	if [[ "$claim_id" =~ ^[1-9][0-9]*$ && "$claim_nonce" =~ ^[A-Za-z0-9_-]+$ ]]; then
+		claim_binding=" claim_id=${claim_id} nonce=${claim_nonce}"
+	fi
 	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
-CLAIM_RELEASED reason=launch_recovery:${failure_reason} runner=${self_login} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) aidevops_version=${aidevops_version} opencode_version=${opencode_version}"
+CLAIM_RELEASED reason=launch_recovery:${failure_reason} runner=${self_login}${claim_binding} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) aidevops_version=${aidevops_version} opencode_version=${opencode_version}"
 
 	# t2814: append worker-log tail when available so the failure is
 	# diagnosable from the audit trail alone (no log-file forensics needed).
@@ -552,12 +557,13 @@ _verify_launch_recovery_state() {
 # latest durable dispatch marker must agree on every generated identity field,
 # and the registered PID/start-token pair must no longer identify a live
 # process. Queued issues retain their established recovery path.
-# Args: issue number, repo slug, ledger entry JSON
+# Args: issue number, repo slug, ledger entry JSON, current login
 #######################################
 _launch_recovery_owns_registered_attempt() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local ledger_entry="$3"
+	local self_login="$4"
 	local fields="" session_key="" attempt_id="" lease_token="" runner_device=""
 	local worker_pid="" owner_process_start="" ledger_status="" lease_phase=""
 
@@ -575,12 +581,26 @@ _launch_recovery_owns_registered_attempt() {
 
 	local comments_endpoint="" latest_dispatch=""
 	comments_endpoint=$(printf 'repos/%s/issues/%s/comments' "$repo_slug" "$issue_number")
-	latest_dispatch=$(gh api "$comments_endpoint" --paginate --jq \
-		'[.[] | select(.body | contains("<!-- aidevops:dispatch "))] | last | .body // ""' 2>/dev/null) || return 1
+	latest_dispatch=$(gh api "$comments_endpoint" --paginate --slurp --jq \
+		'[.[][] | select(.body | contains("<!-- aidevops:dispatch "))] | last | .body // ""' 2>/dev/null) || return 1
 	[[ "$latest_dispatch" == *"lease_token=${lease_token} "* ]] || return 1
 	[[ "$latest_dispatch" == *"device=${runner_device} "* ]] || return 1
 	[[ "$latest_dispatch" == *"session=${session_key} "* ]] || return 1
 	[[ "$latest_dispatch" == *"attempt_id=${attempt_id} "* ]] || return 1
+	local claim_id="" claim_json="" claim_nonce=""
+	claim_id="${latest_dispatch#* claim_id=}"
+	claim_id="${claim_id%% *}"
+	[[ "$claim_id" =~ ^[1-9][0-9]*$ ]] || return 1
+	claim_json=$(gh api "repos/${repo_slug}/issues/comments/${claim_id}" 2>/dev/null) || return 1
+	claim_nonce=$(printf '%s' "$claim_json" | jq -r --arg runner "$self_login" '
+		select(.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")
+		| select((.user.login // "") == $runner)
+		| (.body // "")
+		| capture("(^|[[:space:]])DISPATCH_CLAIM[[:space:]]+nonce=(?<nonce>[A-Za-z0-9_-]+)").nonce
+	' 2>/dev/null) || return 1
+	[[ "$claim_nonce" =~ ^[A-Za-z0-9_-]+$ ]] || return 1
+	_LAUNCH_RECOVERY_CLAIM_ID="$claim_id"
+	_LAUNCH_RECOVERY_CLAIM_NONCE="$claim_nonce"
 	return 0
 }
 
@@ -589,6 +609,8 @@ recover_failed_launch_state() {
 	local repo_slug="$2"
 	local failure_reason="${3:-launch_validation_failed}"
 	local crash_type="${4:-}"
+	_LAUNCH_RECOVERY_CLAIM_ID=""
+	_LAUNCH_RECOVERY_CLAIM_NONCE=""
 
 	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
 		return 0
@@ -643,7 +665,7 @@ recover_failed_launch_state() {
 		return 0
 	fi
 	if [[ "$has_queued" != "true" ]]; then
-		if [[ "$has_in_progress" != "true" ]] || ! _launch_recovery_owns_registered_attempt "$issue_number" "$repo_slug" "$ledger_entry"; then
+		if [[ "$has_in_progress" != "true" ]] || ! _launch_recovery_owns_registered_attempt "$issue_number" "$repo_slug" "$ledger_entry" "$self_login"; then
 			echo "[pulse-wrapper] Launch recovery skipped for #${issue_number} (${repo_slug}): in-progress ownership does not match the failed registered attempt" >>"$LOGFILE"
 			return 0
 		fi
@@ -674,22 +696,25 @@ recover_failed_launch_state() {
 		"$ledger_helper" "${fail_args[@]}" >/dev/null 2>&1 || true
 	fi
 
-	_record_released_launch_failure "$issue_number" "$repo_slug" "$self_login" "$failure_reason" "$crash_type"
+	_record_released_launch_failure "$issue_number" "$repo_slug" "$self_login" "$failure_reason" "$crash_type" \
+		"$_LAUNCH_RECOVERY_CLAIM_ID" "$_LAUNCH_RECOVERY_CLAIM_NONCE"
 	return 0
 }
 
 # Record recovery side effects only after ownership release has been verified
 # and the exact ledger attempt has been marked failed.
-# Args: issue number, repo slug, self login, failure reason, crash type
+# Args: issue number, repo slug, self login, failure reason, crash type, claim ID, claim nonce
 _record_released_launch_failure() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local self_login="$3"
 	local failure_reason="$4"
 	local crash_type="$5"
+	local claim_id="${6:-}"
+	local claim_nonce="${7:-}"
 
 	# t2394: Invalidate stale cross-runner claims immediately (see helper below).
-	_post_launch_recovery_claim_released "$issue_number" "$repo_slug" "$self_login" "$failure_reason"
+	_post_launch_recovery_claim_released "$issue_number" "$repo_slug" "$self_login" "$failure_reason" "$claim_id" "$claim_nonce"
 	# t3197: Write a per-issue dispatch cooldown marker so other runners
 	# (and this one) skip redispatch for the configured cooldown window.
 	# Only fires for `no_worker_process` — the recurring no-spawn failure mode.

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -579,10 +579,17 @@ _launch_recovery_owns_registered_attempt() {
 		[[ -n "$current_start" && "$current_start" != "$owner_process_start" ]] || return 1
 	fi
 
-	local comments_endpoint="" latest_dispatch=""
+	local comments_endpoint="" latest_dispatch="" latest_dispatch_json=""
 	comments_endpoint=$(printf 'repos/%s/issues/%s/comments' "$repo_slug" "$issue_number")
-	latest_dispatch=$(gh api "$comments_endpoint" --paginate --slurp --jq \
-		'[.[][] | select(.body | contains("<!-- aidevops:dispatch "))] | last | .body // ""' 2>/dev/null) || return 1
+	latest_dispatch_json=$(gh api "$comments_endpoint" --paginate --slurp --jq \
+		'[.[][] | select(.body | contains("<!-- aidevops:dispatch "))] | last \
+		| {body:(.body // ""), author_association:(.author_association // ""), login:(.user.login // "")}' \
+		2>/dev/null) || return 1
+	latest_dispatch=$(printf '%s' "$latest_dispatch_json" | jq -r --arg runner "$self_login" '
+		select(.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")
+		| select(.login == $runner)
+		| .body
+	' 2>/dev/null) || return 1
 	[[ "$latest_dispatch" == *"lease_token=${lease_token} "* ]] || return 1
 	[[ "$latest_dispatch" == *"device=${runner_device} "* ]] || return 1
 	[[ "$latest_dispatch" == *"session=${session_key} "* ]] || return 1
@@ -592,8 +599,11 @@ _launch_recovery_owns_registered_attempt() {
 	claim_id="${claim_id%% *}"
 	[[ "$claim_id" =~ ^[1-9][0-9]*$ ]] || return 1
 	claim_json=$(gh api "repos/${repo_slug}/issues/comments/${claim_id}" 2>/dev/null) || return 1
-	claim_nonce=$(printf '%s' "$claim_json" | jq -r --arg runner "$self_login" '
-		select(.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")
+	claim_nonce=$(printf '%s' "$claim_json" | jq -r --arg runner "$self_login" --arg repo "$repo_slug" \
+		--argjson issue "$issue_number" --argjson claim_id "$claim_id" '
+		select(.id == $claim_id)
+		| select((.issue_url // "") | endswith("/repos/\($repo)/issues/\($issue)"))
+		| select(.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")
 		| select((.user.login // "") == $runner)
 		| (.body // "")
 		| capture("(^|[[:space:]])DISPATCH_CLAIM[[:space:]]+nonce=(?<nonce>[A-Za-z0-9_-]+)").nonce

--- a/.agents/scripts/pulse-runtime-recovery.sh
+++ b/.agents/scripts/pulse-runtime-recovery.sh
@@ -67,6 +67,34 @@ _pulse_runtime_recovery_last_attempt_epoch() {
 	return 0
 }
 
+_pulse_runtime_recovery_reconcile_converged() {
+	local canonical_sha="$1"
+	local deployed_sha="$2"
+	local state_file="${AIDEVOPS_PULSE_RUNTIME_RECOVERY_STATE_FILE:-${HOME}/.aidevops/cache/pulse-runtime-recovery.json}"
+	local status=""
+	local key="" value=""
+
+	[[ -f "$state_file" ]] || return 0
+	if command -v jq >/dev/null 2>&1; then
+		status=$(jq -er '
+			select(.schema == "aidevops-pulse-runtime-recovery/v1")
+			| select(.status == "attempting" or .status == "blocked" or .status == "deferred")
+			| .status
+		' "$state_file" 2>/dev/null || true)
+	fi
+	if [[ -z "$status" ]]; then
+		while IFS='=' read -r key value; do
+			if [[ "$key" == "status" && "$value" =~ ^(attempting|blocked|deferred)$ ]]; then
+				status="$value"
+				break
+			fi
+		done <"$state_file"
+	fi
+	[[ -n "$status" ]] || return 0
+	_pulse_runtime_recovery_record "recovered" "activation_converged_externally" "$canonical_sha" "$deployed_sha"
+	return 0
+}
+
 _pulse_runtime_recovery_run_setup() {
 	local setup_script="$1"
 	local timeout_seconds="${AIDEVOPS_PULSE_RUNTIME_RECOVERY_TIMEOUT_SECONDS:-240}"
@@ -152,7 +180,10 @@ pulse_runtime_recover_if_safe() {
 	IFS= read -r deployed_sha <"$stamp_file" || deployed_sha=""
 	deployed_sha="${deployed_sha//[[:space:]]/}"
 	[[ "$canonical_sha" =~ ^[0-9a-fA-F]{7,64}$ && "$deployed_sha" =~ ^[0-9a-fA-F]{7,64}$ ]] || return 0
-	[[ "$canonical_sha" != "$deployed_sha" ]] || return 0
+	if [[ "$canonical_sha" == "$deployed_sha" ]]; then
+		_pulse_runtime_recovery_reconcile_converged "$canonical_sha" "$deployed_sha"
+		return 0
+	fi
 
 	branch=$(git -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 	if [[ "$branch" != "main" ]]; then

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -870,6 +870,34 @@ cmp -s "$handoff_receipt" "${ROOT}/handoff-receipt-valid.json"
 cmp -s "${ROOT}/handoff-state/full-loop.state" "${ROOT}/handoff-state-valid"
 printf 'PASS repeated terminal status reads are stable and side-effect free\n'
 
+mkdir -p "${ROOT}/failing-gh"
+cat >"${ROOT}/failing-gh/gh" <<'GH'
+#!/usr/bin/env bash
+exit 75
+GH
+chmod +x "${ROOT}/failing-gh/gh"
+offline_status=$(PATH="${ROOT}/failing-gh:${PATH}" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" bash "$status_runner")
+printf '%s' "$offline_status" | jq -e \
+	'.executor_completion_state == "COMPLETE"
+	and .resource_cleanup_state == "CLEANUP_DEFERRED"
+	and .next_action == "await-resource-cleanup"
+	and .phase_is_historical == true' >/dev/null
+printf 'PASS terminal status projects its exact receipt when live repository discovery fails\n'
+
+mkdir -p "${ROOT}/wrong-repo-gh"
+cat >"${ROOT}/wrong-repo-gh/gh" <<'GH'
+#!/usr/bin/env bash
+printf '%s\n' wrong/repo
+GH
+chmod +x "${ROOT}/wrong-repo-gh/gh"
+wrong_live_repo_status=$(PATH="${ROOT}/wrong-repo-gh:${PATH}" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" bash "$status_runner")
+printf '%s' "$wrong_live_repo_status" | jq -e \
+	'.executor_completion_state == "COMPLETE"
+	and .resource_cleanup_state == "CLEANUP_DEFERRED"
+	and .next_action == "await-resource-cleanup"
+	and .phase_is_historical == true' >/dev/null
+printf 'PASS persisted repository identity outranks unrelated live repository discovery\n'
+
 printf '{invalid\n' >"$handoff_receipt"
 malformed_status=$(AIDEVOPS_FULL_LOOP_REPO=testorg/repo AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" bash "$status_runner")
 printf '%s' "$malformed_status" | jq -e \

--- a/.agents/scripts/tests/test-gh-transport-budget.py
+++ b/.agents/scripts/tests/test-gh-transport-budget.py
@@ -7,6 +7,7 @@ import importlib.util
 import io
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -54,6 +55,28 @@ class AdmissionTests(unittest.TestCase):
                 other.acquire("core", now=1002)
         finally:
             other.close()
+
+    def test_initialized_open_does_not_replay_schema_writes(self):
+        self.assertEqual(self.budget.db.execute("PRAGMA user_version").fetchone()[0], 1)
+        self.budget.db.execute("BEGIN IMMEDIATE")
+        try:
+            other = Budget.__new__(Budget)
+            other.db = sqlite3.connect(self.directory / "admission.sqlite3", timeout=0.1,
+                                       isolation_level=None)
+            other._ensure_schema()
+            other.db.close()
+        finally:
+            self.budget.db.execute("ROLLBACK")
+
+    def test_future_schema_fails_closed(self):
+        self.budget.close()
+        connection = sqlite3.connect(self.directory / "admission.sqlite3")
+        connection.execute("PRAGMA user_version=2")
+        connection.close()
+        with self.assertRaisesRegex(ValueError, "schema is newer"):
+            Budget(self.directory, "owner-one")
+        self.budget = Budget.__new__(Budget)
+        self.budget.close = lambda: None
 
     def test_stale_and_missing_state_allow_only_one_observation(self):
         self.budget.acquire("core", now=1000)

--- a/.agents/scripts/tests/test-gh-transport-budget.py
+++ b/.agents/scripts/tests/test-gh-transport-budget.py
@@ -78,6 +78,15 @@ class AdmissionTests(unittest.TestCase):
         self.budget = Budget.__new__(Budget)
         self.budget.close = lambda: None
 
+    def test_open_budget_fails_closed_after_concurrent_schema_upgrade(self):
+        connection = sqlite3.connect(self.directory / "admission.sqlite3")
+        connection.execute("PRAGMA user_version=2")
+        connection.close()
+        with self.assertRaisesRegex(ValueError, "schema changed"):
+            with self.budget.transaction():
+                pass
+        self.budget.db.execute("PRAGMA user_version=1")
+
     def test_stale_and_missing_state_allow_only_one_observation(self):
         self.budget.acquire("core", now=1000)
         with self.assertRaises(Deferred):

--- a/.agents/scripts/tests/test-post-launch-in-progress-recovery.sh
+++ b/.agents/scripts/tests/test-post-launch-in-progress-recovery.sh
@@ -36,6 +36,7 @@ issue_assigned="true"
 worker_checks=0
 dispatch_identity='<!-- aidevops:dispatch lease_token=lease-30029 device=runner-device session=issue-30029 attempt_id=attempt-30029 claim_id=77 -->'
 old_dispatch_identity='<!-- aidevops:dispatch lease_token=lease-old device=runner-device session=issue-old attempt_id=attempt-old claim_id=66 -->'
+claim_issue_number=30029
 gh() {
 	local command_name="$1"
 	shift
@@ -45,9 +46,13 @@ gh() {
 	fi
 	if [[ "$command_name" == "api" && "$1" == "repos/owner/repo/issues/30029/comments" ]]; then
 		if [[ " $* " == *" --slurp "* ]]; then
-			printf '%s\n' "$dispatch_identity"
+			jq -cn --arg body "$dispatch_identity" \
+				'{body:$body,author_association:"MEMBER",login:"runner-a"}'
 		else
-			printf '%s\n%s\n' "$old_dispatch_identity" "$dispatch_identity"
+			jq -cn --arg body "$old_dispatch_identity" \
+				'{body:$body,author_association:"MEMBER",login:"runner-a"}'
+			jq -cn --arg body "$dispatch_identity" \
+				'{body:$body,author_association:"MEMBER",login:"runner-a"}'
 		fi
 		return 0
 	fi
@@ -56,7 +61,8 @@ gh() {
 		return 0
 	fi
 	if [[ "$command_name" == "api" && "$1" == "repos/owner/repo/issues/comments/77" ]]; then
-		printf '%s\n' '{"id":77,"body":"DISPATCH_CLAIM nonce=nonce-30029 runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}}'
+		jq -cn --arg issue "$claim_issue_number" \
+			'{id:77,issue_url:("https://api.github.test/repos/owner/repo/issues/" + $issue),body:"DISPATCH_CLAIM nonce=nonce-30029 runner=runner-a",author_association:"MEMBER",user:{login:"runner-a"}}'
 		return 0
 	fi
 	if [[ "$command_name" == "issue" && "$1" == "view" ]]; then
@@ -119,6 +125,20 @@ grep -q 'Launch recovery reset #30029' "$LOGFILE" || {
 
 issue_status="in-progress"
 issue_assigned="true"
+claim_issue_number=99999
+recover_failed_launch_state 30029 owner/repo no_worker_process
+[[ "$issue_status" == "in-progress" && "$issue_assigned" == "true" ]] || {
+	printf 'FAIL: cross-issue claim identity disturbed ownership\n' >&2
+	exit 1
+}
+[[ "$(wc -l <"$RELEASE_ARGS_FILE" | tr -d '[:space:]')" == "1" ]] || {
+	printf 'FAIL: cross-issue claim identity emitted a generation release\n' >&2
+	exit 1
+}
+
+issue_status="in-progress"
+issue_assigned="true"
+claim_issue_number=30029
 dispatch_identity='<!-- aidevops:dispatch lease_token=lease-late device=runner-device session=issue-30029 attempt_id=attempt-late claim_id=78 -->'
 recover_failed_launch_state 30029 owner/repo no_worker_process
 [[ "$issue_status" == "in-progress" && "$issue_assigned" == "true" ]] || {

--- a/.agents/scripts/tests/test-post-launch-in-progress-recovery.sh
+++ b/.agents/scripts/tests/test-post-launch-in-progress-recovery.sh
@@ -35,6 +35,7 @@ issue_status="in-progress"
 issue_assigned="true"
 worker_checks=0
 dispatch_identity='<!-- aidevops:dispatch lease_token=lease-30029 device=runner-device session=issue-30029 attempt_id=attempt-30029 claim_id=77 -->'
+old_dispatch_identity='<!-- aidevops:dispatch lease_token=lease-old device=runner-device session=issue-old attempt_id=attempt-old claim_id=66 -->'
 gh() {
 	local command_name="$1"
 	shift
@@ -43,7 +44,19 @@ gh() {
 		return 0
 	fi
 	if [[ "$command_name" == "api" && "$1" == "repos/owner/repo/issues/30029/comments" ]]; then
-		printf '%s\n' "$dispatch_identity"
+		if [[ " $* " == *" --slurp "* ]]; then
+			printf '%s\n' "$dispatch_identity"
+		else
+			printf '%s\n%s\n' "$old_dispatch_identity" "$dispatch_identity"
+		fi
+		return 0
+	fi
+	if [[ "$command_name" == "api" && "$1" == "repos/owner/repo/issues/comments/66" ]]; then
+		printf '%s\n' '{"id":66,"body":"DISPATCH_CLAIM nonce=nonce-old runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}}'
+		return 0
+	fi
+	if [[ "$command_name" == "api" && "$1" == "repos/owner/repo/issues/comments/77" ]]; then
+		printf '%s\n' '{"id":77,"body":"DISPATCH_CLAIM nonce=nonce-30029 runner=runner-a","author_association":"MEMBER","user":{"login":"runner-a"}}'
 		return 0
 	fi
 	if [[ "$command_name" == "issue" && "$1" == "view" ]]; then
@@ -74,7 +87,10 @@ set_issue_status() {
 
 _process_start_token() { return 1; }
 aidevops_pulse_worker_log_candidates() { return 0; }
-_post_launch_recovery_claim_released() { return 0; }
+export RELEASE_ARGS_FILE="${TEST_TMP}/release-args"
+_post_launch_recovery_claim_released() {
+	printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "${5:-}" "${6:-}" >>"$RELEASE_ARGS_FILE"
+}
 _post_launch_cooldown_marker() { return 0; }
 _record_runner_health_zero_attempt() { return 0; }
 unlock_issue_after_worker() { return 0; }
@@ -92,6 +108,10 @@ grep -q '^fail --session-key issue-30029 --lease-token lease-30029 --attempt-id 
 	printf 'FAIL: exact registered attempt was not failed in the ledger\n' >&2
 	exit 1
 }
+grep -q $'^30029\towner/repo\trunner-a\tno_worker_process\t77\tnonce-30029$' "$RELEASE_ARGS_FILE" || {
+	printf 'FAIL: launch recovery release was not bound to the exact claim generation\n' >&2
+	exit 1
+}
 grep -q 'Launch recovery reset #30029' "$LOGFILE" || {
 	printf 'FAIL: recovery receipt was not recorded\n' >&2
 	exit 1
@@ -107,6 +127,10 @@ recover_failed_launch_state 30029 owner/repo no_worker_process
 }
 [[ "$(wc -l <"$LEDGER_CALLS_FILE" | tr -d '[:space:]')" == "1" ]] || {
 	printf 'FAIL: mismatched late attempt changed the ledger\n' >&2
+	exit 1
+}
+[[ "$(wc -l <"$RELEASE_ARGS_FILE" | tr -d '[:space:]')" == "1" ]] || {
+	printf 'FAIL: mismatched late attempt emitted a generation release\n' >&2
 	exit 1
 }
 

--- a/.agents/scripts/tests/test-pulse-runtime-recovery.sh
+++ b/.agents/scripts/tests/test-pulse-runtime-recovery.sh
@@ -137,6 +137,50 @@ test_dead_owner_lock_is_reclaimed() {
 	[[ ! -e "${fixture}/recovery.lock.d" ]] || fail "reclaimed recovery lock remains after completion"
 }
 
+test_external_convergence_reconciles_stale_state() {
+	local fixture="${TEST_ROOT}/external-convergence"
+	local repo="" home="" canonical_sha=""
+	new_fixture external-convergence
+	IFS= read -r repo <"${fixture}/repo.path"
+	IFS= read -r home <"${fixture}/home.path"
+	canonical_sha=$(git -C "$repo" rev-parse HEAD)
+	mkdir -p "${home}/.aidevops"
+	printf '%s\n' "$canonical_sha" >"${home}/.aidevops/.deployed-sha"
+	jq -n --arg canonical "$canonical_sha" \
+		'{schema:"aidevops-pulse-runtime-recovery/v1",status:"attempting",reason:"safe_canonical_deployment",canonical_sha:$canonical,deployed_sha:"old",recorded_epoch:1}' \
+		>"${fixture}/state.json"
+
+	HOME="$home" \
+		AIDEVOPS_REPO_PATH="$repo" \
+		AIDEVOPS_DEPLOYED_SHA_FILE="${home}/.aidevops/.deployed-sha" \
+		AIDEVOPS_PULSE_RUNTIME_RECOVERY_STATE_FILE="${fixture}/state.json" \
+		AIDEVOPS_PULSE_RUNTIME_RECOVERY_LOCK_DIR="${fixture}/recovery.lock.d" \
+		AIDEVOPS_PULSE_RUNTIME_RECOVERY_NO_REEXEC=1 \
+		pulse_runtime_recover_if_safe
+
+	assert_eq "recovered" "$(jq -r '.status' "${fixture}/state.json")" "external convergence closes a stale recovery attempt"
+	assert_eq "activation_converged_externally" "$(jq -r '.reason' "${fixture}/state.json")" "external convergence records an exact reason"
+	assert_eq "$canonical_sha" "$(jq -r '.canonical_sha' "${fixture}/state.json")" "external convergence records authoritative SHA evidence"
+}
+
+test_external_convergence_reconciles_key_value_state_without_jq() {
+	local state_file="${TEST_ROOT}/fallback-convergence-state"
+	local fake_bin="${TEST_ROOT}/fallback-bin"
+	local command_name=""
+	local status=""
+	mkdir -p "$fake_bin"
+	for command_name in date mkdir mv rm; do
+		ln -s "$(command -v "$command_name")" "${fake_bin}/${command_name}"
+	done
+	printf 'status=attempting\nreason=safe_canonical_deployment\nrecorded_epoch=1\n' >"$state_file"
+	PATH="$fake_bin" AIDEVOPS_PULSE_RUNTIME_RECOVERY_STATE_FILE="$state_file" \
+		_pulse_runtime_recovery_reconcile_converged abc1234 abc1234
+	while IFS='=' read -r command_name status; do
+		[[ "$command_name" != "status" ]] || break
+	done <"$state_file"
+	assert_eq "recovered" "$status" "external convergence closes key-value state without jq"
+}
+
 main() {
 	TEST_ROOT=$(mktemp -d)
 	trap cleanup EXIT
@@ -145,6 +189,8 @@ main() {
 	test_non_exact_main_is_preserved
 	test_key_value_cooldown_state
 	test_dead_owner_lock_is_reclaimed
+	test_external_convergence_reconciles_stale_state
+	test_external_convergence_reconciles_key_value_state_without_jq
 	printf 'Results: %s checks passed\n' "$TESTS_RUN"
 }
 


### PR DESCRIPTION
## Summary

- reconcile stale Pulse runtime-recovery state after external deployment convergence
- persist repository identity so full-loop cleanup status remains exact when live discovery is unavailable or unrelated
- serialize and version GitHub transport schema initialization while preserving no-retry metadata after native execution
- bind failed-launch claim releases to the exact trusted claim generation across paginated comments

## Verification

- `.agents/scripts/linters-local.sh --changed`
- `bash .agents/scripts/tests/test-pulse-runtime-recovery.sh`
- `bash .agents/scripts/tests/test-full-loop-completion-evidence.sh`
- `python3 .agents/scripts/tests/test-gh-transport-budget.py`
- `bash .agents/scripts/tests/test-post-launch-in-progress-recovery.sh`
- `bash .agents/scripts/tests/test-dispatch-claim-helper.sh`
- `bash .agents/scripts/tests/test-dispatch-atomic-lease.sh`
- Independent closeout review: CLEAN

Resolves #31536
Resolves #31532
Resolves #31531
Resolves #31527

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.335 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 1h 56m and 462,876 tokens on this with the user in an interactive session.