### PR TITLE
GH#31545: fix: match stable Pulse link during bundle activation

### DIFF
--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -106,7 +106,8 @@ _pulse_escape_ere() {
 	printf '%s' "$_escaped"
 	return 0
 }
-_PULSE_DEPLOYED_ROOT=$(_pulse_escape_ere "${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}")
+# Setup supplies the stable link separately from its physical bundle root.
+_PULSE_DEPLOYED_ROOT=$(_pulse_escape_ere "${AIDEVOPS_ACTIVE_AGENTS_LINK:-${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}}")
 _PULSE_ACTIVE_ROOT=$(_pulse_escape_ere "$_PULSE_AGENTS_DIR")
 _PULSE_BUNDLES_ROOT=$(_pulse_escape_ere "${AIDEVOPS_RUNTIME_BUNDLES_DIR:-${HOME}/.aidevops/runtime-bundles}")
 _PULSE_DEFAULT_PATTERN="(${_PULSE_DEPLOYED_ROOT}|${_PULSE_ACTIVE_ROOT}|${_PULSE_BUNDLES_ROOT}/[^/]+/agents)/scripts/pulse-wrapper\\.sh( |\$)"

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -1362,16 +1362,18 @@ test_status_sidecar_only_reports_not_running() {
 test_default_pattern_ignores_foreign_user_pulse() {
 	_kill_mocks
 	local foreign_root="${TEST_ROOT}-foreign-user"
+	local active_link="${TEST_ROOT}-active"
+	ln -s "$TEST_ROOT" "$active_link"
 	mkdir -p "${foreign_root}/scripts"
 	cp "${TEST_ROOT}/scripts/pulse-wrapper.sh" "${foreign_root}/scripts/pulse-wrapper.sh"
 	cp "${TEST_ROOT}/scripts/pulse-merge-routine.sh" "${foreign_root}/scripts/pulse-merge-routine.sh"
 	chmod +x "${foreign_root}/scripts/pulse-wrapper.sh"
 	chmod +x "${foreign_root}/scripts/pulse-merge-routine.sh"
-	bash "${TEST_ROOT}/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
+	bash "${active_link}/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
 	local current_pid=$!
 	bash "${foreign_root}/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
 	local foreign_pid=$!
-	bash "${TEST_ROOT}/scripts/pulse-merge-routine.sh" >/dev/null 2>&1 &
+	bash "${active_link}/scripts/pulse-merge-routine.sh" >/dev/null 2>&1 &
 	local current_merge_pid=$!
 	bash "${foreign_root}/scripts/pulse-merge-routine.sh" >/dev/null 2>&1 &
 	local foreign_merge_pid=$!
@@ -1379,6 +1381,7 @@ test_default_pattern_ignores_foreign_user_pulse() {
 
 	local out="" rc=0
 	out=$(env -u AIDEVOPS_PULSE_PROCESS_PATTERN AIDEVOPS_AGENTS_DIR="$TEST_ROOT" \
+		AIDEVOPS_ACTIVE_AGENTS_LINK="$active_link" \
 		AIDEVOPS_RUNTIME_BUNDLES_DIR="${TEST_ROOT}/runtime-bundles" \
 		"$HELPER" status 2>&1) || rc=$?
 	_assert_eq "default pattern: current-user Pulse status exits 0" "0" "$rc"
@@ -1392,6 +1395,7 @@ test_default_pattern_ignores_foreign_user_pulse() {
 	# shellcheck disable=SC2016
 	merge_pids=$(env -u AIDEVOPS_PULSE_MERGE_PROCESS_PATTERN \
 		AIDEVOPS_AGENTS_DIR="$TEST_ROOT" \
+		AIDEVOPS_ACTIVE_AGENTS_LINK="$active_link" \
 		AIDEVOPS_RUNTIME_BUNDLES_DIR="${TEST_ROOT}/runtime-bundles" \
 		bash -c 'source "$1"; _pulse_merge_pids_raw' _ "$HELPER")
 	if [[ "$merge_pids" == *"${current_merge_pid}"* && "$merge_pids" != *"${foreign_merge_pid}"* ]]; then
@@ -1402,6 +1406,7 @@ test_default_pattern_ignores_foreign_user_pulse() {
 
 	kill -KILL "$current_pid" "$foreign_pid" "$current_merge_pid" "$foreign_merge_pid" 2>/dev/null || true
 	wait "$current_pid" "$foreign_pid" "$current_merge_pid" "$foreign_merge_pid" 2>/dev/null || true
+	rm "$active_link"
 	rm -rf "$foreign_root"
 	return 0
 }


### PR DESCRIPTION
## Summary

Prefer the explicitly supplied active symlink in lifecycle process matching while retaining physical bundle matching and user isolation. This repairs the verified false-negative restart check blocking source31540 post-release convergence.

## Files Changed

.agents/scripts/pulse-lifecycle-helper.sh, .agents/scripts/tests/test-pulse-lifecycle-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Lifecycle regression red54/56 then green56/56; ShellCheck and changed-file lint including Bash3.2, complexity and nesting gates passed. Fixture uses setup-style physical bundle root plus stable symlink argv, and verifies other-user exclusion.

Resolves #31545


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.336 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 1d 20h and 4,605,007 tokens on this with the user in an interactive session.