### PR TITLE
GH#31542: protect bounded prelaunch lease handoff

### DIFF
--- a/.agents/reference/dispatch-timing.md
+++ b/.agents/reference/dispatch-timing.md
@@ -42,6 +42,7 @@ pulse-dispatch-worker-launch.sh    — launch sub-stages instrumented
 | `assign_and_label`    | Issue edit: swap assignees + status:queued + origin:worker |
 | `resolve_tier_model`  | Label-based tier resolution + round-robin model select |
 | `lock_issue`          | Verified issue conversation lock (t1894/t1934); linked PRs remain open for CI reviews |
+| `final_ownership_fence` | Live ownership check immediately before queued assignment |
 | `precreate_worktree`  | Git worktree pre-creation (or reuse) + dep restore  |
 | `worker_spawn`        | DB prewarm + setsid/nohup launch + early-exit monitor |
 | `post_launch_hooks`   | Stagger delay + ledger + dispatch comment + claim audit |
@@ -92,6 +93,22 @@ awk -F'\t' '{print $4 "\t" $5}' ~/.aidevops/logs/dispatch-stages.tsv | \
 ```
 
 ## Env Vars
+
+### Prelaunch lease budget
+
+The dispatcher renews its live claim immediately after winning, before comment
+reads and worktree preparation. `AIDEVOPS_DISPATCH_PRELAUNCH_BUDGET_SECONDS`
+defaults to 300 (valid range 1–999). The renewed lease covers the remaining
+preparation interval plus the existing OpenCode warm-up/handoff allowance.
+Preparation has a fixed elapsed-time deadline: the warm-up renewal cannot
+restart it. Expired budgets stop at stage boundaries before further ownership
+publication or spawn; underlying operations retain their own timeout controls.
+Failed renewal aborts through the existing exact-claim cleanup path.
+
+`CLAIM_WON expires_at` reports the persisted lease expiry, not a fresh deadline
+calculated after consensus. Claim acquisition consumes that lease; an expired
+claim is never revived. Keep the default orphan grace and ownership gates intact
+rather than increasing orphan retention to hide slow preparation.
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -1161,7 +1161,14 @@ _resolve_claim_race_result() {
 	oldest_device=$(printf '%s' "$claims" | jq -r --arg fallback "$LEGACY_DEVICE_MARKER" '.[0].device // $fallback' 2>/dev/null) || oldest_device="$LEGACY_DEVICE_MARKER"
 	our_device=$(_resolve_device_id)
 	now_epoch=$(_now_epoch)
-	lease_expires_at="$((now_epoch + DISPATCH_CLAIM_ORPHAN_GRACE))"
+	# Consensus/API latency consumes the persisted lease; logging a fresh
+	# now+grace here falsely promises an extension that was never published.
+	lease_expires_at=$(printf '%s' "$claims" | jq -r '.[0].lease_expires_at // 0') || return 2
+	[[ "$lease_expires_at" =~ ^[0-9]+$ ]] || return 2
+	if [[ "$lease_expires_at" -gt 0 && "$lease_expires_at" -lt "$now_epoch" ]]; then
+		printf 'CLAIM_ERROR: selected lease expired during consensus issue=#%s\n' "$issue_number" >&2
+		return 2
+	fi
 	if [[ "$oldest_nonce" == "$nonce" ]]; then
 		printf 'CLAIM_WON: runner=%s nonce=%s issue=#%s comment_id=%s lease_token=%s device=%s phase=prelaunch expires_at=%s\n' \
 			"$runner" "$nonce" "$issue_number" "$comment_id" "$nonce" "$our_device" "$lease_expires_at"

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -175,15 +175,34 @@ _dlw_final_assignment_guard() {
 	return 1
 }
 
+_dlw_lock_prelaunch_issue() {
+	local issue_number="$1" repo_slug="$2" started_ns=""
+	# Freeze instructions before ownership publication, only within the budget.
+	_dlw_prelaunch_budget_available "$issue_number" "$repo_slug" || return $?
+	started_ns=$(_ds_now_ns)
+	if ! lock_issue_for_worker "$issue_number" "$repo_slug"; then
+		_ds_record "$issue_number" "$repo_slug" "lock_issue" "$started_ns"
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "conversation_lock_failed" 2
+		return $?
+	fi
+	_ds_record "$issue_number" "$repo_slug" "lock_issue" "$started_ns"
+	return 0
+}
+
 _dlw_publish_queued_ownership() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local self_login="$3"
 	local issue_meta_json="$4"
+	local guard_started_ns="" guard_stage="final_ownership_fence"
+	guard_started_ns=$(_ds_now_ns)
 	if ! _dlw_final_assignment_guard "$issue_number" "$repo_slug" "$self_login"; then
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "final_ownership_fence" 2
+		_ds_record "$issue_number" "$repo_slug" "$guard_stage" "$guard_started_ns"
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "$guard_stage" 2
 		return $?
 	fi
+	_ds_record "$issue_number" "$repo_slug" "$guard_stage" "$guard_started_ns"
+	_dlw_prelaunch_budget_available "$issue_number" "$repo_slug" || return $?
 
 	local assignment_started_ns=""
 	assignment_started_ns=$(_ds_now_ns)
@@ -849,10 +868,35 @@ _dlw_prewarm_opencode_db() {
 	return 0
 }
 
+_dlw_begin_prelaunch() {
+	local issue_number="$1" repo_slug="$2" session_key="$3" worker_log="$4"
+	local budget="${AIDEVOPS_DISPATCH_PRELAUNCH_BUDGET_SECONDS:-300}"
+	[[ "$budget" =~ ^[1-9][0-9]{0,2}$ ]] || budget=300
+	# These locals belong to _dispatch_launch_worker and survive command
+	# substitutions used by warm-up/spawn. Never slide the preparation deadline.
+	prelaunch_deadline=$((SECONDS + budget))
+	attempt_id=$(aidevops_generate_execution_id "attempt")
+	attempt_started_at=$(_worker_attempt_start_marker)
+	if ! _dlw_renew_prelaunch_lease "$issue_number" "$repo_slug" "$session_key" "$worker_log" "$attempt_id"; then
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "prelaunch_lease_failed" 2
+		return $?
+	fi
+	return 0
+}
+
+_dlw_prelaunch_budget_available() {
+	local issue_number="$1" repo_slug="$2"
+	if [[ "${prelaunch_deadline:-0}" -gt 0 && "$SECONDS" -ge "$prelaunch_deadline" ]]; then
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "prelaunch_budget_exhausted" 2
+		return $?
+	fi
+	return 0
+}
+
 #######################################
-# Renew the dispatcher's prelaunch lease before the potentially slow OpenCode
-# database warm-up. The worker renews it again after process start; this renewal
-# closes the gap between worktree preparation and that worker-side transition.
+# Protect the complete bounded preparation interval before worktree/API work,
+# then recheck before OpenCode warm-up. The worker renews after process start.
+# Remaining preparation time decreases; retries cannot slide that deadline.
 # Arguments: issue_number repo_slug session_key worker_log
 #######################################
 _dlw_renew_prelaunch_lease() {
@@ -870,10 +914,19 @@ _dlw_renew_prelaunch_lease() {
 	fi
 	[[ "$prewarm_timeout" =~ ^[0-9]+$ ]] || prewarm_timeout=90
 	[[ "$lease_ttl" =~ ^[0-9]+$ ]] || lease_ttl=$((prewarm_timeout + 60))
+	if [[ "${prelaunch_deadline:-0}" -gt 0 ]]; then
+		local remaining=$((prelaunch_deadline - SECONDS))
+		if [[ "$remaining" -le 0 ]]; then
+			_dlw_prelaunch_budget_available "$issue_number" "$repo_slug" || return 1
+			return 1
+		fi
+		lease_ttl=$((lease_ttl + remaining))
+	fi
 
 	_dlw_append_lifecycle_log "$worker_log" "$attempt_id" \
 		"dispatcher_prelaunch_lease_renew_start session=${session_key} pid=$$"
 	AIDEVOPS_DEVICE_ID="${_claim_lease_device:-${AIDEVOPS_DEVICE_ID:-}}" \
+		AIDEVOPS_ATTEMPT_ID="$attempt_id" \
 		"${SCRIPT_DIR}/dispatch-claim-helper.sh" transition prelaunch "$issue_number" \
 		"$repo_slug" "$_claim_lease_token" "$session_key" "$lease_ttl" \
 		>/dev/null 2>&1 || claim_rc=$?
@@ -1815,6 +1868,8 @@ _dispatch_launch_worker() {
 	if ! _dlw_claim_lock_after_canary "$issue_number" "$repo_slug" "$self_login"; then
 		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "claim_lock_failed" 2 || return $?
 	fi
+	local worker_pid attempt_id="" attempt_started_at="" prelaunch_deadline=0
+	_dlw_begin_prelaunch "$issue_number" "$repo_slug" "$session_key" "$worker_log" || return $?
 
 	local zero_output_comment_metrics=""
 	zero_output_comment_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
@@ -1824,6 +1879,7 @@ _dispatch_launch_worker() {
 
 	# t2981: capture pre-creation return code — skip dispatch on failure
 	# instead of falling back to canonical repo on the default branch.
+	_dlw_prelaunch_budget_available "$issue_number" "$repo_slug" || return $?
 	_ds_t0=$(_ds_now_ns)
 	if ! _dlw_precreate_worktree "$issue_number" "$repo_path"; then
 		_ds_record "$issue_number" "$repo_slug" "precreate_worktree" "$_ds_t0"
@@ -1836,21 +1892,14 @@ _dispatch_launch_worker() {
 	_dlw_final_worker_spawn_gates "$issue_number" "$repo_slug" "$worker_worktree_branch" "$worker_worktree_reused" \
 		"${repo_path}/TODO.md" "$worker_worktree_path" "$issue_meta_json" "$repo_path" || return $?
 
-	local worker_pid attempt_id="" attempt_started_at=""
-	attempt_id=$(aidevops_generate_execution_id "attempt")
-	attempt_started_at=$(_worker_attempt_start_marker)
 	local launch_prompt=""
 	launch_prompt=$(_dlw_prepare_prompt_for_launch "$issue_number" "$repo_slug" "$issue_title" "$prompt" "$zero_output_comment_metrics")
 
 	# Freeze the worker-readable instruction surface before queued ownership is
 	# published. A lock failure must not create assignment/status notifications.
-	_ds_t0=$(_ds_now_ns)
-	if ! lock_issue_for_worker "$issue_number" "$repo_slug"; then
-		_ds_record "$issue_number" "$repo_slug" "lock_issue" "$_ds_t0"
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "conversation_lock_failed" 2 || return $?
-	fi
-	_ds_record "$issue_number" "$repo_slug" "lock_issue" "$_ds_t0"
+	_dlw_lock_prelaunch_issue "$issue_number" "$repo_slug" || return $?
 
+	_dlw_prelaunch_budget_available "$issue_number" "$repo_slug" || return $?
 	_dlw_publish_queued_ownership "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json" || return $?
 	_dlw_start_codegraph_init "$issue_number" "$worker_worktree_path"
 

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -2025,6 +2025,25 @@ claim_released reason=worker_complete
 	return 0
 }
 
+test_claim_winner_persisted_expiry() {
+	local result=0
+	(
+		local implementation="" output="" rc=0
+		implementation=$(awk '/^_resolve_claim_race_result\(\) \{/,/^}$/ { print }' "$CLAIM_HELPER")
+		eval "$implementation"
+		LEGACY_DEVICE_MARKER=legacy
+		_resolve_device_id() { printf 'fixture-device'; }
+		_now_epoch() { printf '1050'; }
+		output=$(_resolve_claim_race_result 42 owner/repo runner fixture 10 '[{"nonce":"fixture","runner":"runner","device":"fixture-device","age_seconds":50,"lease_expires_at":1120}]') || return 1
+		[[ "$output" == *"expires_at=1120" ]] || return 1
+		_now_epoch() { printf '1121'; }
+		_resolve_claim_race_result 42 owner/repo runner fixture 10 '[{"nonce":"fixture","runner":"runner","device":"fixture-device","age_seconds":121,"lease_expires_at":1120}]' >/dev/null 2>&1 || rc=$?
+		[[ "$rc" == 2 ]]
+	) || result=1
+	print_result "CLAIM_WON reports persisted expiry and rejects consensus-expired leases" "$result"
+	return 0
+}
+
 #######################################
 # Main
 #######################################
@@ -2033,6 +2052,7 @@ main() {
 	echo ""
 
 	test_help_exits_zero
+	test_claim_winner_persisted_expiry
 	test_claim_missing_args
 	test_claim_non_numeric_issue
 	test_check_missing_args

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -58,6 +58,11 @@ fail() {
 TMP=$(mktemp -d -t t2981.XXXXXX)
 trap 'rm -rf "$TMP"' EXIT
 
+# Sourced launch helpers reclaim Pulse scratch space. Never scan/reclaim the
+# operator's real workspace (or recursively size it) from an offline fixture.
+export AIDEVOPS_TEMP_DIR="${TMP}/agent-tmp"
+mkdir -p "$AIDEVOPS_TEMP_DIR"
+
 export LOGFILE="${TMP}/test-pulse.log"
 export SCRIPT_DIR="$TMP"
 export PULSE_STATS_FILE="${TMP}/pulse-stats.json"
@@ -906,6 +911,64 @@ if [[ "$success_rc" -eq 0 && "$actual_calls" == "hold precreate final-gates prom
 	pass "successful launch acquires queued ownership at final boundary"
 else
 	fail "successful launch acquires queued ownership at final boundary" "rc=$success_rc calls='$actual_calls'"
+fi
+
+test_bounded_prelaunch_handoff() (
+	# Keep the real orchestrator, early/late renewal and spawn boundary; only
+	# replace GitHub and worktree I/O and advance Bash elapsed time, not sleep.
+	_claim_lease_token="fixture-lease"
+	local preparation_delay=125 lease_rc=0
+	export STUB_RENEW_RC=0
+	eval "$(awk '/^_dlw_prepare_opencode_db\(\) \{/,/^}$/ { print }' "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh")"
+	# Sourcing the launcher replaced the early test stub. Keep the actual
+	# renewal path, but do not start a real OpenCode database during this test.
+	_dlw_prewarm_opencode_db() { _DLW_PREWARM_DIR=""; return 0; }
+	cat >"${TMP}/dispatch-claim-helper.sh" <<'LEASE_STUB'
+#!/usr/bin/env bash
+if [[ "$1" == transition ]]; then
+	[[ -n "${AIDEVOPS_ATTEMPT_ID:-}" && "$AIDEVOPS_ATTEMPT_ID" != unknown ]] || exit 1
+	printf 'renew %s\n' "$7" >>"$ORCHESTRATOR_CALLS_FILE"
+	exit "${STUB_RENEW_RC:-0}"
+fi
+printf 'ownership-guard\n' >>"$ORCHESTRATOR_CALLS_FILE"
+exit 0
+LEASE_STUB
+	_dlw_precreate_worktree() {
+		printf 'precreate\n' >>"$ORCHESTRATOR_CALLS_FILE"
+		SECONDS=$((SECONDS + preparation_delay))
+		_DLW_WORKTREE_PATH="$ORCHESTRATOR_WORKTREE"
+		_DLW_WORKTREE_BRANCH="feature/auto-test"
+		_DLW_WORKTREE_REUSED=0
+		return 0
+	}
+	local scenario="" first_line=""
+	for scenario in slow expired renewal-failed; do
+		SECONDS=0 preparation_delay=125 STUB_RENEW_RC=0 lease_rc=0
+		[[ "$scenario" != expired ]] || preparation_delay=301
+		[[ "$scenario" != renewal-failed ]] || STUB_RENEW_RC=1
+		: >"$ORCHESTRATOR_CALLS_FILE"
+		: >"${TMP}/setsid-calls.txt"
+		_dispatch_launch_worker 77782 owner/repo dispatch issue testuser "$FAKE_REPO" prompt issue-77782 "" '{}' || lease_rc=$?
+		IFS= read -r first_line <"$ORCHESTRATOR_CALLS_FILE"
+		[[ "$first_line" == renew\ * ]] || return 1
+		if [[ "$scenario" == slow ]]; then
+			[[ "$lease_rc" == 0 && -s "${TMP}/setsid-calls.txt" ]] || return 1
+			[[ "$(grep -c '^renew ' "$ORCHESTRATOR_CALLS_FILE")" == 2 ]] || return 1
+			# The later renewal only covers the remaining preparation budget.
+			local last_ttl=""
+			last_ttl=$(awk '/^renew / { ttl=$2 } END { print ttl }' "$ORCHESTRATOR_CALLS_FILE")
+			[[ "$last_ttl" -lt "${first_line#renew }" ]] || return 1
+		else
+			[[ "$lease_rc" == 2 && ! -s "${TMP}/setsid-calls.txt" ]] || return 1
+			! grep -q '^assign$' "$ORCHESTRATOR_CALLS_FILE" || return 1
+		fi
+	done
+	return 0
+)
+if test_bounded_prelaunch_handoff; then
+	pass "slow prelaunch is protected early; expired budgets and failed renewals cannot assign/spawn"
+else
+	fail "bounded prelaunch lease handoff" "inspect renewal and preparation stage ordering"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Renew persisted claims before preparation; retain a fixed preparation budget, final ownership fences and truthful expiry diagnostics. Files: dispatch-claim-helper.sh, pulse-dispatch-worker-launch.sh, dispatch-timing.md and existing claim/precreation tests.

## Files Changed

.agents/reference/dispatch-timing.md, .agents/scripts/dispatch-claim-helper.sh, .agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/tests/test-dispatch-claim-helper.sh, .agents/scripts/tests/test-precreation-failure-skip.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified: 49 real-orchestrator offline integration cases pass; claim-helper, warm-start and dirty-worktree suites pass; changed-file linters pass. Independent review found no blocking defects. Review bundle 62487681f701d17109b4cccc9742c7d238e0261d55cfe6b23216ac878f4c5973.

Resolves #31542


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.337 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 21m and 41,512 tokens on this with the user in an interactive session.