### PR TITLE
GH#31550: preserve signed approvals through operational handoffs

### DIFF
--- a/.agents/scripts/approval-helper-continuity.sh
+++ b/.agents/scripts/approval-helper-continuity.sh
@@ -11,6 +11,7 @@
 
 [[ -n "${_APPROVAL_HELPER_CONTINUITY_LOADED:-}" ]] && return 0
 _APPROVAL_HELPER_CONTINUITY_LOADED=1
+_APPROVAL_LABELED_EVENT="labeled"
 
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	_approval_continuity_lib_path="${BASH_SOURCE[0]%/*}"
@@ -37,7 +38,7 @@ _approval_continuity_is_repository_status_default() {
 	local actor="$3"
 	local actor_id="$4"
 	local actor_type="$5"
-	[[ "$event" == "labeled" && "$subject" == "$_APPROVAL_AVAILABLE_LABEL" ]] || return 1
+	[[ "$event" == "$_APPROVAL_LABELED_EVENT" && "$subject" == "$_APPROVAL_AVAILABLE_LABEL" ]] || return 1
 	[[ "$actor" == "github-actions[bot]" ]] || return 1
 	[[ "$actor_id" == "$_APPROVAL_GITHUB_ACTIONS_BOT_ID" ]] || return 1
 	[[ "$actor_type" == "Bot" ]] || return 1
@@ -96,9 +97,10 @@ _approval_continuity_lifecycle_change_allowed() {
 	# #aidevops:trust-boundary — deterministic tier backfill may only select a
 	# canonical workload tier. Status labels remain workflow metadata, but every
 	# resulting timeline mutation still requires authorization during replay.
-	jq -e --argjson signed "$signed_lifecycle" --argjson self_hosting "$self_hosting" '
-		def allowed_label: . == "needs-maintainer-review" or . == "auto-dispatch" or . == "status:available" or . == "status:queued" or . == "status:claimed" or . == "status:in-progress" or . == "status:in-review" or . == "status:done" or . == "status:blocked" or . == "tier:simple" or . == "tier:standard" or . == "tier:thinking";
-		def tier_label: . == "tier:simple" or . == "tier:standard" or . == "tier:thinking";
+	jq -e --argjson signed "$signed_lifecycle" --argjson self_hosting "$self_hosting" \
+		--argjson tiers '["tier:simple","tier:standard","tier:thinking"]' '
+		def tier_label: . as $label | $tiers | index($label) != null;
+		def allowed_label: . == "needs-maintainer-review" or . == "auto-dispatch" or . == "status:available" or . == "status:queued" or . == "status:claimed" or . == "status:in-progress" or . == "status:in-review" or . == "status:done" or . == "status:blocked" or tier_label;
 		.lifecycle as $current |
 		($current.labels | map(.name)) as $current_labels |
 		($signed.labels | map(.name)) as $signed_labels |
@@ -119,8 +121,8 @@ _approval_continuity_lifecycle_change_allowed() {
 			($signed_tiers == 0 and $current_tiers == 1 and $added_tiers == 1 and $removed_tiers == 0)
 			or ($self_hosting and $signed_tiers == 1 and $current_tiers == 1
 				and $added_tiers == 1 and $removed_tiers == 1
-				and ($added_labels | index("tier:thinking")) != null
-				and any($removed_labels[]; . == "tier:simple" or . == "tier:standard"))
+				and ($added_labels | index($tiers[2])) != null
+				and any($removed_labels[]; . == $tiers[0] or . == $tiers[1]))
 		else true end)
 		and ($current.assignees != $signed.assignees or $current.labels != $signed.labels)
 	' <<<"$current_snapshot" >/dev/null 2>&1
@@ -136,13 +138,14 @@ _approval_continuity_self_hosting_audit() {
 	# the normal ordered timeline replay still authenticates every mutation.
 	audits=$(_approval_snapshot_v2_comments_json "$pages" "" conversation "$issued" "$number" "$slug" self-hosting-audit) || return 2
 	actor=$(jq -er 'select(length == 1) | .[0].actor | select(type == "string" and length > 0)' <<<"$audits") || return 1
-	jq -e --arg actor "$actor" --arg issued "$issued" '
+	jq -e --arg actor "$actor" --arg issued "$issued" --arg added "$_APPROVAL_LABELED_EVENT" --arg removed "unlabeled" \
+		--argjson tiers '["tier:simple","tier:standard","tier:thinking"]' '
 		[.[][]? | select(.created_at > $issued)
-		| select((.event == "labeled" or .event == "unlabeled") and ((.label.name // "") | startswith("tier:")))] as $changes
+		| select((.event == $added or .event == $removed) and ((.label.name // "") | startswith("tier:")))] as $changes
 		| ($changes | length) == 2
 		and all($changes[]; .actor.login == $actor)
-		and any($changes[]; .event == "labeled" and .label.name == "tier:thinking")
-		and any($changes[]; .event == "unlabeled" and (.label.name == "tier:simple" or .label.name == "tier:standard"))
+		and any($changes[]; .event == $added and .label.name == $tiers[2])
+		and any($changes[]; .event == $removed and (.label.name == $tiers[0] or .label.name == $tiers[1]))
 	' <<<"$timeline" >/dev/null 2>&1
 	return $?
 }

--- a/.agents/scripts/approval-helper-continuity.sh
+++ b/.agents/scripts/approval-helper-continuity.sh
@@ -91,11 +91,12 @@ _approval_continuity_ordered_mutation_rows() {
 _approval_continuity_lifecycle_change_allowed() {
 	local signed_lifecycle="$1"
 	local current_snapshot="$2"
+	local self_hosting="${3:-false}"
 
 	# #aidevops:trust-boundary — deterministic tier backfill may only select a
 	# canonical workload tier. Status labels remain workflow metadata, but every
 	# resulting timeline mutation still requires authorization during replay.
-	jq -e --argjson signed "$signed_lifecycle" '
+	jq -e --argjson signed "$signed_lifecycle" --argjson self_hosting "$self_hosting" '
 		def allowed_label: . == "needs-maintainer-review" or . == "auto-dispatch" or . == "status:available" or . == "status:queued" or . == "status:claimed" or . == "status:in-progress" or . == "status:in-review" or . == "status:done" or . == "status:blocked" or . == "tier:simple" or . == "tier:standard" or . == "tier:thinking";
 		def tier_label: . == "tier:simple" or . == "tier:standard" or . == "tier:thinking";
 		.lifecycle as $current |
@@ -114,9 +115,35 @@ _approval_continuity_lifecycle_change_allowed() {
 		and $current.milestone == $signed.milestone
 		and $current.lock_anchor == $signed.lock_anchor
 		and ([$added_labels[], $removed_labels[]] | unique | all(allowed_label))
-		and (if ($added_tiers + $removed_tiers) > 0 then $signed_tiers == 0 and $current_tiers == 1 and $added_tiers == 1 and $removed_tiers == 0 else true end)
+		and (if ($added_tiers + $removed_tiers) > 0 then
+			($signed_tiers == 0 and $current_tiers == 1 and $added_tiers == 1 and $removed_tiers == 0)
+			or ($self_hosting and $signed_tiers == 1 and $current_tiers == 1
+				and $added_tiers == 1 and $removed_tiers == 1
+				and ($added_labels | index("tier:thinking")) != null
+				and any($removed_labels[]; . == "tier:simple" or . == "tier:standard"))
+		else true end)
 		and ($current.assignees != $signed.assignees or $current.labels != $signed.labels)
 	' <<<"$current_snapshot" >/dev/null 2>&1
+	return $?
+}
+
+_approval_continuity_self_hosting_audit() {
+	local slug="$1" number="$2" issued="$3" timeline="$4"
+	local pages="" audits="" actor=""
+	pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${number}/comments?per_page=100") || return 2
+	# Reuse the exact canonical matcher, not a second hand-copied writer regex.
+	# #aidevops:trust-boundary — an audit is evidence, never authority by itself;
+	# the normal ordered timeline replay still authenticates every mutation.
+	audits=$(_approval_snapshot_v2_comments_json "$pages" "" conversation "$issued" "$number" "$slug" self-hosting-audit) || return 2
+	actor=$(jq -er 'select(length == 1) | .[0].actor | select(type == "string" and length > 0)' <<<"$audits") || return 1
+	jq -e --arg actor "$actor" --arg issued "$issued" '
+		[.[][]? | select(.created_at > $issued)
+		| select((.event == "labeled" or .event == "unlabeled") and ((.label.name // "") | startswith("tier:")))] as $changes
+		| ($changes | length) == 2
+		and all($changes[]; .actor.login == $actor)
+		and any($changes[]; .event == "labeled" and .label.name == "tier:thinking")
+		and any($changes[]; .event == "unlabeled" and (.label.name == "tier:simple" or .label.name == "tier:standard"))
+	' <<<"$timeline" >/dev/null 2>&1
 	return $?
 }
 
@@ -161,13 +188,15 @@ _approval_verify_locked_issue_continuity() {
 	candidate=$(jq -cS --argjson lifecycle "$signed_lifecycle" '.lifecycle = $lifecycle' <<<"$current_snapshot") || return 1
 	candidate_digest=$(approval_snapshot_v2_digest "$candidate") || return 2
 	[[ "$candidate_digest" == "$signed_digest" ]] || return 1
-	if ! _approval_continuity_lifecycle_change_allowed "$signed_lifecycle" "$current_snapshot"; then
-		return 1
-	fi
-
 	timeline_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/timeline?per_page=100") || return 2
 	mutation_rows=$(_approval_continuity_ordered_mutation_rows "$timeline_pages" "$issued_at" "$approval_comment_id" 2>/dev/null) || return 2
 	[[ -n "$mutation_rows" ]] || return 1
+	if ! _approval_continuity_lifecycle_change_allowed "$signed_lifecycle" "$current_snapshot"; then
+		# Only the existing canonical self-hosting escalation can replace a
+		# signed workload tier; arbitrary tier changes remain approval-bound.
+		_approval_continuity_lifecycle_change_allowed "$signed_lifecycle" "$current_snapshot" true || return 1
+		_approval_continuity_self_hosting_audit "$slug" "$target_number" "$issued_at" "$timeline_pages" || return $?
+	fi
 
 	while IFS=$'\t' read -r event actor subject actor_id actor_type; do
 		[[ -n "$event" ]] || continue

--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -44,6 +44,28 @@ _approval_snapshot_v2_fetch_pages() {
 	return 0
 }
 
+# Keep metadata projection separate from the authenticated audit predicates.
+_approval_snapshot_v2_comment_identity() {
+	cat <<'JQ'
+def comment_identity:
+	{
+		source: $source, id: .id, node_id: (.node_id // ""),
+		author: {
+			id: (.user.id // null), node_id: (.user.node_id // $empty),
+			login: (.user.login // $empty), type: (.user.type // $empty)
+		},
+		author_association: (.author_association // $empty),
+		created_at: (.created_at // $empty),
+		updated_at: (.updated_at // .created_at // $empty),
+		body: (.body // $empty), path: (.path // null),
+		line: (.line // null), side: (.side // null),
+		commit_id: (.commit_id // null),
+		original_commit_id: (.original_commit_id // null)
+	};
+JQ
+	return 0
+}
+
 _approval_snapshot_v2_comments_json() {
 	local pages_json="$1"
 	local excluded_comment_id="${2:-}"
@@ -58,7 +80,7 @@ _approval_snapshot_v2_comments_json() {
 	# audit written after verification. Marker text is attacker-controlled:
 	# excluding arbitrary marker comments would let an external contributor hide
 	# later drift by copying the marker into an unsigned comment.
-	jq -cS --arg excluded "$excluded_comment_id" --arg source "$source_name" --arg cutoff "$issued_at_cutoff" --arg empty "$empty_string" --arg number "$target_number" --arg repo "$target_repo" --arg selection "$selection" '
+	jq -cS --arg excluded "$excluded_comment_id" --arg source "$source_name" --arg cutoff "$issued_at_cutoff" --arg empty "$empty_string" --arg number "$target_number" --arg repo "$target_repo" --arg selection "$selection" "$(_approval_snapshot_v2_comment_identity)"'
 		def trusted_association:
 			. == "OWNER" or . == "MEMBER" or . == "COLLABORATOR";
 		def aidevops_worker_footer:
@@ -133,26 +155,7 @@ _approval_snapshot_v2_comments_json() {
 			and ((.created_at // $empty) > $cutoff)
 			and ((.body // $empty) | canonical_dispatch_audit or canonical_self_hosting_override or canonical_no_work_escalation_skip)
 		) | not)
-		| {
-			source: $source,
-			id: .id,
-			node_id: (.node_id // ""),
-			author: {
-				id: (.user.id // null),
-				node_id: (.user.node_id // $empty),
-				login: (.user.login // $empty),
-				type: (.user.type // $empty)
-			},
-			author_association: (.author_association // $empty),
-			created_at: (.created_at // $empty),
-			updated_at: (.updated_at // .created_at // $empty),
-			body: (.body // $empty),
-			path: (.path // null),
-			line: (.line // null),
-			side: (.side // null),
-			commit_id: (.commit_id // null),
-			original_commit_id: (.original_commit_id // null)
-		}
+		| comment_identity
 		] | sort_by(.source, .id) end
 	' <<<"$pages_json"
 	return $?

--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -49,6 +49,8 @@ _approval_snapshot_v2_comments_json() {
 	local excluded_comment_id="${2:-}"
 	local source_name="${3:-conversation}"
 	local issued_at_cutoff="${4:-}"
+	local target_number="${5:-}" target_repo="${6:-}"
+	local selection="${7:-snapshot}"
 	local empty_string=""
 
 	# #aidevops:trust-boundary — exclude the exact approval comment whose
@@ -56,11 +58,16 @@ _approval_snapshot_v2_comments_json() {
 	# audit written after verification. Marker text is attacker-controlled:
 	# excluding arbitrary marker comments would let an external contributor hide
 	# later drift by copying the marker into an unsigned comment.
-	jq -cS --arg excluded "$excluded_comment_id" --arg source "$source_name" --arg cutoff "$issued_at_cutoff" --arg empty "$empty_string" '
+	jq -cS --arg excluded "$excluded_comment_id" --arg source "$source_name" --arg cutoff "$issued_at_cutoff" --arg empty "$empty_string" --arg number "$target_number" --arg repo "$target_repo" --arg selection "$selection" '
 		def trusted_association:
 			. == "OWNER" or . == "MEMBER" or . == "COLLABORATOR";
 		def aidevops_worker_footer:
 			"(?:\\n<!-- aidevops:origin:worker -->)?\\n<!-- aidevops:sig -->\\n---\\n\\[aidevops\\.sh\\]\\(https://aidevops\\.sh\\) v[A-Za-z0-9._+-]+ [^\\n]+\\n?";
+		def canonical_ever_nmr_remediation:
+			("<!-- ever-nmr-remediation -->\n> Label `needs-maintainer-review` was removed, but the `ever-NMR` history flag is still set. Pulse will continue to skip dispatch until cryptographic approval lands:\n>\n> ```\n> sudo aidevops approve issue " + $number + " " + $repo + "\n> ```\n>\n> This gate cannot be bypassed by label manipulation (security design — see `reference/auto-merge.md` NMR section).") as $body
+			| ($source == "conversation" and $number != "" and $repo != "")
+			and startswith($body)
+			and (.[$body | length:] | test("^(?:\\n<!-- aidevops:origin:worker -->)?\\n<!-- aidevops:sig -->\\n---\\n\\[aidevops\\.sh\\]\\(https://aidevops\\.sh\\) v[0-9]+\\.[0-9]+\\.[0-9]+ automated scan\\.\\n?$"));
 		def canonical_dispatch_audit:
 			test(
 				"^<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\\n(?:" +
@@ -78,7 +85,13 @@ _approval_snapshot_v2_comments_json() {
 			test(
 				"^<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\\n<!-- no-work-escalation-skip -->\\n## Tier Escalation Skipped: Infrastructure Failure \\(no_work\\)\\n\\n\\*\\*Trigger:\\*\\* [0-9]+ worker failure\\(s\\) classified as `no_work` — the worker exited during setup without reading any target files\\.\\n\\*\\*Action:\\*\\* Tier escalation \\*\\*skipped\\*\\*\\. The issue stays at its current tier so the next retry can succeed cheaply once the infrastructure issue resolves\\.\\n\\*\\*Reason:\\*\\* [A-Za-z0-9._:-]+\\n\\n\\*\\*Why no cascade:\\*\\* `no_work` means the worker never produced reliable implementation evidence — it crashed during runtime setup \\(FD exhaustion, plugin init failure, branch naming race, auth refresh race\\) or stale-recovery falsely concluded no progress\\. A more expensive model cannot fix an infrastructure problem it never reached\\. Cascading to `tier:thinking` would waste capacity on a problem the mapped standard or simple model can handle once the infrastructure clears\\.\\n\\nAfter [0-9]+ consecutive `no_work` failures the per-issue no_work circuit breaker \\(t2769\\) applies `status:blocked` and files a machine-recoverable root-cause meta-issue\\.\\n\\n_Automated by `escalate_issue_tier\\(\\)` no_work skip \\(t2387\\) in worker-lifecycle-common\\.sh_\\n<!-- ops:end -->" + aidevops_worker_footer + "$"
 			);
-		[.[][]?
+		if $selection == "self-hosting-audit" then
+			[.[][]? | select(.user.type == "User")
+			| select((.author_association // $empty) | trusted_association)
+			| select($cutoff != $empty and .created_at > $cutoff and (.updated_at // .created_at) == .created_at)
+			| select((.body // $empty) | canonical_self_hosting_override)
+			| {id, actor: .user.login}]
+		else [.[][]?
 		| select((.id | tostring) != $excluded)
 		| select((.user.type // $empty) != "Bot")
 		| select((
@@ -93,7 +106,20 @@ _approval_snapshot_v2_comments_json() {
 			# optional worktree qualifier bounded to its backtick-delimited basename;
 			# trusted prose or copied markers must remain approval-significant.
 			((.author_association // $empty) | trusted_association)
-			and ((.body // $empty) | test("^<!-- aidevops-interactive-claim/v1 -->\\n<!-- ops:start -->\\n> Interactive session claimed by @[^\\n`]+(?: in `[^`\\n]+`)? on [^\\n]+\\.\\n> Pulse dispatch blocked via `status:in-review` \\+ self-assignment\\.\\n<!-- ops:end -->\\n(?:<!-- aidevops:origin:interactive -->\\n)?<!-- aidevops:sig -->\\n---\\n[^\\n]+\\n?$"))
+			# Preserve historical signatures that included pre-existing claimed
+			# audits. The legacy in-review exclusion is unchanged.
+			and (((.body // $empty) | contains("`status:in-review`"))
+				or ($cutoff != $empty and .created_at > $cutoff and (.updated_at // .created_at) == .created_at))
+			and ((.body // $empty) | test("^<!-- aidevops-interactive-claim/v1 -->\\n<!-- ops:start -->\\n> Interactive session claimed by @[^\\n`]+(?: in `[^`\\n]+`)? on [^\\n]+\\.\\n> Pulse dispatch blocked via `status:(?:in-review|claimed)` \\+ self-assignment\\.\\n<!-- ops:end -->\\n(?:<!-- aidevops:origin:interactive -->\\n)?<!-- aidevops:sig -->\\n---\\n[^\\n]+\\n?$"))
+		) | not)
+		| select((
+			# #aidevops:trust-boundary — only the exact historical notification
+			# for this target, from a trusted author, added unedited after signing.
+			# It conveys no implementation instructions or approval authority.
+			((.author_association // $empty) | trusted_association)
+			and ($cutoff != $empty) and (.created_at > $cutoff)
+			and ((.updated_at // .created_at) == .created_at)
+			and ((.body // $empty) | canonical_ever_nmr_remediation)
 		) | not)
 		| select((
 			# #aidevops:trust-boundary — these comments are excluded only when
@@ -127,7 +153,7 @@ _approval_snapshot_v2_comments_json() {
 			commit_id: (.commit_id // null),
 			original_commit_id: (.original_commit_id // null)
 		}
-		] | sort_by(.source, .id)
+		] | sort_by(.source, .id) end
 	' <<<"$pages_json"
 	return $?
 }
@@ -314,7 +340,7 @@ approval_snapshot_v2_build() (
 	fi
 
 	comments_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/comments?per_page=100") || return 1
-	comments_json=$(_approval_snapshot_v2_comments_json "$comments_pages" "$excluded_comment_id" "conversation" "$issued_at_cutoff") || return 1
+	comments_json=$(_approval_snapshot_v2_comments_json "$comments_pages" "$excluded_comment_id" "conversation" "$issued_at_cutoff" "$target_number" "$slug") || return 1
 	timeline_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/timeline?per_page=100") || return 1
 	linked_references_json=$(_approval_snapshot_v2_linked_references_json "$timeline_pages" "$issued_at_cutoff" "$source_timestamp_profile") || return 1
 	if [[ "$target_type" == "$APPROVAL_TARGET_ISSUE" && "$issue_lifecycle_profile" == "$APPROVAL_SNAPSHOT_PROFILE_CURRENT" ]]; then

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -356,6 +356,7 @@ issue_has_required_approval() {
 	local issue_num="$1"
 	local slug="$2"
 	local known_status="${3:-unknown}"
+	_NMR_APPROVAL_RESULT="NOT_REQUIRED"
 
 	# If it was never NMR-labeled, no approval needed
 	if ! issue_was_ever_nmr "$issue_num" "$slug" "$known_status"; then
@@ -371,12 +372,21 @@ issue_has_required_approval() {
 
 	# It was NMR-labeled at some point — check for cryptographic approval
 	local approval_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/approval-helper.sh"
+	_NMR_APPROVAL_RESULT="HELPER_UNAVAILABLE"
 	if [[ -f "$approval_helper" ]]; then
-		local verify_result
-		verify_result=$(bash "$approval_helper" verify "$issue_num" "$slug" 2>/dev/null) || verify_result=""
-		if [[ "$verify_result" == "VERIFIED" ]]; then
+		local verify_result="" verify_rc=0
+		verify_result=$(bash "$approval_helper" verify "$issue_num" "$slug" 2>/dev/null) || verify_rc=$?
+		_NMR_APPROVAL_RESULT="${verify_result:-API_ERROR}"
+		if [[ "$verify_rc" -eq 0 && "$verify_result" == "VERIFIED" ]]; then
 			return 0
 		fi
+		# Preserve the reason: missing keys, stale scope and API uncertainty are
+		# not proof that the maintainer never approved. Dispatch stays blocked.
+		[[ "$verify_rc" -eq 1 && "$verify_result" == "NO_APPROVAL" ]] || {
+			echo "[pulse-wrapper] approval verification blocked #${issue_num} in ${slug}: state=${_NMR_APPROVAL_RESULT} rc=${verify_rc}" >>"$LOGFILE"
+			[[ "$verify_result" != "NO_APPROVAL" ]] || _NMR_APPROVAL_RESULT="API_ERROR"
+			return 1
+		}
 	fi
 
 	# Was ever NMR, no signed approval found — blocked
@@ -1436,7 +1446,7 @@ _nmr_applied_by_maintainer() {
 # Detection logic (all four conditions must hold):
 #   1. Label needs-maintainer-review is absent (label was removed by human)
 #   2. ever-NMR history is set (issue_was_ever_nmr returns true)
-#   3. No cryptographic approval comment exists (approval-helper verify != VERIFIED)
+#   3. Verification positively reports NO_APPROVAL, not uncertainty/staleness
 #   4. No prior <!-- ever-nmr-remediation --> marker exists (idempotency guard)
 #
 # Arguments:
@@ -1458,8 +1468,8 @@ notify_ever_nmr_without_approval() {
 	local has_nmr_label
 	has_nmr_label=$(gh api "repos/${repo_slug}/issues/${issue_number}" \
 		--jq '.labels | map(.name) | index("needs-maintainer-review") != null' \
-		2>/dev/null) || has_nmr_label="false"
-	if [[ "$has_nmr_label" == "true" ]]; then
+		2>/dev/null) || return 0
+	if [[ "$has_nmr_label" != "false" ]]; then
 		# Label still present — no remediation needed, block is visible to user.
 		return 0
 	fi
@@ -1473,17 +1483,21 @@ notify_ever_nmr_without_approval() {
 	# Delegate to issue_has_required_approval with known_status="true" (ever-NMR
 	# confirmed above) so that only the approval helper is consulted, short-
 	# circuiting the redundant timeline API call for ever-NMR provenance.
+	_NMR_APPROVAL_RESULT="UNKNOWN"
 	if issue_has_required_approval "$issue_number" "$repo_slug" "true"; then
 		# Approved — block will clear on next dispatch cycle.
 		return 0
 	fi
+	[[ "${_NMR_APPROVAL_RESULT:-UNKNOWN}" == "NO_APPROVAL" ]] || return 0
 
 	# Condition 4: idempotency guard — never post twice.
 	local already_notified
-	already_notified=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" --paginate \
-		--jq '[.[] | select(.body | test("ever-nmr-remediation"))] | length' \
-		2>/dev/null) || already_notified=0
-	[[ "$already_notified" =~ ^[0-9]+$ ]] || already_notified=0
+	# Check all pages together. A signature published since verification also
+	# suppresses notification; presence alone never grants dispatch authority.
+	already_notified=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" --paginate --slurp \
+		--jq '[.[][] | select((.body // "") | test("ever-nmr-remediation|aidevops-signed-approval"))] | length' \
+		2>/dev/null) || return 0
+	[[ "$already_notified" =~ ^[0-9]+$ ]] || return 0
 	if [[ "$already_notified" -gt 0 ]]; then
 		echo "[pulse-wrapper] notify_ever_nmr_without_approval: #${issue_number} in ${repo_slug} — remediation comment already posted, skipping" >>"$LOGFILE"
 		return 0

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -372,6 +372,7 @@ issue_has_required_approval() {
 
 	# It was NMR-labeled at some point — check for cryptographic approval
 	local approval_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/approval-helper.sh"
+	local missing_result="NO_APPROVAL"
 	_NMR_APPROVAL_RESULT="HELPER_UNAVAILABLE"
 	if [[ -f "$approval_helper" ]]; then
 		local verify_result="" verify_rc=0
@@ -382,9 +383,9 @@ issue_has_required_approval() {
 		fi
 		# Preserve the reason: missing keys, stale scope and API uncertainty are
 		# not proof that the maintainer never approved. Dispatch stays blocked.
-		[[ "$verify_rc" -eq 1 && "$verify_result" == "NO_APPROVAL" ]] || {
+		[[ "$verify_rc" -eq 1 && "$verify_result" == "$missing_result" ]] || {
 			echo "[pulse-wrapper] approval verification blocked #${issue_num} in ${slug}: state=${_NMR_APPROVAL_RESULT} rc=${verify_rc}" >>"$LOGFILE"
-			[[ "$verify_result" != "NO_APPROVAL" ]] || _NMR_APPROVAL_RESULT="API_ERROR"
+			[[ "$verify_result" != "$missing_result" ]] || _NMR_APPROVAL_RESULT="API_ERROR"
 			return 1
 		}
 	fi

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -355,6 +355,25 @@ directory_is_empty() {
 	return 0
 }
 
+render_current_claim_writer() (
+	# Exercise the real writer, not a hand-copied historical comment fixture.
+	# shellcheck source=../interactive-session-helper-stamp.sh
+	source "${SCRIPT_DIR}/../interactive-session-helper-stamp.sh"
+	_isc_hostname_or_fallback() { printf 'Linux'; }
+	gh_issue_comment() {
+		while [[ $# -gt 0 ]]; do
+			if [[ "$1" == "--body" ]]; then
+				printf '%s' "$2" >"${TEST_ROOT}/current-claim.txt"
+				return 0
+			fi
+			shift
+		done
+		return 1
+	}
+	_isc_post_claim_comment 41 owner/repo maintainer /fixture/linked-worktree
+	cat "${TEST_ROOT}/current-claim.txt"
+)
+
 test_trusted_lifecycle_comments() {
 	reset_and_sign pr 42
 	local audit_marker="<!-- aidevops-signed-approval -->
@@ -375,11 +394,8 @@ Auto-approved: cryptographic approval verified. Stale recovery tick reset."
 ---
 [aidevops.sh](https://aidevops.sh) v3.32.175 automated scan."
 	local claim_comments=""
-	local claim_writer_body="<!-- aidevops-interactive-claim/v1 -->
-<!-- ops:start -->
-> Interactive session claimed by @maintainer in \`linked-worktree\` on Linux.
-> Pulse dispatch blocked via \`status:in-review\` + self-assignment.
-<!-- ops:end -->"
+	local claim_writer_body=""
+	claim_writer_body=$(render_current_claim_writer) || return 1
 	local worktree_claim_marker=""
 	worktree_claim_marker=$(AIDEVOPS_SESSION_ORIGIN=interactive AIDEVOPS_SIG_CLI="Test CLI" AIDEVOPS_SIG_CLI_VERSION="1.0.0" AIDEVOPS_SIG_MODEL="test/model" AIDEVOPS_SIG_TOKENS="1" \
 		"${SCRIPT_DIR}/../gh-signature-helper.sh" footer --body "$claim_writer_body") || return 1
@@ -402,6 +418,53 @@ Auto-approved: cryptographic approval verified. Stale recovery tick reset."
 extra trusted commentary" '.[0] += [{id:4305,node_id:"IC_4305",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:08:00Z",updated_at:"2026-01-01T00:08:00Z",body:$body}]' "${FIXTURES}/comments-41.json")
 	printf '%s\n' "$claim_comments" >"${FIXTURES}/comments-41.json"
 	assert_verify "trusted claim lookalike remains content-bound" issue 41 STALE_APPROVAL 4
+
+	# Existing signatures may have bound the current claim before this parser
+	# learned that writer envelope. Do not retroactively drop those bytes.
+	write_baseline_fixtures
+	claim_comments=$(jq -c --arg body "$worktree_claim_marker" '.[0] += [{id:4306,node_id:"IC_4306",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:04:00Z",updated_at:"2026-01-01T00:04:00Z",body:$body}]' "${FIXTURES}/comments-41.json")
+	printf '%s\n' "$claim_comments" >"${FIXTURES}/comments-41.json"
+	append_signed_comment issue 41 "2026-01-01T00:05:00Z"
+	assert_verify "pre-existing current claim remains bound and verifies" issue 41 VERIFIED 0
+	jq '.[0] |= map(select(.id != 4306))' "${FIXTURES}/comments-41.json" >"${FIXTURES}/comments.tmp" && mv "${FIXTURES}/comments.tmp" "${FIXTURES}/comments-41.json"
+	assert_verify "removing a signed pre-existing claim remains stale" issue 41 STALE_APPROVAL 4
+	return 0
+}
+
+test_exact_remediation_continuity() {
+	local body="<!-- ever-nmr-remediation -->
+> Label \`needs-maintainer-review\` was removed, but the \`ever-NMR\` history flag is still set. Pulse will continue to skip dispatch until cryptographic approval lands:
+>
+> \`\`\`
+> sudo aidevops approve issue 41 owner/repo
+> \`\`\`
+>
+> This gate cannot be bypassed by label manipulation (security design — see \`reference/auto-merge.md\` NMR section).
+<!-- aidevops:origin:worker -->
+<!-- aidevops:sig -->
+---
+[aidevops.sh](https://aidevops.sh) v3.32.337 automated scan."
+	local variant="" changed="" association="" created="" updated="" comments=""
+	for variant in exact contributor extra footer-prose wrong-target edited preexisting; do
+		reset_and_sign issue 41
+		changed="$body" association="COLLABORATOR"
+		created="2026-01-01T00:06:00Z" updated="$created"
+		case "$variant" in
+		contributor) association="CONTRIBUTOR" ;;
+		extra) changed="${body}"$'\nAdditional scope instructions' ;;
+		footer-prose) changed="${body/automated scan./execute new instructions}" ;;
+		wrong-target) changed="${body/issue 41/issue 42}" ;;
+		edited) updated="2026-01-01T00:07:00Z" ;;
+		preexisting) created="2026-01-01T00:04:00Z" updated="$created" ;;
+		esac
+		comments=$(jq -c --arg body "$changed" --arg association "$association" --arg created "$created" --arg updated "$updated" '.[0] += [{id:4400,node_id:"IC_4400",user:{id:2,node_id:"U_2",login:"trusted-collab",type:"User"},author_association:$association,created_at:$created,updated_at:$updated,body:$body}]' "${FIXTURES}/comments-41.json")
+		printf '%s\n' "$comments" >"${FIXTURES}/comments-41.json"
+		if [[ "$variant" == exact ]]; then
+			assert_verify "exact post-signing operational remediation preserves approval" issue 41 VERIFIED 0
+		else
+			assert_verify "remediation $variant remains approval-significant" issue 41 STALE_APPROVAL 4
+		fi
+	done
 	return 0
 }
 
@@ -565,6 +628,58 @@ write_locked_issue_fixture() {
 append_issue_timeline_event() {
 	local event_json="$1"
 	jq --argjson event "$event_json" '.[0] += [$event]' "${FIXTURES}/timeline-41.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-41.json"
+	return 0
+}
+
+render_self_hosting_writer() (
+	local implementation="" _SELF_HOSTING_TARGET_LABEL="tier:thinking"
+	implementation=$(awk '/^_sht_apply_label_and_comment\(\) \{/,/^}$/ { print }' "${SCRIPT_DIR}/../pre-dispatch-validator-helper.sh")
+	eval "$implementation"
+	_sht_replace_tier_labels() { return 0; }
+	_log() { return 0; }
+	gh_issue_comment() {
+		while [[ $# -gt 0 ]]; do
+			if [[ "$1" == --body ]]; then
+				printf '%s' "$2" >"${TEST_ROOT}/self-hosting-body.txt"
+				return 0
+			fi
+			shift
+		done
+		return 1
+	}
+	_sht_apply_label_and_comment 41 owner/repo pulse-dispatch- '<!-- self-hosting-tier-override -->' tier:standard
+	cat "${TEST_ROOT}/self-hosting-body.txt"
+	printf '\n<!-- aidevops:origin:worker -->\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) v3.32.337 automated scan.'
+)
+
+test_signed_tier_self_hosting_continuity() {
+	local body="" variant="" actor="" association="" comments="" changed="" created=""
+	body=$(render_self_hosting_writer) || return 1
+	for variant in exact missing wrong-actor contributor edited prose early; do
+		write_locked_issue_fixture
+		jq '.labels |= map(if .name == "tier:standard" then .name = "tier:thinking" else . end)' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp" && mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+		append_issue_timeline_event '{"id":4501,"event":"unlabeled","created_at":"2026-01-01T00:06:00Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:standard"}}'
+		append_issue_timeline_event '{"id":4502,"event":"labeled","created_at":"2026-01-01T00:06:01Z","actor":{"id":1,"login":"maintainer","type":"User"},"label":{"name":"tier:thinking"}}'
+		actor="maintainer" association="OWNER" changed="$body" created="2026-01-01T00:06:02Z"
+		case "$variant" in
+		wrong-actor) actor="trusted-collab" ;;
+		contributor) association="CONTRIBUTOR" ;;
+		prose) changed="${body}"$'\nNew scope' ;;
+		early) created="2026-01-01T00:04:00Z" ;;
+		esac
+		if [[ "$variant" != missing ]]; then
+			comments=$(jq -c --arg body "$changed" --arg actor "$actor" --arg association "$association" --arg created "$created" '.[0] += [{id:4503,node_id:"IC_4503",user:{id:1,node_id:"U_1",login:$actor,type:"User"},author_association:$association,created_at:$created,updated_at:"2026-01-01T00:06:02Z",body:$body}]' "${FIXTURES}/comments-41.json")
+			printf '%s\n' "$comments" >"${FIXTURES}/comments-41.json"
+		fi
+		if [[ "$variant" == edited ]]; then
+			jq '.[0][-1].updated_at = "2026-01-01T00:07:00Z"' "${FIXTURES}/comments-41.json" >"${FIXTURES}/comments.tmp" && mv "${FIXTURES}/comments.tmp" "${FIXTURES}/comments-41.json"
+		fi
+		if [[ "$variant" == exact ]]; then
+			assert_verify "signed tier escalation with real writer audit preserves approval" issue 41 VERIFIED 0
+		else
+			assert_verify "signed tier escalation with $variant audit remains stale" issue 41 STALE_APPROVAL 4
+		fi
+	done
 	return 0
 }
 
@@ -794,11 +909,13 @@ main() {
 	append_signed_comment pr 42 "2026-01-01T00:06:00Z" 4300
 	assert_verify "repeat approval verifies against the newest exact snapshot" pr 42 VERIFIED 0 "$PR_HEAD"
 	test_trusted_lifecycle_comments
+	test_exact_remediation_continuity
 	test_trusted_dispatch_audit_comments
 	test_dispatch_audit_comments_fail_closed
 	test_post_approval_linked_references
 	test_locked_issue_continuity
 	test_locked_issue_tier_backfill_continuity
+	test_signed_tier_self_hosting_continuity
 
 	reset_and_sign pr 42
 	local marker_drift="<!-- aidevops-signed-approval --> unsigned external drift"

--- a/.agents/scripts/tests/test-pulse-nmr-approval.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-approval.sh
@@ -80,20 +80,32 @@ if [[ "${1:-}" == "api" ]]; then
 		exit 0
 	fi
 	jq_filter=""
+	slurp=0
 	shift 2 2>/dev/null || true
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 			--paginate) shift ;;
+			--slurp) slurp=1; shift ;;
 			--jq) jq_filter="$2"; shift 2 ;;
 			*) shift ;;
 		esac
 	done
 	if [[ "$path" == */comments ]]; then
+		[[ "${STUB_COMMENT_ERROR:-0}" != 1 ]] || exit 1
 		if [[ -n "$jq_filter" ]]; then
-			jq -r "$jq_filter" <"$COMMENTS_FIXTURE" 2>/dev/null || echo "0"
+			if [[ "$slurp" == 1 ]]; then
+				jq -s -r "$jq_filter" "$COMMENTS_FIXTURE"
+			else
+				jq -r "$jq_filter" <"$COMMENTS_FIXTURE"
+			fi
 		else
 			cat "$COMMENTS_FIXTURE"
 		fi
+		exit 0
+	fi
+	if [[ "$path" == repos/*/issues/[0-9]* ]]; then
+		[[ "${STUB_ISSUE_ERROR:-0}" != 1 ]] || exit 1
+		printf 'false\n'
 		exit 0
 	fi
 	# GH#21799: REST check-runs endpoint
@@ -261,6 +273,8 @@ issue_has_required_approval() {
 	local repo_slug="$2"
 	local known_status="${3:-}"
 	[[ -n "$issue_num" && -n "$repo_slug" && -n "$known_status" ]] || return 0
+	_NMR_APPROVAL_RESULT="${STUB_APPROVAL_RESULT:-NO_APPROVAL}"
+	[[ "$_NMR_APPROVAL_RESULT" != VERIFIED ]] || return 0
 	return 1
 }
 export -f issue_has_required_approval
@@ -519,6 +533,62 @@ test_j_ever_nmr_remediation_includes_repo_slug() {
 	return 0
 }
 
+check_production_approval_result() (
+	local expected="$1" helper_rc="$2" expected_rc="$3"
+	local AGENTS_DIR="${TEST_ROOT}/approval-state"
+	mkdir -p "${AGENTS_DIR}/scripts"
+	printf '#!/usr/bin/env bash\nprintf "%%s\\n" "%s"\nexit %s\n' "$expected" "$helper_rc" >"${AGENTS_DIR}/scripts/approval-helper.sh"
+	_nmr_issue_author_has_repo_write_authority() { return 1; }
+	local implementation="" rc=0
+	implementation=$(awk '/^issue_has_required_approval\(\) \{/,/^}$/ { print }' "$NMR_SCRIPT")
+	eval "$implementation"
+	issue_has_required_approval 3733 exampleorg/examplerepo true || rc=$?
+	[[ "$rc" == "$expected_rc" && "$_NMR_APPROVAL_RESULT" == "$expected" ]]
+)
+
+test_remediation_does_not_stale_existing_approval() {
+	local pair=""
+	for pair in NO_APPROVAL:1 STALE_APPROVAL:4 NO_KEY:2 API_ERROR:6; do
+		if check_production_approval_result "${pair%:*}" "${pair#*:}" 1; then
+			print_result "production approval gate preserves $pair without granting authority" 0
+		else
+			print_result "production approval gate preserves $pair without granting authority" 1
+		fi
+	done
+	if check_production_approval_result VERIFIED 0 0; then
+		print_result "production approval gate accepts VERIFIED with success status" 0
+	else
+		print_result "production approval gate accepts VERIFIED with success status" 1
+	fi
+	local state=""
+	for state in VERIFIED STALE_APPROVAL NO_KEY API_ERROR HELPER_UNAVAILABLE UNKNOWN; do
+		reset_posted_comment
+		STUB_APPROVAL_RESULT="$state" notify_ever_nmr_without_approval 3733 exampleorg/examplerepo
+		if was_comment_posted; then
+			print_result "no missing-approval notification for $state" 1
+		else
+			print_result "no missing-approval notification for $state" 0
+		fi
+	done
+	reset_posted_comment
+	set_comments '[{"body":"<!-- aidevops-signed-approval -->"}]'
+	notify_ever_nmr_without_approval 3733 exampleorg/examplerepo
+	if was_comment_posted; then
+		print_result "newly published signature suppresses notification race" 1
+	else
+		print_result "newly published signature suppresses notification race" 0
+	fi
+	set_comments '[]'
+	STUB_COMMENT_ERROR=1 notify_ever_nmr_without_approval 3733 exampleorg/examplerepo
+	STUB_ISSUE_ERROR=1 notify_ever_nmr_without_approval 3733 exampleorg/examplerepo
+	if was_comment_posted; then
+		print_result "API uncertainty never creates remediation comments" 1
+	else
+		print_result "API uncertainty never creates remediation comments" 0
+	fi
+	return 0
+}
+
 # Case K: calibrated GraphQL cost drift must fail closed rather than treating
 # an unmetered policy-level review decision as authoritative.
 test_k_graphql_cost_drift_no_candidate() {
@@ -756,6 +826,7 @@ main() {
 	test_h_idempotency_no_duplicate
 	test_i_empty_nmr_timestamp_no_candidate
 	test_j_ever_nmr_remediation_includes_repo_slug
+	test_remediation_does_not_stale_existing_approval
 	test_k_graphql_cost_drift_no_candidate
 	test_l_exact_target_reconciliation_is_bounded_and_fail_closed
 	test_m_reconciliation_protocol_uncertainty_stays_fail_closed

--- a/.agents/scripts/tests/test-pulse-nmr-approval.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-approval.sh
@@ -64,7 +64,17 @@ setup_test_env() {
 	CHECK_RUNS_FIXTURE="${TEST_ROOT}/check-runs.json"
 	POSTED_COMMENT="${TEST_ROOT}/posted-comment.txt"
 	export COMMENTS_FIXTURE PR_LIST_FIXTURE CHECK_RUNS_FIXTURE POSTED_COMMENT
+	install_notification_gh_stub
 
+	# Seed empty fixtures independently of the fake transport implementation.
+	printf '[]\n' >"$COMMENTS_FIXTURE"
+	printf '[]\n' >"$PR_LIST_FIXTURE"
+	printf '{"check_runs":[]}\n' >"$CHECK_RUNS_FIXTURE"
+	: >"$POSTED_COMMENT"
+	return 0
+}
+
+install_notification_gh_stub() {
 	# gh stub: serves comments from COMMENTS_FIXTURE for 'gh api ...comments',
 	# serves exact GraphQL PR-search data from PR_LIST_FIXTURE, serves REST
 	# check-runs from CHECK_RUNS_FIXTURE for 'gh api ...commits/SHA/check-runs'
@@ -146,13 +156,6 @@ printf 'unsupported gh invocation: %s\n' "$*" >&2
 exit 1
 GHEOF
 	chmod +x "${TEST_ROOT}/bin/gh"
-
-	# Seed empty fixtures
-	printf '[]\n' >"$COMMENTS_FIXTURE"
-	printf '[]\n' >"$PR_LIST_FIXTURE"
-	printf '{"check_runs":[]}\n' >"$CHECK_RUNS_FIXTURE"
-	: >"$POSTED_COMMENT"
-
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Fix current claim writer snapshot compatibility, exact historical remediation normalization, authenticated self-hosting tier escalation continuity, and false missing-approval notifications. Prerequisite for #31541 and #31542; does not close those original issues.

## Files Changed

.agents/scripts/approval-helper-continuity.sh, .agents/scripts/approval-snapshot-v2.sh, .agents/scripts/pulse-nmr-approval.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh, .agents/scripts/tests/test-pulse-nmr-approval.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: 90 content-binding tests and 34 NMR notification tests pass; ShellCheck and git diff --check clean; current issue 31541 and 31542 signatures verify read-only through the repaired helper. Independent security review clean. Review bundle 205494db1c54cc7684bf74a1c24449c93a38d7280d4835df133436ce909d368a.

Resolves #31550


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.337 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 1h 13m and 184,305 tokens on this with the user in an interactive session.