### PR TITLE
GH#31558: recover absent worktrees in fenced release preparation

### DIFF
--- a/.agents/reference/release-lane-coordination.md
+++ b/.agents/reference/release-lane-coordination.md
@@ -100,12 +100,20 @@ Age alone never unlocks a lane. Live/recent reservations, legacy/foreign owners,
 publication phases and aggregation recovery are not automatically released. A
 stale `preparing` lane is resumable only by the exact same authorized source and
 increment when the local executor is verifiably dead, its deterministic detached
-worktree remains isolated at the pinned snapshot, no release process survives,
+worktree remains isolated at the pinned snapshot or is proven absent and
+unregistered, no release process survives,
 the persisted source manifest still matches, and the intended tag, protected
 release branch, GitHub release, npm version, and Homebrew version are all proven
 absent. The publisher rotates the operation token through the lane compare-and-swap,
 retains durable `preparing_recovery` evidence, and restarts from a fresh copy of
 the pinned commit; lookup uncertainty or any existing artifact refuses recovery.
+An absent worktree must have neither a filesystem entry nor a dangling symlink;
+a successful Git worktree lookup must also show no registration, including stale
+or prunable registrations. A failed lookup is not absence. Local evidence is
+checked again after publication-channel reads, before the fenced transition.
+The receipt records `worktree_head: null` for absence, never an invented historical
+HEAD. An omitted source assertion reuses the lane manifest only when it exactly
+matches independently persisted authorization; an explicit mismatch still fails.
 Same-source reservation reclaim still removes automatic eligibility, but now
 records a `same-source-reclaim/v1` marker when it removes a modern fenced
 contract. For lanes reclaimed before that marker existed, recovery must verify

--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -656,6 +656,31 @@ _full_loop_recovery_process_uses_path() {
 	return $?
 }
 
+# Return evidence, never reconstruct a removed worktree or invent its old HEAD.
+#aidevops:trust-boundary
+_full_loop_recovery_worktree_evidence() {
+	local release_path="$1" snapshot="$2" base_tag="$3" attempted_tag="$4"
+	local worktree_head="" worktree_version="" worktrees="" tag_rc=0
+	git -C "$REPO_ROOT" show-ref --verify --quiet "refs/tags/${attempted_tag}" || tag_rc=$?
+	[[ "$tag_rc" -eq 1 ]] || return 1
+	if [[ -d "$release_path" && ! -L "$release_path" ]]; then
+		worktree_head=$(git -C "$release_path" rev-parse HEAD 2>/dev/null) || return 1
+		[[ "$worktree_head" == "$snapshot" ]] || return 1
+		! git -C "$release_path" symbolic-ref -q HEAD >/dev/null 2>&1 || return 1
+		worktree_version=$(tr -d '[:space:]' <"$release_path/VERSION") || return 1
+		[[ "v${worktree_version}" == "$base_tag" || "$worktree_version" == "${attempted_tag#v}" ]] || return 1
+		jq -cn --arg head "$worktree_head" '{worktree_state:"isolated",worktree_head:$head}'
+		return $?
+	fi
+	[[ ! -e "$release_path" && ! -L "$release_path" ]] || return 1
+	worktrees=$(git -C "$REPO_ROOT" worktree list --porcelain) || return 1
+	[[ "$worktrees" == worktree\ * ]] || return 1
+	[[ $'\n'"$worktrees"$'\n' != *$'\n'"worktree $release_path"$'\n'* ]] || return 1
+	jq -cn --arg absent "$_FULL_LOOP_RECOVERY_STATE_ABSENT" \
+		'{worktree_state:$absent,worktree_head:null,worktree_registration:$absent,local_tag:$absent}'
+	return $?
+}
+
 # A preparing release runs entirely in an isolated detached worktree until its
 # signed tag is pushed. A dead attempt can restart from the immutable snapshot
 # only after both that worktree and all remote publication precursors are proven
@@ -671,11 +696,9 @@ _full_loop_recovery_dead_preparing() {
 	local snapshot=""
 	local base_tag=""
 	local attempted_tag=""
-	local attempted_version=""
 	local owner_pid=""
 	local release_path=""
-	local worktree_head=""
-	local worktree_version=""
+	local worktree_evidence=""
 	local remote_refs=""
 	local recovery_evidence=""
 	local process_rc=0
@@ -692,12 +715,13 @@ _full_loop_recovery_dead_preparing() {
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 2
 	lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	persisted_sources=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	# An omitted CLI assertion reuses the pinned manifest, never a newer main tip.
+	expected_sources="${expected_sources:-$lane_sources}"
 	[[ "$expected_sources" == "$lane_sources" && "$persisted_sources" == "$lane_sources" ]] || return 1
 	snapshot=$(jq -er '.snapshot_sha | select(test("^[0-9a-f]{40}$"))' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	base_tag=$(jq -er '.snapshot_base_tag | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))' \
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	attempted_tag=$(_full_loop_release_expected_tag_at_commit "$snapshot" "$release_type") || return 1
-	attempted_version="${attempted_tag#v}"
 	owner_pid=$(jq -er '.executor.pid | select(type == "number" and . > 0 and floor == .)' \
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	release_path=$(jq -r '.preparation.worktree // ""' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
@@ -708,13 +732,7 @@ _full_loop_recovery_dead_preparing() {
 	"${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"/aidevops-release-"${source_pr}"-*) ;;
 	*) return 1 ;;
 	esac
-	[[ -d "$release_path" ]] || return 1
-	worktree_head=$(git -C "$release_path" rev-parse HEAD 2>/dev/null) || return 1
-	[[ "$worktree_head" == "$snapshot" ]] || return 1
-	! git -C "$release_path" symbolic-ref -q HEAD >/dev/null 2>&1 || return 1
-	! git -C "$release_path" show-ref --verify --quiet "refs/tags/${attempted_tag}" || return 1
-	worktree_version=$(tr -d '[:space:]' <"$release_path/VERSION") || return 1
-	[[ "v${worktree_version}" == "$base_tag" || "$worktree_version" == "$attempted_version" ]] || return 1
+	worktree_evidence=$(_full_loop_recovery_worktree_evidence "$release_path" "$snapshot" "$base_tag" "$attempted_tag") || return 1
 	_full_loop_recovery_process_uses_path "$release_path" || process_rc=$?
 	[[ "$process_rc" -eq 0 ]] || return 1
 	permission=$(gh api "repos/${repo}" \
@@ -724,13 +742,15 @@ _full_loop_recovery_dead_preparing() {
 	remote_refs=$(git -C "$REPO_ROOT" ls-remote --heads origin \
 		"refs/heads/chore/release-${attempted_tag}-provenance") || return 1
 	[[ -z "$remote_refs" ]] || return 1
+	# Recheck local evidence after remote lookups, just before the fenced CAS.
+	worktree_evidence=$(_full_loop_recovery_worktree_evidence "$release_path" "$snapshot" "$base_tag" "$attempted_tag") || return 1
 	recovery_evidence=$(jq -cn --arg tag "$attempted_tag" --arg expected "$lane_sources" \
-		--arg head "$worktree_head" --arg path "$release_path" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+		--argjson worktree "$worktree_evidence" --arg path "$release_path" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
 		--arg absent "$_FULL_LOOP_RECOVERY_STATE_ABSENT" \
 		'{type:"preparing-recovery/v1",attempted_tag:$tag,expected_sources:$expected,
-		worktree:$path,worktree_head:$head,worktree_state:"isolated",surviving_process:$absent,
+		worktree:$path,surviving_process:$absent,
 		remote_tag:$absent,github_release:$absent,npm:$absent,homebrew:$absent,
-		protected_branch:$absent,checked_at:$now}') || return 1
+		protected_branch:$absent,checked_at:$now} + $worktree') || return 1
 	release_lane_recover_dead_preparing "$repo" "$source_pr" "$lane_sources" "$attempted_tag" "$recovery_evidence"
 	return $?
 }

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -355,14 +355,17 @@ release_lane_recover_dead_preparing() {
 	[[ "$updated_epoch" =~ ^[0-9]+$ && "$now_epoch" =~ ^[0-9]+$ && "$now_epoch" -ge "$updated_epoch" ]] || return 3
 	[[ $((now_epoch - updated_epoch)) -ge "$stale_after" ]] || return 3
 	jq -e --arg tag "$attempted_tag" --arg expected "$expected_sources" --arg sha_pattern '^[0-9a-f]{40}$' \
-		--arg absent "$_AIDEVOPS_RELEASE_LANE_STATE_ABSENT" '
+		--arg absent "$_AIDEVOPS_RELEASE_LANE_STATE_ABSENT" --arg string_type "string" '
 		.type == "preparing-recovery/v1" and .attempted_tag == $tag
 		and .expected_sources == $expected and .remote_tag == $absent
 		and .github_release == $absent and .protected_branch == $absent
 		and .npm == $absent and .homebrew == $absent
-		and .surviving_process == $absent and .worktree_state == "isolated"
-		and (.worktree_head | test($sha_pattern))
-		and (.checked_at | type) == "string" and (.checked_at | length) > 0
+		and .surviving_process == $absent
+		and ((.worktree_state == "isolated" and (.worktree_head | type) == $string_type
+			and (.worktree_head | test($sha_pattern)))
+			or (.worktree_state == $absent and has("worktree_head") and .worktree_head == null
+				and .worktree_registration == $absent and .local_tag == $absent))
+		and (.checked_at | type) == $string_type and (.checked_at | length) > 0
 	' <<<"$recovery_evidence" >/dev/null || return 1
 	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(openssl rand -hex 16 2>/dev/null)" || return 1
 	state_json=$(jq -c --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \

--- a/.agents/scripts/tests/test-release-dead-preparing-recovery.sh
+++ b/.agents/scripts/tests/test-release-dead-preparing-recovery.sh
@@ -31,6 +31,11 @@ PERMISSION=true
 LANE_ABSENT=false
 RECOVERY_CALLS=0
 CAPTURED_EVIDENCE=""
+LOCAL_TAG_RC=1
+REGISTERED=false
+WORKTREE_LOOKUP_RC=0
+REGISTER_AFTER_CHANNELS=false
+ABSENT_PATH="$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-absent"
 
 release_lane_read() {
 	[[ "$LANE_ABSENT" == "false" ]] || return 2
@@ -51,6 +56,7 @@ _full_loop_release_expected_tag_at_commit() {
 }
 
 _full_loop_recovery_verify_channels_absent() {
+	[[ "$REGISTER_AFTER_CHANNELS" != true ]] || REGISTERED=true
 	[[ "$1" == "test/repo" && "$2" == "v1.2.4" && "$CHANNELS_ABSENT" == "true" ]]
 	return $?
 }
@@ -65,7 +71,12 @@ git() {
 	case "$args" in
 	*"rev-parse HEAD"*) printf '%s\n' "$SNAPSHOT" ;;
 	*"symbolic-ref -q HEAD"*) return 1 ;;
-	*"show-ref --verify --quiet refs/tags/v1.2.4"*) return 1 ;;
+	*"show-ref --verify --quiet refs/tags/v1.2.4"*) return "$LOCAL_TAG_RC" ;;
+	*"worktree list --porcelain"*)
+		[[ "$WORKTREE_LOOKUP_RC" == 0 ]] || return "$WORKTREE_LOOKUP_RC"
+		printf 'worktree %s\n\n' "$REPO_ROOT"
+		[[ "$REGISTERED" != true ]] || printf 'worktree %s\nprunable stale registration\n\n' "$ABSENT_PATH"
+		;;
 	*"ls-remote --heads origin refs/heads/chore/release-v1.2.4-provenance"*)
 		[[ "$PROTECTED_BRANCH" == "false" ]] && return 0
 		printf '%s\t%s\n' 4444444444444444444444444444444444444444 refs/heads/chore/release-v1.2.4-provenance
@@ -98,6 +109,10 @@ reset_fixture() {
 	LANE_ABSENT=false
 	RECOVERY_CALLS=0
 	CAPTURED_EVIDENCE=""
+	LOCAL_TAG_RC=1
+	REGISTERED=false
+	WORKTREE_LOOKUP_RC=0
+	REGISTER_AFTER_CHANNELS=false
 	printf '1.2.4\n' >"$AIDEVOPS_WORKTREE_BASE_DIR/aidevops-release-101-42/VERSION"
 	return 0
 }
@@ -135,3 +150,35 @@ for refusal in authorization channels process permission branch version; do
 	[[ "$RECOVERY_CALLS" -eq 0 ]] || exit 1
 done
 printf 'PASS preparing recovery refuses authorization, channel, process, branch, and worktree uncertainty\n'
+
+reset_fixture
+STATE=$(jq -c --arg path "$ABSENT_PATH" '.preparation.worktree=$path' <<<"$STATE")
+_full_loop_recovery_dead_preparing test/repo 101 "" patch >/dev/null
+[[ "$RECOVERY_CALLS" -eq 1 ]] || exit 1
+jq -e '.worktree_state == "absent" and has("worktree_head") and .worktree_head == null
+	and .worktree_registration == "absent" and .local_tag == "absent"' <<<"$CAPTURED_EVIDENCE" >/dev/null
+printf 'PASS absent unregistered worktree recovers with truthful evidence and persisted manifest\n'
+
+for refusal in registration lookup tag tag-error late-registration authorization channels process permission branch symlink; do
+	reset_fixture
+	STATE=$(jq -c --arg path "$ABSENT_PATH" '.preparation.worktree=$path' <<<"$STATE")
+	case "$refusal" in
+	registration) REGISTERED=true ;;
+	lookup) WORKTREE_LOOKUP_RC=128 ;;
+	tag) LOCAL_TAG_RC=0 ;;
+	tag-error) LOCAL_TAG_RC=128 ;;
+	late-registration) REGISTER_AFTER_CHANNELS=true ;;
+	authorization) AUTHORIZATION=wrong-manifest ;;
+	channels) CHANNELS_ABSENT=false ;;
+	process) SURVIVING_PROCESS=true ;;
+	permission) PERMISSION=false ;;
+	branch) PROTECTED_BRANCH=true ;;
+	symlink) ln -s "$TEST_ROOT/nonexistent" "$ABSENT_PATH" ;;
+	esac
+	if _full_loop_recovery_dead_preparing test/repo 101 "" patch >/dev/null 2>&1; then
+		printf 'FAIL unsafe absent-worktree %s state was recovered\n' "$refusal" >&2
+		exit 1
+	fi
+	[[ "$RECOVERY_CALLS" -eq 0 ]] || exit 1
+done
+printf 'PASS absent-worktree recovery refuses stale registrations, lookup uncertainty, tags, drift and all existing gates\n'

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -668,6 +668,14 @@ run_dead_preparing_recovery_test() (
 		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null || return 1
 	jq -e '.phase == "reserved" and (.preparing_recovery.revalidations | length) == 1
 		and .preparing_recovery.revalidations[0].previous_executor.pid == 77' <<<"$written" >/dev/null
+	state=$(jq -c '.phase="preparing" | .updated_at="2020-01-01T00:00:00Z"' <<<"$state") || return 1
+	evidence=$(jq -c '.worktree_state="absent" | .worktree_head=null
+		| .worktree_registration="absent" | .local_tag="absent"' <<<"$evidence") || return 1
+	AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null || return 1
+	jq -e '.phase == "reserved" and (.preparing_recovery.revalidations | length) == 2
+		and .preparing_recovery.revalidations[1].evidence.worktree_state == "absent"
+		and .preparing_recovery.revalidations[1].evidence.worktree_head == null' <<<"$written" >/dev/null
 )
 
 run_reclaimed_contract_recovery_test() (
@@ -780,6 +788,17 @@ run_dead_preparing_refusal_test() (
 		fi
 	done
 	state="$base"
+	local invalid_evidence=""
+	for transform in '.worktree_state="absent"' '.worktree_head=null' \
+		'.worktree_state="absent" | .worktree_head=null | .local_tag="absent"' \
+		'.worktree_state="absent" | .worktree_head=null | .worktree_registration="absent"' \
+		'.worktree_state="absent" | del(.worktree_head) | .worktree_registration="absent" | .local_tag="absent"'; do
+		invalid_evidence=$(jq -c "$transform" <<<"$evidence") || return 1
+		if AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
+			release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$invalid_evidence" >/dev/null 2>&1; then
+			return 1
+		fi
+	done
 	write_rc=2
 	if AIDEVOPS_RELEASE_LANE_STALE_SECONDS=1 \
 		release_lane_recover_dead_preparing test/repo 101 "$expected" v1.2.4 "$evidence" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Add a truthful absent-worktree evidence branch to full-loop-release-aggregate-recovery.sh and release-lane-helper.sh; preserve pinned authorization, artifact absence and dead-owner CAS fences. Extend existing dead-preparing and lane tests; document recovery in release-lane-coordination.md.

## Files Changed

.agents/reference/release-lane-coordination.md, .agents/scripts/full-loop-release-aggregate-recovery.sh, .agents/scripts/release-lane-helper.sh, .agents/scripts/tests/test-release-dead-preparing-recovery.sh, .agents/scripts/tests/test-release-lane.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified through production recovery and lane functions in existing offline fixtures. Dead-preparing recovery, 20 lane test groups and aggregate-recovery suite pass. Changed-file linters pass. Independent security closeout found no blocking defects. Review bundle 6aa9580f835794d66ced156ceba8ba8a1ee9378ec7cf75bc97cfb5d9d46584a7.

Resolves #31558


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.337 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 2m and 53,823 tokens on this with the user in an interactive session.