### PR TITLE
GH#31555: recover missing release preparation safely

### DIFF
--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -656,6 +656,40 @@ _full_loop_recovery_process_uses_path() {
 	return $?
 }
 
+# Publication/authorization probes run before this helper; the existing fenced
+# recovery rechecks lane ownership afterwards. Never invent preservation evidence.
+#aidevops:trust-boundary
+_full_loop_recovery_restore_preparation() {
+	local source_pr="$1"
+	local owner_pid="$2"
+	local release_path="$3"
+	local snapshot="$4"
+	local attempted_tag="$5"
+	local worktree_base="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"
+	local registered=""
+	local tag_rc=0
+	_FULL_LOOP_RECOVERY_WORKTREE_RECONSTRUCTED=false
+	[[ ! -L "$release_path" && "$release_path" == "$worktree_base/aidevops-release-${source_pr}-${owner_pid}" ]] || return 1
+	[[ -d "$release_path" ]] && return 0
+	[[ ! -e "$release_path" && -d "$worktree_base" ]] || return 1
+	[[ "$(_release_lane_executor_observe "$_AIDEVOPS_RELEASE_LANE_JSON" | jq -r '.state')" == "dead" ]] || return 1
+	registered=$(git -C "$REPO_ROOT" worktree list --porcelain) || return 1
+	if printf '%s\n' "$registered" | grep -Fxq "worktree $release_path"; then
+		printf 'Missing release preparation still has a Git registration; refusing reconstruction.\n' >&2
+		return 1
+	fi
+	git -C "$REPO_ROOT" show-ref --verify --quiet "refs/tags/${attempted_tag}" || tag_rc=$?
+	[[ "$tag_rc" -eq 1 ]] || return 1
+	mkdir "$release_path" || return 1
+	if ! git -C "$REPO_ROOT" worktree add --detach "$release_path" "$snapshot" >/dev/null; then
+		rmdir "$release_path" 2>/dev/null || true
+		return 1
+	fi
+	_FULL_LOOP_RECOVERY_WORKTREE_RECONSTRUCTED=true
+	printf 'Reconstructed missing release preparation from its authorized snapshot; publication remains fenced.\n' >&2
+	return 0
+}
+
 # A preparing release runs entirely in an isolated detached worktree until its
 # signed tag is pushed. A dead attempt can restart from the immutable snapshot
 # only after both that worktree and all remote publication precursors are proven
@@ -708,13 +742,6 @@ _full_loop_recovery_dead_preparing() {
 	"${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"/aidevops-release-"${source_pr}"-*) ;;
 	*) return 1 ;;
 	esac
-	[[ -d "$release_path" ]] || return 1
-	worktree_head=$(git -C "$release_path" rev-parse HEAD 2>/dev/null) || return 1
-	[[ "$worktree_head" == "$snapshot" ]] || return 1
-	! git -C "$release_path" symbolic-ref -q HEAD >/dev/null 2>&1 || return 1
-	! git -C "$release_path" show-ref --verify --quiet "refs/tags/${attempted_tag}" || return 1
-	worktree_version=$(tr -d '[:space:]' <"$release_path/VERSION") || return 1
-	[[ "v${worktree_version}" == "$base_tag" || "$worktree_version" == "$attempted_version" ]] || return 1
 	_full_loop_recovery_process_uses_path "$release_path" || process_rc=$?
 	[[ "$process_rc" -eq 0 ]] || return 1
 	permission=$(gh api "repos/${repo}" \
@@ -724,10 +751,22 @@ _full_loop_recovery_dead_preparing() {
 	remote_refs=$(git -C "$REPO_ROOT" ls-remote --heads origin \
 		"refs/heads/chore/release-${attempted_tag}-provenance") || return 1
 	[[ -z "$remote_refs" ]] || return 1
+	_full_loop_recovery_restore_preparation "$source_pr" "$owner_pid" "$release_path" "$snapshot" "$attempted_tag" || {
+		printf 'Release preparation could not be verified or safely reconstructed; lane unchanged.\n' >&2
+		return 1
+	}
+	worktree_head=$(git -C "$release_path" rev-parse HEAD 2>/dev/null) || return 1
+	[[ "$worktree_head" == "$snapshot" ]] || return 1
+	! git -C "$release_path" symbolic-ref -q HEAD >/dev/null 2>&1 || return 1
+	! git -C "$release_path" show-ref --verify --quiet "refs/tags/${attempted_tag}" || return 1
+	worktree_version=$(tr -d '[:space:]' <"$release_path/VERSION") || return 1
+	[[ "v${worktree_version}" == "$base_tag" || "$worktree_version" == "$attempted_version" ]] || return 1
 	recovery_evidence=$(jq -cn --arg tag "$attempted_tag" --arg expected "$lane_sources" \
 		--arg head "$worktree_head" --arg path "$release_path" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+		--argjson reconstructed "$_FULL_LOOP_RECOVERY_WORKTREE_RECONSTRUCTED" \
 		--arg absent "$_FULL_LOOP_RECOVERY_STATE_ABSENT" \
 		'{type:"preparing-recovery/v1",attempted_tag:$tag,expected_sources:$expected,
+		worktree_reconstructed:$reconstructed,
 		worktree:$path,worktree_head:$head,worktree_state:"isolated",surviving_process:$absent,
 		remote_tag:$absent,github_release:$absent,npm:$absent,homebrew:$absent,
 		protected_branch:$absent,checked_at:$now}') || return 1

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -38,12 +38,18 @@ REPO_ROOT=$(_full_loop_release_resolve_repo_root) || {
 }
 _FULL_LOOP_RELEASE_PATH=""
 _FULL_LOOP_RELEASE_CONTROL_PATH=""
+_FULL_LOOP_RELEASE_PREPARATION_PATH=""
 
 cleanup_release_worktree() {
+	local exit_status="$?"
 	local release_path="${_FULL_LOOP_RELEASE_PATH:-}"
 	local control_path="${_FULL_LOOP_RELEASE_CONTROL_PATH:-}"
 	if [[ -n "$release_path" && "$release_path" != "$control_path" && -d "$release_path" ]]; then
-		git -C "$REPO_ROOT" worktree remove "$release_path" >/dev/null 2>&1 || true
+		if [[ "$exit_status" -eq 0 || "$release_path" != "${_FULL_LOOP_RELEASE_PREPARATION_PATH:-}" ]]; then
+			git -C "$REPO_ROOT" worktree remove "$release_path" >/dev/null 2>&1 || true
+		else
+			printf 'Release preparation retained for guarded recovery (exit %s).\n' "$exit_status" >&2
+		fi
 	fi
 	if [[ -n "$control_path" && -d "$control_path" ]]; then
 		git -C "$control_path" worktree remove "$control_path" >/dev/null 2>&1 || true
@@ -332,6 +338,7 @@ _full_loop_release_prepare_new() {
 	fi
 	_full_loop_release_timing_finish release-run-worktree-add "$phase_started" ok
 	_FULL_LOOP_RELEASE_PATH="$release_path"
+	_FULL_LOOP_RELEASE_PREPARATION_PATH="$release_path"
 	trap 'cleanup_release_worktree' EXIT
 
 	phase_started=$(_full_loop_release_timing_start release-run-capture-authorization)

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -273,6 +273,15 @@ jq -e '.status == "failed" and .requested_pr == 43 and .requested_merge == .curr
 	and .attempted_tag == "v2.9.10" and .release_type == "patch"' \
 	"$ROOT/receipts/marcusquinn_aidevops-43.failure.json" >/dev/null
 printf 'PASS failed release persists actionable provenance without publication evidence\n'
+retained_preparation=0
+for retained_path in "$ROOT/worktrees"/aidevops-release-43-*; do
+	[[ -d "$retained_path" ]] && retained_preparation=$((retained_preparation + 1))
+done
+[[ "$retained_preparation" -eq 1 ]] || {
+	printf 'FAIL failed release lost its preparation worktree during EXIT cleanup\n' >&2
+	exit 1
+}
+printf 'PASS failed release retains preparation for guarded recovery\n'
 rm -f "$LANE_HEAD_FILE" "$LANE_STATE_FILE"
 
 if (
@@ -486,5 +495,26 @@ printf 'PASS omitted expected sources still resume a persisted failed pre-public
 	[[ "$resolve_rc" -ne 0 && "$evidence_writes" -eq 1 ]]
 )
 printf 'PASS recovered retries preserve their original failure evidence until preparing\n'
+
+for temporary_kind in aggregate reconcile; do
+	temporary_path="$ROOT/worktrees/aidevops-release-${temporary_kind}-cleanup-test"
+	cleanup_rc=0
+	(
+		cd "$ROOT/repo/linked-branch"
+		export PATH="$ROOT/bin:/usr/bin:/bin"
+		export GIT_CALL_LOG="$ROOT/git.log" FAKE_REPO_ROOT="$ROOT/repo"
+		export AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees"
+		source "$SCRIPT_DIR/full-loop-release-helper.sh" help >/dev/null
+		mkdir -p "$temporary_path"
+		_FULL_LOOP_RELEASE_PATH="$temporary_path"
+		trap 'cleanup_release_worktree' EXIT
+		exit 7
+	) || cleanup_rc=$?
+	[[ "$cleanup_rc" -eq 7 && ! -d "$temporary_path" ]] || {
+		printf 'FAIL temporary %s checkout retained as preparation\n' "$temporary_kind" >&2
+		exit 1
+	}
+done
+printf 'PASS failed aggregate and reconcile temporary checkouts are still cleaned\n'
 
 exit 0

--- a/.agents/scripts/tests/test-release-dead-preparing-recovery.sh
+++ b/.agents/scripts/tests/test-release-dead-preparing-recovery.sh
@@ -60,12 +60,31 @@ _full_loop_recovery_process_uses_path() {
 	return $?
 }
 
+_release_lane_executor_observe() {
+	printf '{"state":"%s"}\n' "$EXECUTOR_STATE"
+	return 0
+}
+
 git() {
 	local args="$*"
 	case "$args" in
 	*"rev-parse HEAD"*) printf '%s\n' "$SNAPSHOT" ;;
 	*"symbolic-ref -q HEAD"*) return 1 ;;
-	*"show-ref --verify --quiet refs/tags/v1.2.4"*) return 1 ;;
+	*"show-ref --verify --quiet refs/tags/v1.2.4"*)
+		[[ "$LOCAL_TAG" == "false" ]] && return 1
+		return 0
+		;;
+	*"worktree list --porcelain"*)
+		[[ "$REGISTRY_ERROR" == "false" ]] || return 128
+		[[ "$REGISTERED" == "true" ]] && printf 'worktree %s\n' "$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42"
+		return 0
+		;;
+	*"worktree add --detach"*)
+		[[ "$6" == "$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42" && "$7" == "$SNAPSHOT" ]] || return 1
+		mkdir -p "$6"
+		printf '1.2.3\n' >"$6/VERSION"
+		RECONSTRUCT_CALLS=$((RECONSTRUCT_CALLS + 1))
+		;;
 	*"ls-remote --heads origin refs/heads/chore/release-v1.2.4-provenance"*)
 		[[ "$PROTECTED_BRANCH" == "false" ]] && return 0
 		printf '%s\t%s\n' 4444444444444444444444444444444444444444 refs/heads/chore/release-v1.2.4-provenance
@@ -98,6 +117,12 @@ reset_fixture() {
 	LANE_ABSENT=false
 	RECOVERY_CALLS=0
 	CAPTURED_EVIDENCE=""
+	EXECUTOR_STATE=dead
+	LOCAL_TAG=false
+	REGISTERED=false
+	REGISTRY_ERROR=false
+	RECONSTRUCT_CALLS=0
+	mkdir -p "$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42"
 	printf '1.2.4\n' >"$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42/VERSION"
 	return 0
 }
@@ -135,3 +160,59 @@ for refusal in authorization channels process permission branch version; do
 	[[ "$RECOVERY_CALLS" -eq 0 ]] || exit 1
 done
 printf 'PASS preparing recovery refuses authorization, channel, process, branch, and worktree uncertainty\n'
+
+reset_fixture
+rm -rf "$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42"
+_full_loop_recovery_dead_preparing test/repo 101 "$EXPECTED" patch >/dev/null
+[[ "$RECOVERY_CALLS" -eq 1 && "$RECONSTRUCT_CALLS" -eq 1 ]] || exit 1
+jq -e '.worktree_reconstructed == true and .worktree_head == "2222222222222222222222222222222222222222"' <<<"$CAPTURED_EVIDENCE" >/dev/null
+printf 'PASS missing preparation reconstructed from exact snapshot with explicit evidence\n'
+
+(
+	unset -f git
+	REPO_ROOT="$TEST_ROOT/real-repo"
+	AIDEVOPS_WORKTREE_BASE_DIR="$TEST_ROOT/real-worktrees"
+	mkdir -p "$REPO_ROOT" "$AIDEVOPS_WORKTREE_BASE_DIR"
+	git init -q "$REPO_ROOT"
+	printf '1.2.3\n' >"$REPO_ROOT/VERSION"
+	git -C "$REPO_ROOT" add VERSION
+	git -C "$REPO_ROOT" -c user.name=Fixture -c user.email=fixture@example.invalid \
+		-c commit.gpgsign=false commit -qm snapshot
+	SNAPSHOT=$(git -C "$REPO_ROOT" rev-parse HEAD)
+	_full_loop_recovery_restore_preparation 101 42 \
+		"$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42" "$SNAPSHOT" v1.2.4
+	[[ "$(git -C "$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42" rev-parse HEAD)" == "$SNAPSHOT" ]]
+	if git -C "$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42" symbolic-ref -q HEAD; then
+		exit 1
+	fi
+	[[ "$_FULL_LOOP_RECOVERY_WORKTREE_RECONSTRUCTED" == "true" ]]
+)
+printf 'PASS real Git reconstruction creates a detached exact-snapshot worktree\n'
+
+for refusal in authorization channels process permission branch executor registration local_tag registry_error directory_symlink symlink; do
+	reset_fixture
+	rm -rf "$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42"
+	case "$refusal" in
+	authorization) AUTHORIZATION='101@9999999999999999999999999999999999999999' ;;
+	channels) CHANNELS_ABSENT=false ;;
+	process) SURVIVING_PROCESS=true ;;
+	permission) PERMISSION=false ;;
+	branch) PROTECTED_BRANCH=true ;;
+	executor) EXECUTOR_STATE=unknown ;;
+	registration) REGISTERED=true ;;
+	local_tag) LOCAL_TAG=true ;;
+	registry_error) REGISTRY_ERROR=true ;;
+	directory_symlink)
+		mkdir -p "$TEST_ROOT/symlink-target"
+		printf '1.2.3\n' >"$TEST_ROOT/symlink-target/VERSION"
+		ln -s "$TEST_ROOT/symlink-target" "$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42"
+		;;
+	symlink) ln -s "$TEST_ROOT/missing" "$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42" ;;
+	esac
+	if _full_loop_recovery_dead_preparing test/repo 101 "$EXPECTED" patch >/dev/null 2>&1; then
+		printf 'FAIL unsafe missing-worktree %s state was recovered\n' "$refusal" >&2
+		exit 1
+	fi
+	[[ "$RECOVERY_CALLS" -eq 0 && "$RECONSTRUCT_CALLS" -eq 0 ]] || exit 1
+done
+printf 'PASS missing preparation refuses uncertain ownership, publication, registration, and paths\n'


### PR DESCRIPTION
## Summary

Resolves #31555.

The release EXIT trap removed clean preparation worktrees on failure, while dead-preparing recovery required the same worktree to still exist. The advertised retry could therefore stop silently after tag discovery, leaving the publisher lane occupied.

- `.agents/scripts/full-loop-release-helper.sh`: retain only registered release preparation on nonzero exit; still clean temporary aggregate/reconciliation checkouts.
- `.agents/scripts/full-loop-release-aggregate-recovery.sh`: reconstruct a missing exact-snapshot preparation only after authorization and publication absence probes, dead local executor evidence, exact non-symlink path, absent Git registration and absent local tag. Reserve the absent directory without overwrite, record reconstruction explicitly, then retain original HEAD/version checks and fenced lane CAS.
- Existing preparation paths reject symlink substitution before directory acceptance. No tag rewriting, source-manifest widening, bypass flags, or raw lane writes.

## Verification

- Red/green missing-worktree regression: original helper stops before reconstruction; repaired helper passes the same scenario.
- `test-release-dead-preparing-recovery.sh` passes under current Bash and macOS Bash 3.2, including authorization/channel/process/permission/branch/version refusals, unknown executor, conflicting registration, local tag, registry error, dangling symlink and directory-target symlink.
- `test-full-loop-release-helper.sh` passes, including failed-preparation preservation and failed aggregate/reconcile temporary-checkout cleanup.
- `test-full-loop-release-aggregate-recovery.sh` passes, preserving existing publication and fencing checks.
- ShellCheck passes on all four changed files; `git diff --check` passes.
- Independent security review found two issues (directory symlink early return and overbroad cleanup retention); both were hand-fixed and covered by regressions. Follow-up review found no remaining blocking defect.

## Runtime Testing

Runtime-verified in an isolated real Git repository: reconstruction produces a detached worktree at the exact snapshot. Publication and refusal paths use isolated fixtures; no live release lane was mutated to test this code. The blocked production release will be retried only through the reviewed canonical helper after merge.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.337 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 2d and 5,261,307 tokens on this with the user in an interactive session.