### PR TITLE
GH#31574: recover repeated health dashboard refresh timeouts

### DIFF
--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -537,6 +537,60 @@ PY
 	return 0
 }
 
+# Worker success rates are cross-repository data. Compute them once per stats
+# cycle instead of repeating the same repository-wide GitHub queries while
+# rendering every dashboard. A timed-out refresh leaves the last good cache in
+# place; absence is rendered as unavailable rather than as a successful sample.
+_worker_success_rates_cache_file() {
+	local runner_user="$1" runner_safe
+	if [[ -n "${WORKER_SUCCESS_RATES_CACHE_FILE:-}" ]]; then
+		printf '%s\n' "$WORKER_SUCCESS_RATES_CACHE_FILE"
+		return 0
+	fi
+	runner_safe=$(_sanitize_runner_identity_for_cache "$runner_user")
+	printf '%s/.aidevops/logs/worker-success-rates-%s.json\n' "$HOME" "$runner_safe"
+	return 0
+}
+
+_refresh_worker_success_rates_cache() {
+	local runner_user="$1"
+	local cache_file
+	cache_file=$(_worker_success_rates_cache_file "$runner_user")
+	local cache_dir="${cache_file%/*}" cache_tmp sr24h_raw sr7d_raw
+
+	mkdir -p "$cache_dir" || return 1
+	sr24h_raw=$(_compute_worker_success_rates "$runner_user" "24") || return $?
+	sr7d_raw=$(_compute_worker_success_rates "$runner_user" "168") || return $?
+	cache_tmp=$(mktemp "${cache_file}.XXXXXX") || return 1
+	jq -n \
+		--arg rate24 "$(printf '%s' "$sr24h_raw" | cut -f3)" \
+		--arg total24 "$(printf '%s' "$sr24h_raw" | cut -f2)" \
+		--arg rate7 "$(printf '%s' "$sr7d_raw" | cut -f3)" \
+		--arg total7 "$(printf '%s' "$sr7d_raw" | cut -f2)" \
+		--arg refreshed_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		'{rate24:$rate24,total24:$total24,rate7:$rate7,total7:$total7,refreshed_at:$refreshed_at}' \
+		>"$cache_tmp" || {
+		rm -f "$cache_tmp"
+		return 1
+	}
+	mv "$cache_tmp" "$cache_file"
+	return 0
+}
+
+_read_worker_success_rates_cache() {
+	local runner_user="$1" cache_file
+	cache_file=$(_worker_success_rates_cache_file "$runner_user")
+	if [[ -f "$cache_file" ]] && jq -e '
+		(.rate24 | type == "string") and (.total24 | test("^[0-9]+$")) and
+		(.rate7 | type == "string") and (.total7 | test("^[0-9]+$"))
+	' "$cache_file" >/dev/null 2>&1; then
+		jq -r '[.rate24,.total24,.rate7,.total7] | @tsv' "$cache_file"
+	else
+		printf '%s\t%s\t%s\t%s\n' '—' '0' '—' '0'
+	fi
+	return 0
+}
+
 #######################################
 # Build the health issue body markdown.
 #
@@ -850,15 +904,10 @@ _assemble_health_issue_body() {
 	session_time_md=$(_gather_session_time_for_repo "$repo_path")
 	person_stats_md=$(_read_person_stats_cache "$slug_safe")
 
-	local sr24h_raw sr7d_raw
-	sr24h_raw=$(_compute_worker_success_rates "$runner_user" "24")
-	sr7d_raw=$(_compute_worker_success_rates "$runner_user" "168")
 	local worker_success_rate_24h worker_total_runs_24h
-	worker_success_rate_24h=$(printf '%s' "$sr24h_raw" | cut -f3)
-	worker_total_runs_24h=$(printf '%s' "$sr24h_raw" | cut -f2)
 	local worker_success_rate_7d worker_total_runs_7d
-	worker_success_rate_7d=$(printf '%s' "$sr7d_raw" | cut -f3)
-	worker_total_runs_7d=$(printf '%s' "$sr7d_raw" | cut -f2)
+	IFS=$'\t' read -r worker_success_rate_24h worker_total_runs_24h \
+		worker_success_rate_7d worker_total_runs_7d < <(_read_worker_success_rates_cache "$runner_user")
 
 	_build_health_issue_body \
 		"$now_iso" "$role_display" "$runner_user" "$repo_slug" \

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -207,6 +207,16 @@ _record_health_issue_refresh_state() {
 	return 0
 }
 
+# Persist the last entered per-repository stage. A bounded child that is killed
+# cannot print a useful stack trace, so this small checkpoint identifies where
+# the next scheduler run should focus without claiming a successful refresh.
+_record_health_repo_stage() {
+	local stage_file="${1:-}" stage="${2:-unknown}"
+	[[ -n "$stage_file" ]] || return 0
+	printf '%s|%s\n' "$stage" "$(date +%s)" >"$stage_file"
+	return 0
+}
+
 #######################################
 # Persist only the trailing issue number for subsequent dashboard updates.
 # Arguments:
@@ -321,9 +331,11 @@ _update_health_issue_for_repo() {
 	local cross_repo_md="${3:-}"
 	local cross_repo_session_time_md="${4:-}"
 	local cross_repo_person_stats_md="${5:-}"
+	local stage_file="${6:-}"
 
 	[[ -z "$repo_slug" ]] && return 0
 
+	_record_health_repo_stage "$stage_file" "identity-and-role"
 	local runner_user
 	runner_user=$(_resolve_current_gh_login_or_fallback)
 
@@ -350,25 +362,33 @@ _update_health_issue_for_repo() {
 	local health_issue_file="${cache_dir}/health-issue-${canonical_identity_cache_safe}-${slug_safe}"
 	mkdir -p "$cache_dir"
 
+	_record_health_repo_stage "$stage_file" "activity-guard"
 	_HEALTH_ISSUE_ACTIVITY_STATE="$_HEALTH_ACTIVITY_STATE_ACTIVE"
-	_check_health_issue_activity_guard \
-		"$repo_slug" "$repo_path" "$runner_user" "$health_issue_file" || return 0
+	if ! _check_health_issue_activity_guard \
+		"$repo_slug" "$repo_path" "$runner_user" "$health_issue_file"; then
+		_record_health_repo_stage "$stage_file" "skipped-idle"
+		return 0
+	fi
 	local activity_state="${_HEALTH_ISSUE_ACTIVITY_STATE:-$_HEALTH_ACTIVITY_STATE_ACTIVE}"
 
+	_record_health_repo_stage "$stage_file" "issue-resolution"
 	local health_issue_number
 	health_issue_number=$(_resolve_health_issue_number \
 		"$repo_slug" "$runner_user" "$runner_role" "$runner_prefix" \
 		"$role_label" "$role_label_color" "$role_label_desc" \
 		"$role_display" "$health_issue_file" \
 		"$canonical_identity" "$identity_aliases")
-	[[ -z "$health_issue_number" ]] && return 0
-	[[ "$health_issue_number" == "$_HEALTH_QUERY_FAILED_SENTINEL" ]] && return 0
+	if [[ -z "$health_issue_number" || "$health_issue_number" == "$_HEALTH_QUERY_FAILED_SENTINEL" ]]; then
+		_record_health_repo_stage "$stage_file" "deferred-issue-resolution"
+		return 0
+	fi
 
 	_cache_health_issue_number "$health_issue_number" "$health_issue_file"
 
 	local now_iso
 	now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+	_record_health_repo_stage "$stage_file" "data-gather"
 	local body
 	body=$(_assemble_health_issue_body \
 		"$repo_slug" "$repo_path" "$runner_user" "$slug_safe" \
@@ -376,6 +396,7 @@ _update_health_issue_for_repo() {
 		"$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md" \
 		"$canonical_identity" "$identity_aliases")
 
+	_record_health_repo_stage "$stage_file" "body-publication"
 	local body_update_ec=0
 	_update_health_issue_body_or_fail "$health_issue_number" "$repo_slug" "$body" || body_update_ec=$?
 	[[ "$body_update_ec" -ne 0 ]] && return "$body_update_ec"
@@ -383,6 +404,7 @@ _update_health_issue_for_repo() {
 		"$health_issue_number" "$repo_slug" "$runner_prefix" "$body" "$now_iso"
 	_record_health_issue_refresh_state "$health_issue_file" "$activity_state"
 
+	_record_health_repo_stage "$stage_file" "maintenance"
 	# Publish the freshness marker before periodic maintenance. The latter can
 	# consume multiple GitHub requests (dedup, label normalization, pinning),
 	# and must not leave the primary operator dashboard stale when the bounded
@@ -404,6 +426,7 @@ _update_health_issue_for_repo() {
 		_ensure_health_issue_pinned "$health_issue_number" "$repo_slug" "$runner_user"
 	fi
 
+	_record_health_repo_stage "$stage_file" "complete"
 	return 0
 }
 
@@ -493,7 +516,7 @@ _order_health_repo_entries() {
 }
 
 _refresh_health_repo_bounded() {
-	local slug="$1" cache repo_timeout
+	local slug="$1" cache repo_timeout result=0 stage="unknown"
 	cache=$(_health_schedule_cache_file "$slug" "$_HEALTH_SCHEDULE_RUNNER")
 	[[ "$(date +%s)" -lt "$((_HEALTH_WORK_DEADLINE - 2))" ]] || return 124
 	mkdir -p "${cache%/*}" || return 1
@@ -501,8 +524,12 @@ _refresh_health_repo_bounded() {
 	repo_timeout=$(_stats_seconds "${STATS_HEALTH_REPO_TIMEOUT:-60}" 60)
 	[[ "$repo_timeout" -gt 0 ]] || repo_timeout=60
 	_stats_run_bounded "$repo_timeout" \
-		"$_HEALTH_WORK_DEADLINE" _update_health_issue_for_repo "$@"
-	return $?
+		"$_HEALTH_WORK_DEADLINE" _update_health_issue_for_repo "$@" "${cache}.stage" || result=$?
+	if [[ "$result" -ne 0 && -f "${cache}.stage" ]]; then
+		IFS='|' read -r stage _ <"${cache}.stage" || stage="unknown"
+		echo "[stats] Health issue update stopped for ${slug} (rc=${result} stage=${stage:-unknown})" >>"$LOGFILE"
+	fi
+	return "$result"
 }
 
 #######################################
@@ -680,6 +707,9 @@ update_health_issues() {
 	# Refresh person-stats cache if stale (t1426: hourly, not every pulse)
 	local aggregate_timeout
 	aggregate_timeout=$(_stats_seconds "${STATS_HEALTH_AGGREGATE_TIMEOUT:-30}" 30)
+	_stats_run_bounded "$aggregate_timeout" "$_HEALTH_WORK_DEADLINE" \
+		_refresh_worker_success_rates_cache "$routine_runner_user" ||
+		echo "[stats] Health dashboard worker success-rate cache deferred/failed" >>"$LOGFILE"
 	_stats_run_bounded "$aggregate_timeout" "$_HEALTH_WORK_DEADLINE" _refresh_person_stats_cache ||
 		echo "[stats] Health dashboard person cache deferred/failed" >>"$LOGFILE"
 

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -300,6 +300,23 @@ _refresh_health_issue_title_from_body() {
 	return 0
 }
 
+_run_health_issue_maintenance() {
+	local repo_slug="$1" runner_user="$2" runner_role="$3" role_label="$4"
+	local role_display="$5" health_issue_number="$6" canonical_identity="$7"
+	local identity_aliases="$8"
+	_periodic_health_issue_dedup \
+		"$repo_slug" "$runner_user" "$runner_role" \
+		"$role_label" "$role_display" "$health_issue_number" \
+		"$canonical_identity" "$identity_aliases"
+	_normalize_health_issue_labels \
+		"$health_issue_number" "$repo_slug" "$runner_user" \
+		"$runner_role" "$canonical_identity"
+	if [[ "$runner_role" == "supervisor" ]]; then
+		_ensure_health_issue_pinned "$health_issue_number" "$repo_slug" "$runner_user"
+	fi
+	return 0
+}
+
 #######################################
 # Update pinned health issue for a single repo
 #
@@ -414,17 +431,9 @@ _update_health_issue_for_repo() {
 	# seconds per repo+runner+role, default 1h). Closes duplicates that
 	# slipped in during past GraphQL rate-limit windows when the cache
 	# was valid so the label-scan inside _find_health_issue never ran.
-	_periodic_health_issue_dedup \
-		"$repo_slug" "$runner_user" "$runner_role" \
-		"$role_label" "$role_display" "$health_issue_number" \
-		"$canonical_identity" "$identity_aliases"
-	_normalize_health_issue_labels \
-		"$health_issue_number" "$repo_slug" "$runner_user" \
-		"$runner_role" "$canonical_identity"
-
-	if [[ "$runner_role" == "supervisor" ]]; then
-		_ensure_health_issue_pinned "$health_issue_number" "$repo_slug" "$runner_user"
-	fi
+	_run_health_issue_maintenance \
+		"$repo_slug" "$runner_user" "$runner_role" "$role_label" \
+		"$role_display" "$health_issue_number" "$canonical_identity" "$identity_aliases"
 
 	_record_health_repo_stage "$stage_file" "complete"
 	return 0
@@ -649,6 +658,16 @@ _health_routine_repo_entries() {
 	return 0
 }
 
+_refresh_health_aggregate_caches() {
+	local runner_user="$1" aggregate_timeout="$2"
+	_stats_run_bounded "$aggregate_timeout" "$_HEALTH_WORK_DEADLINE" \
+		_refresh_worker_success_rates_cache "$runner_user" ||
+		echo "[stats] Health dashboard worker success-rate cache deferred/failed" >>"$LOGFILE"
+	_stats_run_bounded "$aggregate_timeout" "$_HEALTH_WORK_DEADLINE" _refresh_person_stats_cache ||
+		echo "[stats] Health dashboard person cache deferred/failed" >>"$LOGFILE"
+	return 0
+}
+
 #######################################
 # Update health issues for ALL pulse-enabled repos
 #
@@ -707,11 +726,7 @@ update_health_issues() {
 	# Refresh person-stats cache if stale (t1426: hourly, not every pulse)
 	local aggregate_timeout
 	aggregate_timeout=$(_stats_seconds "${STATS_HEALTH_AGGREGATE_TIMEOUT:-30}" 30)
-	_stats_run_bounded "$aggregate_timeout" "$_HEALTH_WORK_DEADLINE" \
-		_refresh_worker_success_rates_cache "$routine_runner_user" ||
-		echo "[stats] Health dashboard worker success-rate cache deferred/failed" >>"$LOGFILE"
-	_stats_run_bounded "$aggregate_timeout" "$_HEALTH_WORK_DEADLINE" _refresh_person_stats_cache ||
-		echo "[stats] Health dashboard person cache deferred/failed" >>"$LOGFILE"
+	_refresh_health_aggregate_caches "$routine_runner_user" "$aggregate_timeout"
 
 	local cross_repo_md=""
 	local cross_repo_session_time_md=""

--- a/.agents/scripts/tests/test-stats-wrapper-timeout.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-timeout.sh
@@ -313,6 +313,62 @@ test_resumable_quality_batches() {
 	return 0
 }
 
+test_health_dashboard_slow_cross_repo_rates_are_bounded_once() {
+	local batch_home
+	batch_home=$(mktemp -d "${TMPDIR:-/tmp}/stats-health-stages.XXXXXX") || return 1
+	if (
+		export HOME="$batch_home" LOGFILE="$batch_home/stats.log"
+		local scripts="${SCRIPT_DIR}/.."
+		local SCRIPT_DIR="$scripts"
+		# shellcheck source=../shared-constants.sh
+		source "$scripts/shared-constants.sh"
+		# shellcheck source=../worker-lifecycle-common.sh
+		source "$scripts/worker-lifecycle-common.sh"
+		# shellcheck source=../stats-functions.sh
+		source "$scripts/stats-functions.sh"
+		_gather_health_stats() {
+			printf '%s\0' 0 '_No open PRs_' 0 0 '_No active workers_' 0 \
+				0 1 0.00 0.00 unknown 0 0 '?' 0 '' '_No diagnostics_'
+		}
+		_gather_activity_stats_for_repo() { printf '_Activity unavailable._\n'; }
+		_gather_session_time_for_repo() { printf '_Session data unavailable._\n'; }
+		_read_person_stats_cache() { printf '_Person stats unavailable._\n'; }
+		_compute_worker_success_rates() {
+			printf '%s\n' "$2" >>"$HOME/rate-attempts"
+			sleep 30
+		}
+		local now rc=0 body
+		now=$(date +%s)
+		_stats_run_bounded 1 "$((now + 5))" _refresh_worker_success_rates_cache tester || rc=$?
+		[[ "$rc" -eq 124 ]] || exit 1
+		[[ "$(wc -l <"$HOME/rate-attempts" | tr -d ' ')" -eq 1 ]] || exit 2
+		body=$(_assemble_health_issue_body owner/repo "$HOME" tester owner-repo \
+			2026-09-08T00:00:00Z Supervisor supervisor '' '' '' tester tester) || exit 3
+		[[ "$body" == *'| 24h | — |'* && "$body" == *'last_refresh: 2026-09-08T00:00:00Z'* ]] || exit 4
+		[[ "$(wc -l <"$HOME/rate-attempts" | tr -d ' ')" -eq 1 ]] || exit 5
+		local stage_file="$HOME/stage"
+		_record_health_repo_stage "$stage_file" body-publication || exit 6
+		[[ "$(<"$stage_file")" == body-publication\|* ]] || exit 7
+		_update_health_issue_for_repo() {
+			_record_health_repo_stage "$6" data-gather
+			sleep 30
+		}
+		local _HEALTH_SCHEDULE_RUNNER=tester _HEALTH_WORK_DEADLINE
+		local STATS_HEALTH_REPO_TIMEOUT=1
+		_HEALTH_WORK_DEADLINE=$(($(date +%s) + 5))
+		rc=0
+		_refresh_health_repo_bounded owner/slow "$HOME" '' '' '' || rc=$?
+		[[ "$rc" -eq 124 ]] || exit 8
+		grep -q 'owner/slow (rc=124 stage=data-gather)' "$LOGFILE" || exit 9
+	); then
+		pass "slow cross-repo rate collection is bounded once and leaves truthful render/stage evidence"
+	else
+		fail "slow cross-repo rate collection is bounded once and leaves truthful render/stage evidence" "fixture exit=$?"
+	fi
+	rm -rf "$batch_home"
+	return 0
+}
+
 _test_stats_preflight_deadlines() {
 	local REPOS_JSON="$HOME/repos.json" start elapsed
 	local STATS_OPTIONAL_WORK_RESERVE_SECONDS=0 QUALITY_SWEEP_CLEANUP_RESERVE_SECONDS=0
@@ -346,6 +402,7 @@ main_test() {
 	test_failed_health_update_still_runs_quality_sweep_once
 	test_healthy_update_runs_health_then_quality_once
 	test_resumable_quality_batches
+	test_health_dashboard_slow_cross_repo_rates_are_bounded_once
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 }


### PR DESCRIPTION
## Summary

Cache repository-wide worker success rates once per stats cycle and persist the exact per-repository stage reached before bounded deferral.

## Files Changed

.agents/scripts/stats-health-dashboard-data.sh, .agents/scripts/stats-health-dashboard.sh, .agents/scripts/tests/test-stats-wrapper-timeout.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — test-stats-wrapper-timeout.sh; health dashboard identity, sentinel, characterization and maintainer tests; ShellCheck

Resolves #31574


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.341 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 9m and 126,397 tokens on this as a headless worker.