### PR TITLE
GH#31584: provision legacy dashboard labels

### DIFF
--- a/.agents/scripts/stats-health-dashboard-issue.sh
+++ b/.agents/scripts/stats-health-dashboard-issue.sh
@@ -39,6 +39,63 @@ _HEALTH_OPERATOR_LABEL_PREFIX="operator:"
 # --- Functions ---
 
 #######################################
+# Provision labels needed by a legacy health dashboard without changing existing
+# repository label metadata. Returns non-zero when inventory or creation fails.
+# Arguments:
+#   $1 - repo slug
+#   $2 - runner user
+#   $3 - runner role (supervisor|contributor)
+#   $4 - canonical operator identity
+#######################################
+_ensure_health_dashboard_labels() {
+	local repo_slug="$1"
+	local runner_user="$2"
+	local runner_role="$3"
+	local canonical_identity="$4"
+	local operator_label="${_HEALTH_OPERATOR_LABEL_PREFIX}${canonical_identity}"
+	local role_label role_label_color role_label_desc
+	if [[ "$runner_role" == "$_ROLE_SUPERVISOR" ]]; then
+		role_label="$_ROLE_SUPERVISOR"
+		role_label_color="1D76DB"
+		role_label_desc="Supervisor health dashboard"
+	else
+		role_label="$_ROLE_CONTRIBUTOR"
+		role_label_color="A2EEEF"
+		role_label_desc="Contributor health dashboard"
+	fi
+	local labels_json rc=0
+
+	labels_json=$(gh label list --repo "$repo_slug" --limit 1000 --json name 2>/dev/null) || rc=$?
+	if [[ $rc -ne 0 || -z "$labels_json" ]]; then
+		echo "[stats] Health issue: label provisioning inventory failed for ${repo_slug} (rc=${rc})" \
+			>>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
+
+	local label_name label_color label_description
+	while IFS='|' read -r label_name label_color label_description; do
+		if printf '%s' "$labels_json" | jq -e --arg name "$label_name" \
+			'any(.[]; .name == $name)' >/dev/null 2>&1; then
+			continue
+		fi
+		if ! gh label create "$label_name" --repo "$repo_slug" --color "$label_color" \
+			--description "$label_description" 2>/dev/null; then
+			echo "[stats] Health issue: failed to provision label ${label_name} in ${repo_slug}" \
+				>>"${LOGFILE:-/dev/null}"
+			return 1
+		fi
+	done <<EOF
+${_HEALTH_PERSISTENT_LABEL}|FBCA04|Persistent issue — do not close
+source:health-dashboard|C2E0C6|Auto-created by stats-functions.sh health dashboard
+${role_label}|${role_label_color}|${role_label_desc}
+${runner_user}|0E8A16|Health dashboard runner: ${runner_user}
+${operator_label}|0E8A16|Canonical dashboard operator: ${canonical_identity}
+origin:worker|C5DEF5|Created by a headless worker
+EOF
+	return 0
+}
+
+#######################################
 # List open health issues matching a role + runner_user pair, filtered
 # by title-prefix. Helper centralises the jq filter so `_find_health_issue`
 # and `_periodic_health_issue_dedup` share one query definition.
@@ -144,6 +201,12 @@ _normalize_health_issue_labels() {
 		opposite_role_label="$_ROLE_CONTRIBUTOR"
 	fi
 	local canonical_label="${_HEALTH_OPERATOR_LABEL_PREFIX}${canonical_identity}"
+	if ! _ensure_health_dashboard_labels "$repo_slug" "$runner_user" \
+		"$runner_role" "$canonical_identity"; then
+		echo "[stats] Health issue: failed to normalize labels for #${issue_number} in ${repo_slug}" \
+			>>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
 
 	local -a edit_args=()
 	local expected_label

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -488,6 +488,10 @@ export HEALTH_FIXTURE=label_hygiene
 gh() {
 	local call="$*"
 	printf '%s\n' "$call" >>"$GH_CALLS"
+	if [[ "$call" == *"label list --repo owner/repo"* ]]; then
+		printf '%s' '[{"name":"persistent"},{"name":"source:health-dashboard"},{"name":"supervisor"},{"name":"github-user"},{"name":"origin:worker"}]'
+		return 0
+	fi
 	if [[ "$call" == *"issue view 20408 --repo owner/repo --json labels"* ]]; then
 		printf '%s' '{"labels":[{"name":"persistent"},{"name":"source:health-dashboard"},{"name":"supervisor"},{"name":"github-user"},{"name":"operator:canonical-operator"},{"name":"origin:worker"},{"name":"origin:interactive"},{"name":"origin:worker-takeover"},{"name":"auto-dispatch"},{"name":"status:available"}]}'
 	fi
@@ -497,10 +501,34 @@ _normalize_health_issue_labels "20408" "owner/repo" "github-user" "supervisor" "
 if grep -q -- '--remove-label auto-dispatch' "$GH_CALLS" \
 	&& grep -q -- '--remove-label status:available' "$GH_CALLS" \
 	&& grep -q -- '--remove-label origin:interactive' "$GH_CALLS" \
-	&& grep -q -- '--remove-label origin:worker-takeover' "$GH_CALLS"; then
-	pass "dashboard label normalization removes task lifecycle labels"
+	&& grep -q -- '--remove-label origin:worker-takeover' "$GH_CALLS" \
+	&& grep -q -- 'label create operator:canonical-operator' "$GH_CALLS" \
+	&& ! grep -q -- 'label create origin:worker' "$GH_CALLS"; then
+	pass "dashboard label normalization provisions missing labels and removes task lifecycle labels"
 else
-	fail "dashboard label normalization removes task lifecycle labels" "calls=$(tr '\n' ';' <"$GH_CALLS")"
+	fail "dashboard label normalization provisions missing labels and removes task lifecycle labels" "calls=$(tr '\n' ';' <"$GH_CALLS")"
+fi
+
+: >"$GH_CALLS"
+: >"$LOGFILE"
+gh() {
+	local call="$*"
+	printf '%s\n' "$call" >>"$GH_CALLS"
+	if [[ "$call" == *"issue view 20408 --repo owner/repo --json labels"* ]]; then
+		printf '%s' '{"labels":[{"name":"persistent"}]}'
+	elif [[ "$call" == *"label list --repo owner/repo"* ]]; then
+		printf '%s' '[]'
+	elif [[ "$call" == *"label create persistent"* ]]; then
+		return 1
+	fi
+	return 0
+}
+_normalize_health_issue_labels "20408" "owner/repo" "github-user" "supervisor" "canonical-operator"
+if grep -q 'failed to provision label persistent' "$LOGFILE" \
+	&& ! grep -q 'issue edit' "$GH_CALLS"; then
+	pass "dashboard label provisioning failure preserves diagnostics and skips normalization"
+else
+	fail "dashboard label provisioning failure preserves diagnostics and skips normalization" "calls=$(tr '\n' ';' <"$GH_CALLS"); log=$(tr '\n' ';' <"$LOGFILE")"
 fi
 
 : >"$GH_CALLS"


### PR DESCRIPTION
## Summary

Provision only absent legacy dashboard label definitions before normalization and retain diagnostics when provisioning fails.

## Files Changed

.agents/scripts/stats-health-dashboard-issue.sh, .agents/scripts/tests/test-health-dashboard-identity-aliases.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; shellcheck .agents/scripts/stats-health-dashboard-issue.sh .agents/scripts/tests/test-health-dashboard-identity-aliases.sh; bun run typecheck

Resolves #31584


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.342 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 6m and 108,890 tokens on this as a headless worker.