### PR TITLE
GH#31580: expose stale worker success-rate caches

### DIFF
--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -539,8 +539,11 @@ PY
 
 # Worker success rates are cross-repository data. Compute them once per stats
 # cycle instead of repeating the same repository-wide GitHub queries while
-# rendering every dashboard. A timed-out refresh leaves the last good cache in
-# place; absence is rendered as unavailable rather than as a successful sample.
+# rendering every dashboard. The stats-wrapper scheduler runs hourly, so retain
+# a sample for at most two scheduler intervals. A timed-out refresh leaves the
+# last good cache in place only while its sample time remains trustworthy;
+# otherwise rendering marks the rates unavailable rather than current.
+WORKER_SUCCESS_RATES_CACHE_MAX_AGE_SECONDS="${WORKER_SUCCESS_RATES_CACHE_MAX_AGE_SECONDS:-7200}"
 _worker_success_rates_cache_file() {
 	local runner_user="$1" runner_safe
 	if [[ -n "${WORKER_SUCCESS_RATES_CACHE_FILE:-}" ]]; then
@@ -578,16 +581,32 @@ _refresh_worker_success_rates_cache() {
 }
 
 _read_worker_success_rates_cache() {
-	local runner_user="$1" cache_file
+	local runner_user="$1" cache_file refreshed_at refreshed_epoch now_epoch cache_age cache_max_age
 	cache_file=$(_worker_success_rates_cache_file "$runner_user")
+	cache_max_age="$WORKER_SUCCESS_RATES_CACHE_MAX_AGE_SECONDS"
+	[[ "$cache_max_age" =~ ^[0-9]+$ ]] || cache_max_age=7200
 	if [[ -f "$cache_file" ]] && jq -e '
-		(.rate24 | type == "string") and (.total24 | test("^[0-9]+$")) and
-		(.rate7 | type == "string") and (.total7 | test("^[0-9]+$"))
+		def is_string: type == "string";
+		(.rate24 | is_string) and (.total24 | test("^[0-9]+$")) and
+		(.rate7 | is_string) and (.total7 | test("^[0-9]+$")) and
+		(.refreshed_at | is_string and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
 	' "$cache_file" >/dev/null 2>&1; then
-		jq -r '[.rate24,.total24,.rate7,.total7] | @tsv' "$cache_file"
-	else
-		printf '%s\t%s\t%s\t%s\n' '—' '0' '—' '0'
+		refreshed_at=$(jq -r '.refreshed_at' "$cache_file")
+		if [[ "$OSTYPE" == darwin* ]]; then
+			refreshed_epoch=$(date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$refreshed_at" +%s 2>/dev/null)
+		else
+			refreshed_epoch=$(date -u -d "$refreshed_at" +%s 2>/dev/null)
+		fi
+		now_epoch=$(date -u +%s)
+		if [[ "$refreshed_epoch" =~ ^[0-9]+$ ]] && [[ "$now_epoch" =~ ^[0-9]+$ ]]; then
+			cache_age=$((now_epoch - refreshed_epoch))
+			if [[ "$cache_age" -ge 0 && "$cache_age" -le "$cache_max_age" ]]; then
+				jq -r '[.rate24,.total24,.rate7,.total7] | @tsv' "$cache_file"
+				return 0
+			fi
+		fi
 	fi
+	printf '%s\t%s\t%s\t%s\n' '—' '0' '—' '0'
 	return 0
 }
 

--- a/.agents/scripts/tests/test-stats-wrapper-timeout.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-timeout.sh
@@ -342,13 +342,40 @@ test_health_dashboard_slow_cross_repo_rates_are_bounded_once() {
 		_stats_run_bounded 1 "$((now + 5))" _refresh_worker_success_rates_cache tester || rc=$?
 		[[ "$rc" -eq 124 ]] || exit 1
 		[[ "$(wc -l <"$HOME/rate-attempts" | tr -d ' ')" -eq 1 ]] || exit 2
+		mkdir -p "$HOME/.aidevops/logs"
+		jq -n --arg refreshed_at '2020-01-01T00:00:00Z' \
+			'{rate24:"80% (4/5)",total24:"5",rate7:"90% (9/10)",total7:"10",refreshed_at:$refreshed_at}' \
+			>"$HOME/.aidevops/logs/worker-success-rates-tester.json"
 		body=$(_assemble_health_issue_body owner/repo "$HOME" tester owner-repo \
 			2026-09-08T00:00:00Z Supervisor supervisor '' '' '' tester tester) || exit 3
 		[[ "$body" == *'| 24h | — |'* && "$body" == *'last_refresh: 2026-09-08T00:00:00Z'* ]] || exit 4
 		[[ "$(wc -l <"$HOME/rate-attempts" | tr -d ' ')" -eq 1 ]] || exit 5
+		jq -n '{rate24:"80% (4/5)",total24:"5",rate7:"90% (9/10)",total7:"10"}' \
+			>"$HOME/.aidevops/logs/worker-success-rates-tester.json"
+		body=$(_assemble_health_issue_body owner/repo "$HOME" tester owner-repo \
+			2026-09-08T00:00:00Z Supervisor supervisor '' '' '' tester tester) || exit 6
+		[[ "$body" == *'| 24h | — |'* ]] || exit 7
+		jq -n --arg refreshed_at 'not-a-timestamp' \
+			'{rate24:"80% (4/5)",total24:"5",rate7:"90% (9/10)",total7:"10",refreshed_at:$refreshed_at}' \
+			>"$HOME/.aidevops/logs/worker-success-rates-tester.json"
+		body=$(_assemble_health_issue_body owner/repo "$HOME" tester owner-repo \
+			2026-09-08T00:00:00Z Supervisor supervisor '' '' '' tester tester) || exit 8
+		[[ "$body" == *'| 24h | — |'* ]] || exit 9
+		jq -n --arg refreshed_at '2999-01-01T00:00:00Z' \
+			'{rate24:"80% (4/5)",total24:"5",rate7:"90% (9/10)",total7:"10",refreshed_at:$refreshed_at}' \
+			>"$HOME/.aidevops/logs/worker-success-rates-tester.json"
+		body=$(_assemble_health_issue_body owner/repo "$HOME" tester owner-repo \
+			2026-09-08T00:00:00Z Supervisor supervisor '' '' '' tester tester) || exit 10
+		[[ "$body" == *'| 24h | — |'* ]] || exit 11
+		jq -n --arg refreshed_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+			'{rate24:"80% (4/5)",total24:"5",rate7:"90% (9/10)",total7:"10",refreshed_at:$refreshed_at}' \
+			>"$HOME/.aidevops/logs/worker-success-rates-tester.json"
+		body=$(_assemble_health_issue_body owner/repo "$HOME" tester owner-repo \
+			2026-09-08T00:00:00Z Supervisor supervisor '' '' '' tester tester) || exit 12
+		[[ "$body" == *'| 24h | 80% (4/5) |'* && "$body" == *'| 7d | 90% (9/10) |'* ]] || exit 13
 		local stage_file="$HOME/stage"
-		_record_health_repo_stage "$stage_file" body-publication || exit 6
-		[[ "$(<"$stage_file")" == body-publication\|* ]] || exit 7
+		_record_health_repo_stage "$stage_file" body-publication || exit 14
+		[[ "$(<"$stage_file")" == body-publication\|* ]] || exit 15
 		_update_health_issue_for_repo() {
 			_record_health_repo_stage "$6" data-gather
 			sleep 30
@@ -358,8 +385,8 @@ test_health_dashboard_slow_cross_repo_rates_are_bounded_once() {
 		_HEALTH_WORK_DEADLINE=$(($(date +%s) + 5))
 		rc=0
 		_refresh_health_repo_bounded owner/slow "$HOME" '' '' '' || rc=$?
-		[[ "$rc" -eq 124 ]] || exit 8
-		grep -q 'owner/slow (rc=124 stage=data-gather)' "$LOGFILE" || exit 9
+		[[ "$rc" -eq 124 ]] || exit 16
+		grep -q 'owner/slow (rc=124 stage=data-gather)' "$LOGFILE" || exit 17
 	); then
 		pass "slow cross-repo rate collection is bounded once and leaves truthful render/stage evidence"
 	else


### PR DESCRIPTION
## Summary

Reject worker success-rate cache entries with missing, malformed, future, or expired sample timestamps while retaining fresh cached values.

## Files Changed

.agents/scripts/stats-health-dashboard-data.sh, .agents/scripts/tests/test-stats-wrapper-timeout.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-stats-wrapper-timeout.sh; shellcheck .agents/scripts/stats-health-dashboard-data.sh .agents/scripts/tests/test-stats-wrapper-timeout.sh; .agents/scripts/linters-local.sh --changed

Resolves #31580


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.342 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 7m and 106,345 tokens on this as a headless worker.