### PR TITLE
GH#31557: execute routines in registered repository context

### DIFF
--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -265,6 +265,11 @@ _routine_execute() {
 	started_epoch=$(date +%s)
 
 	if [[ -n "$run_script" ]]; then
+		if [[ ! -d "$repo_path" ]]; then
+			echo "[pulse-wrapper] routine ${routine_id}: repository directory not found or not a directory: ${repo_path}" >>"$LOGFILE"
+			_routine_finalize_terminal "$routine_id" "$_ROUTINE_STATUS_FAILURE" "$started_epoch"
+			return 1
+		fi
 		local run_parts=()
 		IFS=' ' read -r -a run_parts <<<"$run_script"
 		local script_path="${agents_dir}/${run_parts[0]}"
@@ -278,10 +283,10 @@ _routine_execute() {
 		if [[ "${#run_parts[@]}" -gt 1 ]]; then
 			local script_args=("${run_parts[@]:1}")
 			echo "[pulse-wrapper] routine ${routine_id}: executing script ${script_path} ${script_args[*]}" >>"$LOGFILE"
-			"$script_path" "${script_args[@]}" >>"$LOGFILE" 2>&1 || exit_code=$?
+			(cd "$repo_path" && "$script_path" "${script_args[@]}") >>"$LOGFILE" 2>&1 || exit_code=$?
 		else
 			echo "[pulse-wrapper] routine ${routine_id}: executing script ${script_path}" >>"$LOGFILE"
-			"$script_path" >>"$LOGFILE" 2>&1 || exit_code=$?
+			(cd "$repo_path" && "$script_path") >>"$LOGFILE" 2>&1 || exit_code=$?
 		fi
 		if [[ "$exit_code" -eq "$_ROUTINE_TEMPFAIL_EXIT" ]]; then
 			status="$_ROUTINE_STATUS_DEFERRED"
@@ -299,8 +304,13 @@ _routine_execute() {
 
 	local custom_script="${agents_dir}/custom/scripts/${routine_id}.sh"
 	if [[ -z "$agent_name" && -x "$custom_script" ]]; then
+		if [[ ! -d "$repo_path" ]]; then
+			echo "[pulse-wrapper] routine ${routine_id}: repository directory not found or not a directory: ${repo_path}" >>"$LOGFILE"
+			_routine_finalize_terminal "$routine_id" "$_ROUTINE_STATUS_FAILURE" "$started_epoch"
+			return 1
+		fi
 		echo "[pulse-wrapper] routine ${routine_id}: executing custom script ${custom_script}" >>"$LOGFILE"
-		"$custom_script" >>"$LOGFILE" 2>&1 || exit_code=$?
+		(cd "$repo_path" && "$custom_script") >>"$LOGFILE" 2>&1 || exit_code=$?
 		[[ "$exit_code" -eq 0 ]] || status="$_ROUTINE_STATUS_FAILURE"
 		_routine_finalize_terminal "$routine_id" "$status" "$started_epoch"
 		return 0

--- a/.agents/scripts/tests/test-routine-tracking-updates.sh
+++ b/.agents/scripts/tests/test-routine-tracking-updates.sh
@@ -215,6 +215,61 @@ HELPER
 	return 0
 }
 
+test_pulse_routine_scripts_use_registered_repository() {
+	local fake_home="$TEST_DIR/context-home"
+	local agents_dir="$fake_home/.aidevops/agents"
+	local repo_dir="$TEST_DIR/registered-repo"
+	local launcher_dir="$TEST_DIR/launcher"
+	local configured_capture="$TEST_DIR/configured-cwd"
+	local custom_capture="$TEST_DIR/custom-cwd"
+	local original_cwd=""
+	local caller_cwd=""
+	local missing_failed=0
+	mkdir -p "$agents_dir/scripts" "$agents_dir/custom/scripts" "$repo_dir" "$launcher_dir" "$TEST_DIR/bin"
+	cat >"$agents_dir/scripts/record-cwd.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+printf '%s|%s\n' "$PWD" "$*" >"$ROUTINE_CWD_CAPTURE"
+SCRIPT
+	cat >"$agents_dir/custom/scripts/r-cwd.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+printf '%s\n' "$PWD" >"$ROUTINE_CUSTOM_CWD_CAPTURE"
+SCRIPT
+	cat >"$TEST_DIR/bin/routine-log-helper.sh" <<'HELPER'
+#!/usr/bin/env bash
+exit 0
+HELPER
+	chmod +x "$agents_dir/scripts/record-cwd.sh" "$agents_dir/custom/scripts/r-cwd.sh" "$TEST_DIR/bin/routine-log-helper.sh"
+
+	HOME="$fake_home"
+	ROUTINE_STATE_FILE="$TEST_DIR/context-state.json"
+	LOGFILE="$TEST_DIR/context-pulse.log"
+	ROUTINE_LOG_HELPER="$TEST_DIR/bin/routine-log-helper.sh"
+	ROUTINE_CWD_CAPTURE="$configured_capture"
+	ROUTINE_CUSTOM_CWD_CAPTURE="$custom_capture"
+	export ROUTINE_CWD_CAPTURE ROUTINE_CUSTOM_CWD_CAPTURE
+	original_cwd=$(pwd)
+	cd "$launcher_dir" || return 1
+	caller_cwd=$(pwd)
+	_routine_execute "r-cwd-configured" "configured cwd" "scripts/record-cwd.sh with-argument" "" "$repo_dir"
+	_routine_execute "r-cwd" "custom cwd" "" "" "$repo_dir"
+	if _routine_execute "r-cwd-missing" "missing cwd" "scripts/record-cwd.sh" "" "$TEST_DIR/missing-repo"; then
+		missing_failed=0
+	else
+		missing_failed=1
+	fi
+	if [[ "$(<"$configured_capture")" == "${repo_dir}|with-argument" ]] &&
+		[[ "$(<"$custom_capture")" == "$repo_dir" ]] &&
+		[[ "$(pwd)" == "$caller_cwd" ]] &&
+		[[ "$missing_failed" -eq 1 ]] &&
+		[[ "$(<"$LOGFILE")" == *"repository directory not found or not a directory"* ]]; then
+		print_result "pulse routine scripts use registered repository cwd" 0
+	else
+		print_result "pulse routine scripts use registered repository cwd" 1 "configured=$(<"$configured_capture") custom=$(<"$custom_capture") cwd=$(pwd)"
+	fi
+	cd "$original_cwd" || return 1
+	return 0
+}
+
 test_agent_routine_waits_for_terminal_result() {
 	local capture_file="$TEST_DIR/agent-routine-lifecycle.args"
 	local done_file="$TEST_DIR/agent-routine.done"
@@ -490,6 +545,7 @@ main() {
 	test_core_routine_shell_quote_escapes_single_quotes
 	test_linux_core_scheduler_commands_are_logged
 	test_pulse_routine_update_uses_flags_and_duration
+	test_pulse_routine_scripts_use_registered_repository
 	test_agent_routine_waits_for_terminal_result
 	test_opencode_archive_scheduler_is_daily_and_low_priority
 	test_opencode_archive_scheduler_tolerates_unset_home


### PR DESCRIPTION
## Summary

Run configured and custom Pulse scripts from their registered repository directory and record missing-directory failures.

## Files Changed

.agents/scripts/pulse-routines.sh, .agents/scripts/tests/test-routine-tracking-updates.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-routine-tracking-updates.sh; bash .agents/scripts/tests/test-pulse-routines-selector.sh; .agents/scripts/linters-local.sh --changed; review bundle 74b9a1aae8e356146257a351d234a080d264d69867829ec180ed87cb030c5c7e

Resolves #31557


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.338 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 4m and 95,952 tokens on this as a headless worker.