### PR TITLE
GH#31459: audit and correct Codacy policy drift

### DIFF
--- a/.agents/tools/code-review/codacy.md
+++ b/.agents/tools/code-review/codacy.md
@@ -81,6 +81,29 @@ permission failure even when the token itself is valid. A valid project token
 can authenticate repository reads while still receiving `403` for privileged
 operations; successful authentication is not proof of mutation authority.
 
+### Verified repository policy audit (2026-09-08)
+
+Codacy's repository tool endpoint is the authority for effective tool state;
+the legacy `engines.*.enabled` entries in `.codacy.yml` do not enable or disable
+tools. The verified aidevops policy uses the dedicated `aidevops modern
+runtimes` coding standard with these 17 tools enabled: Agentlinter, Bandit,
+Biome, Brakeman, ESLint, Hadolint, Jackson Linter, Lizard, markdownlint,
+Opengrep, Pylint, RuboCop, ShellCheck, SQLint, Stylelint, Trivy, and TSQLLint.
+PMD and Prospector remain disabled. Bandit, Biome, markdownlint, and ShellCheck
+report that they use their checked-in native configuration files.
+
+The language-settings API exposes enabled/detected languages and extensions,
+not an ECMAScript-version selector. JavaScript and TypeScript are detected and
+enabled. This repository declares ES modules and Node.js 20 or newer, and its
+TypeScript server check targets ES2022. Therefore the ES3/ES5 compatibility
+patterns `ESLint8_es-x_no-modules`,
+`ESLint8_es-x_no-block-scoped-variables`, and
+`ESLint8_es-x_no-trailing-commas` are intentionally disabled. `Bandit_B404` is
+also disabled because `.bandit` documents the narrower subprocess rules that
+remain active. Before correction, exact-SHA overview counts were 84, 56, 40,
+and 83 respectively. Keep the live standard and native files aligned; changing
+the inert `.codacy.yml` engine map is not a tool-setting migration.
+
 ```bash
 # Commit delta statistics (new issues count + complexity delta)
 curl -s -H "api-token: $CODACY_API_TOKEN" \

--- a/.agents/tools/code-review/codacy.md
+++ b/.agents/tools/code-review/codacy.md
@@ -100,9 +100,15 @@ patterns `ESLint8_es-x_no-modules`,
 `ESLint8_es-x_no-block-scoped-variables`, and
 `ESLint8_es-x_no-trailing-commas` are intentionally disabled. `Bandit_B404` is
 also disabled because `.bandit` documents the narrower subprocess rules that
-remain active. Before correction, exact-SHA overview counts were 84, 56, 40,
-and 83 respectively. Keep the live standard and native files aligned; changing
-the inert `.codacy.yml` engine map is not a tool-setting migration.
+remain active. Before correction, exact-SHA overview counts were 84
+(`no-modules`), 56 (`no-block-scoped-variables`), 40 (`no-trailing-commas`),
+and 83 (`B404`). A normal exact-SHA reanalysis cleared the three ESLint counts,
+but retained 83 cached B404 findings even though both the effective pattern and
+`.bandit` disable B404. This is evidence that a cache-cleared support reanalysis
+is still required for native-config policy changes; do not weaken Bandit or
+rewrite safe subprocess imports to compensate for stale derived state. Keep the
+live standard and native files aligned; changing the inert `.codacy.yml` engine
+map is not a tool-setting migration.
 
 ```bash
 # Commit delta statistics (new issues count + complexity delta)


### PR DESCRIPTION
## Summary

- Audit effective Codacy tools, language settings, and four drift patterns
- Apply a repository-specific coding standard that preserves the 17 enabled tools while disabling the four demonstrated noise patterns
- Document verified behavior, modern JavaScript runtime rationale, and the remaining clean-cache boundary

For #31459

## Runtime Testing

Self-assessed documentation and service configuration change. Changed-file lint passed. A normal reanalysis completed for exact default SHA `4abc9e3031e9c945579f24eb098b93087c92ec5b`: all three legacy ESLint counts fell to zero, while 83 cached `Bandit_B404` findings remain until Codacy Support performs the restricted cache-cleared reanalysis.

## Unrelated service evidence

The exact-SHA run also reported a transient ShellCheck container exit 137 and an existing RuboCop coding-standard incompatibility. Neither tool was changed or disabled in this task.


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 40m and 169,881 tokens on this as a headless worker. Overall, 1d 14h since this issue was created.
