### PR TITLE
GH#31564: scope full-loop publication validators

### DIFF
--- a/.agents/scripts/full-loop-helper-commit-validators.sh
+++ b/.agents/scripts/full-loop-helper-commit-validators.sh
@@ -23,12 +23,6 @@
 [[ -n "${_FULL_LOOP_COMMIT_VALIDATORS_LIB_LOADED:-}" ]] && return 0
 _FULL_LOOP_COMMIT_VALIDATORS_LIB_LOADED=1
 
-# Run auto-fix passes (format then lint). Continue past failures —
-# fix scripts may legitimately exit non-zero on un-auto-fixable issues.
-# If auto-fix produced changes, amend the HEAD commit.
-# Sets caller-scope `fix_changes` to 1 if amend happened, 0 otherwise.
-# Args: $1=pm (npm|pnpm|yarn) $2=timeout_secs $3=timeout_available (0|1)
-# Returns 0 on success, 1 if amend failed.
 _restore_validator_repo_root() {
 	local repo_root="$1"
 	local phase="$2"
@@ -45,103 +39,177 @@ _restore_validator_repo_root() {
 	return 0
 }
 
-_run_node_auto_fix() {
-	local pm="$1"
-	local t="$2"
-	local timeout_available="${3:-0}"
-	local repo_root=""
-	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P 2>/dev/null || echo "")
-	if [[ -z "$repo_root" ]]; then
-		print_error "[validators] cannot determine repository root before auto-fix"
+_validator_file_is_node_related() {
+	local changed_file="$1"
+	case "$changed_file" in
+	package.json | package-lock.json | npm-shrinkwrap.json | pnpm-lock.yaml | yarn.lock | bun.lock | bun.lockb | \
+		*.js | *.jsx | *.mjs | *.cjs | *.ts | *.tsx | *.mts | *.cts | \
+		*.eslintrc.* | eslint.config.* | tsconfig*.json | jsconfig*.json | prettier.config.* | .prettierrc*) return 0 ;;
+	esac
+	return 1
+}
+
+_validator_workspace_patterns() {
+	jq -r '.workspaces // empty | if type == "array" then .[] elif type == "object" then (.packages // [])[] else empty end' package.json 2>/dev/null
+}
+
+_validator_workspace_matches() {
+	local scope="$1"
+	local workspace_patterns="$2"
+	local pattern=""
+	while IFS= read -r pattern; do
+		# Workspace declarations are glob patterns (for example packages/*).
+		# shellcheck disable=SC2053
+		[[ -n "$pattern" && "$scope" == $pattern ]] && return 0
+	done <<<"$workspace_patterns"
+	return 1
+}
+
+_validator_all_workspace_scopes() {
+	local workspace_patterns="$1"
+	local manifest="" scope="" scopes=""
+	while IFS= read -r manifest; do
+		[[ "$manifest" == "package.json" ]] && continue
+		scope=${manifest%/package.json}
+		_validator_workspace_matches "$scope" "$workspace_patterns" || continue
+		case $'\n'"$scopes"$'\n' in
+		*$'\n'"$scope"$'\n'*) ;;
+		*) scopes="${scopes}${scopes:+$'\n'}${scope}" ;;
+		esac
+	done < <(git ls-files '*package.json')
+	if _validator_package_has_check package.json; then
+		scopes=".${scopes:+$'\n'}${scopes}"
+	fi
+	if [[ -z "$scopes" ]]; then
+		print_error "[validators] root/shared change requires broader checks, but no check-only workspace scripts are available"
 		return 1
 	fi
-	_restore_validator_repo_root "$repo_root" "startup" || return 1
-	# Build a timeout prefix array; empty when timeout(1) is not available.
-	local -a timeout_prefix=()
-	[[ "$timeout_available" == "1" ]] && timeout_prefix=("timeout" "$t")
-	fix_changes=0
-	local script_name
-	for script_name in format:fix format:write prettier:fix; do
-		if jq -e --arg s "$script_name" '.scripts[$s] // empty' package.json >/dev/null 2>&1; then
-			print_info "[validators] $pm run $script_name (auto-fix)"
-			"${timeout_prefix[@]}" "$pm" run "$script_name" >/dev/null 2>&1 || true
-			_restore_validator_repo_root "$repo_root" "$script_name" || return 1
-			break
-		fi
-	done
-	# Lint auto-fix loop pattern matches format for parallel extension.
-	# shellcheck disable=SC2043
-	for script_name in lint:fix; do
-		if jq -e --arg s "$script_name" '.scripts[$s] // empty' package.json >/dev/null 2>&1; then
-			print_info "[validators] $pm run $script_name (auto-fix)"
-			"${timeout_prefix[@]}" "$pm" run "$script_name" >/dev/null 2>&1 || true
-			_restore_validator_repo_root "$repo_root" "$script_name" || return 1
-			break
-		fi
-	done
-	_restore_validator_repo_root "$repo_root" "auto-fix" || return 1
-	if git diff --quiet 2>/dev/null; then
-		return 0
-	fi
-	print_info "[validators] auto-fix produced changes, amending commit"
-	# Use git add -u (tracked files only) to avoid staging untracked artifacts
-	# that format/lint runners may create (e.g. caches, generated files).
-	git add -u
-	# --no-verify on amend: avoid recursing into pre-commit territory.
-	if ! git commit --amend --no-edit --no-verify >/dev/null 2>&1; then
-		print_error "[validators] failed to amend commit with auto-fix changes"
-		git status -s 2>&1 | head -10 >&2
-		return 1
-	fi
-	fix_changes=1
+	printf '%s\n' "$scopes"
 	return 0
 }
 
-# Run check-only typecheck. Picks first existing script in preference order.
-# Captures output for failure diagnosis. Mentor error on failure.
-# Args: $1=pm $2=timeout_secs $3=timeout_available (0|1)
-# Returns 0 on pass/no-script, 1 on failure.
-_run_node_typecheck() {
-	local pm="$1"
-	local t="$2"
-	local timeout_available="${3:-0}"
-	# Build a timeout prefix array; empty when timeout(1) is not available.
-	local -a timeout_prefix=()
-	[[ "$timeout_available" == "1" ]] && timeout_prefix=("timeout" "$t")
-	local typecheck_script
-	typecheck_script=""
-	local script_name
-	for script_name in typecheck check:types tsc; do
-		if jq -e --arg s "$script_name" '.scripts[$s] // empty' package.json >/dev/null 2>&1; then
-			typecheck_script="$script_name"
-			break
+# Print the package roots that own Node-related files in the complete PR range.
+# A root/shared change intentionally selects the root package and broader checks.
+_validator_scopes() {
+	local changed_files="" workspace_patterns="" changed_file=""
+	local scope=""
+	changed_files=$(_validator_changed_files) || return 1
+	workspace_patterns=$(_validator_workspace_patterns)
+	if [[ -z "$workspace_patterns" ]]; then
+		printf '.\n'
+		return 0
+	fi
+	local scopes=""
+	while IFS= read -r changed_file; do
+		_validator_file_is_node_related "$changed_file" || continue
+		scope=${changed_file%/*}
+		[[ "$scope" == "$changed_file" ]] && scope="."
+		while [[ "$scope" != "." && ! -f "$scope/package.json" ]]; do
+			if [[ "$scope" == */* ]]; then
+				scope=${scope%/*}
+			else
+				scope="."
+			fi
+		done
+		if [[ "$scope" == "." ]]; then
+			_validator_all_workspace_scopes "$workspace_patterns"
+			return $?
+		fi
+		if ! _validator_workspace_matches "$scope" "$workspace_patterns"; then
+			print_error "[validators] cannot map changed Node file to a declared workspace: $changed_file"
+			print_error "[validators] add a package-level check script or correct package.json workspaces before publication"
+			return 1
+		fi
+		case $'\n'"$scopes"$'\n' in
+		*$'\n'"$scope"$'\n'*) ;;
+		*) scopes="${scopes}${scopes:+$'\n'}${scope}" ;;
+		esac
+	done <<<"$changed_files"
+	[[ -n "$scopes" ]] || return 1
+	printf '%s\n' "$scopes"
+	return 0
+}
+
+_validator_select_script() {
+	local package_json="$1" phase="$2" script_name=""
+	local candidates=""
+	case "$phase" in
+	format) candidates=$'format:check\ncheck:format\nprettier:check' ;;
+	lint) candidates=$'lint:check\nlint' ;;
+	typecheck) candidates=$'typecheck\ncheck:types\ntsc' ;;
+	esac
+	while IFS= read -r script_name; do
+		if jq -e --arg s "$script_name" '.scripts[$s] // empty' "$package_json" >/dev/null 2>&1; then
+			printf '%s\n' "$script_name"
+			return 0
+		fi
+	done <<<"$candidates"
+	return 1
+}
+
+_validator_package_has_check() {
+	local package_json="$1" phase=""
+	for phase in format lint typecheck; do
+		_validator_select_script "$package_json" "$phase" >/dev/null && return 0
+	done
+	return 1
+}
+
+_validator_snapshot() {
+	local prefix="$1"
+	git diff --binary --no-ext-diff >"${prefix}.worktree" || return 1
+	git diff --cached --binary --no-ext-diff >"${prefix}.index" || return 1
+	return 0
+}
+
+_validator_state_unchanged() {
+	local before="$1" after="$2" command_label="$3"
+	if cmp -s "${before}.worktree" "${after}.worktree" && cmp -s "${before}.index" "${after}.index"; then
+		return 0
+	fi
+	print_error "[validators] check-only command modified tracked files or index state: $command_label"
+	print_error "[validators] changes were preserved but will not be staged or amended; inspect git status and configure a non-mutating check"
+	git status --short >&2
+	return 1
+}
+
+_run_scoped_node_checks() {
+	local pm="$1" scope="$2" t="$3" snapshot_dir="$4"
+	local package_json="package.json" scope_label="repository root"
+	if [[ "$scope" != "." ]]; then
+		package_json="$scope/package.json"
+		scope_label="$scope"
+	fi
+	local phase="" script_name="" check_count=0 command_rc=0 check_index=0
+	for phase in format lint typecheck; do
+		script_name=$(_validator_select_script "$package_json" "$phase") || continue
+		check_count=$((check_count + 1))
+		check_index=$((check_index + 1))
+		print_info "[validators] scope=${scope_label} reason=$([[ "$scope" == "." ]] && printf 'root-or-shared-change' || printf 'affected-workspace') command=$pm run $script_name"
+		_validator_snapshot "${snapshot_dir}/before-${check_index}" || return 1
+		command_rc=0
+		(
+			cd "$scope" || exit 1
+			timeout_sec "$t" "$pm" run "$script_name"
+		) >"${snapshot_dir}/command-${check_index}.log" 2>&1 || command_rc=$?
+		_restore_validator_repo_root "$(git rev-parse --show-toplevel 2>/dev/null)" "$script_name" || return 1
+		_validator_snapshot "${snapshot_dir}/after-${check_index}" || return 1
+		_validator_state_unchanged "${snapshot_dir}/before-${check_index}" "${snapshot_dir}/after-${check_index}" "$pm run $script_name ($scope_label)" || return 1
+		if [[ "$command_rc" -eq 124 ]]; then
+			print_error "[validators] TIMEOUT after ${t}s: $pm run $script_name ($scope_label)"
+			return 1
+		elif [[ "$command_rc" -ne 0 ]]; then
+			print_error "[validators] CHECK FAILED (exit ${command_rc}): $pm run $script_name ($scope_label)"
+			tail -20 "${snapshot_dir}/command-${check_index}.log" >&2
+			return 1
 		fi
 	done
-	if [[ -z "$typecheck_script" ]]; then
-		return 0
+	if [[ "$check_count" -eq 0 ]]; then
+		print_error "[validators] NO SCOPED CHECKS AVAILABLE for ${scope_label}"
+		print_error "[validators] configure lint, typecheck, or a check-only format script in ${package_json}"
+		return 1
 	fi
-	print_info "[validators] $pm run $typecheck_script (check-only)"
-	# Separate declaration from mktemp assignment: local masks the exit code of
-	# command substitutions, so declare first then assign (Gemini review PR #20898).
-	# mktemp without -t: more portable (GNU and BSD mktemp differ on -t semantics).
-	local tc_log
-	tc_log="$(mktemp)"
-	local tc_rc=0
-	"${timeout_prefix[@]}" "$pm" run "$typecheck_script" >"$tc_log" 2>&1 || tc_rc=$?
-	if [[ "$tc_rc" -eq 0 ]]; then
-		rm -f "$tc_log"
-		return 0
-	fi
-	print_error "[validators] $typecheck_script FAILED — code has type errors"
-	print_error "  last 20 lines:"
-	tail -20 "$tc_log" >&2
-	rm -f "$tc_log"
-	print_error ""
-	print_error "  diagnose:    $pm run $typecheck_script"
-	print_error "  fix errors, commit, then re-run: full-loop-helper.sh commit-and-pr ..."
-	print_error "  bypass:      full-loop-helper.sh commit-and-pr ... --skip-hooks"
-	print_error "               (or AIDEVOPS_SKIP_PROJECT_VALIDATORS=1 env)"
-	return 1
+	return 0
 }
 
 # Orchestrator. Args: $1=skip_hooks (0|1). Returns 0 on pass/skip, 1 on fail.
@@ -163,18 +231,26 @@ _run_project_validators() {
 	print_info "[validators] running node project validators ($pm)..."
 	local validator_timeout
 	validator_timeout="${AIDEVOPS_VALIDATOR_TIMEOUT:-300}"
-	# Detect timeout(1) availability once here; sub-functions receive a flag so
-	# they don't each re-check (portability: macOS may lack timeout without
-	# GNU coreutils; pattern mirrors _rebase_and_push:L941).
-	local timeout_available=0
-	command -v timeout >/dev/null 2>&1 && timeout_available=1
-	local fix_changes=0
-	_run_node_auto_fix "$pm" "$validator_timeout" "$timeout_available" || return 1
-	_run_node_typecheck "$pm" "$validator_timeout" "$timeout_available" || return 1
-	if [[ "$fix_changes" == "1" ]]; then
-		print_info "[validators] passed (auto-fix amended into commit)"
-	else
-		print_info "[validators] passed"
+	if ! [[ "$validator_timeout" =~ ^[1-9][0-9]*$ ]]; then
+		print_error "[validators] AIDEVOPS_VALIDATOR_TIMEOUT must be a positive integer"
+		return 1
 	fi
+	if ! command -v "$pm" >/dev/null 2>&1; then
+		print_error "[validators] REQUIRED COMMAND UNAVAILABLE: $pm"
+		return 1
+	fi
+	local scopes="" snapshot_dir=""
+	local scope=""
+	scopes=$(_validator_scopes) || return 1
+	snapshot_dir=$(mktemp -d) || return 1
+	while IFS= read -r scope; do
+		[[ -n "$scope" ]] || continue
+		_run_scoped_node_checks "$pm" "$scope" "$validator_timeout" "$snapshot_dir" || {
+			rm -rf "$snapshot_dir"
+			return 1
+		}
+	done <<<"$scopes"
+	rm -rf "$snapshot_dir"
+	print_info "[validators] passed (check-only scope: ${scopes//$'\n'/, })"
 	return 0
 }

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -1037,8 +1037,8 @@ _finalize_wip_history() {
 #   _run_project_validators       — orchestrator
 #   _validators_should_run        — bypass-path check
 #   _detect_node_project          — node-project detection (returns pm)
-#   _run_node_auto_fix            — format/lint auto-fix + amend
-#   _run_node_typecheck           — typecheck check-only
+#   _validator_scopes             — affected-workspace/root scope selection
+#   _run_scoped_node_checks       — bounded, mutation-guarded check-only scripts
 
 # Print every file changed between the remote default branch and HEAD.
 # The merge-base range keeps classification aligned with the complete PR diff
@@ -1126,17 +1126,18 @@ _detect_node_project() {
 		return 1
 	fi
 	local has_relevant_scripts
-	# Only include scripts that are actually executed by the runner.
-	# "format" and "lint" (without :fix suffix) are omitted because the runner
-	# only attempts format:fix/format:write/prettier:fix and lint:fix — detecting
-	# on bare format/lint causes false positives where validators report "passed"
-	# without actually running anything (Augment review, PR #20898).
+	# Check-only scripts and workspaces are executable validation surfaces. Legacy
+	# mutating-only scripts are also detected so the orchestrator can fail with
+	# actionable configuration guidance instead of silently reporting success.
 	has_relevant_scripts=$(jq -r '
-		.scripts // {} |
-		[has("format:fix"),has("format:write"),has("prettier:fix"),
-		 has("lint:fix"),
-		 has("typecheck"),has("check:types"),has("tsc")] |
-		any
+		(.scripts // {} |
+		 [has("format:check"),has("check:format"),has("prettier:check"),
+		  has("lint:check"),has("lint"),
+		  has("typecheck"),has("check:types"),has("tsc"),
+		  has("format:fix"),has("format:write"),has("prettier:fix"),has("lint:fix")] |
+		 any) or
+		((.workspaces // []) |
+		 if arrays then length > 0 else ((.packages? // []) | length > 0) end)
 	' package.json 2>/dev/null || echo "false")
 	if [[ "$has_relevant_scripts" != "true" ]]; then
 		return 1
@@ -1146,10 +1147,6 @@ _detect_node_project() {
 		pm="pnpm"
 	elif [[ -f yarn.lock ]]; then
 		pm="yarn"
-	fi
-	if ! command -v "$pm" >/dev/null 2>&1; then
-		print_warning "[validators] $pm not available on PATH — skipping (set AIDEVOPS_SKIP_PROJECT_VALIDATORS=1 to silence)"
-		return 1
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-full-loop-project-validators-shell-only.sh
+++ b/.agents/scripts/tests/test-full-loop-project-validators-shell-only.sh
@@ -48,6 +48,15 @@ print_error() {
 	return 0
 }
 
+# Production callers inherit the portable implementation from shared-constants.
+# This focused source-level fixture supplies the same command contract.
+timeout_sec() {
+	local _seconds="$1"
+	shift
+	"$@"
+	return $?
+}
+
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck source=../full-loop-helper-commit.sh
 source "${SCRIPT_DIR}/full-loop-helper-commit.sh"
@@ -65,15 +74,11 @@ FAKE_BIN="${TEST_ROOT}/bin"
 mkdir -p "$FAKE_BIN"
 cat >"${FAKE_BIN}/npm" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' "npm should not run for shell-only diffs" >>"${NPM_CALL_LOG:?}"
-if [[ "${NPM_FAKE_ACTION:-}" == "delete-cwd-after-edit" ]]; then
-	printf '%s\n' 'fixed' >>"${NPM_FIX_TARGET:?}"
-	if [[ -n "${NPM_DELETE_DIR:-}" ]]; then
-		rm -rf "$NPM_DELETE_DIR"
-	fi
-	exit 0
+printf '%s|%s\n' "$PWD" "$*" >>"${NPM_CALL_LOG:?}"
+if [[ "${NPM_FAKE_ACTION:-}" == "mutate-other" ]]; then
+	printf '%s\n' 'validator mutation' >>"${NPM_FIX_TARGET:?}"
 fi
-exit "${NPM_FAKE_RC:-2}"
+exit "${NPM_FAKE_RC:-0}"
 EOF
 chmod +x "${FAKE_BIN}/npm"
 
@@ -173,37 +178,143 @@ else
 	print_result "docs-only branch skips project validators" 1 "rc=${case3_rc}, npm_log=$(wc -c <"$NPM_CALL_LOG" 2>/dev/null || printf 0)"
 fi
 
-# Case 4: if an auto-fix command removes the process' current subdirectory,
-# the validator restores the repository root before running git diff/add/amend.
-# This guards the GH#22526 failure class where amend hit getcwd() from a stale
-# cwd and reported: fatal: Unable to read current working directory.
-CWD_REPO="${TEST_ROOT}/cwd-restore"
-make_repo "$CWD_REPO"
-mkdir -p "${CWD_REPO}/vanishing"
-(
-	cd "$CWD_REPO" || exit 1
-	cat >package.json <<'EOF'
-{"scripts":{"format:fix":"node scripts/fix.js"}}
+make_workspace_repo() {
+	local repo_dir="$1"
+	mkdir -p "$repo_dir/packages/a" "$repo_dir/packages/b"
+	(
+		cd "$repo_dir" || exit 1
+		git init -q
+		git config commit.gpgsign false
+		git config tag.gpgsign false
+		git branch -M develop
+		cat >package.json <<'EOF'
+{"private":true,"workspaces":["packages/*"],"scripts":{"lint:fix":"unsafe-root-fixer"}}
 EOF
-	printf '%s\n' 'before' >tracked.txt
-	git add package.json tracked.txt
-	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'node project'
-)
-NPM_CALL_LOG="${TEST_ROOT}/npm-cwd.log"
-NPM_FIX_TARGET="${CWD_REPO}/tracked.txt"
-NPM_DELETE_DIR="${CWD_REPO}/vanishing"
-export NPM_CALL_LOG NPM_FIX_TARGET NPM_DELETE_DIR NPM_FAKE_ACTION=delete-cwd-after-edit NPM_FAKE_RC=0
+		printf '%s\n' '{"scripts":{"lint":"eslint .","typecheck":"tsc --noEmit"}}' >packages/a/package.json
+		printf '%s\n' '{"scripts":{"lint":"eslint ."}}' >packages/b/package.json
+		printf '%s\n' 'export const a = 1;' >packages/a/index.ts
+		printf '%s\n' 'export const b = 1;' >packages/b/index.ts
+		git add .
+		git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'initial workspace'
+		git remote add origin .
+		git update-ref refs/remotes/origin/develop HEAD
+		git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+		git switch -qc feature/test
+	) || return 1
+	return 0
+}
+
+# Case 4: a package-A-only change runs only package A checks. Pre-existing
+# staged and unstaged edits in package B retain their bytes and index state.
+WORKSPACE_REPO="${TEST_ROOT}/workspace-scope"
+make_workspace_repo "$WORKSPACE_REPO"
+NPM_CALL_LOG="${TEST_ROOT}/npm-workspace.log"
+export NPM_CALL_LOG NPM_FAKE_ACTION='' NPM_FAKE_RC=0
 (
-	cd "${CWD_REPO}/vanishing" || exit 1
-	PATH="${FAKE_BIN}:$PATH" fix_changes=0 _run_node_auto_fix npm 30 0
+	cd "$WORKSPACE_REPO" || exit 1
+	printf '%s\n' 'export const a = 2;' >packages/a/index.ts
+	git add packages/a/index.ts
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'change package a'
+	printf '%s\n' 'pre-existing staged package b edit' >>packages/b/index.ts
+	git add packages/b/index.ts
+	printf '%s\n' 'pre-existing unstaged package b edit' >>packages/b/index.ts
+	PATH="${FAKE_BIN}:$PATH" _run_project_validators 0
 )
 case4_rc=$?
-case4_head_subject=$(git -C "$CWD_REPO" log -1 --format=%s 2>/dev/null || printf '')
-case4_file=$(git -C "$CWD_REPO" show HEAD:tracked.txt 2>/dev/null || printf '')
-if [[ "$case4_rc" -eq 0 && "$case4_head_subject" == "node project" && "$case4_file" == $'before\nfixed' ]]; then
-	print_result "auto-fix restores repo root before amend when cwd disappears" 0
+case4_b=$(git -C "$WORKSPACE_REPO" diff -- packages/b/index.ts)
+case4_cached=$(git -C "$WORKSPACE_REPO" diff --cached --name-only)
+case4_index_b=$(git -C "$WORKSPACE_REPO" show :packages/b/index.ts)
+if [[ "$case4_rc" -eq 0 && "$case4_b" == *"pre-existing unstaged package b edit"* && "$case4_cached" == "packages/b/index.ts" && "$case4_index_b" == *"pre-existing staged package b edit"* ]] &&
+	[[ $(wc -l <"$NPM_CALL_LOG") -eq 2 ]] && ! grep -q '/packages/b|' "$NPM_CALL_LOG" && ! grep -q 'unsafe-root-fixer' "$NPM_CALL_LOG"; then
+	print_result "affected workspace checks preserve unrelated tracked edits" 0
 else
-	print_result "auto-fix restores repo root before amend when cwd disappears" 1 "rc=${case4_rc}, subject=${case4_head_subject}, file=${case4_file}"
+	print_result "affected workspace checks preserve unrelated tracked edits" 1 "rc=${case4_rc}, cached=${case4_cached}"
+fi
+
+# Case 5: a nominally check-only script that mutates package B fails closed.
+MUTATION_REPO="${TEST_ROOT}/workspace-mutation"
+make_workspace_repo "$MUTATION_REPO"
+NPM_CALL_LOG="${TEST_ROOT}/npm-mutation.log"
+NPM_FIX_TARGET="${MUTATION_REPO}/packages/b/index.ts"
+export NPM_CALL_LOG NPM_FIX_TARGET NPM_FAKE_ACTION=mutate-other NPM_FAKE_RC=0
+(
+	cd "$MUTATION_REPO" || exit 1
+	printf '%s\n' 'export const a = 2;' >packages/a/index.ts
+	git add packages/a/index.ts
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'change package a'
+	PATH="${FAKE_BIN}:$PATH" _run_project_validators 0
+)
+case5_rc=$?
+case5_head=$(git -C "$MUTATION_REPO" show HEAD:packages/b/index.ts)
+case5_worktree=$(git -C "$MUTATION_REPO" diff -- packages/b/index.ts)
+case5_cached=$(git -C "$MUTATION_REPO" diff --cached --name-only)
+if [[ "$case5_rc" -ne 0 && "$case5_head" == 'export const b = 1;' && "$case5_worktree" == *"validator mutation"* && -z "$case5_cached" ]]; then
+	print_result "out-of-scope validator mutation fails without staging or amend" 0
+else
+	print_result "out-of-scope validator mutation fails without staging or amend" 1 "rc=${case5_rc}, cached=${case5_cached}"
+fi
+
+# Case 6: portable timeout status is distinct from a validator check failure.
+TIMEOUT_REPO="${TEST_ROOT}/validator-timeout"
+make_repo "$TIMEOUT_REPO"
+NPM_CALL_LOG="${TEST_ROOT}/npm-timeout.log"
+export NPM_CALL_LOG NPM_FAKE_ACTION='' NPM_FAKE_RC=0
+(
+	cd "$TIMEOUT_REPO" || exit 1
+	printf '%s\n' 'const answer: number = 42;' >index.ts
+	git add index.ts
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'typescript change'
+	timeout_sec() { return 124; }
+	PATH="${FAKE_BIN}:$PATH" _run_project_validators 0
+) 2>"${TEST_ROOT}/timeout-error.log"
+case6_rc=$?
+if [[ "$case6_rc" -ne 0 ]] && grep -q 'TIMEOUT after' "${TEST_ROOT}/timeout-error.log"; then
+	print_result "portable validator timeout is a distinct failure" 0
+else
+	print_result "portable validator timeout is a distinct failure" 1 "rc=${case6_rc}"
+fi
+
+# Case 7: a root/shared Node change visibly broadens to every declared workspace
+# without invoking the root's mutating-only lint:fix script.
+ROOT_SCOPE_REPO="${TEST_ROOT}/root-shared-scope"
+make_workspace_repo "$ROOT_SCOPE_REPO"
+NPM_CALL_LOG="${TEST_ROOT}/npm-root-scope.log"
+export NPM_CALL_LOG NPM_FAKE_ACTION='' NPM_FAKE_RC=0
+(
+	cd "$ROOT_SCOPE_REPO" || exit 1
+	cat >package.json <<'EOF'
+{"private":true,"workspaces":["packages/*"],"engines":{"node":">=20"},"scripts":{"lint:fix":"unsafe-root-fixer"}}
+EOF
+	git add package.json
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'change shared node contract'
+	PATH="${FAKE_BIN}:$PATH" _run_project_validators 0
+)
+case7_rc=$?
+if [[ "$case7_rc" -eq 0 && $(wc -l <"$NPM_CALL_LOG") -eq 3 ]] &&
+	grep -q '/packages/a|' "$NPM_CALL_LOG" && grep -q '/packages/b|' "$NPM_CALL_LOG" && ! grep -q 'unsafe-root-fixer' "$NPM_CALL_LOG"; then
+	print_result "root shared changes broaden to check-only workspace validation" 0
+else
+	print_result "root shared changes broaden to check-only workspace validation" 1 "rc=${case7_rc}, calls=$(wc -l <"$NPM_CALL_LOG")"
+fi
+
+# Case 8: mutating-only root scripts are never executed and cannot create a
+# false green; publication fails with check-only configuration guidance.
+UNSCOPED_REPO="${TEST_ROOT}/mutating-only"
+make_repo "$UNSCOPED_REPO"
+NPM_CALL_LOG="${TEST_ROOT}/npm-mutating-only.log"
+export NPM_CALL_LOG NPM_FAKE_ACTION='' NPM_FAKE_RC=0
+(
+	cd "$UNSCOPED_REPO" || exit 1
+	printf '%s\n' '{"scripts":{"format:fix":"prettier --write ."}}' >package.json
+	git add package.json
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'configure mutating-only formatter'
+	PATH="${FAKE_BIN}:$PATH" _run_project_validators 0
+) 2>"${TEST_ROOT}/unscoped-error.log"
+case8_rc=$?
+if [[ "$case8_rc" -ne 0 && ! -s "$NPM_CALL_LOG" ]] && grep -q 'NO SCOPED CHECKS AVAILABLE' "${TEST_ROOT}/unscoped-error.log"; then
+	print_result "mutating-only scripts fail with scoped-check guidance" 0
+else
+	print_result "mutating-only scripts fail with scoped-check guidance" 1 "rc=${case8_rc}, calls=$(wc -l <"$NPM_CALL_LOG" 2>/dev/null || printf 0)"
 fi
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Run bounded check-only validators for affected workspaces while preserving unrelated tracked and staged edits

## Files Changed

.agents/scripts/full-loop-helper-commit-validators.sh, .agents/scripts/full-loop-helper-commit.sh, .agents/scripts/tests/test-full-loop-project-validators-shell-only.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — focused validator fixtures (8 cases), non-main default-branch fixtures, ShellCheck, Bash syntax, and changed-file lint

Resolves #31564


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.339 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 28m and 251,127 tokens on this as a headless worker.
