### PR TITLE
GH#31588: dispatch OpenCode canary reviews

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -185,18 +185,19 @@ aidevops_ensure_symlink_target() {
 # 1.18.16 after a credential-free same-revision baseline comparison; GH#30393
 # promoted 1.18.18 after making that comparison self-contained; GH#30695
 # promoted 1.18.23 after the isolated baseline and candidate probes passed;
-# GH#30957 promoted 1.18.25 after the same isolated comparison passed. Keep the
-# complete compatibility decision visible and machine-readable; general installs
-# track latest because the observed failure scope is Linux headless.
-readonly OPENCODE_PINNED_VERSION="1.18.25"
+# GH#30957 promoted 1.18.25 and GH#31588 promoted 1.18.29 after the same isolated
+# comparison passed. Keep the complete compatibility decision visible and
+# machine-readable; general installs track latest because the observed failure
+# scope is Linux headless.
+readonly OPENCODE_PINNED_VERSION="1.18.29"
 readonly OPENCODE_PIN_REASON="GH#28766 Linux headless bootstrap stalled with isolated XDG_DATA_HOME"
 readonly OPENCODE_PIN_PLATFORM="Linux"
 readonly OPENCODE_PIN_RUNTIME_MODE="headless"
 readonly OPENCODE_PIN_INTRODUCED_DATE="2026-07-30"
-readonly OPENCODE_PIN_LAST_CANARY_DATE="2026-09-01"
-readonly OPENCODE_PIN_LAST_CANARY_RESULT="pass:1.18.25"
-readonly OPENCODE_PIN_REVIEW_DEADLINE="2026-09-08"
-readonly OPENCODE_PLUGIN_TESTED_VERSION="1.18.25"
+readonly OPENCODE_PIN_LAST_CANARY_DATE="2026-09-08"
+readonly OPENCODE_PIN_LAST_CANARY_RESULT="pass:1.18.29"
+readonly OPENCODE_PIN_REVIEW_DEADLINE="2026-09-15"
+readonly OPENCODE_PLUGIN_TESTED_VERSION="1.18.29"
 
 aidevops_opencode_pin_applies() {
 	local platform="${1:-$(uname -s 2>/dev/null || printf 'unknown')}"

--- a/.agents/scripts/tests/test-opencode-pin-policy.sh
+++ b/.agents/scripts/tests/test-opencode-pin-policy.sh
@@ -19,13 +19,13 @@ assert_eq() {
 	fi
 }
 
-assert_eq "pin version is explicit" "1.18.25" "$OPENCODE_PINNED_VERSION"
+assert_eq "pin version is explicit" "1.18.29" "$OPENCODE_PINNED_VERSION"
 assert_eq "pin platform is scoped" "Linux" "$OPENCODE_PIN_PLATFORM"
 assert_eq "pin runtime is scoped" "headless" "$OPENCODE_PIN_RUNTIME_MODE"
 assert_eq "introduction date is recorded" "2026-07-30" "$OPENCODE_PIN_INTRODUCED_DATE"
-assert_eq "last canary is recorded" "2026-09-01" "$OPENCODE_PIN_LAST_CANARY_DATE"
-assert_eq "review deadline is recorded" "2026-09-08" "$OPENCODE_PIN_REVIEW_DEADLINE"
-assert_eq "plugin compatibility signal is explicit" "1.18.25" "$OPENCODE_PLUGIN_TESTED_VERSION"
+assert_eq "last canary is recorded" "2026-09-08" "$OPENCODE_PIN_LAST_CANARY_DATE"
+assert_eq "review deadline is recorded" "2026-09-15" "$OPENCODE_PIN_REVIEW_DEADLINE"
+assert_eq "plugin compatibility signal is explicit" "1.18.29" "$OPENCODE_PLUGIN_TESTED_VERSION"
 
 scope_rc=0
 aidevops_opencode_pin_applies Linux headless || scope_rc=$?
@@ -40,7 +40,7 @@ assert_eq "interactive setup is outside observed scope" "1" "$scope_rc"
 status=$(
 	PATH="/usr/bin:/bin" "$REPO_ROOT/.agents/scripts/opencode-pin-canary.sh" status
 )
-[[ "$status" == *"pinned=1.18.25"* && "$status" == *"registry-latest="* && "$status" == *"plugin-tested=1.18.25"* && "$status" == *"last-canary=2026-09-01"* ]] || {
+[[ "$status" == *"pinned=1.18.29"* && "$status" == *"registry-latest="* && "$status" == *"plugin-tested=1.18.29"* && "$status" == *"last-canary=2026-09-08"* ]] || {
 	printf 'FAIL: status omits compatibility evidence: %s\n' "$status" >&2
 	fail=$((fail + 1))
 }
@@ -49,7 +49,7 @@ workflow="$REPO_ROOT/.github/workflows/opencode-pin-canary.yml"
 canary_script="$REPO_ROOT/.agents/scripts/opencode-pin-canary.sh"
 if grep -q 'persist-credentials: false' "$workflow" && grep -q 'record-review:' "$workflow" &&
 	grep -q 'needs: linux-headless-canary' "$workflow" &&
-	grep -q 'actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0' "$workflow"; then
+	grep -q 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' "$workflow"; then
 	printf 'PASS: candidate execution is separated from the issue-write token\n'
 else
 	printf 'FAIL: candidate execution can retain or reach repository write credentials\n' >&2
@@ -76,6 +76,16 @@ if grep -q 'cron:' "$workflow" && grep -q "title=\"Promote passing OpenCode comp
 	printf 'PASS: scheduled passing candidates create a promotion review\n'
 else
 	printf 'FAIL: scheduled passing-candidate promotion path is missing\n' >&2
+	fail=$((fail + 1))
+fi
+if grep -q "'labels\[\]=origin:worker'" "$workflow" &&
+	grep -q "'labels\[\]=auto-dispatch'" "$workflow" &&
+	grep -q "'labels\[\]=tier:standard'" "$workflow" &&
+	grep -q "'labels\[\]=status:available'" "$workflow" &&
+	! grep -q "'labels\[\]=status:in-review'" "$workflow"; then
+	printf 'PASS: generated compatibility work is available to Pulse workers\n'
+else
+	printf 'FAIL: generated compatibility work is not worker-dispatchable\n' >&2
 	fail=$((fail + 1))
 fi
 if grep -q "title=\"OpenCode compatibility pin review is due\"" "$workflow" &&

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -91,7 +91,7 @@ extract_function
 printf 'Test 0: OpenCode remains pinned to the last verified headless release\n'
 # shellcheck source=../shared-constants.sh
 source "$SHARED_CONSTANTS"
-assert_eq "OpenCode headless regression pin" "1.18.25" "$OPENCODE_PINNED_VERSION"
+assert_eq "OpenCode headless regression pin" "1.18.29" "$OPENCODE_PINNED_VERSION"
 
 printf 'Test 0a: routine freshness tracks registry outside Linux headless dispatch\n'
 mkdir -p "$SANDBOX/routine-freshness/bin"
@@ -212,7 +212,7 @@ assert_eq "npm OpenCode upgrade command" "npm install -g opencode-ai@1.15.10" "$
 printf 'Test 4: headless guard provisions an isolated pin without changing newer general install\n'
 mkdir -p "$SANDBOX/version-guard/runtime" "$SANDBOX/version-guard/bin" "$SANDBOX/version-guard/state"
 write_executable "$SANDBOX/version-guard/runtime/opencode" '#!/usr/bin/env bash
-printf "1.18.26\n"'
+printf "1.18.30\n"'
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
 write_executable "$SANDBOX/version-guard/bin/npm" '#!/usr/bin/env bash
 printf "%s\n" "$*" >>"'"$SANDBOX"'/version-guard/calls"
@@ -224,7 +224,7 @@ done
 mkdir -p "$prefix/node_modules/opencode-linux-x64/bin"
 cat >"$prefix/node_modules/opencode-linux-x64/bin/opencode" <<"BIN"
 #!/usr/bin/env bash
-printf "1.18.25\n"
+printf "1.18.29\n"
 BIN
 chmod +x "$prefix/node_modules/opencode-linux-x64/bin/opencode"'
 guard_rc=0
@@ -244,10 +244,10 @@ headless_bin=""
 ) || guard_rc=$?
 assert_eq "headless pin repair status" "0" "$guard_rc"
 headless_bin=$(<"$SANDBOX/version-guard/headless-bin")
-assert_eq "general install remains newer" "1.18.26" "$("$SANDBOX/version-guard/runtime/opencode")"
-assert_eq "isolated headless runtime is pinned" "1.18.25" "$("$headless_bin")"
+assert_eq "general install remains newer" "1.18.30" "$("$SANDBOX/version-guard/runtime/opencode")"
+assert_eq "isolated headless runtime is pinned" "1.18.29" "$("$headless_bin")"
 install_call=$(<"$SANDBOX/version-guard/calls")
-[[ "$install_call" == "install --ignore-scripts --no-audit --no-fund --prefix "*"/opencode-runtimes/.1.18.25.install."*"/prefix opencode-ai@1.18.25" ]] && install_shape="valid" || install_shape="invalid"
+[[ "$install_call" == "install --ignore-scripts --no-audit --no-fund --prefix "*"/opencode-runtimes/.1.18.29.install."*"/prefix opencode-ai@1.18.29" ]] && install_shape="valid" || install_shape="invalid"
 assert_eq "isolated install requests exact pin" "valid" "$install_shape"
 
 printf 'Test 4b: existing isolated pin is reused without package-manager mutation\n'
@@ -270,7 +270,7 @@ assert_eq "existing isolated runtime avoids second install" "1" "$(wc -l <"$SAND
 printf 'Test 4c: stale pin repair locks are cleared after the bounded wait\n'
 mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes" "$SANDBOX/version-stale-lock/bin"
 write_executable "$SANDBOX/version-stale-lock/runtime-opencode" '#!/usr/bin/env bash
-printf "1.18.26\n"'
+printf "1.18.30\n"'
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
 write_executable "$SANDBOX/version-stale-lock/bin/npm" '#!/usr/bin/env bash
 prefix=""
@@ -281,14 +281,14 @@ done
 mkdir -p "$prefix/node_modules/opencode-linux-x64/bin"
 cat >"$prefix/node_modules/opencode-linux-x64/bin/opencode" <<"BIN"
 #!/usr/bin/env bash
-printf "1.18.25\n"
+printf "1.18.29\n"
 BIN
 chmod +x "$prefix/node_modules/opencode-linux-x64/bin/opencode"'
 (:) &
 dead_installer_pid=$!
 wait "$dead_installer_pid" || true
 mkdir -p "$SANDBOX/version-stale-lock/state/opencode-pin-repair.lock"
-mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.25.install.$dead_installer_pid"
+mkdir -p "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.29.install.$dead_installer_pid"
 stale_lock_rc=0
 (
 	source_extracted
@@ -306,14 +306,14 @@ stale_lock_rc=0
 ) || stale_lock_rc=$?
 assert_eq "stale lock repair status" "0" "$stale_lock_rc"
 assert_eq "stale lock is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-pin-repair.lock" ]] && printf '1\n' || printf '0\n')"
-assert_eq "dead install temp is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.25.install.$dead_installer_pid" ]] && printf '1\n' || printf '0\n')"
+assert_eq "dead install temp is removed" "0" "$([[ -e "$SANDBOX/version-stale-lock/state/opencode-runtimes/.1.18.29.install.$dead_installer_pid" ]] && printf '1\n' || printf '0\n')"
 stale_headless_bin=$(<"$SANDBOX/version-stale-lock/headless-bin")
-assert_eq "stale lock path provisions pinned runtime" "1.18.25" "$("$stale_headless_bin")"
+assert_eq "stale lock path provisions pinned runtime" "1.18.29" "$("$stale_headless_bin")"
 
 printf 'Test 5: headless version guard fails closed when isolated provisioning fails\n'
 mkdir -p "$SANDBOX/version-install-failure/state"
 write_executable "$SANDBOX/version-install-failure/opencode" '#!/usr/bin/env bash
-printf "1.18.26\n"'
+printf "1.18.30\n"'
 write_executable "$SANDBOX/version-install-failure/npm" '#!/usr/bin/env bash
 exit 42'
 guard_rc=0

--- a/.github/workflows/opencode-pin-canary.yml
+++ b/.github/workflows/opencode-pin-canary.yml
@@ -80,4 +80,5 @@ jobs:
             "Status: ${status}" "Result: ${result}" \
             'Files: `.agents/scripts/shared-constants.sh`, `.agents/plugins/opencode-aidevops/package.json`, and `.agents/plugins/opencode-aidevops/package-lock.json`. Retain the current fail-closed pin after failed or inconclusive results; after a passing rerun, advance the tested version, dates, result, and plugin lock together. Verify with `.agents/scripts/tests/test-opencode-pin-policy.sh` and the workflow canary.')
           gh api --method POST "repos/${REPO}/issues" -f title="$title" -f body="$body" \
-            -f 'labels[]=origin:worker' -f 'labels[]=status:in-review' >/dev/null
+            -f 'labels[]=origin:worker' -f 'labels[]=auto-dispatch' \
+            -f 'labels[]=tier:standard' -f 'labels[]=status:available' >/dev/null


### PR DESCRIPTION
## Summary

Promote the verified OpenCode 1.18.29 Linux-headless pin and create future canary review issues as explicit Pulse worker handoffs.

## Files Changed

.agents/scripts/shared-constants.sh, .agents/scripts/tests/test-opencode-pin-policy.sh, .agents/scripts/tests/test-tool-version-check-opencode.sh, .github/workflows/opencode-pin-canary.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — OpenCode pin policy test, tool version guard test, ShellCheck, diff check, and changed-file linters pass.

Resolves #31588


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.342 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 19m and 117,793 tokens on this with the user in an interactive session.