### PR TITLE
GH#31553: make canonical maintenance resumable within stage budget

### DIFF
--- a/.agents/scripts/pulse-canonical-maintenance.sh
+++ b/.agents/scripts/pulse-canonical-maintenance.sh
@@ -45,28 +45,94 @@ unset _PULSE_CM_SCRIPT_DIR
 # ---------------------------------------------------------------------------
 # _canonical_maintenance_run_with_timeout
 #
-# Runs a command with a timeout, falling back to running directly if the
-# `timeout` utility is not available (common on stock macOS without coreutils).
+# Runs a command with a timeout. Stock macOS uses gtimeout when installed or
+# Perl's inherited alarm when GNU timeout is unavailable.
 # Arguments: $1 - timeout_seconds, $2.. - command and args
 # ---------------------------------------------------------------------------
 _canonical_maintenance_run_with_timeout() {
 	local timeout_seconds="$1"
+	local command_rc=0
 	shift
 	if command -v timeout &>/dev/null; then
 		timeout "$timeout_seconds" "$@"
-	else
-		"$@"
+		return $?
 	fi
-	return $?
+	if command -v gtimeout &>/dev/null; then
+		gtimeout "$timeout_seconds" "$@"
+		return $?
+	fi
+	# Perl source is intentionally single-quoted. alarm survives exec and bounds
+	# the replacement process without introducing a detached timeout owner.
+	# shellcheck disable=SC2016
+	perl -e '$timeout=shift; alarm $timeout; exec @ARGV' "$timeout_seconds" "$@" || command_rc=$?
+	[[ "$command_rc" -eq 142 ]] && return 124
+	return "$command_rc"
 }
 
 # ---------------------------------------------------------------------------
 # Configuration constants (overridable via env)
 # ---------------------------------------------------------------------------
-CANONICAL_MAINTENANCE_CADENCE="${CANONICAL_MAINTENANCE_CADENCE:-1800}"       # 30 min
+CANONICAL_MAINTENANCE_CADENCE="${CANONICAL_MAINTENANCE_CADENCE:-1800}" # 30 min
 CANONICAL_MAINTENANCE_LAST_RUN="${CANONICAL_MAINTENANCE_LAST_RUN:-${HOME}/.aidevops/.agent-workspace/pulse-canonical-maintenance-last-run}"
-CANONICAL_MAINTENANCE_TIMEOUT="${CANONICAL_MAINTENANCE_TIMEOUT:-60}"         # 60s per-repo hard timeout
+CANONICAL_MAINTENANCE_TIMEOUT="${CANONICAL_MAINTENANCE_TIMEOUT:-60}" # 60s per-repo hard timeout
 CANONICAL_MAINTENANCE_CLAIM_STAMP_DIR="${CANONICAL_MAINTENANCE_CLAIM_STAMP_DIR:-${HOME}/.aidevops/.agent-workspace/interactive-claims}"
+CANONICAL_MAINTENANCE_CHECKPOINT="${CANONICAL_MAINTENANCE_CHECKPOINT:-${CANONICAL_MAINTENANCE_LAST_RUN}.checkpoint}"
+CANONICAL_MAINTENANCE_STAGE_BUDGET_SECONDS="${CANONICAL_MAINTENANCE_STAGE_BUDGET_SECONDS:-${PRE_RUN_STAGE_TIMEOUT:-600}}"
+CANONICAL_MAINTENANCE_STAGE_RESERVE_SECONDS="${CANONICAL_MAINTENANCE_STAGE_RESERVE_SECONDS:-5}"
+
+_canonical_maintenance_checkpoint_has_repo() {
+	local phase="$1"
+	local repo_path="$2"
+	[[ -f "$CANONICAL_MAINTENANCE_CHECKPOINT" ]] || return 1
+	jq -e --arg phase "$phase" --arg path "$repo_path" \
+		'.phase == $phase and (.completed // [] | index($path) != null)' \
+		"$CANONICAL_MAINTENANCE_CHECKPOINT" >/dev/null 2>&1
+}
+
+_canonical_maintenance_write_checkpoint() {
+	local phase="$1"
+	local repo_path="${2:-}"
+	local checkpoint_dir="${CANONICAL_MAINTENANCE_CHECKPOINT%/*}"
+	local tmp_file=""
+	[[ "$checkpoint_dir" == "$CANONICAL_MAINTENANCE_CHECKPOINT" ]] && checkpoint_dir="."
+	mkdir -p "$checkpoint_dir" 2>/dev/null || return 1
+	tmp_file=$(mktemp "${CANONICAL_MAINTENANCE_CHECKPOINT}.tmp.XXXXXX") || return 1
+	if [[ -n "$repo_path" && -f "$CANONICAL_MAINTENANCE_CHECKPOINT" ]]; then
+		jq --arg phase "$phase" --arg path "$repo_path" \
+			'{phase: $phase, completed: (if .phase == $phase then ((.completed // []) + [$path] | unique) else [$path] end)}' \
+			"$CANONICAL_MAINTENANCE_CHECKPOINT" >"$tmp_file" 2>/dev/null || true
+	elif [[ -n "$repo_path" ]]; then
+		jq -n --arg phase "$phase" --arg path "$repo_path" '{phase: $phase, completed: [$path]}' >"$tmp_file"
+	else
+		jq -n --arg phase "$phase" '{phase: $phase, completed: []}' >"$tmp_file"
+	fi
+	if [[ ! -s "$tmp_file" ]]; then
+		rm -f "$tmp_file"
+		return 1
+	fi
+	mv "$tmp_file" "$CANONICAL_MAINTENANCE_CHECKPOINT"
+}
+
+_canonical_maintenance_phase() {
+	if [[ -f "$CANONICAL_MAINTENANCE_CHECKPOINT" ]]; then
+		jq -r '.phase // "diagnostic"' "$CANONICAL_MAINTENANCE_CHECKPOINT" 2>/dev/null || printf '%s\n' diagnostic
+	else
+		printf '%s\n' diagnostic
+	fi
+}
+
+_canonical_maintenance_operation_timeout() {
+	local started_epoch="$1"
+	local now_epoch remaining operation_timeout
+	now_epoch=$(date +%s)
+	remaining=$((CANONICAL_MAINTENANCE_STAGE_BUDGET_SECONDS - (now_epoch - started_epoch) - CANONICAL_MAINTENANCE_STAGE_RESERVE_SECONDS))
+	if [[ "$remaining" -le 0 ]]; then
+		return 1
+	fi
+	operation_timeout="$CANONICAL_MAINTENANCE_TIMEOUT"
+	[[ "$operation_timeout" -gt "$remaining" ]] && operation_timeout="$remaining"
+	printf '%s\n' "$operation_timeout"
+}
 
 # ---------------------------------------------------------------------------
 # _get_default_branch_for_repo
@@ -137,8 +203,8 @@ _canonical_maintenance_has_active_session() {
 			# t2421: command-aware liveness — bare kill -0 lies on macOS PID reuse.
 			local stamp_hash=""
 			stamp_hash=$(jq -r '.owner_argv_hash // empty' "$stamp" 2>/dev/null || echo "")
-			if [[ -n "$stamp_pid" ]] && [[ "$stamp_pid" =~ ^[0-9]+$ ]] && \
-			   _is_process_alive_and_matches "$stamp_pid" "${WORKER_PROCESS_PATTERN:-}" "$stamp_hash"; then
+			if [[ -n "$stamp_pid" ]] && [[ "$stamp_pid" =~ ^[0-9]+$ ]] &&
+				_is_process_alive_and_matches "$stamp_pid" "${WORKER_PROCESS_PATTERN:-}" "$stamp_hash"; then
 				return 0
 			fi
 		fi
@@ -222,6 +288,7 @@ _canonical_ff_should_skip_repo() {
 _canonical_ff_single_repo() {
 	local repo_path="$1"
 	local dry_run="$2"
+	local operation_timeout="${3:-$CANONICAL_MAINTENANCE_TIMEOUT}"
 
 	# Determine default branch — skip rather than assume if origin/HEAD is not set.
 	local main_branch
@@ -235,11 +302,13 @@ _canonical_ff_single_repo() {
 	if [[ "$dry_run" == "1" ]]; then
 		echo "[DRY_RUN] Would diagnose origin for ${repo_path}"
 	else
-		local remote_sha=""
-		remote_sha=$(_canonical_maintenance_run_with_timeout "$CANONICAL_MAINTENANCE_TIMEOUT" git -C "$repo_path" ls-remote origin "refs/heads/${main_branch}" 2>/dev/null | awk 'NR == 1 {print $1}') || {
+		local remote_sha="" remote_rc=0
+		remote_sha=$(_canonical_maintenance_run_with_timeout "$operation_timeout" git -C "$repo_path" ls-remote origin "refs/heads/${main_branch}" 2>/dev/null | awk 'NR == 1 {print $1}') || remote_rc=$?
+		if [[ "$remote_rc" -ne 0 ]]; then
 			echo "[pulse-canonical-maintenance] Remote diagnostic failed/timed out for ${repo_path}" >>"${LOGFILE:-/dev/null}"
+			[[ "$remote_rc" -eq 124 ]] && return 2
 			return 1
-		}
+		fi
 		if [[ -z "$remote_sha" ]]; then
 			echo "[pulse-canonical-maintenance] Skipping ${repo_path} — remote ${main_branch} not found" >>"${LOGFILE:-/dev/null}"
 			return 1
@@ -267,25 +336,42 @@ _canonical_ff_single_repo() {
 # ---------------------------------------------------------------------------
 _canonical_fast_forward() {
 	local dry_run="${1:-0}"
+	local started_epoch="${2:-0}"
 	local repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 	[[ -f "$repos_json" ]] && command -v jq &>/dev/null || return 0
 
 	local -a _repo_list=()
 	mapfile -t _repo_list < <(jq -r '.initialized_repos[] | select(.maintenance != false) | select((.pulse // false) == true) | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null)
 
-	local repo_path ff_count=0 skip_count=0
+	local repo_path operation_timeout ff_count=0 skip_count=0
 	for repo_path in "${_repo_list[@]}"; do
 		[[ -z "$repo_path" ]] && continue
 		[[ ! -d "$repo_path/.git" ]] && continue
+		if [[ "$dry_run" -eq 0 && "$started_epoch" -gt 0 ]] && _canonical_maintenance_checkpoint_has_repo diagnostic "$repo_path"; then
+			continue
+		fi
+		operation_timeout="$CANONICAL_MAINTENANCE_TIMEOUT"
+		if [[ "$dry_run" -eq 0 && "$started_epoch" -gt 0 ]] && ! operation_timeout=$(_canonical_maintenance_operation_timeout "$started_epoch"); then
+			echo "[pulse-canonical-maintenance] Diagnostic pass yielded with resumable progress" >>"${LOGFILE:-/dev/null}"
+			return 2
+		fi
 
 		if _canonical_ff_should_skip_repo "$repo_path"; then
 			skip_count=$((skip_count + 1))
+			[[ "$dry_run" -eq 0 && "$started_epoch" -gt 0 ]] && _canonical_maintenance_write_checkpoint diagnostic "$repo_path" || true
 			continue
 		fi
 
-		if _canonical_ff_single_repo "$repo_path" "$dry_run"; then
+		local ff_rc=0
+		_canonical_ff_single_repo "$repo_path" "$dry_run" "$operation_timeout" || ff_rc=$?
+		if [[ "$ff_rc" -eq 2 ]]; then
+			echo "[pulse-canonical-maintenance] Diagnostic pass yielded after timeout for ${repo_path}" >>"${LOGFILE:-/dev/null}"
+			return 2
+		fi
+		if [[ "$ff_rc" -eq 0 ]]; then
 			ff_count=$((ff_count + 1))
 		fi
+		[[ "$dry_run" -eq 0 && "$started_epoch" -gt 0 ]] && _canonical_maintenance_write_checkpoint diagnostic "$repo_path" || true
 	done
 
 	echo "[pulse-canonical-maintenance] Diagnostic pass: ${ff_count} repos stale/diverged, ${skip_count} skipped" >>"${LOGFILE:-/dev/null}"
@@ -304,6 +390,7 @@ _stale_worktree_sweep_single_repo() {
 	local repo_path="$1"
 	local dry_run="$2"
 	local worktree_helper="$3"
+	local operation_timeout="${4:-$CANONICAL_MAINTENANCE_TIMEOUT}"
 	local _wt_prefix="^worktree "
 
 	if [[ "$dry_run" == "1" ]]; then
@@ -328,7 +415,7 @@ _stale_worktree_sweep_single_repo() {
 	local sweep_rc=0
 	(
 		cd -- "$repo_path" || exit 125
-		_canonical_maintenance_run_with_timeout "$CANONICAL_MAINTENANCE_TIMEOUT" "$worktree_helper" clean --auto --force-merged
+		_canonical_maintenance_run_with_timeout "$operation_timeout" "$worktree_helper" clean --auto --force-merged
 	) >>"${LOGFILE:-/dev/null}" 2>&1 || sweep_rc=$?
 	if [[ "$sweep_rc" -ne 0 ]]; then
 		if [[ "$sweep_rc" -eq 124 ]]; then
@@ -337,6 +424,7 @@ _stale_worktree_sweep_single_repo() {
 			echo "[pulse-canonical-maintenance] Worktree sweep skipped for ${repo_path} (helper exited ${sweep_rc})" >>"${LOGFILE:-/dev/null}"
 		fi
 		printf '0'
+		[[ "$sweep_rc" -eq 124 ]] && return 2
 		return 0
 	fi
 
@@ -369,6 +457,7 @@ _stale_worktree_sweep_single_repo() {
 # ---------------------------------------------------------------------------
 _stale_worktree_sweep() {
 	local dry_run="${1:-0}"
+	local started_epoch="${2:-0}"
 	local repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 	[[ -f "$repos_json" ]] && command -v jq &>/dev/null || return 0
 
@@ -393,15 +482,33 @@ _stale_worktree_sweep() {
 	local -a _repo_list=()
 	mapfile -t _repo_list < <(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null)
 
-	local repo_path sweep_count=0
+	local repo_path operation_timeout sweep_count=0
 	for repo_path in "${_repo_list[@]}"; do
 		[[ -z "$repo_path" ]] && continue
-		if ! git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1; then
-			echo "[pulse-canonical-maintenance] Skipping ${repo_path} — not a git repository" >>"${LOGFILE:-/dev/null}"
+		if [[ "$dry_run" -eq 0 && "$started_epoch" -gt 0 ]] && _canonical_maintenance_checkpoint_has_repo sweep "$repo_path"; then
 			continue
 		fi
-		local removed=0
-		removed=$(_stale_worktree_sweep_single_repo "$repo_path" "$dry_run" "$worktree_helper")
+		operation_timeout="$CANONICAL_MAINTENANCE_TIMEOUT"
+		if [[ "$dry_run" -eq 0 && "$started_epoch" -gt 0 ]] && ! operation_timeout=$(_canonical_maintenance_operation_timeout "$started_epoch"); then
+			echo "[pulse-canonical-maintenance] Worktree sweep yielded with resumable progress" >>"${LOGFILE:-/dev/null}"
+			return 2
+		fi
+		if ! git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1; then
+			echo "[pulse-canonical-maintenance] Skipping ${repo_path} — not a git repository" >>"${LOGFILE:-/dev/null}"
+			[[ "$dry_run" -eq 0 && "$started_epoch" -gt 0 ]] && _canonical_maintenance_write_checkpoint sweep "$repo_path" || true
+			continue
+		fi
+		if _canonical_maintenance_has_active_session "$repo_path"; then
+			echo "[pulse-canonical-maintenance] Skipping worktree sweep for ${repo_path} — active session detected" >>"${LOGFILE:-/dev/null}"
+			[[ "$dry_run" -eq 0 && "$started_epoch" -gt 0 ]] && _canonical_maintenance_write_checkpoint sweep "$repo_path" || true
+			continue
+		fi
+		local removed=0 sweep_repo_rc=0
+		removed=$(_stale_worktree_sweep_single_repo "$repo_path" "$dry_run" "$worktree_helper" "$operation_timeout") || sweep_repo_rc=$?
+		if [[ "$sweep_repo_rc" -eq 2 ]]; then
+			echo "[pulse-canonical-maintenance] Worktree sweep yielded after timeout for ${repo_path}" >>"${LOGFILE:-/dev/null}"
+			return 2
+		fi
 		# t2559 defense-in-depth: sanitise the captured count before arithmetic.
 		# Even with the stdout fix in _stale_worktree_sweep_single_repo, guard
 		# against future regressions where stray text might leak into $removed.
@@ -409,6 +516,7 @@ _stale_worktree_sweep() {
 		removed="${removed//[^0-9]/}"
 		removed="${removed:-0}"
 		sweep_count=$((sweep_count + removed))
+		[[ "$dry_run" -eq 0 && "$started_epoch" -gt 0 ]] && _canonical_maintenance_write_checkpoint sweep "$repo_path" || true
 	done
 
 	echo "[pulse-canonical-maintenance] Worktree sweep: ${sweep_count} total removed" >>"${LOGFILE:-/dev/null}"
@@ -429,8 +537,9 @@ run_canonical_maintenance() {
 		dry_run=1
 	fi
 
-	local now_epoch
+	local now_epoch started_epoch phase pass_rc=0
 	now_epoch=$(date +%s)
+	started_epoch="$now_epoch"
 
 	# Cadence gate (skip in dry-run mode to always show output)
 	if [[ "$dry_run" -eq 0 ]] && ! _canonical_maintenance_check_cadence "$now_epoch"; then
@@ -439,13 +548,27 @@ run_canonical_maintenance() {
 
 	echo "[pulse-canonical-maintenance] Starting canonical maintenance pass" >>"${LOGFILE:-/dev/null}"
 
-	_canonical_fast_forward "$dry_run"
-	_stale_worktree_sweep "$dry_run"
+	phase=$(_canonical_maintenance_phase)
+	if [[ "$dry_run" -eq 1 || "$phase" == "diagnostic" ]]; then
+		_canonical_fast_forward "$dry_run" "$started_epoch" || pass_rc=$?
+		if [[ "$pass_rc" -eq 2 ]]; then
+			return 0
+		fi
+		if [[ "$dry_run" -eq 0 ]]; then
+			_canonical_maintenance_write_checkpoint sweep || return 0
+		fi
+	fi
+	pass_rc=0
+	_stale_worktree_sweep "$dry_run" "$started_epoch" || pass_rc=$?
+	if [[ "$pass_rc" -eq 2 ]]; then
+		return 0
+	fi
 
 	# Update cadence state file
 	if [[ "$dry_run" -eq 0 ]]; then
 		mkdir -p "$(dirname "$CANONICAL_MAINTENANCE_LAST_RUN")" 2>/dev/null || true
 		echo "$now_epoch" >"$CANONICAL_MAINTENANCE_LAST_RUN"
+		rm -f "$CANONICAL_MAINTENANCE_CHECKPOINT"
 	fi
 
 	echo "[pulse-canonical-maintenance] Canonical maintenance pass complete" >>"${LOGFILE:-/dev/null}"

--- a/.agents/scripts/pulse-canonical-maintenance.sh
+++ b/.agents/scripts/pulse-canonical-maintenance.sh
@@ -123,7 +123,7 @@ _canonical_maintenance_phase() {
 
 _canonical_maintenance_operation_timeout() {
 	local started_epoch="$1"
-	local now_epoch remaining operation_timeout
+	local now_epoch="" remaining=0 operation_timeout=0
 	now_epoch=$(date +%s)
 	remaining=$((CANONICAL_MAINTENANCE_STAGE_BUDGET_SECONDS - (now_epoch - started_epoch) - CANONICAL_MAINTENANCE_STAGE_RESERVE_SECONDS))
 	if [[ "$remaining" -le 0 ]]; then
@@ -343,7 +343,7 @@ _canonical_fast_forward() {
 	local -a _repo_list=()
 	mapfile -t _repo_list < <(jq -r '.initialized_repos[] | select(.maintenance != false) | select((.pulse // false) == true) | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null)
 
-	local repo_path operation_timeout ff_count=0 skip_count=0
+	local repo_path="" operation_timeout=0 ff_count=0 skip_count=0
 	for repo_path in "${_repo_list[@]}"; do
 		[[ -z "$repo_path" ]] && continue
 		[[ ! -d "$repo_path/.git" ]] && continue
@@ -482,7 +482,7 @@ _stale_worktree_sweep() {
 	local -a _repo_list=()
 	mapfile -t _repo_list < <(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null)
 
-	local repo_path operation_timeout sweep_count=0
+	local repo_path="" operation_timeout=0 sweep_count=0
 	for repo_path in "${_repo_list[@]}"; do
 		[[ -z "$repo_path" ]] && continue
 		if [[ "$dry_run" -eq 0 && "$started_epoch" -gt 0 ]] && _canonical_maintenance_checkpoint_has_repo sweep "$repo_path"; then
@@ -537,7 +537,7 @@ run_canonical_maintenance() {
 		dry_run=1
 	fi
 
-	local now_epoch started_epoch phase pass_rc=0
+	local now_epoch="" started_epoch=0 phase="" pass_rc=0
 	now_epoch=$(date +%s)
 	started_epoch="$now_epoch"
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1300,7 +1300,8 @@ _pulse_run_deterministic_pipeline() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag appeared — skipping canonical maintenance" >>"$LOGFILE"
 	else
-		_pulse_run_budget_priority_stage_with_timeout "canonical_maintenance" "$PRE_RUN_STAGE_TIMEOUT" \
+		CANONICAL_MAINTENANCE_STAGE_BUDGET_SECONDS="$PRE_RUN_STAGE_TIMEOUT" \
+			_pulse_run_budget_priority_stage_with_timeout "canonical_maintenance" "$PRE_RUN_STAGE_TIMEOUT" \
 			run_canonical_maintenance || true
 	fi
 

--- a/.agents/scripts/tests/test-pulse-canonical-maintenance.sh
+++ b/.agents/scripts/tests/test-pulse-canonical-maintenance.sh
@@ -190,7 +190,7 @@ test_skip_on_dirty() {
 	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
 
 	# Capture log output
-	true > "$LOGFILE"
+	true >"$LOGFILE"
 	_canonical_fast_forward "0"
 
 	if grep -q "dirty tree" "$LOGFILE"; then
@@ -220,7 +220,7 @@ EOF
 	# Reset cadence
 	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
 
-	true > "$LOGFILE"
+	true >"$LOGFILE"
 	_canonical_fast_forward "0"
 	export WORKER_PROCESS_PATTERN="$previous_worker_process_pattern"
 
@@ -252,7 +252,7 @@ test_fast_forward_success() {
 	before_head=$(git -C "$clone_dir" rev-parse HEAD)
 	before_index=$(cksum <"$clone_dir/.git/index")
 	before_tree=$(cksum <"$clone_dir/file.txt")
-	true > "$LOGFILE"
+	true >"$LOGFILE"
 	_canonical_fast_forward "0"
 
 	if grep -q "Diagnostic:.*differs from origin/main" "$LOGFILE" &&
@@ -278,7 +278,7 @@ test_already_up_to_date() {
 	(cd "$clone_dir" && git fetch origin --quiet) >/dev/null 2>&1
 
 	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
-	true > "$LOGFILE"
+	true >"$LOGFILE"
 	_canonical_fast_forward "0"
 
 	if grep -q "already up to date" "$LOGFILE"; then
@@ -331,7 +331,7 @@ test_skip_not_on_main() {
 	(cd "$clone_dir" && git checkout -b feature/test) >/dev/null 2>&1
 
 	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
-	true > "$LOGFILE"
+	true >"$LOGFILE"
 	_canonical_fast_forward "0"
 
 	if grep -q "not on main" "$LOGFILE"; then
@@ -363,7 +363,7 @@ EOS
 
 	local scheduler_cwd="${TEST_ROOT}/scheduler-cwd"
 	mkdir -p "$scheduler_cwd"
-	true > "$LOGFILE"
+	true >"$LOGFILE"
 
 	local removed
 	removed=$(cd "$scheduler_cwd" && _stale_worktree_sweep_single_repo "$clone_dir" "0" "$helper_path")
@@ -388,7 +388,7 @@ test_worktree_sweep_non_git_path_skips() {
 EOF
 	export REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 
-	true > "$LOGFILE"
+	true >"$LOGFILE"
 	_stale_worktree_sweep "0"
 
 	if grep -q "Skipping ${non_git_dir} — not a git repository" "$LOGFILE" && ! grep -q "timed out" "$LOGFILE"; then
@@ -396,6 +396,190 @@ EOF
 	else
 		print_result "worktree-sweep-non-git-path-skips" 1 "(expected non-git skip without timeout; log=$(cat "$LOGFILE"))"
 	fi
+	return 0
+}
+
+_setup_budget_repos() {
+	local repo_count="${1:-3}"
+	local repos_body=""
+	local index repo_path
+	for ((index = 1; index <= repo_count; index++)); do
+		repo_path="${TEST_ROOT}/budget-repo-${index}"
+		rm -rf "$repo_path"
+		git init "$repo_path" >/dev/null 2>&1
+		[[ -n "$repos_body" ]] && repos_body="${repos_body},"
+		repos_body="${repos_body}{\"slug\":\"test/budget-${index}\",\"path\":\"${repo_path}\",\"pulse\":false}"
+	done
+	printf '{"initialized_repos":[%s]}\n' "$repos_body" >"${HOME}/.config/aidevops/repos.json"
+	export REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+	return 0
+}
+
+_setup_fake_sweep_helper() {
+	local helper_dir="${TEST_ROOT}/budget-helper"
+	mkdir -p "$helper_dir"
+	cat >"${helper_dir}/worktree-helper.sh" <<'EOS'
+#!/usr/bin/env bash
+printf '%s\n' "$PWD" >>"$SWEEP_VISITS"
+if [[ -z "${FAKE_SLOW_REPO:-}" || "$PWD" == "$FAKE_SLOW_REPO" ]]; then
+	sleep "${FAKE_SWEEP_SLEEP:-0}"
+fi
+exit 0
+EOS
+	chmod +x "${helper_dir}/worktree-helper.sh"
+	SCRIPT_DIR="$helper_dir"
+	export SCRIPT_DIR
+	return 0
+}
+
+# =============================================================================
+# Test 12: A slow child is bounded, checkpointed, and resumed without replay
+# =============================================================================
+test_budget_yield_and_resume() {
+	_setup_budget_repos 3
+	_setup_fake_sweep_helper
+	export SWEEP_VISITS="${TEST_ROOT}/sweep-visits"
+	export FAKE_SWEEP_SLEEP=5
+	export FAKE_SLOW_REPO="${TEST_ROOT}/budget-repo-2"
+	CANONICAL_MAINTENANCE_LAST_RUN="${TEST_ROOT}/budget-last-run"
+	CANONICAL_MAINTENANCE_CHECKPOINT="${CANONICAL_MAINTENANCE_LAST_RUN}.checkpoint"
+	CANONICAL_MAINTENANCE_STAGE_BUDGET_SECONDS=3
+	CANONICAL_MAINTENANCE_STAGE_RESERVE_SECONDS=1
+	CANONICAL_MAINTENANCE_TIMEOUT=60
+	rm -f "$SWEEP_VISITS" "$CANONICAL_MAINTENANCE_LAST_RUN" "$CANONICAL_MAINTENANCE_CHECKPOINT"
+	_canonical_maintenance_write_checkpoint sweep
+
+	local started elapsed first_repo slow_repo first_count slow_count
+	started=$(date +%s)
+	run_canonical_maintenance
+	elapsed=$(($(date +%s) - started))
+	first_repo=$(jq -r '.completed[0] // ""' "$CANONICAL_MAINTENANCE_CHECKPOINT" 2>/dev/null)
+	slow_repo="$FAKE_SLOW_REPO"
+	first_count=$(grep -Fxc "$first_repo" "$SWEEP_VISITS" 2>/dev/null || true)
+	slow_count=$(grep -Fxc "$slow_repo" "$SWEEP_VISITS" 2>/dev/null || true)
+	if [[ "$elapsed" -lt 3 && -n "$first_repo" && "$first_count" -eq 1 && ! -f "$CANONICAL_MAINTENANCE_LAST_RUN" ]] &&
+		[[ "$slow_count" -eq 1 ]] && grep -q "yielded after timeout" "$LOGFILE"; then
+		print_result "budget-yield-before-outer-timeout" 0
+	else
+		print_result "budget-yield-before-outer-timeout" 1 "(elapsed=${elapsed}; checkpoint=$(cat "$CANONICAL_MAINTENANCE_CHECKPOINT" 2>/dev/null); log=$(cat "$LOGFILE"))"
+	fi
+
+	export FAKE_SWEEP_SLEEP=0
+	export FAKE_SLOW_REPO=""
+	CANONICAL_MAINTENANCE_STAGE_BUDGET_SECONDS=10
+	run_canonical_maintenance
+	first_count=$(grep -Fxc "$first_repo" "$SWEEP_VISITS" 2>/dev/null || true)
+	slow_count=$(grep -Fxc "$slow_repo" "$SWEEP_VISITS" 2>/dev/null || true)
+	if [[ "$first_count" -eq 1 && "$slow_count" -eq 2 && -f "$CANONICAL_MAINTENANCE_LAST_RUN" && ! -f "$CANONICAL_MAINTENANCE_CHECKPOINT" ]]; then
+		print_result "budget-resume-without-replay" 0
+	else
+		print_result "budget-resume-without-replay" 1 "(first_repo_visits=${first_count}; slow_repo_visits=${slow_count}; visits=$(cat "$SWEEP_VISITS" 2>/dev/null))"
+	fi
+	SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+	export SCRIPT_DIR
+	return 0
+}
+
+# =============================================================================
+# Test 13: Stock-macOS Perl fallback still bounds a slow child
+# =============================================================================
+test_portable_timeout_fallback() {
+	local fallback_bin="${TEST_ROOT}/fallback-bin"
+	local command_path started elapsed timeout_rc=0
+	mkdir -p "$fallback_bin"
+	command_path=$(command -v perl)
+	ln -sf "$command_path" "${fallback_bin}/perl"
+	command_path=$(command -v sleep)
+	ln -sf "$command_path" "${fallback_bin}/sleep"
+	started=$(date +%s)
+	PATH="$fallback_bin" _canonical_maintenance_run_with_timeout 1 sleep 5 || timeout_rc=$?
+	elapsed=$(($(date +%s) - started))
+	if [[ "$timeout_rc" -eq 124 && "$elapsed" -lt 3 ]]; then
+		print_result "portable-timeout-fallback-bounds-child" 0
+	else
+		print_result "portable-timeout-fallback-bounds-child" 1 "(rc=${timeout_rc}; elapsed=${elapsed})"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 14: Reordered and removed registrations preserve identity-safe progress
+# =============================================================================
+test_checkpoint_registration_identity() {
+	_setup_budget_repos 3
+	_setup_fake_sweep_helper
+	export SWEEP_VISITS="${TEST_ROOT}/identity-visits"
+	export FAKE_SWEEP_SLEEP=0
+	CANONICAL_MAINTENANCE_LAST_RUN="${TEST_ROOT}/identity-last-run"
+	CANONICAL_MAINTENANCE_CHECKPOINT="${CANONICAL_MAINTENANCE_LAST_RUN}.checkpoint"
+	CANONICAL_MAINTENANCE_STAGE_BUDGET_SECONDS=10
+	CANONICAL_MAINTENANCE_STAGE_RESERVE_SECONDS=1
+	rm -f "$SWEEP_VISITS" "$CANONICAL_MAINTENANCE_LAST_RUN" "$CANONICAL_MAINTENANCE_CHECKPOINT"
+	_canonical_maintenance_write_checkpoint sweep "${TEST_ROOT}/budget-repo-2"
+	cat >"$REPOS_JSON" <<EOF
+{"initialized_repos":[
+ {"slug":"test/budget-3","path":"${TEST_ROOT}/budget-repo-3","pulse":false},
+ {"slug":"test/budget-2","path":"${TEST_ROOT}/budget-repo-2","pulse":false},
+ {"slug":"test/budget-1","path":"${TEST_ROOT}/budget-repo-1","pulse":false}
+]}
+EOF
+	run_canonical_maintenance
+	if ! grep -Fxq "${TEST_ROOT}/budget-repo-2" "$SWEEP_VISITS" &&
+		grep -Fxq "${TEST_ROOT}/budget-repo-3" "$SWEEP_VISITS" &&
+		grep -Fxq "${TEST_ROOT}/budget-repo-1" "$SWEEP_VISITS"; then
+		print_result "checkpoint-reorder-uses-repository-identity" 0
+	else
+		print_result "checkpoint-reorder-uses-repository-identity" 1 "(visits=$(cat "$SWEEP_VISITS" 2>/dev/null))"
+	fi
+
+	rm -f "$SWEEP_VISITS" "$CANONICAL_MAINTENANCE_LAST_RUN"
+	_canonical_maintenance_write_checkpoint sweep "${TEST_ROOT}/budget-repo-2"
+	cat >"$REPOS_JSON" <<EOF
+{"initialized_repos":[{"slug":"test/budget-1","path":"${TEST_ROOT}/budget-repo-1","pulse":false}]}
+EOF
+	run_canonical_maintenance
+	if [[ "$(cat "$SWEEP_VISITS")" == "${TEST_ROOT}/budget-repo-1" && -f "$CANONICAL_MAINTENANCE_LAST_RUN" ]]; then
+		print_result "checkpoint-removed-registration-does-not-starve" 0
+	else
+		print_result "checkpoint-removed-registration-does-not-starve" 1 "(visits=$(cat "$SWEEP_VISITS" 2>/dev/null))"
+	fi
+	SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+	export SCRIPT_DIR
+	return 0
+}
+
+# =============================================================================
+# Test 15: Worktree sweep preserves active-owner exclusions
+# =============================================================================
+test_sweep_skips_active_session() {
+	_setup_budget_repos 1
+	_setup_fake_sweep_helper
+	export SWEEP_VISITS="${TEST_ROOT}/active-sweep-visits"
+	export FAKE_SWEEP_SLEEP=0
+	export FAKE_SLOW_REPO=""
+	CANONICAL_MAINTENANCE_LAST_RUN="${TEST_ROOT}/active-last-run"
+	CANONICAL_MAINTENANCE_CHECKPOINT="${CANONICAL_MAINTENANCE_LAST_RUN}.checkpoint"
+	CANONICAL_MAINTENANCE_STAGE_BUDGET_SECONDS=10
+	CANONICAL_MAINTENANCE_STAGE_RESERVE_SECONDS=1
+	local stamp_dir="$CANONICAL_MAINTENANCE_CLAIM_STAMP_DIR"
+	local previous_worker_process_pattern="${WORKER_PROCESS_PATTERN:-}"
+	mkdir -p "$stamp_dir"
+	cat >"${stamp_dir}/budget-active.json" <<EOF
+{"worktree":"${TEST_ROOT}/budget-repo-1","pid":$$,"issue":31553}
+EOF
+	export WORKER_PROCESS_PATTERN=""
+	rm -f "$SWEEP_VISITS" "$CANONICAL_MAINTENANCE_LAST_RUN" "$CANONICAL_MAINTENANCE_CHECKPOINT"
+	_canonical_maintenance_write_checkpoint sweep
+	run_canonical_maintenance
+	export WORKER_PROCESS_PATTERN="$previous_worker_process_pattern"
+	rm -f "${stamp_dir}/budget-active.json"
+	if [[ ! -f "$SWEEP_VISITS" ]] && grep -q "Skipping worktree sweep.*active session" "$LOGFILE"; then
+		print_result "worktree-sweep-skips-active-session" 0
+	else
+		print_result "worktree-sweep-skips-active-session" 1 "(visits=$(cat "$SWEEP_VISITS" 2>/dev/null); log=$(cat "$LOGFILE"))"
+	fi
+	SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+	export SCRIPT_DIR
 	return 0
 }
 
@@ -413,6 +597,10 @@ test_dry_run
 test_skip_not_on_main
 test_worktree_sweep_uses_repo_cwd
 test_worktree_sweep_non_git_path_skips
+test_budget_yield_and_resume
+test_portable_timeout_fallback
+test_checkpoint_registration_identity
+test_sweep_skips_active_session
 
 # =============================================================================
 # Summary

--- a/.agents/scripts/tests/test-pulse-canonical-maintenance.sh
+++ b/.agents/scripts/tests/test-pulse-canonical-maintenance.sh
@@ -402,7 +402,7 @@ EOF
 _setup_budget_repos() {
 	local repo_count="${1:-3}"
 	local repos_body=""
-	local index repo_path
+	local index=0 repo_path=""
 	for ((index = 1; index <= repo_count; index++)); do
 		repo_path="${TEST_ROOT}/budget-repo-${index}"
 		rm -rf "$repo_path"
@@ -449,7 +449,7 @@ test_budget_yield_and_resume() {
 	rm -f "$SWEEP_VISITS" "$CANONICAL_MAINTENANCE_LAST_RUN" "$CANONICAL_MAINTENANCE_CHECKPOINT"
 	_canonical_maintenance_write_checkpoint sweep
 
-	local started elapsed first_repo slow_repo first_count slow_count
+	local started=0 elapsed=0 first_repo="" slow_repo="" first_count=0 slow_count=0
 	started=$(date +%s)
 	run_canonical_maintenance
 	elapsed=$(($(date +%s) - started))
@@ -485,7 +485,7 @@ test_budget_yield_and_resume() {
 # =============================================================================
 test_portable_timeout_fallback() {
 	local fallback_bin="${TEST_ROOT}/fallback-bin"
-	local command_path started elapsed timeout_rc=0
+	local command_path="" started=0 elapsed=0 timeout_rc=0
 	mkdir -p "$fallback_bin"
 	command_path=$(command -v perl)
 	ln -sf "$command_path" "${fallback_bin}/perl"


### PR DESCRIPTION
## Summary

Add phase-aware repository checkpoints, remaining-budget child timeouts, interrupted-operation retries, and active-owner sweep exclusions.

## Files Changed

.agents/scripts/pulse-canonical-maintenance.sh, .agents/scripts/pulse-wrapper.sh, .agents/scripts/tests/test-pulse-canonical-maintenance.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 18 canonical-maintenance regression tests pass; changed-file lint and ShellCheck pass.

Resolves #31553


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.337 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 19m and 149,272 tokens on this as a headless worker.