### PR TITLE
GH#31548: preserve Beads hook chaining and bound privacy diff scans

### DIFF
--- a/.agents/scripts/install-canonical-guard.sh
+++ b/.agents/scripts/install-canonical-guard.sh
@@ -13,18 +13,18 @@
 #
 # Model: mirrors .agents/scripts/install-privacy-guard.sh (t1965).
 #
-# The installer targets the git COMMON dir (`git rev-parse --git-common-dir`)
-# so worktrees share the hook with the parent repo. If a pre-existing hook
-# that is not ours is found, we refuse to overwrite and print chaining
-# instructions.
+# The installer respects the effective core.hooksPath, which may be shared by
+# worktrees. Refuse unmanaged hooks; preserve a complete trailing Beads section
+# when refreshing our dispatcher. Never use this installer to edit another
+# session's shared hook without coordinating ownership first.
 
 set -euo pipefail
 
-RED=$'\033[0;31m'
-GREEN=$'\033[0;32m'
-YELLOW=$'\033[1;33m'
-BLUE=$'\033[0;34m'
-NC=$'\033[0m'
+[[ -n "${RED+x}" ]] || RED=$'\033[0;31m'
+[[ -n "${GREEN+x}" ]] || GREEN=$'\033[0;32m'
+[[ -n "${YELLOW+x}" ]] || YELLOW=$'\033[1;33m'
+[[ -n "${BLUE+x}" ]] || BLUE=$'\033[0;34m'
+[[ -n "${NC+x}" ]] || NC=$'\033[0m'
 
 print_info() { printf '%s[INFO]%s %s\n' "$BLUE" "$NC" "$1"; }
 print_success() { printf '%s[OK]%s %s\n' "$GREEN" "$NC" "$1"; }
@@ -83,12 +83,46 @@ _git_hooks_dir() {
 }
 
 #######################################
+# Extract only a single complete trailing Beads section. Fail closed if the
+# markers are ambiguous or other code follows it; never silently discard it.
+#######################################
+_beads_section() {
+	local hook_path="$1"
+	awk '
+		/^# --- BEGIN BEADS INTEGRATION v[^ ]+ ---$/ {
+			if (started++) invalid = 1
+			# The version immediately precedes the closing marker.
+			version = $(NF - 1)
+			active = 1
+			print
+			next
+		}
+		/^# --- END BEADS INTEGRATION( v[^ ]+)? ---$/ {
+			if (!active || ended++) invalid = 1
+			if (NF == 7 && $(NF - 1) != version) invalid = 1
+			active = 0
+			print
+			next
+		}
+		/BEADS INTEGRATION/ { invalid = 1 }
+		active { print; next }
+		ended && /[^[:space:]]/ { invalid = 1 }
+		END { if (invalid || active || started != ended) exit 1 }
+	' "$hook_path"
+	return $?
+}
+
+#######################################
 # Install the hook. Refuses to overwrite unmanaged pre-existing hooks.
 #######################################
-cmd_install() {
+cmd_install() (
 	local hooks_dir
 	hooks_dir=$(_git_hooks_dir) || return 1
 	local hook_path="${hooks_dir}/post-checkout"
+	if [[ -L "$hook_path" || (-e "$hook_path" && ! -f "$hook_path") ]]; then
+		print_error "refusing non-regular or symlink hook: $hook_path"
+		return 1
+	fi
 	mkdir -p "$(dirname "$hook_path")"
 
 	local source_hook
@@ -99,7 +133,12 @@ cmd_install() {
 		return 1
 	fi
 
+	local beads_section=""
 	if [[ -f "$hook_path" ]]; then
+		if ! beads_section=$(_beads_section "$hook_path"); then
+			print_error "ambiguous Beads integration; leaving existing hook unchanged"
+			return 1
+		fi
 		if grep -q "$HOOK_MARKER" "$hook_path" 2>/dev/null; then
 			print_info "canonical-on-main-guard already installed at $hook_path — refreshing"
 		elif grep -q "$LEGACY_MARKER" "$hook_path" 2>/dev/null; then
@@ -118,7 +157,12 @@ cmd_install() {
 		fi
 	fi
 
-	cat >"$hook_path" <<HOOKEOF
+	local staged_hook=""
+	staged_hook=$(mktemp "${hook_path}.tmp.XXXXXX") || return 1
+	trap 'rm -f "$staged_hook"' EXIT
+	local deployed_literal=""
+	printf -v deployed_literal '%q' "$DEPLOYED_HOOK"
+	cat >"$staged_hook" <<HOOKEOF
 #!/usr/bin/env bash
 $HOOK_MARKER
 # Managed by .agents/scripts/install-canonical-guard.sh — do not edit.
@@ -130,22 +174,27 @@ _repo_hook=""
 if git_dir=\$(git rev-parse --show-toplevel 2>/dev/null); then
 	_repo_hook="\${git_dir}/.agents/hooks/canonical-on-main-guard.sh"
 fi
-_deployed_hook="$DEPLOYED_HOOK"
+_deployed_hook=$deployed_literal
 
 if [[ -n "\$_repo_hook" && -f "\$_repo_hook" ]]; then
-	exec "\$_repo_hook" "\$@"
+	"\$_repo_hook" "\$@" || exit \$?
 elif [[ -f "\$_deployed_hook" ]]; then
-	exec "\$_deployed_hook" "\$@"
+	"\$_deployed_hook" "\$@" || exit \$?
 else
 	printf 'CRITICAL: aidevops canonical guard source is missing\n' >&2
 	exit 1
 fi
 HOOKEOF
-	chmod +x "$hook_path"
+	if [[ -n "$beads_section" ]]; then
+		printf '\n%s\n' "$beads_section" >>"$staged_hook"
+	fi
+	bash -n "$staged_hook" || return 1
+	chmod 755 "$staged_hook" || return 1
+	mv -f "$staged_hook" "$hook_path" || return 1
 	print_success "installed canonical-on-main-guard at $hook_path"
 	print_info "source hook: $source_hook"
 	return 0
-}
+)
 
 #######################################
 # Remove the hook if (and only if) it is managed by us.
@@ -155,12 +204,20 @@ cmd_uninstall() {
 	hooks_dir=$(_git_hooks_dir) || return 1
 	local hook_path="${hooks_dir}/post-checkout"
 
+	if [[ -L "$hook_path" ]]; then
+		print_error "refusing symlink hook: $hook_path"
+		return 1
+	fi
 	if [[ ! -f "$hook_path" ]]; then
 		print_info "no post-checkout hook installed"
 		return 0
 	fi
 
 	if grep -q "$HOOK_MARKER" "$hook_path" 2>/dev/null; then
+		if grep -q 'BEADS INTEGRATION' "$hook_path"; then
+			print_error "hook also contains Beads integration; refusing to remove it"
+			return 1
+		fi
 		rm -f "$hook_path"
 		print_success "removed canonical-on-main-guard post-checkout hook"
 		return 0

--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -823,6 +823,44 @@ privacy_scan_secret_material_text() {
 }
 
 #######################################
+# Stream a conservative candidate diff in one process. Synthetic one-line hunk
+# headers retain original line numbers for the authoritative scanners below.
+# Public mode is only used with empty entity and custom-path inventories.
+#######################################
+_privacy_builtin_candidate_diff() {
+	local diff_text="$1"
+	local mode="$2"
+	printf '%s\n' "$diff_text" | awk -v credentials="$PRIVACY_CREDENTIAL_PREFIX_ERE" -v mode="$mode" -v debug="${PRIVACY_GUARD_DEBUG:-0}" '
+		/^\+\+\+ b\// { pem = 0; print; next }
+		/^\+\+\+ / { next }
+		/^@@ / {
+			header = $0
+			sub(/^@@ -[^+]*\+/, "", header)
+			split(header, fields, /[, ]/)
+			line = fields[1] + 0
+			next
+		}
+		/^\+/ {
+			text = substr($0, 2)
+			if (text ~ /-----BEGIN[[:space:]][A-Z0-9[:space:]]*PRIVATE[[:space:]]KEY-----/) pem = 1
+			candidate = pem || text ~ credentials || index(text, "PRIVATE")
+			if (mode == "public" && (index(text, "/" "Users/") || index(text, "/" "home/") || index(text, "~/") || index(text, "file://"))) candidate = 1
+			if (candidate) {
+				candidates++
+				printf "@@ -0,0 +%d,1 @@\n", line
+				print
+			}
+			if (text ~ /-----END[[:space:]][A-Z0-9[:space:]]*PRIVATE[[:space:]]KEY-----/) pem = 0
+			line++
+			next
+		}
+		/^ / { line++ }
+		END { if (debug == 1) printf "[privacy-guard][INFO] %s filter: %d diff lines, %d candidate lines\n", mode, NR, candidates > "/dev/stderr" }
+	'
+	return $?
+}
+
+#######################################
 # Scan all added diff lines for private-key material.
 # Arguments:
 #   $1 - base SHA (remote tip); may be all zeros for a new branch push
@@ -846,13 +884,14 @@ privacy_scan_secret_material_diff() {
 	local diff_output
 	diff_output=$(git diff --unified=0 --no-color "$diff_base" "$head_sha" 2>/dev/null) || return 0
 	[[ -z "$diff_output" ]] && return 0
+	diff_output=$(_privacy_builtin_candidate_diff "$diff_output" secret) || return 2
 
 	local hits=0 current_file="" line_num=0 in_pem=0
 	local aidevops_script_basenames
 	aidevops_script_basenames=$(_privacy_aidevops_script_reference_basenames)
 	while IFS= read -r line; do
 		case "$line" in
-		"+++ b/"*) current_file="${line#+++ b/}"; line_num=0 ;;
+		"+++ b/"*) current_file="${line#+++ b/}"; line_num=0; in_pem=0 ;;
 		"--- "*) ;;
 		"@@ "*)
 			local rest="${line#@@ -*+}"
@@ -862,8 +901,12 @@ privacy_scan_secret_material_diff() {
 		"+"*)
 			[[ "$line" == "+++ "* ]] && continue
 			local added="${line:1}"
-			local scan_added
-			scan_added=$(_privacy_redact_aidevops_script_references "$added" "$aidevops_script_basenames")
+			local scan_added="$added"
+			# Redaction only affects credential-like script references. Avoid a
+			# subshell on every ordinary added line, without skipping PEM state.
+			if [[ "$added" =~ $PRIVACY_CREDENTIAL_PREFIX_ERE ]]; then
+				scan_added=$(_privacy_redact_aidevops_script_references "$added" "$aidevops_script_basenames")
+			fi
 			if [[ "$scan_added" != "$added" ]]; then
 				printf '%s:%s: [privacy-scan][ALLOW] aidevops script file reference\n' "$current_file" "$line_num" >&2
 			fi
@@ -878,7 +921,7 @@ privacy_scan_secret_material_diff() {
 			if [[ "$scan_added" =~ -----END[[:space:]][A-Z0-9[:space:]]*PRIVATE[[:space:]]KEY----- ]]; then
 				in_pem=0
 			fi
-			if printf '%s' "$scan_added" | grep -qE -- "$PRIVACY_CREDENTIAL_PREFIX_ERE"; then
+			if [[ "$scan_added" =~ $PRIVACY_CREDENTIAL_PREFIX_ERE ]]; then
 				printf '%s:%s: credential token prefix\n' "$current_file" "$line_num"
 				hits=$((hits + 1))
 			fi
@@ -1040,6 +1083,8 @@ privacy_scan_public_diff() {
 	local diff_base="$base_sha" diff_output
 	local current_file="" line_num=0 hits=0 line added matching_hits scan_rc hit
 	local aidevops_script_basenames
+	local configured_paths="$HOME/.aidevops/configs/privacy-guard-private-path-patterns.txt"
+	local filtered=0
 
 	[[ -f "$entities_file" ]] || return 2
 	if [[ "$base_sha" =~ ^0+$ ]]; then
@@ -1049,6 +1094,10 @@ privacy_scan_public_diff() {
 		[[ -z "$diff_base" ]] && diff_base=$(git hash-object -t tree /dev/null)
 	fi
 	diff_output=$(git diff --unified=0 --no-color "$diff_base" "$head_sha" -- . 2>/dev/null) || return 2
+	if [[ ! -s "$entities_file" && ! -s "$configured_paths" ]]; then
+		diff_output=$(_privacy_builtin_candidate_diff "$diff_output" public) || return 2
+		filtered=1
+	fi
 	aidevops_script_basenames=$(_privacy_aidevops_script_reference_basenames)
 	while IFS= read -r line; do
 		case "$line" in
@@ -1079,6 +1128,11 @@ privacy_scan_public_diff() {
 		" "*) line_num=$((line_num + 1)) ;;
 		esac
 	done <<<"$diff_output"
+	# Do not approve a filtered scan if custom rules appeared during the scan.
+	[[ -f "$entities_file" ]] || return 2
+	if [[ "$filtered" -eq 1 && (-s "$entities_file" || -s "$configured_paths") ]]; then
+		return 2
+	fi
 	[[ "$hits" -gt 0 ]] && return 1
 	return 0
 }

--- a/.agents/scripts/test-canonical-guard.sh
+++ b/.agents/scripts/test-canonical-guard.sh
@@ -6,16 +6,27 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HOOK="${SCRIPT_DIR}/../hooks/canonical-on-main-guard.sh"
-INSTALLER="${SCRIPT_DIR}/install-canonical-guard.sh"
+INSTALLER="${CANONICAL_GUARD_INSTALLER:-${SCRIPT_DIR}/install-canonical-guard.sh}"
 ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT
+# Never use or change the operator's deployed hooks in synthetic repositories.
+export HOME="${ROOT}/home"
 REPO="${ROOT}/repo"
 LINKED="${ROOT}/linked"
 TESTS=0
 FAILURES=0
 
-pass() { TESTS=$((TESTS + 1)); printf 'PASS %s\n' "$1"; return 0; }
-fail() { TESTS=$((TESTS + 1)); FAILURES=$((FAILURES + 1)); printf 'FAIL %s\n' "$1"; return 0; }
+pass() {
+	TESTS=$((TESTS + 1))
+	printf 'PASS %s\n' "$1"
+	return 0
+}
+fail() {
+	TESTS=$((TESTS + 1))
+	FAILURES=$((FAILURES + 1))
+	printf 'FAIL %s\n' "$1"
+	return 0
+}
 
 mkdir -p "$REPO"
 git -C "$REPO" init -q -b main
@@ -66,6 +77,141 @@ if [[ ! -e "${REPO}/.git/hooks/post-checkout" ]]; then
 	pass "installer does not report inactive default hook path"
 else
 	fail "installer wrote inactive default hook path"
+fi
+
+POST_CHECKOUT="${REPO}/.custom-hooks/post-checkout"
+mkdir -p "${REPO}/.agents/hooks" "${ROOT}/bin" "$HOME"
+export TRACE="${ROOT}/trace"
+export PATH="${ROOT}/bin:$PATH"
+cat >"${REPO}/.agents/hooks/canonical-on-main-guard.sh" <<'GUARD'
+#!/usr/bin/env bash
+printf 'guard\n' >>"$TRACE"
+exit "${GUARD_STATUS:-0}"
+GUARD
+cat >"${ROOT}/bin/bd" <<'BEADS'
+#!/usr/bin/env bash
+printf 'beads:%s:%s:%s:%s:%s:%s:%s\n' "${BD_GIT_HOOK:-}" "$1" "$2" "$3" "$4" "$5" "$6" >>"$TRACE"
+exit "${BEADS_STATUS:-0}"
+BEADS
+chmod +x "${REPO}/.agents/hooks/canonical-on-main-guard.sh" "${ROOT}/bin/bd"
+cat >"${ROOT}/beads-section" <<'SECTION'
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  bd hooks run post-checkout "$@"
+  _bd_exit=$?
+  if [ "$_bd_exit" -eq 3 ]; then _bd_exit=0; fi
+  if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---
+SECTION
+if [[ -n "${CANONICAL_GUARD_HOOK_FIXTURE:-}" ]]; then
+	# Exercise a reviewed real-world hook without installing it in its source repo.
+	cp "$CANONICAL_GUARD_HOOK_FIXTURE" "$POST_CHECKOUT"
+	sed -n '/^# --- BEGIN BEADS INTEGRATION/,$p' "$POST_CHECKOUT" >"${ROOT}/beads-section"
+else
+	cat "${ROOT}/beads-section" >>"$POST_CHECKOUT"
+fi
+if (cd "$REPO" && bash "$INSTALLER" install >/dev/null 2>&1); then
+	pass "refresh accepts a complete Beads section"
+else
+	fail "refresh accepts a complete Beads section"
+fi
+sed -n '/^# --- BEGIN BEADS INTEGRATION/,$p' "$POST_CHECKOUT" >"${ROOT}/retained-section"
+if cmp -s "${ROOT}/beads-section" "${ROOT}/retained-section"; then
+	pass "refresh preserves Beads section verbatim"
+else
+	fail "refresh preserves Beads section verbatim"
+fi
+cp "$POST_CHECKOUT" "${ROOT}/refreshed-hook"
+if (cd "$REPO" && bash "$INSTALLER" install >/dev/null 2>&1) && cmp -s "$POST_CHECKOUT" "${ROOT}/refreshed-hook"; then
+	pass "repeated refresh is byte-idempotent"
+else
+	fail "repeated refresh is byte-idempotent"
+fi
+printf 'guard\nbeads:1:hooks:run:post-checkout:old value:new value:1\n' >"${ROOT}/expected-trace"
+: >"$TRACE"
+if (cd "$REPO" && bash "$POST_CHECKOUT" 'old value' 'new value' 1) && cmp -s "$TRACE" "${ROOT}/expected-trace"; then
+	pass "guard runs before Beads exactly once with quoted arguments"
+else
+	fail "guard runs before Beads exactly once with quoted arguments"
+fi
+fixture_head=$(git -C "$REPO" rev-parse HEAD)
+printf 'guard\nbeads:1:hooks:run:post-checkout:%s:%s:0\n' "$fixture_head" "$fixture_head" >"${ROOT}/expected-trace"
+: >"$TRACE"
+if git -C "$REPO" checkout -- README.md && cmp -s "$TRACE" "${ROOT}/expected-trace"; then
+	pass "actual Git file checkout invokes guard then Beads"
+else
+	fail "actual Git file checkout invokes guard then Beads"
+fi
+: >"$TRACE"
+result=0
+(cd "$REPO" && GUARD_STATUS=17 bash "$POST_CHECKOUT" old new 1) || result=$?
+if [[ "$result" -eq 17 && "$(cat "$TRACE")" == guard ]]; then
+	pass "guard failure propagates and prevents Beads execution"
+else
+	fail "guard failure propagates and prevents Beads execution"
+fi
+result=0
+(cd "$REPO" && BEADS_STATUS=19 bash "$POST_CHECKOUT" old new 1) || result=$?
+[[ "$result" -eq 19 ]] && pass "Beads failure propagates" || fail "Beads failure propagates"
+if (cd "$REPO" && BEADS_STATUS=3 bash "$POST_CHECKOUT" old new 1); then
+	pass "Beads uninitialized-database policy is preserved"
+else
+	fail "Beads uninitialized-database policy is preserved"
+fi
+mv "${REPO}/.agents/hooks/canonical-on-main-guard.sh" "${ROOT}/guard"
+: >"$TRACE"
+if (cd "$REPO" && bash "$POST_CHECKOUT" old new 1 >/dev/null 2>&1) || [[ -s "$TRACE" ]]; then
+	fail "missing guard fails closed before Beads"
+else
+	pass "missing guard fails closed before Beads"
+fi
+mkdir -p "${HOME}/.aidevops/agents/hooks"
+cp "${ROOT}/guard" "${HOME}/.aidevops/agents/hooks/canonical-on-main-guard.sh"
+if (cd "$REPO" && bash "$POST_CHECKOUT" old new 1); then
+	pass "deployed fallback still supports Beads chaining"
+else
+	fail "deployed fallback still supports Beads chaining"
+fi
+if (cd "$REPO" && bash "$INSTALLER" uninstall >/dev/null 2>&1) || ! cmp -s "$POST_CHECKOUT" "${ROOT}/refreshed-hook"; then
+	fail "uninstall refuses to delete a shared Beads hook"
+else
+	pass "uninstall refuses to delete a shared Beads hook"
+fi
+for scenario in missing-end duplicate mismatched-version trailing-code invalid-shell; do
+	cp "${ROOT}/refreshed-hook" "$POST_CHECKOUT"
+	case "$scenario" in
+	missing-end) sed '/^# --- END BEADS INTEGRATION/d' "${ROOT}/refreshed-hook" >"$POST_CHECKOUT" ;;
+	duplicate) cat "${ROOT}/beads-section" >>"$POST_CHECKOUT" ;;
+	mismatched-version) sed 's/END BEADS INTEGRATION v1.0.3/END BEADS INTEGRATION v9.9.9/' "${ROOT}/refreshed-hook" >"$POST_CHECKOUT" ;;
+	trailing-code) printf '\nprintf unexpected\n' >>"$POST_CHECKOUT" ;;
+	invalid-shell) sed '/^# --- END BEADS INTEGRATION/i\
+if\
+' "${ROOT}/refreshed-hook" >"$POST_CHECKOUT" ;;
+	esac
+	cp "$POST_CHECKOUT" "${ROOT}/before-refusal"
+	if (cd "$REPO" && bash "$INSTALLER" install >/dev/null 2>&1) || ! cmp -s "$POST_CHECKOUT" "${ROOT}/before-refusal"; then
+		fail "refuses $scenario without modifying original hook"
+	else
+		pass "refuses $scenario without modifying original hook"
+	fi
+done
+rm "$POST_CHECKOUT"
+ln -s "${ROOT}/refreshed-hook" "$POST_CHECKOUT"
+if (cd "$REPO" && bash "$INSTALLER" install >/dev/null 2>&1) || [[ ! -L "$POST_CHECKOUT" ]]; then
+	fail "refuses symbolic-link hook targets"
+else
+	pass "refuses symbolic-link hook targets"
+fi
+rm "$POST_CHECKOUT"
+printf '#!/usr/bin/env bash\nprintf unmanaged\n' >"$POST_CHECKOUT"
+cp "$POST_CHECKOUT" "${ROOT}/unmanaged"
+if (cd "$REPO" && bash "$INSTALLER" install >/dev/null 2>&1) || ! cmp -s "$POST_CHECKOUT" "${ROOT}/unmanaged"; then
+	fail "refuses unmanaged hooks without overwriting them"
+else
+	pass "refuses unmanaged hooks without overwriting them"
 fi
 
 printf '\nTests: %d, Failures: %d\n' "$TESTS" "$FAILURES"

--- a/.agents/scripts/test-privacy-guard.sh
+++ b/.agents/scripts/test-privacy-guard.sh
@@ -341,23 +341,20 @@ else
 	fail "is_target_public: unparseable URL should return 2 (got $rc)"
 fi
 
-# Test: stale cache entry (older than TTL) is NOT used — the function should
-# fall through to a fresh probe. We can't stub gh, so we seed a stale private
-# entry for a slug we KNOW is public (our own aidevops repo), set TTL=1, and
-# verify the result matches the live state rather than the stale cache.
-# If gh is unavailable, this test is skipped (fail-open returns 2, not a bug).
-if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-	_seed_cache "marcusquinn/aidevops" true 9999
-	PRIVACY_CACHE_TTL=1 privacy_is_target_public "git@github.com:marcusquinn/aidevops.git"
-	rc=$?
-	# Live aidevops repo is public → fresh probe should return 0, overriding the stale private entry
-	if [[ "$rc" -eq 0 ]]; then
-		pass "is_target_public: stale cache entry is refreshed via fresh probe"
-	else
-		fail "is_target_public: stale cache should have been refreshed (got $rc)"
-	fi
+# A stale cache must trigger a fresh probe. Stub only the probe transport so
+# GitHub availability and account-level cooldowns cannot change this test.
+cat >"${TMP}/fresh-public-probe" <<'PROBE'
+#!/usr/bin/env bash
+printf 'false\n'
+PROBE
+chmod +x "${TMP}/fresh-public-probe"
+_seed_cache "owner/stale-public" true 9999
+PRIVACY_GH_BIN="${TMP}/fresh-public-probe" PRIVACY_CACHE_TTL=1 privacy_is_target_public "git@github.com:owner/stale-public.git"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	pass "is_target_public: stale cache entry is refreshed via fresh probe"
 else
-	pass "is_target_public: stale cache refresh test skipped (gh unavailable)"
+	fail "is_target_public: stale cache should have been refreshed (got $rc)"
 fi
 
 # Reset cache for hook-dispatch tests

--- a/.agents/scripts/tests/test-privacy-diff-fast-path.sh
+++ b/.agents/scripts/tests/test-privacy-diff-fast-path.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+# Offline synthetic regression cases; no real repositories or credentials.
+set -uo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit 1
+HELPER="${SCRIPT_DIR}/../privacy-guard-helper.sh"
+ROOT=$(mktemp -d) || exit 1
+trap 'rm -rf "$ROOT"' EXIT
+export HOME="${ROOT}/home"
+mkdir -p "$HOME/.aidevops/configs"
+ENTITIES="${ROOT}/entities"
+DIFF="${ROOT}/diff"
+TRACE="${ROOT}/trace"
+: >"$ENTITIES"
+: >"$TRACE"
+PASS=0
+FAIL=0
+
+pass() {
+	PASS=$((PASS + 1))
+	printf 'PASS %s\n' "$1"
+	return 0
+}
+fail() {
+	FAIL=$((FAIL + 1))
+	printf 'FAIL %s\n' "$1"
+	return 0
+}
+
+# Only substitute Git's read-only diff output. No network or commits needed.
+git() {
+	local operation="${1:-}"
+	[[ "$operation" == diff ]] || return 2
+	cat "$DIFF"
+	return 0
+}
+
+fixture() {
+	printf '%s\n' '+++ b/example.txt' '@@ -0,0 +1,1 @@' >"$DIFF"
+	local line
+	for line in "$@"; do printf '+%s\n' "$line" >>"$DIFF"; done
+	return 0
+}
+
+expect() {
+	local expected="$1" label="$2"
+	shift 2
+	local status=0
+	"$@" >"${ROOT}/result" 2>"${ROOT}/stderr" || status=$?
+	if [[ "$status" -eq "$expected" ]]; then pass "$label"; else fail "$label"; fi
+	return 0
+}
+
+# shellcheck source=../privacy-guard-helper.sh
+source "$HELPER"
+
+# Deterministic work-count checks rather than wall-clock timing thresholds.
+_privacy_redact_aidevops_script_references() {
+	local text="$1"
+	printf 'redact\n' >>"$TRACE"
+	printf '%s' "$text"
+	return 0
+}
+privacy_scan_public_text() {
+	printf 'public\n' >>"$TRACE"
+	return 0
+}
+fixture 'ordinary source line'
+for ((i = 0; i < 5000; i++)); do printf '+ordinary source line\n' >>"$DIFF"; done
+expect 0 'large benign diff passes secret scan' privacy_scan_secret_material_diff base head
+expect 0 'large benign diff passes public scan' privacy_scan_public_diff base head "$ENTITIES"
+if [[ ! -s "$TRACE" ]]; then
+	pass 'benign lines do not fork redactors or per-line public scanners'
+else
+	fail 'benign lines do not fork redactors or per-line public scanners'
+fi
+printf 'person\tSynthetic Name\n' >"$ENTITIES"
+fixture 'ordinary line'
+expect 0 'nonempty inventory retains authoritative scanning' privacy_scan_public_diff base head "$ENTITIES"
+[[ -s "$TRACE" ]] && pass 'custom inventory disables fast rejection' || fail 'custom inventory disables fast rejection'
+: >"$ENTITIES"
+: >"$TRACE"
+printf 'ordinary\n' >"$HOME/.aidevops/configs/privacy-guard-private-path-patterns.txt"
+expect 0 'configured path rules retain authoritative scanning' privacy_scan_public_diff base head "$ENTITIES"
+[[ -s "$TRACE" ]] && pass 'custom path rules disable fast rejection' || fail 'custom path rules disable fast rejection'
+rm "$HOME/.aidevops/configs/privacy-guard-private-path-patterns.txt"
+
+# Restore the real scanners for detection, redaction, and line-number checks.
+# shellcheck source=../privacy-guard-helper.sh
+source "$HELPER"
+synthetic_token="s""k-""0123456789abcdefghijkl"
+fixture 'clean line' "example: $synthetic_token"
+expect 1 'credential candidate remains blocked' privacy_scan_secret_material_diff base head
+if [[ "$(cat "${ROOT}/result")" == 'example.txt:2: credential token prefix' ]]; then
+	pass 'line numbers survive skipped clean lines'
+else
+	fail 'line numbers survive skipped clean lines'
+fi
+expect 1 'public scanner still blocks credential candidates' privacy_scan_public_diff base head "$ENTITIES"
+fixture "-----BEGIN ""PRIVATE KEY-----" 'synthetic non-key contents' "-----END ""PRIVATE KEY-----"
+expect 1 'PEM state remains blocked across ordinary-looking lines' privacy_scan_secret_material_diff base head
+if [[ "$(cat "${ROOT}/result")" == *'example.txt:2: private-key PEM block content'* ]]; then
+	pass 'PEM body lines remain covered'
+else
+	fail 'PEM body lines remain covered'
+fi
+fixture "-----BEGIN ""PRIVATE KEY-----" 'synthetic non-key contents'
+printf '%s\n' '+++ b/unrelated.txt' '@@ -0,0 +1,1 @@' '+ordinary line' >>"$DIFF"
+expect 1 'unterminated key opening is still blocked' privacy_scan_secret_material_diff base head
+if [[ "$(cat "${ROOT}/result")" != *'unrelated.txt:'* ]]; then
+	pass 'PEM state does not leak across file boundaries'
+else
+	fail 'PEM state does not leak across file boundaries'
+fi
+tilde='~'
+for path in '/Us''ers/example/item' '/ho''me/example/item' "${tilde}/Git/example" 'file:///'Users/example/item; do
+	fixture "source: $path"
+	expect 1 'built-in local path candidate remains blocked' privacy_scan_public_diff base head "$ENTITIES"
+done
+printf 'person\tSynthetic Name\n' >"$ENTITIES"
+fixture 'Synthetic Name'
+expect 1 'private entity remains blocked' privacy_scan_public_diff base head "$ENTITIES"
+: >"$ENTITIES"
+printf '^ordinary$\n' >"$HOME/.aidevops/configs/privacy-guard-private-path-patterns.txt"
+fixture 'ordinary'
+expect 1 'custom anchored path rule remains blocked' privacy_scan_public_diff base head "$ENTITIES"
+expect 2 'missing inventory is not treated as clean' privacy_scan_public_diff base head "${ROOT}/missing"
+
+printf 'Tests: %d, Failures: %d\n' "$((PASS + FAIL))" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Resolves #31548

Preserve a complete trailing Beads integration section when refreshing the
canonical post-checkout dispatcher, and make that section reachable after a
successful guard check.

The previous dispatcher used `exec` or exited before appended Beads code, while
the installer replaced the whole managed hook during refresh. This change fixes
both control flow and refresh preservation without weakening guard failures.

The pre-push path also exposed expensive per-line privacy scanning and PEM state
leaking between unrelated files. A follow-up commit conservatively filters
built-in candidates in one streaming pass, keeps original file/line reporting,
and scopes PEM state to each file. Custom inventories retain the full scan.

## Files Scope

- `.agents/scripts/install-canonical-guard.sh`
- `.agents/scripts/test-canonical-guard.sh`
- `.agents/scripts/privacy-guard-helper.sh`
- `.agents/scripts/test-privacy-guard.sh`
- `.agents/scripts/tests/test-privacy-diff-fast-path.sh`

## Safety behaviour

- Propagate nonzero guard results before running Beads.
- Preserve one complete trailing Beads section, including matching versioned
  markers; refuse malformed, duplicate, mismatched, or ambiguous sections.
- Stage and syntax-check output before replacing the installed hook.
- Refuse symlink/non-regular targets and uninstalling a mixed Beads hook.
- Retain existing Beads section policies rather than silently changing them.

## Verification

- `bash .agents/scripts/test-canonical-guard.sh`: 24 tests passed.
- The same suite passed with a reviewed real-world hook supplied as a local
  fixture, including an actual Git file checkout in a synthetic repository.
- ShellCheck passed on all changed shell files; formatting passed on the hook
  repair files, with existing advisory formatting debt in the privacy helpers.
- Privacy regression suites passed: 21 fast-path/file-state cases, 27 guard
  cases, and 18 public-write cases. The cache-refresh case now uses the supported
  probe stub instead of making a live GitHub request from an offline test suite.
- A large inherited upstream comparison completed in 10.29 seconds and still
  blocked key-header literals, rather than timing out after 300 seconds. The
  actual repair diff passed the privacy hook against its upstream base in 4.40
  seconds. These are local observations, not universal performance guarantees.
- Changed-file local quality checks, explicit secret scans, and pre-commit
  validation passed without disabling checks.
- An earlier expanded suite reproduced nine failures against the old installer.

Tests use an isolated HOME and a controlled Beads stub; they do not mutate a
real task database. A post-checkout hook detects state after checkout, not before.

## Review and rollout

Review-only request. Do not auto-merge or deploy. A project hook repair alone is
not update-durable while its installer still discards the Beads section. Review
framework delivery and downstream activation together. No private project data,
local paths, credentials, or production content are included in this request.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.337 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 3h 25m and 417,726 tokens on this with the user in an interactive session.