### PR TITLE
GH#31541: recover quota during continuous traffic and preserve deferrals

### DIFF
--- a/.agents/reference/github-api-transport.md
+++ b/.agents/reference/github-api-transport.md
@@ -89,16 +89,36 @@ child environment; credentials are never exported to a long-lived parent.
   with `attempted=false`, a local admission reason and `retry_at`; callers can
   reschedule without treating a local deferral as a GitHub rejection. No alternate
   transport retry or cached application response is substituted.
+  The shim retries at most once, only for proven unattempted local admission and
+  only when the supplied deadline fits a five-second wait. Longer or invalid
+  deadlines return rescheduling evidence immediately. Required-context readers
+  and the merge gate retain the reason and deadline, including cached failures;
+  unknown required checks never become a passing result. A successful retry does
+  not leak the superseded error into JSON output.
 - Missing/stale observations permit one serialized observation, not an assumed
   new allowance. Unknown execution remains debt until a later response from
   the same credential covers it. Out-of-order responses cannot restore spent
   quota inside a live reset window.
-- A stale positive balance can revalidate through one accounted GET after 60
-  seconds without a newer observation/probe. No active request, real cooldown,
+- A stale positive balance can revalidate through one accounted GET every 60
+  seconds, independently of ordinary response freshness. Once due, new admissions
+  yield until active work drains; admissions also wait for the probe to finish.
+  Continuous healthy traffic therefore cannot indefinitely postpone recovery.
+  The existing revalidation table stores the cadence anchor; no schema migration
+  is needed. Older callers stay conservative, but only updated callers provide
+  the drain/serialization guarantee during a mixed-version rollout.
+  No active request, real cooldown,
   exhaustion or uncertain spend may be bypassed. The exact probe reservation
   can repair a stale balance only with causally newer resource-owned headers and
-  a single bound credential; ambiguous/shared scopes stay conservative. This is
+  a single bound credential or an explicitly configured canonical owner;
+  unresolved shared scopes stay conservative. This is
   bounded recovery, not an alternative transport or a status-endpoint grant.
+- Set `AIDEVOPS_GH_BUDGET_DIAGNOSTICS=1` for numeric response and scope-binding
+  transition evidence in `budget-transitions.jsonl` beside `admission.sqlite3`.
+  The mode-600 log records previous/incoming/accepted balances and reset times,
+  ordering, probe recovery and the conservative decision after commit. It never
+  contaminates CLI JSON or logs credentials, owners, endpoints or response bodies.
+  Disable it after capturing evidence; logging errors never alter admission.
+  This diagnoses future transitions, not the unproven origin of an existing balance.
 - `python3 gh_transport_budget.py status` reads local admission evidence without
   HTTP, credential values or database mutation. Pulse Check reports this separately
   from GraphQL. Label-eligible queue counts are not proof of launch admission.

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -84,6 +84,24 @@ _full_loop_persist_pr_check_evidence() {
 	return 0
 }
 
+_full_loop_local_admission_evidence() {
+	local diagnostics="$1" line=""
+	while IFS= read -r line; do
+		case "$line" in
+		'[gh-transport] error_kind=github-api-read-deferred attempted=false deferred_by=local_admission '*)
+			FULL_LOOP_PRE_MERGE_BLOCKER_KIND="${line#*error_kind=}"
+			FULL_LOOP_PRE_MERGE_BLOCKER_KIND="${FULL_LOOP_PRE_MERGE_BLOCKER_KIND%% *}"
+			FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="retry-when-capacity-returns"
+			[[ ! "$line" =~ retry_at=([0-9]+([.][0-9]+)?) ]] || FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="${BASH_REMATCH[1]}"
+			FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="$FULL_LOOP_PRE_MERGE_BLOCKER_KIND"
+			FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="$line"
+			return 0
+			;;
+		esac
+	done <<<"$diagnostics"
+	return 1
+}
+
 _full_loop_query_required_checks() {
 	local pr_number="$1"
 	local repo="$2"
@@ -105,24 +123,32 @@ _full_loop_query_required_checks() {
 	FULL_LOOP_PRE_MERGE_BLOCKER_KIND=""
 	FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL=""
 
-	required_contexts=$(_required_contexts_for_default_branch "$repo") || required_contexts_rc=$?
+	required_checks_stderr_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-full-loop-required-checks.XXXXXX") || {
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="stderr-capture-unavailable"
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="cannot capture gh stderr"
+		return 1
+	}
+	required_contexts=$(_required_contexts_for_default_branch "$repo" 2>"$required_checks_stderr_file") || required_contexts_rc=$?
+	if [[ "$required_contexts_rc" -ne 0 ]] && _full_loop_local_admission_evidence "$(<"$required_checks_stderr_file")"; then
+		rm -f "$required_checks_stderr_file"
+		return 1
+	fi
 	if [[ "$required_contexts_rc" -eq 0 && -z "$required_contexts" ]]; then
+		rm -f "$required_checks_stderr_file"
 		FULL_LOOP_REQUIRED_CHECKS_JSON="[]"
 		FULL_LOOP_REQUIRED_CHECKS_SUCCESS_EVIDENCE="no-required-checks"
 		FULL_LOOP_REQUIRED_CHECKS_SUCCESS_SUMMARY="no required checks are configured"
 		return 0
 	fi
 
-	required_checks_stderr_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-full-loop-required-checks.XXXXXX") || {
-		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="stderr-capture-unavailable"
-		FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="cannot capture gh stderr"
-		return 1
-	}
 	required_checks=$(gh_pr_checks_exact_json "$repo" "$pr_number" required \
 		2>"$required_checks_stderr_file") || required_rc=$?
 	required_checks_stderr=$(<"$required_checks_stderr_file")
 	rm -f "$required_checks_stderr_file"
 	FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="exact check read exit ${required_rc}"
+	if [[ "$required_rc" -ne 0 ]] && _full_loop_local_admission_evidence "$required_checks_stderr"; then
+		return 1
+	fi
 	if [[ "$required_checks_stderr" == *"error_kind=github-api-cooldown"* ]]; then
 		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="github-api-cooldown"
 		FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="unknown"

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -1894,6 +1894,9 @@ _merge_report_pre_merge_gate_failure() {
 			print_error "Merge deferred: GitHub API cooldown is active; retry after the cooldown expires."
 		fi
 		;;
+	github-api-read-deferred)
+		print_error "Merge deferred by GitHub read admission: ${FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL:-retry when capacity returns}"
+		;;
 	review-bot)
 		print_error "Merge blocked by review bot gate. Address bot findings or wait for reviews."
 		;;

--- a/.agents/scripts/gh-transport-controls.sh
+++ b/.agents/scripts/gh-transport-controls.sh
@@ -58,6 +58,31 @@ _gh_transport_capture_errors() {
 	return "$rc"
 }
 
+_gh_transport_local_retry_delay() {
+	local metadata="$1" fallback="$2"
+	python3 -c '
+import json, math, sys, time
+with open(sys.argv[1], encoding="utf-8") as stream:
+    deadline = json.load(stream).get("retry_at")
+if deadline is None:
+    delay = min(5.0, float(sys.argv[2]))
+elif isinstance(deadline, (int, float)) and not isinstance(deadline, bool) and math.isfinite(deadline):
+    delay = max(0.0, deadline - time.time())
+else:
+    delay = -1
+print(f"{delay:.6f}" if 0 <= delay <= 5 else "-1")
+' "$metadata" "$fallback"
+	return $?
+}
+
+_gh_transport_emit_local_deferral() {
+	local metadata="$1"
+	jq -r 'select(.attempted == false and .deferred_by == "local_admission") |
+		"[gh-transport] error_kind=github-api-read-deferred attempted=false deferred_by=local_admission retry_at=\(if (.retry_at | type) == "number" then .retry_at else "unknown" end) reason=\((.reason // "unknown") | tojson)"' \
+		"$metadata" >&2
+	return $?
+}
+
 # _GHGT_HANDLED distinguishes unsupported-before-execution from native exit125.
 # Supported REST records metadata here, not a second attempt in the ordinary
 # recorder. Exact capture retains its existing multi-response-frame owner.
@@ -84,15 +109,19 @@ _gh_transport_run_rest() {
 	if [[ "$rc" -eq 75 && "$attempted" != true && "$deferred_by" == "local_admission" ]]; then
 		local retry_delay="${AIDEVOPS_GH_LOCAL_ADMISSION_RETRY_DELAY_SECONDS:-1}"
 		[[ "$retry_delay" =~ ^[0-5]([.][0-9]+)?$ ]] || retry_delay=1
-		command cat "$error_file" >&2
-		printf '[gh-transport] retrying one request that local admission proved was not attempted\n' >&2
-		sleep "$retry_delay"
-		: >"$error_file"
-		rc=0
-		python3 "${_GHGT_DIR}/gh-transport-governor.py" "$metadata" "$executable" "$@" 2>"$error_file" || rc=$?
+		retry_delay=$(_gh_transport_local_retry_delay "$metadata" "$retry_delay") || retry_delay=-1
+		if [[ "$retry_delay" != -1 ]]; then
+			sleep "$retry_delay"
+			: >"$error_file"
+			rc=0
+			python3 "${_GHGT_DIR}/gh-transport-governor.py" "$metadata" "$executable" "$@" 2>"$error_file" || rc=$?
+		fi
 	fi
 	end_ms=$(_gh_now_ms)
 	command cat "$error_file" >&2
+	if [[ "$rc" -eq 75 ]]; then
+		_gh_transport_emit_local_deferral "$metadata" || true
+	fi
 	attempted=$(jq -r '.attempted // false' "$metadata" 2>/dev/null) || attempted=false
 	if [[ "$rc" -eq 125 && "$attempted" != true ]]; then
 		rm -f -- "$metadata" "$error_file"

--- a/.agents/scripts/gh_transport_budget.py
+++ b/.agents/scripts/gh_transport_budget.py
@@ -21,7 +21,10 @@ from pathlib import Path
 from gh_transport_capacity import capacity_wait
 from gh_transport_identity import quota_owner
 from gh_transport_reconcile import reconcile_scope as _reconcile_scope
-from gh_transport_recovery import admission_status, mark_dead_reservations, probe_recovers, reserve_probe_allowed
+from gh_transport_recovery import (
+    admission_status, mark_dead_reservations, probe_recovers,
+    record_budget_transition, reserve_probe_allowed, revalidation_wait,
+)
 from gh_transport_schema import SCHEMA_VERSION, ensure_schema
 
 
@@ -103,13 +106,15 @@ class Budget:
         try:
             self._ensure_schema()
             with self.transaction():
-                self._bind_scope()
+                binding_events = self._bind_scope()
         except BaseException:
             self.db.close()
             raise
         # A configured owner is authoritative only after its requested scope is
         # canonical. A legacy owner->unresolved alias still needs reconciliation.
         self.attributed = attributed and self.scope == requested_scope
+        for event in binding_events:
+            record_budget_transition(self, *event, event="scope_binding")
 
     def _ensure_schema(self) -> None:
         ensure_schema(self.db)
@@ -122,7 +127,8 @@ class Budget:
             scope = row[0]
         raise ValueError("quota scope alias cycle")
 
-    def _bind_scope(self) -> None:
+    def _bind_scope(self) -> list:
+        events = []
         self.scope = self._root(self.scope)
         bound = self.db.execute(
             "SELECT scope FROM binding WHERE credential=?", (self.credential,)
@@ -145,6 +151,11 @@ class Budget:
                 )
                 self.db.execute("INSERT OR REPLACE INTO quota VALUES(?,?,?,?,?,?,?)",
                                 (previous, row[0], *values))
+                events.append((
+                    {"remaining": old[0], "reset": old[1]} if old else None,
+                    {"remaining": row[1], "reset": row[2]},
+                    {"remaining": values[0], "reset": values[1]}, False, None,
+                ))
             self.db.execute("DELETE FROM quota WHERE scope=?", (self.scope,))
             self.db.execute("UPDATE reservation SET scope=? WHERE scope=?", (previous, self.scope))
             self.db.execute("UPDATE admission_history SET scope=? WHERE scope=?", (previous, self.scope))
@@ -165,6 +176,7 @@ class Budget:
             self.db.execute("INSERT OR REPLACE INTO alias VALUES(?,?)", (self.scope, previous))
             self.scope = previous
         self.db.execute("INSERT OR REPLACE INTO binding VALUES(?,?)", (self.credential, self.scope))
+        return events
 
     @contextmanager
     def transaction(self):
@@ -205,6 +217,9 @@ class Budget:
                     f"local primary capacity exhausted (remaining={row[0]}, reserved={total}, "
                     f"reset={int(row[1])})", retry_at=row[1],
                 )
+            if revalidation_wait(self, resource, row, active, now):
+                raise Deferred("waiting for serialized quota revalidation",
+                               retryable=True, retry_at=now + 1)
             # Expired/missing observations are not a new 5,000-point grant.
             # Permit one serialized real request to obtain fresh headers.
             fresh = row and 0 <= now - row[2] <= 20 and row[1] > now
@@ -282,6 +297,14 @@ class Budget:
                     "UPDATE reservation SET uncertain=1,started=? WHERE id=?",
                     (now, reservation),
                 )
+        if valid:
+            record_budget_transition(
+                self,
+                {"remaining": row[0], "reset": row[1]} if row else None,
+                {"remaining": int(remaining), "reset": int(reset)},
+                {"remaining": available, "reset": reset_at},
+                recovered, bool(row and started >= row[2]),
+            )
 
     def close(self) -> None:
         self.db.close()

--- a/.agents/scripts/gh_transport_recovery.py
+++ b/.agents/scripts/gh_transport_recovery.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2026 Marcus Quinn
 """Bounded recovery predicates and read-only REST admission diagnostics."""
 
+import json
 import os
 import sqlite3
 import time
@@ -28,7 +29,52 @@ def reserve_probe_allowed(row, active, total, previous, now):
     if active or row[0] - total < 1:
         return False
     last_probe = previous[0] if previous else row[2]
-    return now - max(row[2], last_probe) >= 60
+    return now - last_probe >= 60
+
+
+def revalidation_wait(budget, resource, row, active, now):
+    """Persist cadence independently of response freshness; drain before probing.
+
+    Reuses the existing schema. An empty reservation ID is only a cadence anchor,
+    never a grant; older readers remain conservative and cannot recover through it.
+    """
+    if not row or row[1] <= now:
+        return False
+    budget.db.execute("INSERT OR IGNORE INTO revalidation VALUES(?,?,?,?)",
+                      (budget.scope, resource, row[2], ""))
+    previous = budget.db.execute(
+        "SELECT started,reservation_id FROM revalidation WHERE scope=? AND resource=?",
+        (budget.scope, resource),
+    ).fetchone()
+    probe_active = budget.db.execute(
+        "SELECT 1 FROM reservation WHERE id=? AND scope=? AND resource=? AND uncertain=0",
+        (previous[1], budget.scope, resource),
+    ).fetchone()
+    return bool(probe_active or (active and now - previous[0] >= 60))
+
+
+def record_budget_transition(budget, previous, incoming, accepted, recovered, ordered,
+                             *, event="response_observation"):
+    """Opt-in numeric evidence only: never headers, endpoints or identities."""
+    if os.environ.get("AIDEVOPS_GH_BUDGET_DIAGNOSTICS") != "1":
+        return
+    record = json.dumps({
+        "event": event, "previous": previous, "observed_at": time.time(),
+        "incoming": incoming, "accepted": accepted, "probe_recovered": recovered,
+        "causally_newer": ordered,
+        "reason": "serialized_probe" if recovered else "conservative_observation",
+    }, sort_keys=True)
+    try:
+        fd = os.open(budget.path.parent / "budget-transitions.jsonl",
+                     os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+        with os.fdopen(fd, "a", encoding="utf-8") as stream:
+            if os.fstat(stream.fileno()).st_uid != os.getuid():
+                return
+            os.fchmod(stream.fileno(), 0o600)
+            print(record, file=stream)
+    except OSError:
+        # Optional evidence must never change admission or contaminate CLI JSON.
+        return
 
 
 def probe_recovers(budget, reservation, resource, row, reset_at):

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -179,6 +179,18 @@ _ruleset_ref_matches_default_branch() {
 # Stdout: newline-delimited contexts
 # Returns: 0=resolved, 1=API/parse error
 #######################################
+_pmrc_emit_local_deferral() {
+	local diagnostics="$1" line=""
+	while IFS= read -r line; do
+		case "$line" in
+		'[gh-transport] error_kind=github-api-read-deferred attempted=false deferred_by=local_admission '*)
+			printf '%s\n' "$line" >&2
+			;;
+		esac
+	done <<<"$diagnostics"
+	return 0
+}
+
 _required_contexts_from_rulesets_for_default_branch() {
 	local repo_slug="$1"
 	local default_branch="$2"
@@ -186,6 +198,7 @@ _required_contexts_from_rulesets_for_default_branch() {
 
 	rulesets_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/rulesets" 2>&1) || rulesets_rc=$?
 	if [[ "$rulesets_rc" -ne 0 ]]; then
+		_pmrc_emit_local_deferral "$rulesets_json"
 		if _pmrc_private_plan_feature_unavailable "$rulesets_json"; then
 			aidevops_log_line "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: rulesets unavailable for ${repo_slug} on the private plan (HTTP 403) — empty contexts (GH#29484)"
 			return 0
@@ -218,7 +231,8 @@ _required_contexts_from_rulesets_for_default_branch() {
 	local matches_default=0 excluded_default=0 contexts=""
 	while IFS= read -r id; do
 		[[ -n "$id" ]] || continue
-		detail=$(_pmrc_gh_read gh api "repos/${repo_slug}/rulesets/${id}" 2>/dev/null) || {
+		detail=$(_pmrc_gh_read gh api "repos/${repo_slug}/rulesets/${id}" 2>&1) || {
+			_pmrc_emit_local_deferral "$detail"
 			aidevops_log_line "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: ruleset detail ${id} failed for ${repo_slug} — caller will fail closed (GH#23019)"
 			rm -f "$contexts_tmp"
 			return 1
@@ -286,8 +300,9 @@ _required_contexts_from_rulesets_for_default_branch() {
 _required_contexts_for_default_branch_uncached() {
 	local repo_slug="$1"
 	local default_branch="" default_branch_rc=0
-	default_branch=$(_pmrc_gh_read gh api "repos/${repo_slug}" --jq '.default_branch' 2>/dev/null) || default_branch_rc=$?
+	default_branch=$(_pmrc_gh_read gh api "repos/${repo_slug}" --jq '.default_branch' 2>&1) || default_branch_rc=$?
 	if [[ "$default_branch_rc" -ne 0 || -z "$default_branch" ]]; then
+		_pmrc_emit_local_deferral "$default_branch"
 		aidevops_log_line "[pulse-merge] _required_contexts_for_default_branch: failed to resolve default branch for ${repo_slug} (read_exit=${default_branch_rc}, output_bytes=${#default_branch}) — caller will fail closed (t2922)"
 		return 1
 	fi
@@ -299,6 +314,7 @@ _required_contexts_for_default_branch_uncached() {
 		"repos/${repo_slug}/branches/${default_branch}/protection/required_status_checks" \
 		2>&1) || protection_rc=$?
 	if [[ "$protection_rc" -ne 0 ]]; then
+		_pmrc_emit_local_deferral "$protection_resp"
 		local classic_unavailable_reason=""
 		if grep -qi 'HTTP 404\|Not Found' <<<"$protection_resp"; then
 			classic_unavailable_reason="HTTP 404"
@@ -347,6 +363,9 @@ _required_contexts_for_default_branch() {
 		if [[ -f "$cache_rc_file" && -f "$cache_body_file" ]]; then
 			cache_rc=$(<"$cache_rc_file")
 			[[ "$cache_rc" =~ ^[0-9]+$ ]] || cache_rc=1
+			if [[ "$cache_rc" -ne 0 && -f "${cache_body_file}.error" ]]; then
+				_pmrc_emit_local_deferral "$(<"${cache_body_file}.error")"
+			fi
 			if [[ "$cache_rc" -eq 0 && -s "$cache_body_file" ]]; then
 				while IFS= read -r contexts; do
 					printf '%s\n' "$contexts"
@@ -356,7 +375,12 @@ _required_contexts_for_default_branch() {
 		fi
 	fi
 
-	contexts=$(_required_contexts_for_default_branch_uncached "$repo_slug") || rc=$?
+	if [[ -n "$cache_body_file" ]]; then
+		contexts=$(_required_contexts_for_default_branch_uncached "$repo_slug" 2>"${cache_body_file}.error") || rc=$?
+		[[ "$rc" -eq 0 ]] || _pmrc_emit_local_deferral "$(<"${cache_body_file}.error")"
+	else
+		contexts=$(_required_contexts_for_default_branch_uncached "$repo_slug") || rc=$?
+	fi
 	if [[ -n "$cache_body_file" && -n "$cache_rc_file" ]]; then
 		printf '%s\n' "$rc" >"$cache_rc_file"
 		if [[ -n "$contexts" ]]; then

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -1503,6 +1503,48 @@ test_prospective_todo_merge_guard() {
 	return 0
 }
 
+test_local_deferral_survives_context_resolution() {
+	local result=0
+	(
+		local scripts_dir="${SCRIPT_DIR}/.." attempt="" rc=0
+		# shellcheck source=/dev/null
+		source "$scripts_dir/shared-constants.sh"
+		# shellcheck source=/dev/null
+		source "$scripts_dir/pulse-merge-required-checks.sh"
+		# shellcheck source=/dev/null
+		source "$scripts_dir/full-loop-helper-commit.sh"
+		aidevops_log_line() { return 0; }
+		_pmrc_gh_read() {
+			case "$3" in
+			repos/testorg/testrepo) printf 'main\n' ;;
+			*/protection/required_status_checks) printf '{"contexts":[]}\n' ;;
+			*/rulesets)
+				printf '[gh-transport] error_kind=github-api-read-deferred attempted=false deferred_by=local_admission retry_at=1893456000 reason="fixture quota wait"\n' >&2
+				return 75
+				;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		gh_pr_checks_exact_json() {
+			touch "$TEST_ROOT/unexpected-exact-read"
+			return 0
+		}
+		export AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR="$TEST_ROOT/deferral-context-cache"
+		mkdir -p "$AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR"
+		for attempt in first cached; do
+			rc=0
+			_full_loop_query_required_checks 42 testorg/testrepo feature/test || rc=$?
+			[[ "$rc" -eq 1 && "$FULL_LOOP_PRE_MERGE_BLOCKER_KIND" == github-api-read-deferred ]] || return 1
+			[[ "$FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL" == 1893456000 ]] || return 1
+			[[ "$FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL" == *'reason="fixture quota wait"'* ]] || return 1
+			[[ ! -e "$TEST_ROOT/unexpected-exact-read" ]] || return 1
+		done
+	) || result=1
+	print_result "local deferral survives ruleset resolution and cache without a fallback check read" "$result"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -1521,6 +1563,7 @@ main() {
 	test_graphql_rate_limit_auto_no_rest_fallback
 	test_review_gate_failure_blocks_rest_fallback
 	test_cooldown_gate_failure_reports_cooldown
+	test_local_deferral_survives_context_resolution
 	test_auto_review_required_interactive_admin_fallback
 	test_auto_review_required_headless_no_admin_fallback
 	test_stale_cache_401_retry

--- a/.agents/scripts/tests/test-gh-shim-transport-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-transport-cases.sh
@@ -4,7 +4,7 @@
 # Sourced by the existing hermetic gh shim harness after legacy-path coverage.
 
 printf '\nTest 27: shared raw transport controls and response-owned quota\n'
-for library in gh-transport-controls.sh gh-transport-governor.py gh_transport_budget.py gh_transport_identity.py gh_transport_reconcile.py gh_transport_recovery.py gh_transport_capacity.py shared-gh-secondary-cooldown.sh shared-gh-primary-cooldown.sh; do
+for library in gh-transport-controls.sh gh-transport-governor.py gh_transport_budget.py gh_transport_schema.py gh_transport_identity.py gh_transport_reconcile.py gh_transport_recovery.py gh_transport_capacity.py shared-gh-secondary-cooldown.sh shared-gh-primary-cooldown.sh; do
 	cp "${REPO_DIR}/.agents/scripts/${library}" "${TMP}/scripts/${library}"
 done
 mkdir -p "${TMP}/governor/tmp"
@@ -107,6 +107,15 @@ fi
 
 # Exact capture owns multi-frame native attempts. The normal final-response
 # adapter must never take that route away from an explicitly metered window.
+# Load the same accounting/transport dependencies as the real shim before
+# exercising the transport function directly in this shell.
+# shellcheck source=/dev/null
+source "${TMP}/scripts/gh-api-instrument.sh"
+# shellcheck source=/dev/null
+source "${TMP}/scripts/gh-quota-attribution-lib.sh"
+# shellcheck source=/dev/null
+source "${TMP}/scripts/gh-native-transport-lib.sh"
+export AIDEVOPS_GH_LOGICAL_ID=fixture-local-admission
 # shellcheck source=/dev/null
 source "${TMP}/scripts/gh-transport-controls.sh"
 
@@ -120,7 +129,8 @@ python3() {
 		printf '%s\n' "$governor_calls" >"$_governor_count_file"
 		local metadata="$2"
 		if [[ "$governor_calls" -eq 1 ]]; then
-			printf '{"attempted":false,"deferred_by":"local_admission","retry_at":1}\n' >"$metadata"
+			printf '{"attempted":false,"deferred_by":"local_admission","retry_at":%s,"reason":"fixture quota wait"}\n' "${_governor_retry_at:-1}" >"$metadata"
+			printf '[gh-transport] deferred: fixture quota wait\n' >&2
 			return 75
 		fi
 		printf '{"attempted":true,"status":200,"resource":"core","remaining":4999,"reset":%s,"retry_after":null,"cost":1}\n' "$_governor_reset" >"$metadata"
@@ -131,14 +141,27 @@ python3() {
 }
 _governor_rc=0
 _governor_output=$(AIDEVOPS_GH_LOCAL_ADMISSION_RETRY_DELAY_SECONDS=0 \
-	_gh_transport_run_rest "${TMP}/bin/gh" rest gh_api_rest 0 api user 2>/dev/null) || _governor_rc=$?
-unset -f python3
+	_gh_transport_run_rest "${TMP}/bin/gh" rest gh_api_rest 0 api user 2>"${TMP}/governor/retry-error") || _governor_rc=$?
 _governor_calls=$(<"$_governor_count_file")
-if [[ "$_governor_calls" -eq 2 && "$_governor_output" == '{"fixture":true}' ]]; then
+if [[ "$_governor_calls" -eq 2 && "$_governor_output" == '{"fixture":true}' && ! -s "${TMP}/governor/retry-error" ]]; then
 	_pass "local admission deferral retries once only after attempted=false evidence"
 else
-	_fail "local admission deferral was not retried safely (rc=${_governor_rc} calls=${_governor_calls} output=${_governor_output:-<empty>})"
+	_fail "local admission deferral was not retried safely (rc=${_governor_rc} calls=${_governor_calls} output=${_governor_output:-<empty>})" "$(<"${TMP}/governor/retry-error")"
 fi
+
+printf '0\n' >"$_governor_count_file"
+_governor_retry_at=$(($(date +%s) + 120))
+_governor_rc=0
+_gh_transport_run_rest "${TMP}/bin/gh" rest gh_api_rest 0 api user \
+	>/dev/null 2>"${TMP}/governor/deferred-error" || _governor_rc=$?
+if [[ "$_governor_rc" -eq 75 && "$(<"$_governor_count_file")" -eq 1 ]] &&
+	grep -q "attempted=false deferred_by=local_admission retry_at=${_governor_retry_at}" "${TMP}/governor/deferred-error"; then
+	_pass "future admission deadline preserves explicit evidence without an early retry"
+else
+	_fail "future admission deadline was retried early or lost its evidence"
+fi
+unset -f python3
+unset _governor_retry_at
 
 _governor_rc=0
 AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 _gh_transport_run_rest \

--- a/.agents/scripts/tests/test-gh-transport-budget.py
+++ b/.agents/scripts/tests/test-gh-transport-budget.py
@@ -127,6 +127,46 @@ class AdmissionTests(unittest.TestCase):
         self.budget.finish(probe, "core", headers(99), started=1061, now=1062)
         self.budget.acquire("core", now=1063)
 
+    def test_continuous_responses_do_not_slide_revalidation_deadline(self):
+        self.seed(763)
+        for now in (1010, 1020, 1030, 1040, 1050, 1060):
+            request = self.budget.acquire("core", now=now)
+            self.budget.finish(request, "core", headers(4934), started=now, now=now + 0.1)
+        self.assertEqual(self.budget.db.execute("SELECT remaining FROM quota").fetchone()[0], 763)
+        probe = self.budget.acquire("core", now=1061)
+        with self.assertRaisesRegex(Deferred, "serialized quota revalidation"):
+            self.budget.acquire("core", now=1061.1)
+        self.budget.finish(probe, "core", headers(4934), started=1061, now=1062)
+        self.assertEqual(self.budget.db.execute("SELECT remaining FROM quota").fetchone()[0], 4934)
+
+    def test_due_revalidation_drains_active_work_without_erasing_debt(self):
+        self.seed(763)
+        earlier = self.budget.acquire("core", now=1050)
+        with self.assertRaisesRegex(Deferred, "serialized quota revalidation"):
+            self.budget.acquire("core", now=1061)
+        self.budget.finish(earlier, "core", {}, started=1050, now=1062)
+        probe = self.budget.acquire("core", now=1063)
+        self.assertEqual(self.budget.db.execute("SELECT COUNT(*) FROM reservation").fetchone()[0], 2)
+        self.budget.finish(probe, "core", headers(4934), started=1063, now=1064)
+        self.assertEqual(self.budget.db.execute("SELECT COUNT(*) FROM reservation").fetchone()[0], 0)
+
+    def test_budget_diagnostics_are_opt_in_and_identity_free(self):
+        self.seed(763)
+        diagnostic = self.directory / "budget-transitions.jsonl"
+        self.assertFalse(diagnostic.exists())
+        output = io.StringIO()
+        with patch.dict(os.environ, {"AIDEVOPS_GH_BUDGET_DIAGNOSTICS": "1"}), patch("sys.stderr", output):
+            request = self.budget.acquire("core", now=1010)
+            self.budget.finish(request, "core", headers(4934), started=1010, now=1011)
+        self.assertEqual(output.getvalue(), "")
+        event = json.loads(diagnostic.read_text())
+        self.assertEqual(event["previous"]["remaining"], 763)
+        self.assertEqual(event["incoming"]["remaining"], 4934)
+        self.assertEqual(event["accepted"]["remaining"], 763)
+        self.assertFalse(event["probe_recovered"])
+        self.assertNotIn("owner-one", diagnostic.read_text())
+        self.assertEqual(diagnostic.stat().st_mode & 0o777, 0o600)
+
     def test_serialized_reserve_probe_repairs_same_credential_stale_balance(self):
         self.seed(100)
         probe = self.budget.acquire("core", now=1061)


### PR DESCRIPTION
## Summary

Decouple revalidation cadence from response freshness using the existing table; drain active work and serialize the accounted probe without relaxing debt, credential, ordering or cooldown checks. Add private opt-in numeric response/binding transition evidence. Preserve local-admission reason and retry_at through transport, required contexts/cache, and merge diagnostics; retry once only within the supplied bounded deadline.

## Files Changed

.agents/reference/github-api-transport.md, .agents/scripts/full-loop-helper-commit.sh, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/gh-transport-controls.sh, .agents/scripts/gh_transport_budget.py, .agents/scripts/gh_transport_recovery.py, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/tests/test-full-loop-merge.sh, .agents/scripts/tests/test-gh-shim-transport-cases.sh, .agents/scripts/tests/test-gh-transport-budget.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 49 admission tests pass, including continuous traffic, active drain, uncertain debt and private diagnostics. Existing gh shim, required-context filter and full-loop merge suites pass, including unattempted deadline handling and cached deferral propagation. Changed-file linters pass. Independent closeout found no blocking defects; evidence bundle ab78ec977b725a827dde499b5b1970d34abe68d6e90212725b9df72e78239e7d.

Resolves #31541


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.338 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 8m and 74,196 tokens on this with the user in an interactive session.