### PR TITLE
GH#31568: retain release tag identity through reconciliation

### DIFF
--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -518,7 +518,7 @@ _full_loop_release_existing_with_lane() {
 			"$_FULL_LOOP_AGGREGATE_RECOVERY_PHASE" | "$_AIDEVOPS_RELEASE_LANE_PHASE_AGGREGATION_REFRESH" | "$_FULL_LOOP_AGGREGATE_COMMIT_PHASE")
 				printf 'Aggregate recovery transaction remains fenced in phase %s\n' "$lane_phase"
 				;;
-			*) release_lane_update "$existing_repo" "$source_pr" "remote-publication" || return 1 ;;
+			*) release_lane_update "$existing_repo" "$source_pr" "remote-publication" "${_FULL_LOOP_RELEASE_FOUND_TAG:-}" || return 1 ;;
 			esac
 		fi
 	fi

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -24,6 +24,7 @@ _FULL_LOOP_RELEASE_MODE_RECONCILE="reconcile"
 _FULL_LOOP_RELEASE_STEP_QUEUE_POSTFLIGHT="Queue exact-tag postflight"
 _FULL_LOOP_RELEASE_PROVENANCE_PREDICATE="https://slsa.dev/provenance/v1"
 _FULL_LOOP_RELEASE_TRUE="true"
+_FULL_LOOP_RELEASE_SHA_REGEX='^[0-9a-f]{40}$'
 _FULL_LOOP_RELEASE_VERSION_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
 _FULL_LOOP_RELEASE_TIMESTAMP_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
 
@@ -517,12 +518,13 @@ _full_loop_release_find_workflow_run() {
 		--arg selection_mode "$selection_mode" --arg completed "$_FULL_LOOP_RELEASE_STATUS_COMPLETED" \
 		--arg success "$_FULL_LOOP_RELEASE_CONCLUSION_SUCCESS" \
 		--arg string_type "$_FULL_LOOP_RELEASE_JSON_STRING_TYPE" \
+		--arg sha_regex "$_FULL_LOOP_RELEASE_SHA_REGEX" \
 		--argjson push "$push_runs" --argjson recovery "$recovery_runs" '
 		([($push.workflow_runs[]? | select(.event == $push_event and .head_branch == $tag and .head_sha == $sha))]
 		 + [($recovery.workflow_runs[]?
 			| select(.event == $recovery_event and .head_branch == "main"
 				and ((.head_sha | type) == $string_type)
-				and (.head_sha | test("^[0-9a-f]{40}$"))
+				and (.head_sha | test($sha_regex))
 				and .display_title == ($title + " [" + $sha + "." + .head_sha + "]")))])
 		| if $selection_mode == "successful" then
 			map(select(.status == $completed and .conclusion == $success))
@@ -531,6 +533,7 @@ _full_loop_release_find_workflow_run() {
 	') || return 1
 	[[ -n "$_FULL_LOOP_RELEASE_RUN_JSON" && "$_FULL_LOOP_RELEASE_RUN_JSON" != "null" ]] || return 3
 	jq -e --arg string_type "$_FULL_LOOP_RELEASE_JSON_STRING_TYPE" \
+		--arg sha_regex "$_FULL_LOOP_RELEASE_SHA_REGEX" \
 		--arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" \
 		--arg completed "$_FULL_LOOP_RELEASE_STATUS_COMPLETED" \
 		--arg push_event "$_FULL_LOOP_RELEASE_EVENT_PUSH" \
@@ -538,7 +541,7 @@ _full_loop_release_find_workflow_run() {
 		((.id | type) == $number_type)
 		and (.event == $push_event or .event == $recovery_event)
 		and ((.head_sha | type) == $string_type)
-		and (.head_sha | test("^[0-9a-f]{40}$"))
+		and (.head_sha | test($sha_regex))
 		and ((.status | type) == $string_type)
 		and ((.status // "") | length > 0)
 		and ((.created_at | type) == $string_type)
@@ -945,12 +948,23 @@ _full_loop_release_validate_published_reconciliation_intent() {
 		<<<"$observed_json") || return 1
 	release_authorization_compare "$persisted_sources" "$observed_sources" || return 1
 	release_lane_read "$repo" || return 1
-	jq -e --argjson source_pr "$requested_pr" --arg tag_name "$tag_name" '
-		.active == true and .source_pr == $source_pr and .tag == $tag_name
-		and (.expected_sources | type) == "string"
+	# A verified published tag can precede its interrupted lane bookkeeping.
+	# Recover only a missing tag bound to the exact modern signed snapshot.
+	#aidevops:trust-boundary
+	jq -e --argjson source_pr "$requested_pr" --arg tag_name "$tag_name" --argjson signed_source "$source_json" \
+		--arg string_type "$_FULL_LOOP_RELEASE_JSON_STRING_TYPE" --arg sha_regex "$_FULL_LOOP_RELEASE_SHA_REGEX" '
+		.active == true and .source_pr == $source_pr
+		and (.tag == $tag_name or (.tag == null and .snapshot_manifest_bound == true
+			and (.snapshot_sha | type) == $string_type
+			and (.snapshot_sha | test($sha_regex))
+			and .snapshot_sha == $signed_source.source_merge))
+		and (.expected_sources | type) == $string_type
 		and (.phase == "remote-publication" or .phase == "exact-tag-deployment")
 		and ((.terminal_receipt // null) == null)
-	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || {
+		printf 'Published reconciliation refused: lane source/tag/snapshot identity does not match verified release %s for PR #%s.\n' "$tag_name" "$requested_pr" >&2
+		return 1
+	}
 	lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	if [[ "$lane_sources" != "$persisted_sources" ]]; then
 		lane_intent_json=$(release_authorization_intent_json "$lane_sources") || return 1

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -517,4 +517,32 @@ for temporary_kind in aggregate reconcile; do
 done
 printf 'PASS failed aggregate and reconcile temporary checkouts are still cleaned\n'
 
+(
+	cd "$ROOT/repo/linked-branch"
+	export PATH="$ROOT/bin:/usr/bin:/bin"
+	export GIT_CALL_LOG="$ROOT/git.log" FAKE_REPO_ROOT="$ROOT/repo"
+	export AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees"
+	source "$SCRIPT_DIR/full-loop-release-helper.sh" help >/dev/null
+	_full_loop_resolve_repo() { printf 'test/repo\n'; }
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON='{"active":true,"source_pr":42,"phase":"preparing","tag":null,"operation_token":"fixture-token"}'
+		return 0
+	}
+	release_lane_liveness_report() { return 0; }
+	_full_loop_release_existing_command() {
+		_FULL_LOOP_RELEASE_FOUND_TAG=v1.2.3
+		return 8
+	}
+	updated=0
+	release_lane_update() {
+		[[ "$1" == "test/repo" && "$2" == "42" && "$3" == "remote-publication" && "${4:-}" == "v1.2.3" ]] || return 1
+		updated=1
+		return 0
+	}
+	existing_rc=0
+	_full_loop_release_existing_with_lane reconcile 42 || existing_rc=$?
+	[[ "$existing_rc" -eq 8 && "$updated" -eq 1 ]]
+)
+printf 'PASS pending reconciliation persists its verified discovered tag\n'
+
 exit 0

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -856,11 +856,12 @@ _full_loop_read_release_authorization() {
 	return 0
 }
 lane_expected_sources='90@1111111111111111111111111111111111111111'
+lane_patch_json='{}'
 release_lane_read() {
 	local repo="$1"
 	[[ "$repo" == "test/repo" ]] || return 1
-	_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg expected "$lane_expected_sources" \
-		'{active:true,source_pr:90,expected_sources:$expected,phase:"remote-publication",tag:"v1.2.3",terminal_receipt:null}') || return 1
+	_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg expected "$lane_expected_sources" --argjson patch "$lane_patch_json" \
+		'{active:true,source_pr:90,expected_sources:$expected,phase:"remote-publication",tag:"v1.2.3",terminal_receipt:null} + $patch') || return 1
 	return 0
 }
 _full_loop_release_resolve_tag_commit() {
@@ -918,6 +919,34 @@ for lane_expected_sources in \
 	fi
 done
 lane_expected_sources='90@1111111111111111111111111111111111111111'
+lane_patch_json='{"tag":null,"snapshot_manifest_bound":true,"snapshot_sha":"1111111111111111111111111111111111111111"}'
+if ! (
+	tag_bound=0
+	release_lane_update_if_owned() {
+		[[ "$1" == "test/repo" && "$2" == "90" && "$3" == "exact-tag-deployment" && "$4" == "v1.2.3" ]] || return 1
+		tag_bound=1
+		return 0
+	}
+	_full_loop_release_finalize_reconciliation test/repo 90 v1.2.3 || exit 1
+	[[ "$tag_bound" -eq 1 ]]
+); then
+	printf 'FAIL published null-tag lane with exact bound snapshot could not resume\n'
+	exit 1
+fi
+for lane_patch_json in \
+	'{"tag":"v9.9.9","snapshot_manifest_bound":true,"snapshot_sha":"1111111111111111111111111111111111111111"}' \
+	'{"tag":null,"snapshot_manifest_bound":true,"snapshot_sha":"2222222222222222222222222222222222222222"}' \
+	'{"tag":null,"snapshot_manifest_bound":false,"snapshot_sha":"1111111111111111111111111111111111111111"}' \
+	'{"tag":null}' \
+	'{"tag":null,"snapshot_manifest_bound":true,"snapshot_sha":"1111111111111111111111111111111111111111","source_pr":91}' \
+	'{"tag":null,"snapshot_manifest_bound":true,"snapshot_sha":"1111111111111111111111111111111111111111","terminal_receipt":{}}'; do
+	if _full_loop_release_finalize_reconciliation test/repo 90 v1.2.3; then
+		printf 'FAIL unsafe null-tag lane accepted: %s\n' "$lane_patch_json"
+		exit 1
+	fi
+done
+lane_patch_json='{}'
+printf 'PASS null-tag reconciliation requires exact modern snapshot and retains mismatch refusals\n'
 SCRIPT_DIR="$saved_script_dir"
 _FULL_LOOP_RELEASE_PATH=""
 printf 'PASS reconciliation uses hardened tag runtime and accepts only equivalent legacy lane intent\n'


### PR DESCRIPTION
## Summary

Resolves #31568.

Interrupted reconciliation could recover and publish a signed release while leaving the owned lane in `remote-publication` with `tag=null`. Finalization then refused exact tag equality without explaining the missing bookkeeping.

- `.agents/scripts/full-loop-release-helper.sh`: pass the verified discovered tag through the existing pending-reconcile lane update.
- `.agents/scripts/full-loop-release-reconcile.sh`: accept an already-published missing tag only when existing persisted/observed authorization matches and the modern manifest-bound lane snapshot exactly matches the signed release source commit. Keep source, phase, terminal-receipt and non-null tag mismatch refusals. The normal fenced exact-tag-deployment transition records the identity after validation.
- Add an explicit refusal diagnostic and reuse SHA/type constants without changing workflow-run validation semantics.

## Verification

- Red/green regression reproduced the published null-tag refusal and then passed the exact-bound-snapshot case.
- Existing `test-full-loop-release-helper.sh` and `test-full-loop-release-reconcile.sh` pass, including the reconcile suite under macOS Bash 3.2.
- Tests assert both pending remote-publication and final exact-tag-deployment transitions receive the verified tag; reject mismatched tag/snapshot/source, missing manifest binding, and terminal receipt.
- All local linters passed; ShellCheck and `git diff --check` passed after the final test addition.
- Independent security review approved the source change. Its optional transition-assertion gap was addressed in the existing fixture.

## Runtime Testing

Runtime-verified through isolated executable shell/JQ fixtures for interrupted state transitions and publication checks. No live lane metadata was edited to test the repair. The real source31556 v3.32.339 reconciliation will be retried through the canonical helper after merge; no new bump or tag rewrite for that published release.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.338 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 2d 1h and 5,381,116 tokens on this with the user in an interactive session.