### PR TITLE
GH#31593: add safe batch GitHub publication

### DIFF
--- a/.agents/reference/gh-command-discipline.md
+++ b/.agents/reference/gh-command-discipline.md
@@ -78,6 +78,28 @@ their existing behavior.
   comment` or `gh-write-helper.sh pr comment`. Use `--body-file -` for streamed
   bodies; the executable loads the audited create/edit/comment wrappers
   internally without caller-side `source`.
+- Explicit bounded publication uses `gh-write-helper.sh batch MANIFEST.json`.
+  The owner-only manifest and every body file must live under
+  `AIDEVOPS_TEMP_DIR`. Schema `aidevops.github-write-batch/v1` accepts 1-10
+  independent operations in one repository: `issue_comment`, `pr_comment`,
+  `issue_edit`, `pr_edit`, `issue_add_labels`, `issue_remove_labels`,
+  `pr_add_labels`, and `pr_remove_labels`. Each operation requires a stable `id`
+  and positive `number`; comments require `body_file`, edits require `title`
+  and/or `body_file`, and label changes require `labels`. Unknown fields fail
+  closed. Batch mode rejects protected lifecycle/provenance labels; use their
+  dedicated helpers instead.
+  It validates the complete set and fresh repository state before one aliased
+  GraphQL mutation, then writes an owner-only per-operation receipt. Never replay
+  an `unknown` result. Comments carry an `aidevops:batch` marker. Recovery scans
+  a complete bounded fresh comment window and must prove that marker absent
+  before placing a proven-missing comment in a manifest whose `recovery_of`
+  identifies the owner-only
+  original receipt and its manifest digest. Only operations recorded `unknown`
+  may be recovered, and the operation identity and payload digest must match the
+  receipt. Metadata recovery likewise requires fresh exact state. Keep dependent
+  writes sequential when a later operation needs state produced by an earlier
+  operation. A recovery manifest uses `"recovery_of":{"manifest_sha256":"...",
+  "receipt_file":"<owner-only-absolute-path>"}`.
 - ANTI-PATTERN (blocked by t2893 enforcement): same-command heredoc, process
   substitution, command substitution, or shell-variable body construction such
   as passing a heredoc through command substitution to `--body`, passing

--- a/.agents/scripts/gh-write-batch.py
+++ b/.agents/scripts/gh-write-batch.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from gh_write_batch_graphql import mutation, preflight_query
+
 SCHEMA = "aidevops.github-write-batch/v1"
 PREPARED_SCHEMA = "aidevops.github-write-batch-prepared/v1"
 RECEIPT_SCHEMA = "aidevops.github-write-batch-receipt/v1"
@@ -57,14 +59,6 @@ class BodyPreparation(NamedTuple):
     root: Path
     marker_sha: str
     signature_helper: Path
-
-
-class MutationBuild(NamedTuple):
-    """Mutable containers shared while compiling one GraphQL mutation."""
-
-    label_ids: dict[str, str]
-    declarations: list[str]
-    variables: dict[str, Any]
 
 
 def now_iso() -> str:
@@ -403,30 +397,6 @@ def graphql_call(query: str, variables: dict[str, Any], timeout: int) -> tuple[i
         return 124, stdout, stderr, True
 
 
-def preflight_query(prepared: dict[str, Any]) -> tuple[str, dict[str, Any]]:
-    declarations = ["$owner:String!", "$name:String!"]
-    fields: list[str] = ["viewerPermission"]
-    variables: dict[str, Any] = {}
-    owner, name = prepared["repository"].split("/", 1)
-    variables.update(owner=owner, name=name)
-    labels = sorted({label for op in prepared["operations"] for label in op.get("labels", [])})
-    for index, operation in enumerate(prepared["operations"]):
-        declarations.append(f"$number{index}:Int!")
-        variables[f"number{index}"] = operation["number"]
-        comments = ""
-        if prepared.get("recovery_of") and operation["kind"].endswith("_comment"):
-            comments = " comments(last:100){nodes{body} pageInfo{hasPreviousPage}}"
-        fields.append(
-            f't{index}:issueOrPullRequest(number:$number{index}){{__typename ... on Issue{{id number title body labels(first:100){{nodes{{id name}} pageInfo{{hasNextPage}}}}{comments}}} ... on PullRequest{{id number title body labels(first:100){{nodes{{id name}} pageInfo{{hasNextPage}}}}{comments}}}}}}}'
-        )
-    for index, label in enumerate(labels):
-        declarations.append(f"$label{index}:String!")
-        variables[f"label{index}"] = label
-        fields.append(f'l{index}:label(name:$label{index}){{id name}}')
-    query = f"query({','.join(declarations)}){{repository(owner:$owner,name:$name){{{' '.join(fields)}}}}}"
-    return query, variables
-
-
 def preflight_label_ids(prepared: dict[str, Any], repository: dict[str, Any]) -> dict[str, str]:
     label_ids: dict[str, str] = {}
     label_names = sorted({label for op in prepared["operations"] for label in op.get("labels", [])})
@@ -523,77 +493,6 @@ def checked_body(operation: dict[str, Any]) -> str:
     if hashlib.sha256(body.encode("utf-8")).hexdigest() != operation["body_sha256"]:
         raise BatchError(f"operation {operation['id']} prepared body changed before publication")
     return body
-
-
-def comment_mutation(
-    index: int, alias: str, operation: dict[str, Any], build: MutationBuild
-) -> str:
-    build.declarations.append(f"$body{index}:String!")
-    build.variables[f"body{index}"] = checked_body(operation)
-    return f'{alias}:addComment(input:{{subjectId:$target{index},body:$body{index},clientMutationId:$client{index}}}){{clientMutationId commentEdge{{node{{id url}}}}}}'
-
-
-def edit_mutation(
-    index: int, alias: str, operation: dict[str, Any], build: MutationBuild
-) -> str:
-    mutation_name = "updatePullRequest" if operation["kind"] == "pr_edit" else "updateIssue"
-    inputs = [f"id:$target{index}", f"clientMutationId:$client{index}"]
-    for field in ("title", "body"):
-        operation_key = "body_file" if field == "body" else field
-        if operation_key not in operation:
-            continue
-        build.declarations.append(f"${field}{index}:String!")
-        build.variables[f"{field}{index}"] = (
-            checked_body(operation) if field == "body" else operation[operation_key]
-        )
-        inputs.append(f"{field}:${field}{index}")
-    result_name = "pullRequest" if operation["kind"] == "pr_edit" else "issue"
-    return f'{alias}:{mutation_name}(input:{{{",".join(inputs)}}}){{clientMutationId {result_name}{{id number}}}}'
-
-
-def label_mutation(
-    index: int, alias: str, operation: dict[str, Any], build: MutationBuild
-) -> str:
-    build.declarations.append(f"$labels{index}:[ID!]!")
-    build.variables[f"labels{index}"] = [build.label_ids[label] for label in operation["labels"]]
-    mutation_name = (
-        "addLabelsToLabelable" if operation["kind"].endswith("add_labels") else "removeLabelsFromLabelable"
-    )
-    return f'{alias}:{mutation_name}(input:{{labelableId:$target{index},labelIds:$labels{index},clientMutationId:$client{index}}}){{clientMutationId}}'
-
-
-def mutation_field(
-    index: int, alias: str, operation: dict[str, Any], build: MutationBuild
-) -> str:
-    kind = operation["kind"]
-    if kind.endswith("_comment"):
-        return comment_mutation(index, alias, operation, build)
-    if kind.endswith("_edit"):
-        return edit_mutation(index, alias, operation, build)
-    return label_mutation(index, alias, operation, build)
-
-
-def mutation(
-    prepared: dict[str, Any], label_ids: dict[str, str], already: set[str]
-) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
-    declarations: list[str] = []
-    fields: list[str] = []
-    variables: dict[str, Any] = {}
-    build = MutationBuild(label_ids, declarations, variables)
-    attempted: list[dict[str, Any]] = []
-    for index, operation in enumerate(prepared["operations"]):
-        if operation["id"] in already:
-            continue
-        alias = f"o{index}"
-        operation["alias"] = alias
-        attempted.append(operation)
-        declarations.extend((f"$target{index}:ID!", f"$client{index}:String!"))
-        variables[f"target{index}"] = operation["target_id"]
-        variables[f"client{index}"] = operation["id"]
-        fields.append(mutation_field(index, alias, operation, build))
-    if not attempted:
-        return "", {}, []
-    return f"mutation({','.join(declarations)}){{{' '.join(fields)}}}", variables, attempted
 
 
 def base_receipt(prepared: dict[str, Any]) -> dict[str, Any]:
@@ -746,7 +645,7 @@ def execute(args: argparse.Namespace) -> int:
     for operation_id in already:
         by_id[operation_id]["status"] = "already_succeeded"
         by_id[operation_id]["detail"] = "fresh_state_already_matches"
-    query, variables, attempted = mutation(prepared, label_ids, already)
+    query, variables, attempted = mutation(prepared, label_ids, already, checked_body)
     if not attempted:
         emit_receipt(receipt_path, receipt)
         print(json.dumps(receipt, sort_keys=True))

--- a/.agents/scripts/gh-write-batch.py
+++ b/.agents/scripts/gh-write-batch.py
@@ -8,13 +8,14 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import stat
 import subprocess
 import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 SCHEMA = "aidevops.github-write-batch/v1"
 PREPARED_SCHEMA = "aidevops.github-write-batch-prepared/v1"
@@ -50,6 +51,22 @@ class BatchError(Exception):
     """A fail-closed validation or execution error."""
 
 
+class BodyPreparation(NamedTuple):
+    """Trusted context used while normalizing manifest body files."""
+
+    root: Path
+    marker_sha: str
+    signature_helper: Path
+
+
+class MutationBuild(NamedTuple):
+    """Mutable containers shared while compiling one GraphQL mutation."""
+
+    label_ids: dict[str, str]
+    declarations: list[str]
+    variables: dict[str, Any]
+
+
 def now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -79,7 +96,7 @@ def private_input(path_value: str, root: Path, label: str) -> Path:
 
 def write_private_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    os.chmod(path.parent, 0o700)
+    os.chmod(path.parent, 0o700)  # nosec B103 - owner-only writable directory
     fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     try:
         os.fchmod(fd, 0o600)
@@ -121,7 +138,7 @@ def unsigned_body(text: str) -> str:
 
 def signature_footer(helper: Path) -> str:
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 - fixed owner-controlled helper path
             [str(helper), "footer"], text=True, capture_output=True, timeout=10, check=False
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
@@ -133,18 +150,16 @@ def signature_footer(helper: Path) -> str:
 
 def copy_body(
     source: Path,
-    root: Path,
     kind: str,
     operation_id: str,
-    marker_sha: str,
-    helper: Path,
+    context: BodyPreparation,
 ) -> tuple[str, str, str]:
     body = source.read_text(encoding="utf-8")
     source_digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
     if len(body.encode("utf-8")) > MAX_BODY_BYTES or not substantive(body):
         raise BatchError(f"operation {operation_id} body is empty or exceeds {MAX_BODY_BYTES} bytes")
     needs_signature = kind in {"issue_comment", "pr_comment", "pr_edit"}
-    marker = f"<!-- aidevops:batch:{marker_sha}:{operation_id} -->"
+    marker = f"<!-- aidevops:batch:{context.marker_sha}:{operation_id} -->"
     if kind in {"issue_comment", "pr_comment"} and marker not in body.splitlines():
         signature_at = body.find("<!-- aidevops:sig -->")
         if signature_at >= 0:
@@ -152,8 +167,8 @@ def copy_body(
         else:
             body = f"{body.rstrip()}\n\n{marker}\n"
     if needs_signature and "<!-- aidevops:sig -->" not in body.splitlines():
-        body = f"{body}{signature_footer(helper)}"
-    fd, copied = tempfile.mkstemp(prefix="gh-write-batch-body.", dir=root)
+        body = f"{body}{signature_footer(context.signature_helper)}"
+    fd, copied = tempfile.mkstemp(prefix="gh-write-batch-body.", dir=context.root)
     with os.fdopen(fd, "w", encoding="utf-8") as stream:
         os.fchmod(stream.fileno(), 0o600)
         stream.write(body)
@@ -186,52 +201,143 @@ def operation_intent_sha(operation: dict[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def prepare(args: argparse.Namespace) -> int:
+def load_manifest(args: argparse.Namespace) -> tuple[Path, Path, dict[str, Any], str]:
     root = private_root(args.temp_root)
     manifest_path = private_input(args.manifest, root, "manifest")
     helper = Path(args.signature_helper).resolve(strict=True)
-    manifest_bytes = manifest_path.read_bytes()
-    manifest_sha = hashlib.sha256(manifest_bytes).hexdigest()
-    manifest = load_json(manifest_path, "manifest")
+    manifest_sha = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    return root, helper, load_json(manifest_path, "manifest"), manifest_sha
+
+
+def validate_manifest(manifest: dict[str, Any]) -> tuple[str, list[dict[str, Any]]]:
     exact_keys(manifest, {"schema", "repository", "operations", "recovery_of"}, "manifest")
     if manifest.get("schema") != SCHEMA:
         raise BatchError(f"manifest schema must be {SCHEMA}")
     repository = manifest.get("repository")
     if not isinstance(repository, str) or not REPO_RE.fullmatch(repository):
         raise BatchError("manifest repository must be an exact owner/name slug")
-    recovery_of = manifest.get("recovery_of")
-    recovery_operations: dict[str, dict[str, Any]] = {}
-    marker_sha = manifest_sha
-    if recovery_of is not None:
-        if not isinstance(recovery_of, dict):
-            raise BatchError("recovery_of must identify an owner-only receipt")
-        exact_keys(recovery_of, {"manifest_sha256", "receipt_file"}, "recovery_of")
-        recovery_sha = recovery_of.get("manifest_sha256")
-        if not isinstance(recovery_sha, str) or not re.fullmatch(r"[0-9a-f]{64}", recovery_sha):
-            raise BatchError("recovery_of manifest_sha256 is invalid")
-        receipt_path = private_input(recovery_of.get("receipt_file"), root, "recovery receipt")
-        recovery_receipt = load_json(receipt_path, "recovery receipt")
-        if (
-            recovery_receipt.get("schema") != RECEIPT_SCHEMA
-            or recovery_receipt.get("manifest_sha256") != recovery_sha
-            or recovery_receipt.get("repository") != repository
-        ):
-            raise BatchError("recovery receipt does not match this repository and manifest")
-        receipt_marker_sha = recovery_receipt.get("marker_sha256")
-        if not isinstance(receipt_marker_sha, str) or not re.fullmatch(r"[0-9a-f]{64}", receipt_marker_sha):
-            raise BatchError("recovery receipt marker lineage is invalid")
-        receipt_operations = recovery_receipt.get("operations")
-        if not isinstance(receipt_operations, list):
-            raise BatchError("recovery receipt operations are invalid")
-        recovery_operations = {
-            operation.get("id"): operation
-            for operation in receipt_operations
-            if isinstance(operation, dict) and isinstance(operation.get("id"), str)
-        }
-        marker_sha = receipt_marker_sha
     raw_operations = manifest.get("operations")
     if not isinstance(raw_operations, list) or not 1 <= len(raw_operations) <= MAX_OPERATIONS:
         raise BatchError(f"manifest must contain 1-{MAX_OPERATIONS} operations")
+    return repository, raw_operations
+
+
+def load_recovery(
+    recovery_of: Any, root: Path, repository: str, manifest_sha: str
+) -> tuple[dict[str, dict[str, Any]], str]:
+    if recovery_of is None:
+        return {}, manifest_sha
+    if not isinstance(recovery_of, dict):
+        raise BatchError("recovery_of must identify an owner-only receipt")
+    exact_keys(recovery_of, {"manifest_sha256", "receipt_file"}, "recovery_of")
+    recovery_sha = recovery_of.get("manifest_sha256")
+    if not isinstance(recovery_sha, str) or not re.fullmatch(r"[0-9a-f]{64}", recovery_sha):
+        raise BatchError("recovery_of manifest_sha256 is invalid")
+    receipt_path = private_input(recovery_of.get("receipt_file"), root, "recovery receipt")
+    receipt = load_json(receipt_path, "recovery receipt")
+    if (
+        receipt.get("schema") != RECEIPT_SCHEMA
+        or receipt.get("manifest_sha256") != recovery_sha
+        or receipt.get("repository") != repository
+    ):
+        raise BatchError("recovery receipt does not match this repository and manifest")
+    marker_sha = receipt.get("marker_sha256")
+    if not isinstance(marker_sha, str) or not re.fullmatch(r"[0-9a-f]{64}", marker_sha):
+        raise BatchError("recovery receipt marker lineage is invalid")
+    receipt_operations = receipt.get("operations")
+    if not isinstance(receipt_operations, list):
+        raise BatchError("recovery receipt operations are invalid")
+    operations = {
+        operation.get("id"): operation
+        for operation in receipt_operations
+        if isinstance(operation, dict) and isinstance(operation.get("id"), str)
+    }
+    return operations, marker_sha
+
+
+def validate_operation_identity(raw: Any, index: int) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise BatchError(f"operation {index} must be an object")
+    exact_keys(raw, {"id", "kind", "number", "body_file", "title", "labels"}, f"operation {index}")
+    operation_id = raw.get("id")
+    kind = raw.get("kind")
+    number = raw.get("number")
+    if not isinstance(operation_id, str) or not ID_RE.fullmatch(operation_id):
+        raise BatchError(f"operation {index} id is invalid")
+    if kind not in KINDS:
+        raise BatchError(f"operation {operation_id} kind is unsupported")
+    if isinstance(number, bool) or not isinstance(number, int) or number < 1:
+        raise BatchError(f"operation {operation_id} number must be a positive integer")
+    return {
+        "id": operation_id,
+        "kind": kind,
+        "number": number,
+        "target_type": "PullRequest" if kind.startswith("pr_") else "Issue",
+    }
+
+
+def validate_comment_shape(raw: dict[str, Any], operation: dict[str, Any]) -> str:
+    if "body_file" not in raw or "title" in raw or "labels" in raw:
+        raise BatchError(f"operation {operation['id']} comment shape is invalid")
+    return "comment"
+
+
+def validate_edit_shape(raw: dict[str, Any], operation: dict[str, Any]) -> str:
+    if "labels" in raw or ("body_file" not in raw and "title" not in raw):
+        raise BatchError(f"operation {operation['id']} edit shape is invalid")
+    title = raw.get("title")
+    if title is not None:
+        stub = isinstance(title, str) and re.fullmatch(r"(?:t[0-9]+|GH#[0-9]+):\s*", title.strip())
+        if not isinstance(title, str) or not title.strip() or len(title) > 256 or stub:
+            raise BatchError(f"operation {operation['id']} title is invalid")
+        operation["title"] = title
+    return "scalar"
+
+
+def validate_label_shape(raw: dict[str, Any], operation: dict[str, Any]) -> str:
+    if "labels" not in raw or "body_file" in raw or "title" in raw:
+        raise BatchError(f"operation {operation['id']} label shape is invalid")
+    operation["labels"] = validate_labels(raw["labels"], operation["id"])
+    return "labels"
+
+
+def normalize_operation(
+    raw: Any, index: int, context: BodyPreparation, copied_files: list[str]
+) -> tuple[dict[str, Any], str]:
+    operation = validate_operation_identity(raw, index)
+    kind = operation["kind"]
+    if kind.endswith("_comment"):
+        field = validate_comment_shape(raw, operation)
+    elif kind.endswith("_edit"):
+        field = validate_edit_shape(raw, operation)
+    else:
+        field = validate_label_shape(raw, operation)
+    if "body_file" in raw:
+        source = private_input(raw["body_file"], context.root, f"operation {operation['id']} body")
+        copied, body_sha, source_sha = copy_body(source, kind, operation["id"], context)
+        copied_files.append(copied)
+        operation.update(body_file=copied, body_sha256=body_sha, source_sha256=source_sha)
+    return operation, field
+
+
+def validate_recovery_operation(
+    operation: dict[str, Any], recovery_operations: dict[str, dict[str, Any]]
+) -> None:
+    previous = recovery_operations.get(operation["id"])
+    if not isinstance(previous, dict) or previous.get("status") != "unknown":
+        raise BatchError(f"operation {operation['id']} is not unknown in the recovery receipt")
+    if previous.get("kind") != operation["kind"] or previous.get("number") != operation["number"]:
+        raise BatchError(f"operation {operation['id']} does not match its recovery receipt identity")
+    if previous.get("intent_sha256") != operation_intent_sha(operation):
+        raise BatchError(f"operation {operation['id']} payload does not match its recovery receipt")
+
+
+def prepare(args: argparse.Namespace) -> int:
+    root, helper, manifest, manifest_sha = load_manifest(args)
+    repository, raw_operations = validate_manifest(manifest)
+    recovery_of = manifest.get("recovery_of")
+    recovery_operations, marker_sha = load_recovery(recovery_of, root, repository, manifest_sha)
+    context = BodyPreparation(root, marker_sha, helper)
 
     operation_ids: set[str] = set()
     field_owners: set[tuple[str, int, str]] = set()
@@ -239,72 +345,19 @@ def prepare(args: argparse.Namespace) -> int:
     copied_files: list[str] = []
     try:
         for index, raw in enumerate(raw_operations):
-            if not isinstance(raw, dict):
-                raise BatchError(f"operation {index} must be an object")
-            exact_keys(raw, {"id", "kind", "number", "body_file", "title", "labels"}, f"operation {index}")
-            operation_id = raw.get("id")
-            kind = raw.get("kind")
-            number = raw.get("number")
-            if not isinstance(operation_id, str) or not ID_RE.fullmatch(operation_id):
-                raise BatchError(f"operation {index} id is invalid")
+            operation, field = normalize_operation(raw, index, context, copied_files)
+            operation_id = operation["id"]
             if operation_id in operation_ids:
                 raise BatchError(f"duplicate operation id {operation_id}")
             operation_ids.add(operation_id)
-            if kind not in KINDS:
-                raise BatchError(f"operation {operation_id} kind is unsupported")
-            if isinstance(number, bool) or not isinstance(number, int) or number < 1:
-                raise BatchError(f"operation {operation_id} number must be a positive integer")
-            target_type = "PullRequest" if kind.startswith("pr_") else "Issue"
-            operation: dict[str, Any] = {
-                "id": operation_id,
-                "kind": kind,
-                "number": number,
-                "target_type": target_type,
-            }
-            if kind.endswith("_comment"):
-                if "body_file" not in raw or "title" in raw or "labels" in raw:
-                    raise BatchError(f"operation {operation_id} comment shape is invalid")
-                field = "comment"
-            elif kind.endswith("_edit"):
-                if "labels" in raw or ("body_file" not in raw and "title" not in raw):
-                    raise BatchError(f"operation {operation_id} edit shape is invalid")
-                title = raw.get("title")
-                if title is not None:
-                    if (
-                        not isinstance(title, str)
-                        or not title.strip()
-                        or len(title) > 256
-                        or re.fullmatch(r"(?:t[0-9]+|GH#[0-9]+):\s*", title.strip())
-                    ):
-                        raise BatchError(f"operation {operation_id} title is invalid")
-                    operation["title"] = title
-                field = "scalar"
-            else:
-                if "labels" not in raw or "body_file" in raw or "title" in raw:
-                    raise BatchError(f"operation {operation_id} label shape is invalid")
-                operation["labels"] = validate_labels(raw["labels"], operation_id)
-                field = "labels"
-            owner_key = (target_type, number, field)
+            owner_key = (operation["target_type"], operation["number"], field)
             if field != "comment" and owner_key in field_owners:
-                raise BatchError(f"dependent operations repeat {field} on {target_type} #{number}")
-            field_owners.add(owner_key)
-            if "body_file" in raw:
-                source = private_input(raw["body_file"], root, f"operation {operation_id} body")
-                copied, body_sha, source_sha = copy_body(
-                    source, root, kind, operation_id, marker_sha, helper
+                raise BatchError(
+                    f"dependent operations repeat {field} on {operation['target_type']} #{operation['number']}"
                 )
-                copied_files.append(copied)
-                operation["body_file"] = copied
-                operation["body_sha256"] = body_sha
-                operation["source_sha256"] = source_sha
+            field_owners.add(owner_key)
             if recovery_of is not None:
-                previous = recovery_operations.get(operation_id)
-                if not isinstance(previous, dict) or previous.get("status") != "unknown":
-                    raise BatchError(f"operation {operation_id} is not unknown in the recovery receipt")
-                if previous.get("kind") != kind or previous.get("number") != number:
-                    raise BatchError(f"operation {operation_id} does not match its recovery receipt identity")
-                if previous.get("intent_sha256") != operation_intent_sha(operation):
-                    raise BatchError(f"operation {operation_id} payload does not match its recovery receipt")
+                validate_recovery_operation(operation, recovery_operations)
             operations.append(operation)
         unknown_ids = {
             operation_id
@@ -331,9 +384,12 @@ def prepare(args: argparse.Namespace) -> int:
 
 def graphql_call(query: str, variables: dict[str, Any], timeout: int) -> tuple[int, str, str, bool]:
     payload = json.dumps({"query": query, "variables": variables})
+    gh_executable = shutil.which("gh")
+    if not gh_executable:
+        return 127, "", "gh executable is unavailable", False
     try:
-        result = subprocess.run(
-            ["gh", "api", "graphql", "--input", "-"],
+        result = subprocess.run(  # nosec B603 - resolved managed PATH shim or gh executable
+            [gh_executable, "api", "graphql", "--input", "-"],
             input=payload,
             text=True,
             capture_output=True,
@@ -371,6 +427,79 @@ def preflight_query(prepared: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     return query, variables
 
 
+def preflight_label_ids(prepared: dict[str, Any], repository: dict[str, Any]) -> dict[str, str]:
+    label_ids: dict[str, str] = {}
+    label_names = sorted({label for op in prepared["operations"] for label in op.get("labels", [])})
+    for index, label in enumerate(label_names):
+        node = repository.get(f"l{index}")
+        if not isinstance(node, dict) or node.get("name") != label or not isinstance(node.get("id"), str):
+            raise BatchError(f"unknown repository label {label}")
+        label_ids[label] = node["id"]
+    return label_ids
+
+
+def preflight_target(
+    repository: dict[str, Any], index: int, operation: dict[str, Any]
+) -> dict[str, Any]:
+    target = repository.get(f"t{index}")
+    if not isinstance(target, dict) or target.get("__typename") != operation["target_type"]:
+        raise BatchError(f"operation {operation['id']} target does not match {operation['target_type']}")
+    if not isinstance(target.get("id"), str) or target.get("number") != operation["number"]:
+        raise BatchError(f"operation {operation['id']} target identity is invalid")
+    operation["target_id"] = target["id"]
+    return target
+
+
+def recovery_comment_already(
+    prepared: dict[str, Any], operation: dict[str, Any], target: dict[str, Any]
+) -> bool:
+    comments = target.get("comments")
+    if not isinstance(comments, dict):
+        raise BatchError(f"operation {operation['id']} recovery comments are unavailable")
+    marker = f"<!-- aidevops:batch:{prepared['recovery_of']}:{operation['id']} -->"
+    bodies = [node.get("body") for node in comments.get("nodes", []) if isinstance(node, dict)]
+    if any(isinstance(body, str) and marker in body.splitlines() for body in bodies):
+        return True
+    if comments.get("pageInfo", {}).get("hasPreviousPage") is not False:
+        raise BatchError(f"operation {operation['id']} cannot prove the recovery marker absent")
+    return False
+
+
+def edit_already(operation: dict[str, Any], target: dict[str, Any]) -> bool:
+    title_matches = "title" not in operation or target.get("title") == operation["title"]
+    if "body_file" not in operation:
+        return title_matches
+    body = checked_body(operation)
+    target_body = target.get("body")
+    if operation["kind"] == "pr_edit" and isinstance(target_body, str):
+        return title_matches and unsigned_body(target_body) == unsigned_body(body)
+    return title_matches and target_body == body
+
+
+def labels_already(operation: dict[str, Any], target: dict[str, Any]) -> bool:
+    labels = target.get("labels")
+    if not isinstance(labels, dict) or labels.get("pageInfo", {}).get("hasNextPage") is not False:
+        raise BatchError(f"operation {operation['id']} cannot establish exact target labels")
+    current = {node.get("name") for node in labels.get("nodes", []) if isinstance(node, dict)}
+    requested = set(operation["labels"])
+    if operation["kind"].endswith("add_labels"):
+        return requested <= current
+    return requested.isdisjoint(current)
+
+
+def operation_already(
+    prepared: dict[str, Any], operation: dict[str, Any], target: dict[str, Any]
+) -> bool:
+    kind = operation["kind"]
+    if prepared.get("recovery_of") and kind.endswith("_comment"):
+        return recovery_comment_already(prepared, operation, target)
+    if kind.endswith("_edit"):
+        return edit_already(operation, target)
+    if kind.endswith("add_labels") or kind.endswith("remove_labels"):
+        return labels_already(operation, target)
+    return False
+
+
 def validate_preflight(prepared: dict[str, Any], payload: dict[str, Any]) -> tuple[dict[str, str], set[str]]:
     if payload.get("errors"):
         raise BatchError("repository preflight returned GraphQL errors")
@@ -379,55 +508,12 @@ def validate_preflight(prepared: dict[str, Any], payload: dict[str, Any]) -> tup
         raise BatchError("repository preflight returned no repository")
     if repository.get("viewerPermission") not in {"ADMIN", "MAINTAIN", "WRITE"}:
         raise BatchError("batch publication requires repository write authority")
-    label_ids: dict[str, str] = {}
-    label_names = sorted({label for op in prepared["operations"] for label in op.get("labels", [])})
-    for index, label in enumerate(label_names):
-        node = repository.get(f"l{index}")
-        if not isinstance(node, dict) or node.get("name") != label or not isinstance(node.get("id"), str):
-            raise BatchError(f"unknown repository label {label}")
-        label_ids[label] = node["id"]
+    label_ids = preflight_label_ids(prepared, repository)
     already: set[str] = set()
     for index, operation in enumerate(prepared["operations"]):
-        target = repository.get(f"t{index}")
-        if not isinstance(target, dict) or target.get("__typename") != operation["target_type"]:
-            raise BatchError(f"operation {operation['id']} target does not match {operation['target_type']}")
-        if not isinstance(target.get("id"), str) or target.get("number") != operation["number"]:
-            raise BatchError(f"operation {operation['id']} target identity is invalid")
-        operation["target_id"] = target["id"]
-        kind = operation["kind"]
-        if prepared.get("recovery_of") and kind.endswith("_comment"):
-            comments = target.get("comments")
-            if not isinstance(comments, dict):
-                raise BatchError(f"operation {operation['id']} recovery comments are unavailable")
-            marker = f"<!-- aidevops:batch:{prepared['recovery_of']}:{operation['id']} -->"
-            bodies = [node.get("body") for node in comments.get("nodes", []) if isinstance(node, dict)]
-            if any(isinstance(body, str) and marker in body.splitlines() for body in bodies):
-                already.add(operation["id"])
-            elif comments.get("pageInfo", {}).get("hasPreviousPage") is not False:
-                raise BatchError(f"operation {operation['id']} cannot prove the recovery marker absent")
-        elif kind.endswith("_edit"):
-            unchanged = True
-            if "title" in operation:
-                unchanged = unchanged and target.get("title") == operation["title"]
-            if "body_file" in operation:
-                body = checked_body(operation)
-                target_body = target.get("body")
-                if kind == "pr_edit" and isinstance(target_body, str):
-                    unchanged = unchanged and unsigned_body(target_body) == unsigned_body(body)
-                else:
-                    unchanged = unchanged and target_body == body
-            if unchanged:
-                already.add(operation["id"])
-        elif kind.endswith("add_labels") or kind.endswith("remove_labels"):
-            labels = target.get("labels")
-            if not isinstance(labels, dict) or labels.get("pageInfo", {}).get("hasNextPage") is not False:
-                raise BatchError(f"operation {operation['id']} cannot establish exact target labels")
-            current = {node.get("name") for node in labels.get("nodes", []) if isinstance(node, dict)}
-            requested = set(operation["labels"])
-            if (kind.endswith("add_labels") and requested <= current) or (
-                kind.endswith("remove_labels") and requested.isdisjoint(current)
-            ):
-                already.add(operation["id"])
+        target = preflight_target(repository, index, operation)
+        if operation_already(prepared, operation, target):
+            already.add(operation["id"])
     return label_ids, already
 
 
@@ -439,10 +525,61 @@ def checked_body(operation: dict[str, Any]) -> str:
     return body
 
 
-def mutation(prepared: dict[str, Any], label_ids: dict[str, str], already: set[str]) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
+def comment_mutation(
+    index: int, alias: str, operation: dict[str, Any], build: MutationBuild
+) -> str:
+    build.declarations.append(f"$body{index}:String!")
+    build.variables[f"body{index}"] = checked_body(operation)
+    return f'{alias}:addComment(input:{{subjectId:$target{index},body:$body{index},clientMutationId:$client{index}}}){{clientMutationId commentEdge{{node{{id url}}}}}}'
+
+
+def edit_mutation(
+    index: int, alias: str, operation: dict[str, Any], build: MutationBuild
+) -> str:
+    mutation_name = "updatePullRequest" if operation["kind"] == "pr_edit" else "updateIssue"
+    inputs = [f"id:$target{index}", f"clientMutationId:$client{index}"]
+    for field in ("title", "body"):
+        operation_key = "body_file" if field == "body" else field
+        if operation_key not in operation:
+            continue
+        build.declarations.append(f"${field}{index}:String!")
+        build.variables[f"{field}{index}"] = (
+            checked_body(operation) if field == "body" else operation[operation_key]
+        )
+        inputs.append(f"{field}:${field}{index}")
+    result_name = "pullRequest" if operation["kind"] == "pr_edit" else "issue"
+    return f'{alias}:{mutation_name}(input:{{{",".join(inputs)}}}){{clientMutationId {result_name}{{id number}}}}'
+
+
+def label_mutation(
+    index: int, alias: str, operation: dict[str, Any], build: MutationBuild
+) -> str:
+    build.declarations.append(f"$labels{index}:[ID!]!")
+    build.variables[f"labels{index}"] = [build.label_ids[label] for label in operation["labels"]]
+    mutation_name = (
+        "addLabelsToLabelable" if operation["kind"].endswith("add_labels") else "removeLabelsFromLabelable"
+    )
+    return f'{alias}:{mutation_name}(input:{{labelableId:$target{index},labelIds:$labels{index},clientMutationId:$client{index}}}){{clientMutationId}}'
+
+
+def mutation_field(
+    index: int, alias: str, operation: dict[str, Any], build: MutationBuild
+) -> str:
+    kind = operation["kind"]
+    if kind.endswith("_comment"):
+        return comment_mutation(index, alias, operation, build)
+    if kind.endswith("_edit"):
+        return edit_mutation(index, alias, operation, build)
+    return label_mutation(index, alias, operation, build)
+
+
+def mutation(
+    prepared: dict[str, Any], label_ids: dict[str, str], already: set[str]
+) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
     declarations: list[str] = []
     fields: list[str] = []
     variables: dict[str, Any] = {}
+    build = MutationBuild(label_ids, declarations, variables)
     attempted: list[dict[str, Any]] = []
     for index, operation in enumerate(prepared["operations"]):
         if operation["id"] in already:
@@ -453,29 +590,7 @@ def mutation(prepared: dict[str, Any], label_ids: dict[str, str], already: set[s
         declarations.extend((f"$target{index}:ID!", f"$client{index}:String!"))
         variables[f"target{index}"] = operation["target_id"]
         variables[f"client{index}"] = operation["id"]
-        kind = operation["kind"]
-        if kind.endswith("_comment"):
-            declarations.append(f"$body{index}:String!")
-            variables[f"body{index}"] = checked_body(operation)
-            fields.append(f'{alias}:addComment(input:{{subjectId:$target{index},body:$body{index},clientMutationId:$client{index}}}){{clientMutationId commentEdge{{node{{id url}}}}}}')
-        elif kind.endswith("_edit"):
-            mutation_name = "updatePullRequest" if kind == "pr_edit" else "updateIssue"
-            inputs = [f"id:$target{index}", f"clientMutationId:$client{index}"]
-            if "title" in operation:
-                declarations.append(f"$title{index}:String!")
-                variables[f"title{index}"] = operation["title"]
-                inputs.append(f"title:$title{index}")
-            if "body_file" in operation:
-                declarations.append(f"$body{index}:String!")
-                variables[f"body{index}"] = checked_body(operation)
-                inputs.append(f"body:$body{index}")
-            result_name = "pullRequest" if kind == "pr_edit" else "issue"
-            fields.append(f'{alias}:{mutation_name}(input:{{{",".join(inputs)}}}){{clientMutationId {result_name}{{id number}}}}')
-        else:
-            declarations.append(f"$labels{index}:[ID!]!")
-            variables[f"labels{index}"] = [label_ids[label] for label in operation["labels"]]
-            mutation_name = "addLabelsToLabelable" if kind.endswith("add_labels") else "removeLabelsFromLabelable"
-            fields.append(f'{alias}:{mutation_name}(input:{{labelableId:$target{index},labelIds:$labels{index},clientMutationId:$client{index}}}){{clientMutationId}}')
+        fields.append(mutation_field(index, alias, operation, build))
     if not attempted:
         return "", {}, []
     return f"mutation({','.join(declarations)}){{{' '.join(fields)}}}", variables, attempted
@@ -519,94 +634,126 @@ def receipt_status(receipt: dict[str, Any]) -> str:
     return "deferred"
 
 
-def execute(args: argparse.Namespace) -> int:
-    prepared_path = Path(args.prepared)
-    prepared = load_json(prepared_path, "prepared manifest")
-    if prepared.get("schema") != PREPARED_SCHEMA:
-        raise BatchError("prepared manifest schema is invalid")
-    receipt = base_receipt(prepared)
-    read_timeout = max(1, int(os.environ.get("AIDEVOPS_GH_BATCH_READ_TIMEOUT", "15")))
-    default_write_timeout = max(
-        1,
-        int(os.environ.get("AIDEVOPS_GH_WRITE_TIMEOUT", "45")) - read_timeout - 5,
-    )
-    write_timeout = max(
-        1,
-        int(os.environ.get("AIDEVOPS_GH_BATCH_WRITE_TIMEOUT", str(default_write_timeout))),
-    )
+def emit_receipt(path: Path, receipt: dict[str, Any]) -> None:
+    receipt["overall"] = receipt_status(receipt)
+    write_private_json(path, receipt)
+
+
+def run_preflight(
+    prepared: dict[str, Any], receipt: dict[str, Any], receipt_path: Path, timeout: int
+) -> tuple[int, dict[str, str], set[str]]:
     query, variables = preflight_query(prepared)
-    rc, stdout, stderr, timed_out = graphql_call(query, variables, read_timeout)
+    rc, stdout, stderr, timed_out = graphql_call(query, variables, timeout)
     if rc != 0 or timed_out:
         status = "deferred" if rc == 75 else "rejected"
         set_all(receipt, status, "preflight_deferred" if rc == 75 else "preflight_failed")
-        receipt["overall"] = receipt_status(receipt)
-        write_private_json(Path(args.receipt), receipt)
+        emit_receipt(receipt_path, receipt)
         print(stderr.strip(), file=sys.stderr)
-        return rc or 1
+        return rc or 1, {}, set()
     try:
         preflight = json.loads(stdout)
         label_ids, already = validate_preflight(prepared, preflight)
     except (json.JSONDecodeError, BatchError) as exc:
         set_all(receipt, "rejected", str(exc))
-        receipt["overall"] = "failed"
-        write_private_json(Path(args.receipt), receipt)
+        emit_receipt(receipt_path, receipt)
         print(str(exc), file=sys.stderr)
-        return 1
+        return 1, {}, set()
+    return 0, label_ids, already
+
+
+def set_attempted(
+    attempted: list[dict[str, Any]], by_id: dict[str, dict[str, Any]], status: str, detail: str
+) -> None:
+    for operation in attempted:
+        by_id[operation["id"]]["status"] = status
+        by_id[operation["id"]]["detail"] = detail
+
+
+def classify_alias(
+    operation: dict[str, Any], data: dict[str, Any], errors: list[Any], receipt_operation: dict[str, Any]
+) -> None:
+    alias = operation["alias"]
+    scoped_error = any(
+        isinstance(error, dict)
+        and error.get("path")
+        and error.get("path", [None])[0] == alias
+        for error in errors
+    )
+    alias_data = data.get(alias)
+    if isinstance(alias_data, dict) and alias_data.get("clientMutationId") == operation["id"] and not scoped_error:
+        receipt_operation["status"] = "succeeded"
+        receipt_operation["detail"] = "durable_alias_result"
+        node = alias_data.get("commentEdge", {}).get("node")
+        if isinstance(node, dict):
+            receipt_operation["remote_id"] = node.get("id")
+            receipt_operation["url"] = node.get("url")
+        return
+    receipt_operation["status"] = "failed" if scoped_error else "unknown"
+    receipt_operation["detail"] = (
+        "graphql_alias_error" if scoped_error else "missing_alias_result_no_automatic_replay"
+    )
+
+
+def classify_mutation(
+    rc: int,
+    stdout: str,
+    timed_out: bool,
+    attempted: list[dict[str, Any]],
+    by_id: dict[str, dict[str, Any]],
+) -> None:
+    if timed_out:
+        set_attempted(attempted, by_id, "unknown", "mutation_timeout_no_automatic_replay")
+        return
+    if rc == 75:
+        set_attempted(attempted, by_id, "deferred", "mutation_admission_deferred_before_backend_call")
+        return
+    try:
+        result = json.loads(stdout)
+    except json.JSONDecodeError:
+        result = None
+    if not isinstance(result, dict):
+        set_attempted(attempted, by_id, "unknown", "mutation_result_not_json_no_automatic_replay")
+        return
+    data = result.get("data") if isinstance(result.get("data"), dict) else {}
+    errors = result.get("errors") if isinstance(result.get("errors"), list) else []
+    for operation in attempted:
+        classify_alias(operation, data, errors, by_id[operation["id"]])
+
+
+def batch_timeouts() -> tuple[int, int]:
+    read_timeout = max(1, int(os.environ.get("AIDEVOPS_GH_BATCH_READ_TIMEOUT", "15")))
+    default_write_timeout = max(
+        1,
+        int(os.environ.get("AIDEVOPS_GH_WRITE_TIMEOUT", "45")) - read_timeout - 5,
+    )
+    return read_timeout, max(
+        1,
+        int(os.environ.get("AIDEVOPS_GH_BATCH_WRITE_TIMEOUT", str(default_write_timeout))),
+    )
+
+
+def execute(args: argparse.Namespace) -> int:
+    prepared = load_json(Path(args.prepared), "prepared manifest")
+    if prepared.get("schema") != PREPARED_SCHEMA:
+        raise BatchError("prepared manifest schema is invalid")
+    receipt_path = Path(args.receipt)
+    receipt = base_receipt(prepared)
+    read_timeout, write_timeout = batch_timeouts()
+    preflight_rc, label_ids, already = run_preflight(prepared, receipt, receipt_path, read_timeout)
+    if preflight_rc != 0:
+        return preflight_rc
     by_id = {operation["id"]: operation for operation in receipt["operations"]}
     for operation_id in already:
         by_id[operation_id]["status"] = "already_succeeded"
         by_id[operation_id]["detail"] = "fresh_state_already_matches"
     query, variables, attempted = mutation(prepared, label_ids, already)
     if not attempted:
-        receipt["overall"] = "succeeded"
-        write_private_json(Path(args.receipt), receipt)
+        emit_receipt(receipt_path, receipt)
         print(json.dumps(receipt, sort_keys=True))
         return 0
     rc, stdout, stderr, timed_out = graphql_call(query, variables, write_timeout)
-    if timed_out:
-        for operation in attempted:
-            by_id[operation["id"]]["status"] = "unknown"
-            by_id[operation["id"]]["detail"] = "mutation_timeout_no_automatic_replay"
-    elif rc == 75:
-        for operation in attempted:
-            by_id[operation["id"]]["status"] = "deferred"
-            by_id[operation["id"]]["detail"] = "mutation_admission_deferred_before_backend_call"
-    else:
-        try:
-            result = json.loads(stdout)
-        except json.JSONDecodeError:
-            result = None
-        if not isinstance(result, dict):
-            for operation in attempted:
-                by_id[operation["id"]]["status"] = "unknown"
-                by_id[operation["id"]]["detail"] = "mutation_result_not_json_no_automatic_replay"
-        else:
-            data = result.get("data") if isinstance(result.get("data"), dict) else {}
-            errors = result.get("errors") if isinstance(result.get("errors"), list) else []
-            for operation in attempted:
-                alias = operation["alias"]
-                scoped_error = any(
-                    isinstance(error, dict)
-                    and error.get("path")
-                    and error.get("path", [None])[0] == alias
-                    for error in errors
-                )
-                alias_data = data.get(alias)
-                if isinstance(alias_data, dict) and alias_data.get("clientMutationId") == operation["id"] and not scoped_error:
-                    by_id[operation["id"]]["status"] = "succeeded"
-                    by_id[operation["id"]]["detail"] = "durable_alias_result"
-                    node = alias_data.get("commentEdge", {}).get("node")
-                    if isinstance(node, dict):
-                        by_id[operation["id"]]["remote_id"] = node.get("id")
-                        by_id[operation["id"]]["url"] = node.get("url")
-                elif scoped_error:
-                    by_id[operation["id"]]["status"] = "failed"
-                    by_id[operation["id"]]["detail"] = "graphql_alias_error"
-                else:
-                    by_id[operation["id"]]["status"] = "unknown"
-                    by_id[operation["id"]]["detail"] = "missing_alias_result_no_automatic_replay"
-    receipt["overall"] = receipt_status(receipt)
-    write_private_json(Path(args.receipt), receipt)
+    classify_mutation(rc, stdout, timed_out, attempted, by_id)
+    emit_receipt(receipt_path, receipt)
     print(json.dumps(receipt, sort_keys=True))
     if stderr.strip():
         print(stderr.strip(), file=sys.stderr)

--- a/.agents/scripts/gh-write-batch.py
+++ b/.agents/scripts/gh-write-batch.py
@@ -1,0 +1,656 @@
+#!/usr/bin/env python3
+"""Prepare and execute bounded, safety-preserving GitHub write batches."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "aidevops.github-write-batch/v1"
+PREPARED_SCHEMA = "aidevops.github-write-batch-prepared/v1"
+RECEIPT_SCHEMA = "aidevops.github-write-batch-receipt/v1"
+MAX_OPERATIONS = 10
+MAX_BODY_BYTES = 1_000_000
+KINDS = {
+    "issue_comment",
+    "pr_comment",
+    "issue_edit",
+    "pr_edit",
+    "issue_add_labels",
+    "issue_remove_labels",
+    "pr_add_labels",
+    "pr_remove_labels",
+}
+PROTECTED_LABELS = {
+    "needs-maintainer-review",
+    "ai-approved",
+    "external-contributor",
+    "parent-task",
+    "auto-dispatch",
+    "hold-for-review",
+    "no-auto-dispatch",
+    "lockdown",
+}
+PROTECTED_LABEL_PREFIXES = ("origin:", "status:", "solved:", "publication:")
+REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+
+
+class BatchError(Exception):
+    """A fail-closed validation or execution error."""
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def private_root(value: str) -> Path:
+    root = Path(value).expanduser().resolve(strict=True)
+    info = root.stat()
+    if not root.is_dir() or info.st_uid != os.geteuid() or stat.S_IMODE(info.st_mode) & 0o077:
+        raise BatchError("temporary root must be an owner-only directory")
+    return root
+
+
+def private_input(path_value: str, root: Path, label: str) -> Path:
+    if not isinstance(path_value, str) or not path_value or any(ord(ch) < 32 for ch in path_value):
+        raise BatchError(f"{label} path is invalid")
+    raw = Path(path_value).expanduser()
+    if not raw.is_absolute() or raw.is_symlink():
+        raise BatchError(f"{label} must be an absolute non-symlink file")
+    path = raw.resolve(strict=True)
+    if path.parent != root and root not in path.parents:
+        raise BatchError(f"{label} must be under AIDEVOPS_TEMP_DIR")
+    info = path.stat()
+    if not path.is_file() or info.st_uid != os.geteuid() or stat.S_IMODE(info.st_mode) & 0o077:
+        raise BatchError(f"{label} must be an owner-only regular file")
+    return path
+
+
+def write_private_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(path.parent, 0o700)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, sort_keys=True, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        os.chmod(path, 0o600)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise BatchError(f"{label} is not valid UTF-8 JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise BatchError(f"{label} root must be an object")
+    return value
+
+
+def exact_keys(value: dict[str, Any], allowed: set[str], label: str) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise BatchError(f"{label} contains unsupported fields: {', '.join(unknown)}")
+
+
+def substantive(text: str) -> bool:
+    return bool(unsigned_body(text))
+
+
+def unsigned_body(text: str) -> str:
+    return text.split("<!-- aidevops:sig -->", 1)[0].rstrip()
+
+
+def signature_footer(helper: Path) -> str:
+    try:
+        result = subprocess.run(
+            [str(helper), "footer"], text=True, capture_output=True, timeout=10, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise BatchError(f"signature helper failed: {exc}") from exc
+    if result.returncode != 0 or "<!-- aidevops:sig -->" not in result.stdout:
+        raise BatchError("signature helper did not return a canonical footer")
+    return result.stdout
+
+
+def copy_body(
+    source: Path,
+    root: Path,
+    kind: str,
+    operation_id: str,
+    marker_sha: str,
+    helper: Path,
+) -> tuple[str, str, str]:
+    body = source.read_text(encoding="utf-8")
+    source_digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    if len(body.encode("utf-8")) > MAX_BODY_BYTES or not substantive(body):
+        raise BatchError(f"operation {operation_id} body is empty or exceeds {MAX_BODY_BYTES} bytes")
+    needs_signature = kind in {"issue_comment", "pr_comment", "pr_edit"}
+    marker = f"<!-- aidevops:batch:{marker_sha}:{operation_id} -->"
+    if kind in {"issue_comment", "pr_comment"} and marker not in body.splitlines():
+        signature_at = body.find("<!-- aidevops:sig -->")
+        if signature_at >= 0:
+            body = f"{body[:signature_at].rstrip()}\n{marker}\n\n{body[signature_at:]}"
+        else:
+            body = f"{body.rstrip()}\n\n{marker}\n"
+    if needs_signature and "<!-- aidevops:sig -->" not in body.splitlines():
+        body = f"{body}{signature_footer(helper)}"
+    fd, copied = tempfile.mkstemp(prefix="gh-write-batch-body.", dir=root)
+    with os.fdopen(fd, "w", encoding="utf-8") as stream:
+        os.fchmod(stream.fileno(), 0o600)
+        stream.write(body)
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    return copied, digest, source_digest
+
+
+def validate_labels(value: Any, operation_id: str) -> list[str]:
+    if not isinstance(value, list) or not value or len(value) > 10:
+        raise BatchError(f"operation {operation_id} labels must contain 1-10 values")
+    labels: list[str] = []
+    for label in value:
+        if not isinstance(label, str) or not label or len(label) > 100 or label.strip() != label:
+            raise BatchError(f"operation {operation_id} has an invalid label")
+        if label in PROTECTED_LABELS or label.startswith(PROTECTED_LABEL_PREFIXES):
+            raise BatchError(f"operation {operation_id} cannot mutate protected label {label}")
+        if label in labels:
+            raise BatchError(f"operation {operation_id} repeats label {label}")
+        labels.append(label)
+    return labels
+
+
+def operation_intent_sha(operation: dict[str, Any]) -> str:
+    intent = {
+        key: operation[key]
+        for key in ("kind", "number", "source_sha256", "title", "labels")
+        if key in operation
+    }
+    encoded = json.dumps(intent, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def prepare(args: argparse.Namespace) -> int:
+    root = private_root(args.temp_root)
+    manifest_path = private_input(args.manifest, root, "manifest")
+    helper = Path(args.signature_helper).resolve(strict=True)
+    manifest_bytes = manifest_path.read_bytes()
+    manifest_sha = hashlib.sha256(manifest_bytes).hexdigest()
+    manifest = load_json(manifest_path, "manifest")
+    exact_keys(manifest, {"schema", "repository", "operations", "recovery_of"}, "manifest")
+    if manifest.get("schema") != SCHEMA:
+        raise BatchError(f"manifest schema must be {SCHEMA}")
+    repository = manifest.get("repository")
+    if not isinstance(repository, str) or not REPO_RE.fullmatch(repository):
+        raise BatchError("manifest repository must be an exact owner/name slug")
+    recovery_of = manifest.get("recovery_of")
+    recovery_operations: dict[str, dict[str, Any]] = {}
+    marker_sha = manifest_sha
+    if recovery_of is not None:
+        if not isinstance(recovery_of, dict):
+            raise BatchError("recovery_of must identify an owner-only receipt")
+        exact_keys(recovery_of, {"manifest_sha256", "receipt_file"}, "recovery_of")
+        recovery_sha = recovery_of.get("manifest_sha256")
+        if not isinstance(recovery_sha, str) or not re.fullmatch(r"[0-9a-f]{64}", recovery_sha):
+            raise BatchError("recovery_of manifest_sha256 is invalid")
+        receipt_path = private_input(recovery_of.get("receipt_file"), root, "recovery receipt")
+        recovery_receipt = load_json(receipt_path, "recovery receipt")
+        if (
+            recovery_receipt.get("schema") != RECEIPT_SCHEMA
+            or recovery_receipt.get("manifest_sha256") != recovery_sha
+            or recovery_receipt.get("repository") != repository
+        ):
+            raise BatchError("recovery receipt does not match this repository and manifest")
+        receipt_marker_sha = recovery_receipt.get("marker_sha256")
+        if not isinstance(receipt_marker_sha, str) or not re.fullmatch(r"[0-9a-f]{64}", receipt_marker_sha):
+            raise BatchError("recovery receipt marker lineage is invalid")
+        receipt_operations = recovery_receipt.get("operations")
+        if not isinstance(receipt_operations, list):
+            raise BatchError("recovery receipt operations are invalid")
+        recovery_operations = {
+            operation.get("id"): operation
+            for operation in receipt_operations
+            if isinstance(operation, dict) and isinstance(operation.get("id"), str)
+        }
+        marker_sha = receipt_marker_sha
+    raw_operations = manifest.get("operations")
+    if not isinstance(raw_operations, list) or not 1 <= len(raw_operations) <= MAX_OPERATIONS:
+        raise BatchError(f"manifest must contain 1-{MAX_OPERATIONS} operations")
+
+    operation_ids: set[str] = set()
+    field_owners: set[tuple[str, int, str]] = set()
+    operations: list[dict[str, Any]] = []
+    copied_files: list[str] = []
+    try:
+        for index, raw in enumerate(raw_operations):
+            if not isinstance(raw, dict):
+                raise BatchError(f"operation {index} must be an object")
+            exact_keys(raw, {"id", "kind", "number", "body_file", "title", "labels"}, f"operation {index}")
+            operation_id = raw.get("id")
+            kind = raw.get("kind")
+            number = raw.get("number")
+            if not isinstance(operation_id, str) or not ID_RE.fullmatch(operation_id):
+                raise BatchError(f"operation {index} id is invalid")
+            if operation_id in operation_ids:
+                raise BatchError(f"duplicate operation id {operation_id}")
+            operation_ids.add(operation_id)
+            if kind not in KINDS:
+                raise BatchError(f"operation {operation_id} kind is unsupported")
+            if isinstance(number, bool) or not isinstance(number, int) or number < 1:
+                raise BatchError(f"operation {operation_id} number must be a positive integer")
+            target_type = "PullRequest" if kind.startswith("pr_") else "Issue"
+            operation: dict[str, Any] = {
+                "id": operation_id,
+                "kind": kind,
+                "number": number,
+                "target_type": target_type,
+            }
+            if kind.endswith("_comment"):
+                if "body_file" not in raw or "title" in raw or "labels" in raw:
+                    raise BatchError(f"operation {operation_id} comment shape is invalid")
+                field = "comment"
+            elif kind.endswith("_edit"):
+                if "labels" in raw or ("body_file" not in raw and "title" not in raw):
+                    raise BatchError(f"operation {operation_id} edit shape is invalid")
+                title = raw.get("title")
+                if title is not None:
+                    if (
+                        not isinstance(title, str)
+                        or not title.strip()
+                        or len(title) > 256
+                        or re.fullmatch(r"(?:t[0-9]+|GH#[0-9]+):\s*", title.strip())
+                    ):
+                        raise BatchError(f"operation {operation_id} title is invalid")
+                    operation["title"] = title
+                field = "scalar"
+            else:
+                if "labels" not in raw or "body_file" in raw or "title" in raw:
+                    raise BatchError(f"operation {operation_id} label shape is invalid")
+                operation["labels"] = validate_labels(raw["labels"], operation_id)
+                field = "labels"
+            owner_key = (target_type, number, field)
+            if field != "comment" and owner_key in field_owners:
+                raise BatchError(f"dependent operations repeat {field} on {target_type} #{number}")
+            field_owners.add(owner_key)
+            if "body_file" in raw:
+                source = private_input(raw["body_file"], root, f"operation {operation_id} body")
+                copied, body_sha, source_sha = copy_body(
+                    source, root, kind, operation_id, marker_sha, helper
+                )
+                copied_files.append(copied)
+                operation["body_file"] = copied
+                operation["body_sha256"] = body_sha
+                operation["source_sha256"] = source_sha
+            if recovery_of is not None:
+                previous = recovery_operations.get(operation_id)
+                if not isinstance(previous, dict) or previous.get("status") != "unknown":
+                    raise BatchError(f"operation {operation_id} is not unknown in the recovery receipt")
+                if previous.get("kind") != kind or previous.get("number") != number:
+                    raise BatchError(f"operation {operation_id} does not match its recovery receipt identity")
+                if previous.get("intent_sha256") != operation_intent_sha(operation):
+                    raise BatchError(f"operation {operation_id} payload does not match its recovery receipt")
+            operations.append(operation)
+        unknown_ids = {
+            operation_id
+            for operation_id, operation in recovery_operations.items()
+            if operation.get("status") == "unknown"
+        }
+        if recovery_of is not None and operation_ids != unknown_ids:
+            raise BatchError("recovery manifest must contain exactly the receipt's unknown operations")
+        prepared = {
+            "schema": PREPARED_SCHEMA,
+            "manifest_sha256": manifest_sha,
+            "repository": repository,
+            "recovery_of": marker_sha if recovery_of is not None else None,
+            "prepared_at": now_iso(),
+            "operations": operations,
+        }
+        write_private_json(Path(args.output), prepared)
+    except Exception:
+        for copied in copied_files:
+            Path(copied).unlink(missing_ok=True)
+        raise
+    return 0
+
+
+def graphql_call(query: str, variables: dict[str, Any], timeout: int) -> tuple[int, str, str, bool]:
+    payload = json.dumps({"query": query, "variables": variables})
+    try:
+        result = subprocess.run(
+            ["gh", "api", "graphql", "--input", "-"],
+            input=payload,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        return result.returncode, result.stdout, result.stderr, False
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout.decode() if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = exc.stderr.decode() if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+        return 124, stdout, stderr, True
+
+
+def preflight_query(prepared: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    declarations = ["$owner:String!", "$name:String!"]
+    fields: list[str] = ["viewerPermission"]
+    variables: dict[str, Any] = {}
+    owner, name = prepared["repository"].split("/", 1)
+    variables.update(owner=owner, name=name)
+    labels = sorted({label for op in prepared["operations"] for label in op.get("labels", [])})
+    for index, operation in enumerate(prepared["operations"]):
+        declarations.append(f"$number{index}:Int!")
+        variables[f"number{index}"] = operation["number"]
+        comments = ""
+        if prepared.get("recovery_of") and operation["kind"].endswith("_comment"):
+            comments = " comments(last:100){nodes{body} pageInfo{hasPreviousPage}}"
+        fields.append(
+            f't{index}:issueOrPullRequest(number:$number{index}){{__typename ... on Issue{{id number title body labels(first:100){{nodes{{id name}} pageInfo{{hasNextPage}}}}{comments}}} ... on PullRequest{{id number title body labels(first:100){{nodes{{id name}} pageInfo{{hasNextPage}}}}{comments}}}}}}}'
+        )
+    for index, label in enumerate(labels):
+        declarations.append(f"$label{index}:String!")
+        variables[f"label{index}"] = label
+        fields.append(f'l{index}:label(name:$label{index}){{id name}}')
+    query = f"query({','.join(declarations)}){{repository(owner:$owner,name:$name){{{' '.join(fields)}}}}}"
+    return query, variables
+
+
+def validate_preflight(prepared: dict[str, Any], payload: dict[str, Any]) -> tuple[dict[str, str], set[str]]:
+    if payload.get("errors"):
+        raise BatchError("repository preflight returned GraphQL errors")
+    repository = payload.get("data", {}).get("repository")
+    if not isinstance(repository, dict):
+        raise BatchError("repository preflight returned no repository")
+    if repository.get("viewerPermission") not in {"ADMIN", "MAINTAIN", "WRITE"}:
+        raise BatchError("batch publication requires repository write authority")
+    label_ids: dict[str, str] = {}
+    label_names = sorted({label for op in prepared["operations"] for label in op.get("labels", [])})
+    for index, label in enumerate(label_names):
+        node = repository.get(f"l{index}")
+        if not isinstance(node, dict) or node.get("name") != label or not isinstance(node.get("id"), str):
+            raise BatchError(f"unknown repository label {label}")
+        label_ids[label] = node["id"]
+    already: set[str] = set()
+    for index, operation in enumerate(prepared["operations"]):
+        target = repository.get(f"t{index}")
+        if not isinstance(target, dict) or target.get("__typename") != operation["target_type"]:
+            raise BatchError(f"operation {operation['id']} target does not match {operation['target_type']}")
+        if not isinstance(target.get("id"), str) or target.get("number") != operation["number"]:
+            raise BatchError(f"operation {operation['id']} target identity is invalid")
+        operation["target_id"] = target["id"]
+        kind = operation["kind"]
+        if prepared.get("recovery_of") and kind.endswith("_comment"):
+            comments = target.get("comments")
+            if not isinstance(comments, dict):
+                raise BatchError(f"operation {operation['id']} recovery comments are unavailable")
+            marker = f"<!-- aidevops:batch:{prepared['recovery_of']}:{operation['id']} -->"
+            bodies = [node.get("body") for node in comments.get("nodes", []) if isinstance(node, dict)]
+            if any(isinstance(body, str) and marker in body.splitlines() for body in bodies):
+                already.add(operation["id"])
+            elif comments.get("pageInfo", {}).get("hasPreviousPage") is not False:
+                raise BatchError(f"operation {operation['id']} cannot prove the recovery marker absent")
+        elif kind.endswith("_edit"):
+            unchanged = True
+            if "title" in operation:
+                unchanged = unchanged and target.get("title") == operation["title"]
+            if "body_file" in operation:
+                body = checked_body(operation)
+                target_body = target.get("body")
+                if kind == "pr_edit" and isinstance(target_body, str):
+                    unchanged = unchanged and unsigned_body(target_body) == unsigned_body(body)
+                else:
+                    unchanged = unchanged and target_body == body
+            if unchanged:
+                already.add(operation["id"])
+        elif kind.endswith("add_labels") or kind.endswith("remove_labels"):
+            labels = target.get("labels")
+            if not isinstance(labels, dict) or labels.get("pageInfo", {}).get("hasNextPage") is not False:
+                raise BatchError(f"operation {operation['id']} cannot establish exact target labels")
+            current = {node.get("name") for node in labels.get("nodes", []) if isinstance(node, dict)}
+            requested = set(operation["labels"])
+            if (kind.endswith("add_labels") and requested <= current) or (
+                kind.endswith("remove_labels") and requested.isdisjoint(current)
+            ):
+                already.add(operation["id"])
+    return label_ids, already
+
+
+def checked_body(operation: dict[str, Any]) -> str:
+    path = Path(operation["body_file"])
+    body = path.read_text(encoding="utf-8")
+    if hashlib.sha256(body.encode("utf-8")).hexdigest() != operation["body_sha256"]:
+        raise BatchError(f"operation {operation['id']} prepared body changed before publication")
+    return body
+
+
+def mutation(prepared: dict[str, Any], label_ids: dict[str, str], already: set[str]) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
+    declarations: list[str] = []
+    fields: list[str] = []
+    variables: dict[str, Any] = {}
+    attempted: list[dict[str, Any]] = []
+    for index, operation in enumerate(prepared["operations"]):
+        if operation["id"] in already:
+            continue
+        alias = f"o{index}"
+        operation["alias"] = alias
+        attempted.append(operation)
+        declarations.extend((f"$target{index}:ID!", f"$client{index}:String!"))
+        variables[f"target{index}"] = operation["target_id"]
+        variables[f"client{index}"] = operation["id"]
+        kind = operation["kind"]
+        if kind.endswith("_comment"):
+            declarations.append(f"$body{index}:String!")
+            variables[f"body{index}"] = checked_body(operation)
+            fields.append(f'{alias}:addComment(input:{{subjectId:$target{index},body:$body{index},clientMutationId:$client{index}}}){{clientMutationId commentEdge{{node{{id url}}}}}}')
+        elif kind.endswith("_edit"):
+            mutation_name = "updatePullRequest" if kind == "pr_edit" else "updateIssue"
+            inputs = [f"id:$target{index}", f"clientMutationId:$client{index}"]
+            if "title" in operation:
+                declarations.append(f"$title{index}:String!")
+                variables[f"title{index}"] = operation["title"]
+                inputs.append(f"title:$title{index}")
+            if "body_file" in operation:
+                declarations.append(f"$body{index}:String!")
+                variables[f"body{index}"] = checked_body(operation)
+                inputs.append(f"body:$body{index}")
+            result_name = "pullRequest" if kind == "pr_edit" else "issue"
+            fields.append(f'{alias}:{mutation_name}(input:{{{",".join(inputs)}}}){{clientMutationId {result_name}{{id number}}}}')
+        else:
+            declarations.append(f"$labels{index}:[ID!]!")
+            variables[f"labels{index}"] = [label_ids[label] for label in operation["labels"]]
+            mutation_name = "addLabelsToLabelable" if kind.endswith("add_labels") else "removeLabelsFromLabelable"
+            fields.append(f'{alias}:{mutation_name}(input:{{labelableId:$target{index},labelIds:$labels{index},clientMutationId:$client{index}}}){{clientMutationId}}')
+    if not attempted:
+        return "", {}, []
+    return f"mutation({','.join(declarations)}){{{' '.join(fields)}}}", variables, attempted
+
+
+def base_receipt(prepared: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema": RECEIPT_SCHEMA,
+        "manifest_sha256": prepared["manifest_sha256"],
+        "marker_sha256": prepared.get("recovery_of") or prepared["manifest_sha256"],
+        "repository": prepared["repository"],
+        "created_at": now_iso(),
+        "overall": "unknown",
+        "operations": [
+            {
+                "id": op["id"],
+                "kind": op["kind"],
+                "number": op["number"],
+                "intent_sha256": operation_intent_sha(op),
+                "status": "unknown",
+            }
+            for op in prepared["operations"]
+        ],
+    }
+
+
+def set_all(receipt: dict[str, Any], status: str, detail: str) -> None:
+    for operation in receipt["operations"]:
+        operation["status"] = status
+        operation["detail"] = detail
+
+
+def receipt_status(receipt: dict[str, Any]) -> str:
+    statuses = {operation["status"] for operation in receipt["operations"]}
+    if statuses <= {"succeeded", "already_succeeded"}:
+        return "succeeded"
+    if "unknown" in statuses:
+        return "unknown"
+    if "failed" in statuses or "rejected" in statuses:
+        return "failed"
+    return "deferred"
+
+
+def execute(args: argparse.Namespace) -> int:
+    prepared_path = Path(args.prepared)
+    prepared = load_json(prepared_path, "prepared manifest")
+    if prepared.get("schema") != PREPARED_SCHEMA:
+        raise BatchError("prepared manifest schema is invalid")
+    receipt = base_receipt(prepared)
+    read_timeout = max(1, int(os.environ.get("AIDEVOPS_GH_BATCH_READ_TIMEOUT", "15")))
+    default_write_timeout = max(
+        1,
+        int(os.environ.get("AIDEVOPS_GH_WRITE_TIMEOUT", "45")) - read_timeout - 5,
+    )
+    write_timeout = max(
+        1,
+        int(os.environ.get("AIDEVOPS_GH_BATCH_WRITE_TIMEOUT", str(default_write_timeout))),
+    )
+    query, variables = preflight_query(prepared)
+    rc, stdout, stderr, timed_out = graphql_call(query, variables, read_timeout)
+    if rc != 0 or timed_out:
+        status = "deferred" if rc == 75 else "rejected"
+        set_all(receipt, status, "preflight_deferred" if rc == 75 else "preflight_failed")
+        receipt["overall"] = receipt_status(receipt)
+        write_private_json(Path(args.receipt), receipt)
+        print(stderr.strip(), file=sys.stderr)
+        return rc or 1
+    try:
+        preflight = json.loads(stdout)
+        label_ids, already = validate_preflight(prepared, preflight)
+    except (json.JSONDecodeError, BatchError) as exc:
+        set_all(receipt, "rejected", str(exc))
+        receipt["overall"] = "failed"
+        write_private_json(Path(args.receipt), receipt)
+        print(str(exc), file=sys.stderr)
+        return 1
+    by_id = {operation["id"]: operation for operation in receipt["operations"]}
+    for operation_id in already:
+        by_id[operation_id]["status"] = "already_succeeded"
+        by_id[operation_id]["detail"] = "fresh_state_already_matches"
+    query, variables, attempted = mutation(prepared, label_ids, already)
+    if not attempted:
+        receipt["overall"] = "succeeded"
+        write_private_json(Path(args.receipt), receipt)
+        print(json.dumps(receipt, sort_keys=True))
+        return 0
+    rc, stdout, stderr, timed_out = graphql_call(query, variables, write_timeout)
+    if timed_out:
+        for operation in attempted:
+            by_id[operation["id"]]["status"] = "unknown"
+            by_id[operation["id"]]["detail"] = "mutation_timeout_no_automatic_replay"
+    elif rc == 75:
+        for operation in attempted:
+            by_id[operation["id"]]["status"] = "deferred"
+            by_id[operation["id"]]["detail"] = "mutation_admission_deferred_before_backend_call"
+    else:
+        try:
+            result = json.loads(stdout)
+        except json.JSONDecodeError:
+            result = None
+        if not isinstance(result, dict):
+            for operation in attempted:
+                by_id[operation["id"]]["status"] = "unknown"
+                by_id[operation["id"]]["detail"] = "mutation_result_not_json_no_automatic_replay"
+        else:
+            data = result.get("data") if isinstance(result.get("data"), dict) else {}
+            errors = result.get("errors") if isinstance(result.get("errors"), list) else []
+            for operation in attempted:
+                alias = operation["alias"]
+                scoped_error = any(
+                    isinstance(error, dict)
+                    and error.get("path")
+                    and error.get("path", [None])[0] == alias
+                    for error in errors
+                )
+                alias_data = data.get(alias)
+                if isinstance(alias_data, dict) and alias_data.get("clientMutationId") == operation["id"] and not scoped_error:
+                    by_id[operation["id"]]["status"] = "succeeded"
+                    by_id[operation["id"]]["detail"] = "durable_alias_result"
+                    node = alias_data.get("commentEdge", {}).get("node")
+                    if isinstance(node, dict):
+                        by_id[operation["id"]]["remote_id"] = node.get("id")
+                        by_id[operation["id"]]["url"] = node.get("url")
+                elif scoped_error:
+                    by_id[operation["id"]]["status"] = "failed"
+                    by_id[operation["id"]]["detail"] = "graphql_alias_error"
+                else:
+                    by_id[operation["id"]]["status"] = "unknown"
+                    by_id[operation["id"]]["detail"] = "missing_alias_result_no_automatic_replay"
+    receipt["overall"] = receipt_status(receipt)
+    write_private_json(Path(args.receipt), receipt)
+    print(json.dumps(receipt, sort_keys=True))
+    if stderr.strip():
+        print(stderr.strip(), file=sys.stderr)
+    return 0 if receipt["overall"] == "succeeded" else 1
+
+
+def reject(args: argparse.Namespace) -> int:
+    prepared = load_json(Path(args.prepared), "prepared manifest")
+    receipt = base_receipt(prepared)
+    set_all(receipt, "rejected", args.reason)
+    receipt["overall"] = "failed"
+    write_private_json(Path(args.receipt), receipt)
+    return 1
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    subparsers = result.add_subparsers(dest="command", required=True)
+    prepare_parser = subparsers.add_parser("prepare")
+    prepare_parser.add_argument("--manifest", required=True)
+    prepare_parser.add_argument("--temp-root", required=True)
+    prepare_parser.add_argument("--signature-helper", required=True)
+    prepare_parser.add_argument("--output", required=True)
+    prepare_parser.set_defaults(function=prepare)
+    execute_parser = subparsers.add_parser("execute")
+    execute_parser.add_argument("--prepared", required=True)
+    execute_parser.add_argument("--receipt", required=True)
+    execute_parser.set_defaults(function=execute)
+    reject_parser = subparsers.add_parser("reject")
+    reject_parser.add_argument("--prepared", required=True)
+    reject_parser.add_argument("--receipt", required=True)
+    reject_parser.add_argument("--reason", required=True)
+    reject_parser.set_defaults(function=reject)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        return args.function(args)
+    except (BatchError, OSError, UnicodeError, ValueError) as exc:
+        print(f"gh-write-batch: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/gh-write-helper.sh
+++ b/.agents/scripts/gh-write-helper.sh
@@ -14,6 +14,7 @@ usage() {
 	printf 'Usage: gh-write-helper.sh {issue|pr} create [gh create options]\n'
 	printf '       gh-write-helper.sh {issue|pr} edit <number-or-url> [gh edit options]\n'
 	printf '       gh-write-helper.sh {issue|pr} comment <number-or-url> [gh comment options]\n'
+	printf '       gh-write-helper.sh batch MANIFEST.json\n'
 	printf 'Bodies may use --body-file - to read stdin once through the safe wrapper.\n'
 	return 0
 }
@@ -24,6 +25,11 @@ main() {
 	if [[ "$resource" == "help" || "$resource" == "--help" || "$resource" == "-h" ]]; then
 		usage
 		return 0
+	fi
+	if [[ "$resource" == "batch" ]]; then
+		shift
+		gh_write_batch "$@"
+		return $?
 	fi
 	if [[ "$action" != "create" && "$action" != "edit" && "$action" != "comment" ]]; then
 		usage >&2

--- a/.agents/scripts/gh_write_batch_graphql.py
+++ b/.agents/scripts/gh_write_batch_graphql.py
@@ -1,0 +1,105 @@
+"""Pure GraphQL compilation for managed GitHub write batches."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, NamedTuple
+
+BodyLoader = Callable[[dict[str, Any]], str]
+
+
+class MutationBuild(NamedTuple):
+    """Mutable containers shared while compiling one GraphQL mutation."""
+
+    label_ids: dict[str, str]
+    declarations: list[str]
+    variables: dict[str, Any]
+    body_loader: BodyLoader
+
+
+def preflight_query(prepared: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    declarations = ["$owner:String!", "$name:String!"]
+    fields: list[str] = ["viewerPermission"]
+    owner, name = prepared["repository"].split("/", 1)
+    variables: dict[str, Any] = {"owner": owner, "name": name}
+    labels = sorted({label for op in prepared["operations"] for label in op.get("labels", [])})
+    for index, operation in enumerate(prepared["operations"]):
+        declarations.append(f"$number{index}:Int!")
+        variables[f"number{index}"] = operation["number"]
+        comments = ""
+        if prepared.get("recovery_of") and operation["kind"].endswith("_comment"):
+            comments = " comments(last:100){nodes{body} pageInfo{hasPreviousPage}}"
+        fields.append(
+            f't{index}:issueOrPullRequest(number:$number{index}){{__typename ... on Issue{{id number title body labels(first:100){{nodes{{id name}} pageInfo{{hasNextPage}}}}{comments}}} ... on PullRequest{{id number title body labels(first:100){{nodes{{id name}} pageInfo{{hasNextPage}}}}{comments}}}}}}}'
+        )
+    for index, label in enumerate(labels):
+        declarations.append(f"$label{index}:String!")
+        variables[f"label{index}"] = label
+        fields.append(f'l{index}:label(name:$label{index}){{id name}}')
+    query = f"query({','.join(declarations)}){{repository(owner:$owner,name:$name){{{' '.join(fields)}}}}}"
+    return query, variables
+
+
+def comment_mutation(index: int, alias: str, operation: dict[str, Any], build: MutationBuild) -> str:
+    build.declarations.append(f"$body{index}:String!")
+    build.variables[f"body{index}"] = build.body_loader(operation)
+    return f'{alias}:addComment(input:{{subjectId:$target{index},body:$body{index},clientMutationId:$client{index}}}){{clientMutationId commentEdge{{node{{id url}}}}}}'
+
+
+def edit_mutation(index: int, alias: str, operation: dict[str, Any], build: MutationBuild) -> str:
+    mutation_name = "updatePullRequest" if operation["kind"] == "pr_edit" else "updateIssue"
+    inputs = [f"id:$target{index}", f"clientMutationId:$client{index}"]
+    for field in ("title", "body"):
+        operation_key = "body_file" if field == "body" else field
+        if operation_key not in operation:
+            continue
+        build.declarations.append(f"${field}{index}:String!")
+        build.variables[f"{field}{index}"] = (
+            build.body_loader(operation) if field == "body" else operation[operation_key]
+        )
+        inputs.append(f"{field}:${field}{index}")
+    result_name = "pullRequest" if operation["kind"] == "pr_edit" else "issue"
+    return f'{alias}:{mutation_name}(input:{{{",".join(inputs)}}}){{clientMutationId {result_name}{{id number}}}}'
+
+
+def label_mutation(index: int, alias: str, operation: dict[str, Any], build: MutationBuild) -> str:
+    build.declarations.append(f"$labels{index}:[ID!]!")
+    build.variables[f"labels{index}"] = [build.label_ids[label] for label in operation["labels"]]
+    mutation_name = (
+        "addLabelsToLabelable" if operation["kind"].endswith("add_labels") else "removeLabelsFromLabelable"
+    )
+    return f'{alias}:{mutation_name}(input:{{labelableId:$target{index},labelIds:$labels{index},clientMutationId:$client{index}}}){{clientMutationId}}'
+
+
+def mutation_field(index: int, alias: str, operation: dict[str, Any], build: MutationBuild) -> str:
+    kind = operation["kind"]
+    if kind.endswith("_comment"):
+        return comment_mutation(index, alias, operation, build)
+    if kind.endswith("_edit"):
+        return edit_mutation(index, alias, operation, build)
+    return label_mutation(index, alias, operation, build)
+
+
+def mutation(
+    prepared: dict[str, Any],
+    label_ids: dict[str, str],
+    already: set[str],
+    body_loader: BodyLoader,
+) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
+    declarations: list[str] = []
+    fields: list[str] = []
+    variables: dict[str, Any] = {}
+    build = MutationBuild(label_ids, declarations, variables, body_loader)
+    attempted: list[dict[str, Any]] = []
+    for index, operation in enumerate(prepared["operations"]):
+        if operation["id"] in already:
+            continue
+        alias = f"o{index}"
+        operation["alias"] = alias
+        attempted.append(operation)
+        declarations.extend((f"$target{index}:ID!", f"$client{index}:String!"))
+        variables[f"target{index}"] = operation["target_id"]
+        variables[f"client{index}"] = operation["id"]
+        fields.append(mutation_field(index, alias, operation, build))
+    if not attempted:
+        return "", {}, []
+    return f"mutation({','.join(declarations)}){{{' '.join(fields)}}}", variables, attempted

--- a/.agents/scripts/gh_write_batch_graphql.py
+++ b/.agents/scripts/gh_write_batch_graphql.py
@@ -28,8 +28,13 @@ def preflight_query(prepared: dict[str, Any]) -> tuple[str, dict[str, Any]]:
         comments = ""
         if prepared.get("recovery_of") and operation["kind"].endswith("_comment"):
             comments = " comments(last:100){nodes{body} pageInfo{hasPreviousPage}}"
+        target_fields = (
+            "id number title body "
+            f"labels(first:100){{nodes{{id name}} pageInfo{{hasNextPage}}}}{comments}"
+        )
         fields.append(
-            f't{index}:issueOrPullRequest(number:$number{index}){{__typename ... on Issue{{id number title body labels(first:100){{nodes{{id name}} pageInfo{{hasNextPage}}}}{comments}}} ... on PullRequest{{id number title body labels(first:100){{nodes{{id name}} pageInfo{{hasNextPage}}}}{comments}}}}}}}'
+            f"t{index}:issueOrPullRequest(number:$number{index}){{__typename "
+            f"... on Issue{{{target_fields}}} ... on PullRequest{{{target_fields}}}}}"
         )
     for index, label in enumerate(labels):
         declarations.append(f"$label{index}:String!")
@@ -46,8 +51,10 @@ def comment_mutation(index: int, alias: str, operation: dict[str, Any], build: M
 
 
 def edit_mutation(index: int, alias: str, operation: dict[str, Any], build: MutationBuild) -> str:
-    mutation_name = "updatePullRequest" if operation["kind"] == "pr_edit" else "updateIssue"
-    inputs = [f"id:$target{index}", f"clientMutationId:$client{index}"]
+    pull_request = operation["kind"] == "pr_edit"
+    mutation_name = "updatePullRequest" if pull_request else "updateIssue"
+    id_field = "pullRequestId" if pull_request else "id"
+    inputs = [f"{id_field}:$target{index}", f"clientMutationId:$client{index}"]
     for field in ("title", "body"):
         operation_key = "body_file" if field == "body" else field
         if operation_key not in operation:
@@ -57,7 +64,7 @@ def edit_mutation(index: int, alias: str, operation: dict[str, Any], build: Muta
             build.body_loader(operation) if field == "body" else operation[operation_key]
         )
         inputs.append(f"{field}:${field}{index}")
-    result_name = "pullRequest" if operation["kind"] == "pr_edit" else "issue"
+    result_name = "pullRequest" if pull_request else "issue"
     return f'{alias}:{mutation_name}(input:{{{",".join(inputs)}}}){{clientMutationId {result_name}{{id number}}}}'
 
 

--- a/.agents/scripts/shared-gh-wrappers-batch.sh
+++ b/.agents/scripts/shared-gh-wrappers-batch.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+[[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]] && set -euo pipefail
+[[ -n "${_SHARED_GH_WRAPPERS_BATCH_LOADED:-}" ]] && return 0
+_SHARED_GH_WRAPPERS_BATCH_LOADED=1
+
+_gh_write_batch_private_temp() {
+	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	[[ -d "$temp_root" ]] || {
+		printf '[aidevops][gh-batch][BLOCK] AIDEVOPS_TEMP_DIR is unavailable\n' >&2
+		return 1
+	}
+	local previous_umask path
+	previous_umask=$(umask)
+	umask 077
+	path=$(mktemp "${temp_root%/}/gh-write-batch.${1}.XXXXXX") || {
+		umask "$previous_umask"
+		return 1
+	}
+	umask "$previous_umask"
+	printf '%s\n' "$path"
+	return 0
+}
+
+_gh_write_batch_execute() {
+	local prepared="$1" receipt="$2"
+	python3 "${_SHARED_GH_WRAPPERS_DIR}/gh-write-batch.py" execute \
+		--prepared "$prepared" --receipt "$receipt"
+	return $?
+}
+
+gh_write_batch() {
+	_gh_wrapper_enter_cleanup_scope
+	local manifest="${1:-}"
+	[[ -n "$manifest" && $# -eq 1 ]] || {
+		printf 'Usage: gh-write-helper.sh batch MANIFEST.json\n' >&2
+		return 2
+	}
+	command -v python3 >/dev/null 2>&1 && command -v jq >/dev/null 2>&1 || {
+		printf '[aidevops][gh-batch][BLOCK] python3 and jq are required\n' >&2
+		return 2
+	}
+	# This local, no-network gate must precede privacy probes and every other
+	# possible GitHub call. The PATH shim rechecks immediately before each call.
+	_gh_secondary_cooldown_preflight write || return $?
+
+	local prepared receipt cleanup_cmd temp_root
+	temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	prepared=$(_gh_write_batch_private_temp prepared) || return 1
+	receipt=$(_gh_write_batch_private_temp receipt) || {
+		rm -f -- "$prepared"
+		return 1
+	}
+	printf -v cleanup_cmd 'rm -f -- %q' "$prepared"
+	push_cleanup "$cleanup_cmd"
+	if ! python3 "${_SHARED_GH_WRAPPERS_DIR}/gh-write-batch.py" prepare \
+		--manifest "$manifest" --temp-root "$temp_root" \
+		--signature-helper "${_SHARED_GH_WRAPPERS_DIR}/gh-signature-helper.sh" \
+		--output "$prepared"; then
+		rm -f -- "$receipt"
+		return 1
+	fi
+
+	local repo body_file body_sha actual_sha title
+	local -a privacy_args
+	repo=$(jq -r '.repository' "$prepared") || return 1
+	privacy_args=(--repo "$repo")
+	while IFS=$'\t' read -r body_file body_sha; do
+		[[ -n "$body_file" ]] || continue
+		printf -v cleanup_cmd 'rm -f -- %q' "$body_file"
+		push_cleanup "$cleanup_cmd"
+		actual_sha=$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$body_file") || return 1
+		if [[ "$actual_sha" != "$body_sha" ]]; then
+			python3 "${_SHARED_GH_WRAPPERS_DIR}/gh-write-batch.py" reject \
+				--prepared "$prepared" --receipt "$receipt" --reason body_integrity_failed >/dev/null 2>&1 || true
+			printf '[aidevops][gh-batch][BLOCK] body integrity validation failed; receipt=%s\n' "$receipt" >&2
+			return 1
+		fi
+		privacy_args+=(--body-file "$body_file")
+	done < <(jq -r '.operations[] | select(.body_file != null) | [.body_file,.body_sha256] | @tsv' "$prepared")
+	while IFS= read -r title; do
+		[[ -n "$title" ]] && privacy_args+=(--title "$title")
+	done < <(jq -r '.operations[] | select(.title != null) | .title' "$prepared")
+	if ! _gh_guard_public_write_args "${privacy_args[@]}"; then
+		python3 "${_SHARED_GH_WRAPPERS_DIR}/gh-write-batch.py" reject \
+			--prepared "$prepared" --receipt "$receipt" --reason privacy_validation_failed >/dev/null 2>&1 || true
+		printf '[aidevops][gh-batch][BLOCK] privacy validation failed; receipt=%s\n' "$receipt" >&2
+		return 1
+	fi
+
+	gh_record_call graphql gh_write_batch 2>/dev/null || true
+	local rc=0
+	_gh_with_timeout write _gh_write_batch_execute "$prepared" "$receipt" || rc=$?
+	printf '[aidevops][gh-batch] receipt=%s\n' "$receipt" >&2
+	return "$rc"
+}

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -14,6 +14,7 @@
 #   - shared-gh-wrappers-session.sh       — session origin, token, internal helpers
 #   - shared-gh-wrappers-create.sh        — issue/PR creation, comments, parent linking
 #   - shared-gh-wrappers-safe-edit.sh     — safe edit/close/merge with audit logging
+#   - shared-gh-wrappers-batch.sh         — bounded manifest-based GitHub writes
 #   - shared-gh-wrappers-status.sh        — status labels, read wrappers with REST fallback
 #   - shared-gh-wrappers-checks.sh        — PR check status via REST check-suites/check-runs (GH#21799)
 #   - shared-gh-wrappers-rest-fallback.sh — REST fallback translators (pre-existing)
@@ -890,6 +891,10 @@ if [[ -n "$_SHARED_GH_WRAPPERS_DIR" ]]; then
 	# shellcheck source=shared-gh-wrappers-create.sh
 	# shellcheck disable=SC1091  # sub-library resolved at runtime via $_SHARED_GH_WRAPPERS_DIR
 	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-create.sh"
+	if [[ -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-batch.sh" ]]; then
+		# shellcheck source=shared-gh-wrappers-batch.sh
+		source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-batch.sh"
+	fi
 
 	# shellcheck source=shared-gh-wrappers-safe-edit.sh
 	# shellcheck disable=SC1091  # sub-library resolved at runtime via $_SHARED_GH_WRAPPERS_DIR

--- a/.agents/scripts/tests/test-gh-write-batch-wrapper.sh
+++ b/.agents/scripts/tests/test-gh-write-batch-wrapper.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)"
+TEST_TMP="$(mktemp -d -t gh-write-batch-wrapper.XXXXXX)"
+trap 'rm -rf "$TEST_TMP"' EXIT
+export AIDEVOPS_TEMP_DIR="${TEST_TMP}/private"
+mkdir -m 700 "$AIDEVOPS_TEMP_DIR"
+
+# shellcheck source=../shared-gh-wrappers.sh
+source "${SCRIPTS_DIR}/shared-gh-wrappers.sh"
+
+GUARD_CALLS=0
+EXECUTE_CALLS=0
+_gh_guard_public_write_args() {
+	GUARD_CALLS=$((GUARD_CALLS + 1))
+	return 0
+}
+_gh_with_timeout() {
+	EXECUTE_CALLS=$((EXECUTE_CALLS + 1))
+	return 0
+}
+_gh_secondary_cooldown_preflight() { return 75; }
+
+set +e
+gh_write_batch "${AIDEVOPS_TEMP_DIR}/does-not-need-to-exist.json" >/dev/null 2>&1
+cooldown_rc=$?
+set -e
+if [[ "$cooldown_rc" -ne 75 || "$GUARD_CALLS" -ne 0 || "$EXECUTE_CALLS" -ne 0 ]]; then
+	printf 'FAIL: active cooldown must make zero privacy/backend calls\n' >&2
+	exit 1
+fi
+
+printf 'PASS: active cooldown makes zero backend calls\n'
+
+BODY_FILE="${AIDEVOPS_TEMP_DIR}/body.md"
+MANIFEST_FILE="${AIDEVOPS_TEMP_DIR}/manifest.json"
+printf 'Public comment body\n' >"$BODY_FILE"
+printf '%s\n' "{\"schema\":\"aidevops.github-write-batch/v1\",\"repository\":\"test/repo\",\"operations\":[{\"id\":\"comment\",\"kind\":\"issue_comment\",\"number\":1,\"body_file\":\"${BODY_FILE}\"}]}" >"$MANIFEST_FILE"
+chmod 600 "$BODY_FILE" "$MANIFEST_FILE"
+_gh_secondary_cooldown_preflight() { return 0; }
+_gh_guard_public_write_args() {
+	GUARD_CALLS=$((GUARD_CALLS + 1))
+	return 1
+}
+set +e
+gh_write_batch "$MANIFEST_FILE" >/dev/null 2>&1
+privacy_rc=$?
+set -e
+if [[ "$privacy_rc" -eq 0 || "$GUARD_CALLS" -ne 1 || "$EXECUTE_CALLS" -ne 0 ]]; then
+	printf 'FAIL: privacy rejection must stop before the GraphQL backend\n' >&2
+	exit 1
+fi
+
+printf 'PASS: privacy rejection stops before the GraphQL backend\n'
+
+STUB_BIN="${TEST_TMP}/bin"
+GH_CALLS="${TEST_TMP}/gh-calls"
+BATCH_OUTPUT="${TEST_TMP}/batch-output.json"
+mkdir "$STUB_BIN"
+export GH_CALLS
+cat >"${STUB_BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+calls=0
+[[ ! -f "$GH_CALLS" ]] || calls=$(<"$GH_CALLS")
+calls=$((calls + 1))
+printf '%s\n' "$calls" >"$GH_CALLS"
+if [[ "$calls" -eq 1 ]]; then
+	printf '%s\n' '{"data":{"repository":{"viewerPermission":"WRITE","t0":{"__typename":"Issue","id":"I1","number":1,"title":"Old","body":"Old","labels":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}'
+else
+	printf '%s\n' '{"data":{"o0":{"clientMutationId":"comment","commentEdge":{"node":{"id":"C1"}}}}}'
+fi
+STUB
+chmod +x "${STUB_BIN}/gh"
+_gh_guard_public_write_args() { return 0; }
+_gh_with_timeout() {
+	shift
+	"$@"
+}
+PATH="${STUB_BIN}:$PATH" gh_write_batch "$MANIFEST_FILE" >"$BATCH_OUTPUT" 2>/dev/null
+if [[ "$(<"$GH_CALLS")" -ne 2 ]] || ! grep -q '"overall": "succeeded"' "$BATCH_OUTPUT"; then
+	printf 'FAIL: admitted batch must use one preflight and one successful mutation\n' >&2
+	exit 1
+fi
+
+printf 'PASS: admitted batch uses one preflight and one mutation\n'

--- a/.agents/scripts/tests/test-gh-write-batch.py
+++ b/.agents/scripts/tests/test-gh-write-batch.py
@@ -7,6 +7,7 @@ import argparse
 import importlib.util
 import json
 import os
+import sys
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -15,6 +16,7 @@ from pathlib import Path
 from unittest import mock
 
 SCRIPT = Path(__file__).resolve().parents[1] / "gh-write-batch.py"
+sys.path.insert(0, str(SCRIPT.parent))
 SPEC = importlib.util.spec_from_file_location("gh_write_batch", SCRIPT)
 if SPEC is None or SPEC.loader is None:
     raise RuntimeError("unable to load gh-write-batch.py")

--- a/.agents/scripts/tests/test-gh-write-batch.py
+++ b/.agents/scripts/tests/test-gh-write-batch.py
@@ -16,7 +16,8 @@ from unittest import mock
 
 SCRIPT = Path(__file__).resolve().parents[1] / "gh-write-batch.py"
 SPEC = importlib.util.spec_from_file_location("gh_write_batch", SCRIPT)
-assert SPEC and SPEC.loader
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("unable to load gh-write-batch.py")
 BATCH = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(BATCH)
 
@@ -25,12 +26,12 @@ class BatchTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory(prefix="gh-write-batch-test.")
         self.root = Path(self.temporary.name)
-        os.chmod(self.root, 0o700)
+        os.chmod(self.root, 0o700)  # nosec B103 - owner-only writable fixture directory
         self.signature = self.private_file(
             "signature-helper.sh",
             "#!/usr/bin/env bash\nprintf '%s\\n' '<!-- aidevops:sig -->' 'canonical footer'\n",
         )
-        os.chmod(self.signature, 0o700)
+        os.chmod(self.signature, 0o500)
 
     def tearDown(self) -> None:
         self.temporary.cleanup()
@@ -95,6 +96,16 @@ class BatchTests(unittest.TestCase):
             result = BATCH.execute(args)
         return result, json.loads(receipt_path.read_text(encoding="utf-8"))
 
+    def two_comment_batch(self) -> tuple[dict, dict]:
+        body = self.private_file("body.md", "Comment\n")
+        prepared = self.prepare(
+            [
+                {"id": "one", "kind": "issue_comment", "number": 1, "body_file": str(body)},
+                {"id": "two", "kind": "pr_comment", "number": 2, "body_file": str(body)},
+            ]
+        )
+        return prepared, self.preflight(prepared)
+
     def test_prepare_signs_comments_and_rejects_unsafe_shapes(self) -> None:
         body = self.private_file("body.md", "Substantive comment\n")
         prepared = self.prepare(
@@ -141,15 +152,8 @@ class BatchTests(unittest.TestCase):
         self.assertEqual(receipt["overall"], "succeeded")
         self.assertEqual({op["status"] for op in receipt["operations"]}, {"succeeded"})
 
-    def test_partial_error_timeout_and_authority_fail_closed(self) -> None:
-        body = self.private_file("body.md", "Comment\n")
-        prepared = self.prepare(
-            [
-                {"id": "one", "kind": "issue_comment", "number": 1, "body_file": str(body)},
-                {"id": "two", "kind": "pr_comment", "number": 2, "body_file": str(body)},
-            ]
-        )
-        preflight = self.preflight(prepared)
+    def test_partial_and_graphql_errors_fail_closed(self) -> None:
+        prepared, preflight = self.two_comment_batch()
         partial = {
             "data": {
                 "o0": {
@@ -179,6 +183,8 @@ class BatchTests(unittest.TestCase):
         )
         self.assertEqual({op["status"] for op in receipt["operations"]}, {"unknown"})
 
+    def test_timeout_deferred_and_preflight_rejections(self) -> None:
+        prepared, preflight = self.two_comment_batch()
         _, receipt = self.execute(
             prepared,
             [(0, json.dumps(preflight), "", False), (124, "", "timeout", True)],
@@ -210,7 +216,7 @@ class BatchTests(unittest.TestCase):
         self.assertEqual(result, 1)
         self.assertEqual(receipt["operations"][0]["status"], "rejected")
 
-    def test_recovery_uses_original_marker_and_prevents_duplicate_comment(self) -> None:
+    def test_comment_recovery_uses_marker_and_exact_payload(self) -> None:
         body = self.private_file("recovery-body.md", "Recover me\n")
         original = self.prepare(
             [{"id": "recover", "kind": "issue_comment", "number": 9, "body_file": str(body)}]
@@ -238,6 +244,7 @@ class BatchTests(unittest.TestCase):
                 {"manifest_sha256": original["manifest_sha256"], "receipt_file": str(receipt_path)},
             )
 
+    def test_pr_edit_recovery_ignores_dynamic_signature_footer(self) -> None:
         pr_body = self.private_file("pr-body.md", "Stable PR content\n")
         original_edit = self.prepare(
             [{"id": "edit", "kind": "pr_edit", "number": 10, "body_file": str(pr_body)}]
@@ -248,10 +255,12 @@ class BatchTests(unittest.TestCase):
         original_published_body = Path(original_edit["operations"][0]["body_file"]).read_text(
             encoding="utf-8"
         )
-        self.signature.write_text(
+        self.signature.unlink()
+        self.signature = self.private_file(
+            "signature-helper.sh",
             "#!/usr/bin/env bash\nprintf '%s\\n' '<!-- aidevops:sig -->' 'new canonical footer'\n",
-            encoding="utf-8",
         )
+        os.chmod(self.signature, 0o500)
         recovered_edit = self.prepare(
             [{"id": "edit", "kind": "pr_edit", "number": 10, "body_file": str(pr_body)}],
             {

--- a/.agents/scripts/tests/test-gh-write-batch.py
+++ b/.agents/scripts/tests/test-gh-write-batch.py
@@ -142,7 +142,8 @@ class BatchTests(unittest.TestCase):
             ]
         )
         preflight = self.preflight(prepared)
-        _, preflight_variables = BATCH.preflight_query(prepared)
+        preflight_query, preflight_variables = BATCH.preflight_query(prepared)
+        self.assertEqual(preflight_query.count("{"), preflight_query.count("}"))
         self.assertEqual(preflight_variables["label0"], "alpha")
         self.assertEqual(preflight_variables["label1"], "zeta")
         mutation = {"data": {"o0": {"clientMutationId": "labels"}, "o1": {"clientMutationId": "edit", "issue": {"id": "T1", "number": 4}}}}
@@ -153,6 +154,12 @@ class BatchTests(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertEqual(receipt["overall"], "succeeded")
         self.assertEqual({op["status"] for op in receipt["operations"]}, {"succeeded"})
+
+    def test_pr_edit_uses_graphql_pull_request_identifier(self) -> None:
+        prepared = self.prepare([{"id": "edit", "kind": "pr_edit", "number": 4, "title": "Updated"}])
+        label_ids, already = BATCH.validate_preflight(prepared, self.preflight(prepared))
+        query, _, _ = BATCH.mutation(prepared, label_ids, already, BATCH.checked_body)
+        self.assertIn("pullRequestId:$target0", query)
 
     def test_partial_and_graphql_errors_fail_closed(self) -> None:
         prepared, preflight = self.two_comment_batch()

--- a/.agents/scripts/tests/test-gh-write-batch.py
+++ b/.agents/scripts/tests/test-gh-write-batch.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Hermetic regression tests for bounded managed GitHub write batches."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).resolve().parents[1] / "gh-write-batch.py"
+SPEC = importlib.util.spec_from_file_location("gh_write_batch", SCRIPT)
+assert SPEC and SPEC.loader
+BATCH = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(BATCH)
+
+
+class BatchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="gh-write-batch-test.")
+        self.root = Path(self.temporary.name)
+        os.chmod(self.root, 0o700)
+        self.signature = self.private_file(
+            "signature-helper.sh",
+            "#!/usr/bin/env bash\nprintf '%s\\n' '<!-- aidevops:sig -->' 'canonical footer'\n",
+        )
+        os.chmod(self.signature, 0o700)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def private_file(self, name: str, content: str) -> Path:
+        path = self.root / name
+        path.write_text(content, encoding="utf-8")
+        os.chmod(path, 0o600)
+        return path
+
+    def prepare(self, operations: list[dict], recovery_of: dict | None = None) -> dict:
+        manifest = {
+            "schema": BATCH.SCHEMA,
+            "repository": "test/repo",
+            "operations": operations,
+        }
+        if recovery_of is not None:
+            manifest["recovery_of"] = recovery_of
+        manifest_path = self.private_file("manifest.json", json.dumps(manifest))
+        prepared_path = self.root / "prepared.json"
+        args = argparse.Namespace(
+            manifest=str(manifest_path),
+            temp_root=str(self.root),
+            signature_helper=str(self.signature),
+            output=str(prepared_path),
+        )
+        self.assertEqual(BATCH.prepare(args), 0)
+        return json.loads(prepared_path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def preflight(prepared: dict, permission: str = "WRITE", marker: str | None = None) -> dict:
+        repository: dict = {"viewerPermission": permission}
+        labels = sorted({label for op in prepared["operations"] for label in op.get("labels", [])})
+        for index, label in enumerate(labels):
+            repository[f"l{index}"] = {"id": f"L{index}", "name": label}
+        for index, operation in enumerate(prepared["operations"]):
+            target = {
+                "__typename": operation["target_type"],
+                "id": f"T{index}",
+                "number": operation["number"],
+                "title": "old title",
+                "body": "old body",
+                "labels": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+            }
+            if prepared.get("recovery_of") and operation["kind"].endswith("_comment"):
+                target["comments"] = {
+                    "nodes": [{"body": marker}] if marker else [],
+                    "pageInfo": {"hasPreviousPage": False},
+                }
+            repository[f"t{index}"] = target
+        return {"data": {"repository": repository}}
+
+    def execute(self, prepared: dict, calls: list[tuple]) -> tuple[int, dict]:
+        prepared_path = self.private_file("execute.json", json.dumps(prepared))
+        receipt_path = self.root / "receipt.json"
+        args = argparse.Namespace(prepared=str(prepared_path), receipt=str(receipt_path))
+        with (
+            mock.patch.object(BATCH, "graphql_call", side_effect=calls),
+            redirect_stdout(StringIO()),
+            redirect_stderr(StringIO()),
+        ):
+            result = BATCH.execute(args)
+        return result, json.loads(receipt_path.read_text(encoding="utf-8"))
+
+    def test_prepare_signs_comments_and_rejects_unsafe_shapes(self) -> None:
+        body = self.private_file("body.md", "Substantive comment\n")
+        prepared = self.prepare(
+            [{"id": "comment", "kind": "issue_comment", "number": 7, "body_file": str(body)}]
+        )
+        copied = Path(prepared["operations"][0]["body_file"]).read_text(encoding="utf-8")
+        self.assertEqual(copied.count("<!-- aidevops:sig -->"), 1)
+        self.assertIn(f"<!-- aidevops:batch:{prepared['manifest_sha256']}:comment -->", copied)
+
+        outside = Path(tempfile.gettempdir()) / "gh-write-batch-unsafe.md"
+        outside.write_text("unsafe", encoding="utf-8")
+        os.chmod(outside, 0o600)
+        self.addCleanup(outside.unlink, missing_ok=True)
+        with self.assertRaisesRegex(BATCH.BatchError, "under AIDEVOPS_TEMP_DIR"):
+            self.prepare(
+                [{"id": "unsafe", "kind": "pr_comment", "number": 8, "body_file": str(outside)}]
+            )
+        with self.assertRaisesRegex(BATCH.BatchError, "unsupported fields"):
+            self.prepare([{"id": "mixed", "kind": "issue_add_labels", "number": 1, "labels": ["bug"], "repository": "other/repo"}])
+        with self.assertRaisesRegex(BATCH.BatchError, "1-10 operations"):
+            self.prepare(
+                [{"id": f"op{index}", "kind": "issue_add_labels", "number": index + 1, "labels": ["bug"]} for index in range(11)]
+            )
+        with self.assertRaisesRegex(BATCH.BatchError, "protected label"):
+            self.prepare([{"id": "origin", "kind": "pr_add_labels", "number": 2, "labels": ["origin:interactive"]}])
+
+    def test_all_success_and_label_alias_order(self) -> None:
+        prepared = self.prepare(
+            [
+                {"id": "labels", "kind": "pr_add_labels", "number": 3, "labels": ["zeta", "alpha"]},
+                {"id": "edit", "kind": "issue_edit", "number": 4, "title": "Updated title"},
+            ]
+        )
+        preflight = self.preflight(prepared)
+        _, preflight_variables = BATCH.preflight_query(prepared)
+        self.assertEqual(preflight_variables["label0"], "alpha")
+        self.assertEqual(preflight_variables["label1"], "zeta")
+        mutation = {"data": {"o0": {"clientMutationId": "labels"}, "o1": {"clientMutationId": "edit", "issue": {"id": "T1", "number": 4}}}}
+        result, receipt = self.execute(
+            prepared,
+            [(0, json.dumps(preflight), "", False), (0, json.dumps(mutation), "", False)],
+        )
+        self.assertEqual(result, 0)
+        self.assertEqual(receipt["overall"], "succeeded")
+        self.assertEqual({op["status"] for op in receipt["operations"]}, {"succeeded"})
+
+    def test_partial_error_timeout_and_authority_fail_closed(self) -> None:
+        body = self.private_file("body.md", "Comment\n")
+        prepared = self.prepare(
+            [
+                {"id": "one", "kind": "issue_comment", "number": 1, "body_file": str(body)},
+                {"id": "two", "kind": "pr_comment", "number": 2, "body_file": str(body)},
+            ]
+        )
+        preflight = self.preflight(prepared)
+        partial = {
+            "data": {
+                "o0": {
+                    "clientMutationId": "one",
+                    "commentEdge": {"node": {"id": "C1"}},
+                }
+            }
+        }
+        result, receipt = self.execute(
+            prepared,
+            [(0, json.dumps(preflight), "", False), (1, json.dumps(partial), "error", False)],
+        )
+        self.assertEqual(result, 1)
+        self.assertEqual([op["status"] for op in receipt["operations"]], ["succeeded", "unknown"])
+
+        scoped_error = {"data": {"o0": None, "o1": None}, "errors": [{"path": ["o0"], "message": "failed"}]}
+        _, receipt = self.execute(
+            prepared,
+            [(0, json.dumps(preflight), "", False), (1, json.dumps(scoped_error), "", False)],
+        )
+        self.assertEqual([op["status"] for op in receipt["operations"]], ["failed", "unknown"])
+
+        global_error = {"data": None, "errors": [{"message": "service unavailable"}]}
+        _, receipt = self.execute(
+            prepared,
+            [(0, json.dumps(preflight), "", False), (1, json.dumps(global_error), "", False)],
+        )
+        self.assertEqual({op["status"] for op in receipt["operations"]}, {"unknown"})
+
+        _, receipt = self.execute(
+            prepared,
+            [(0, json.dumps(preflight), "", False), (124, "", "timeout", True)],
+        )
+        self.assertEqual({op["status"] for op in receipt["operations"]}, {"unknown"})
+
+        _, receipt = self.execute(
+            prepared,
+            [(0, json.dumps(preflight), "", False), (75, "", "retry_at=123", False)],
+        )
+        self.assertEqual({op["status"] for op in receipt["operations"]}, {"deferred"})
+
+        result, receipt = self.execute(
+            prepared,
+            [(0, json.dumps(self.preflight(prepared, permission="READ")), "", False)],
+        )
+        self.assertEqual(result, 1)
+        self.assertEqual({op["status"] for op in receipt["operations"]}, {"rejected"})
+
+        label_prepared = self.prepare(
+            [{"id": "label", "kind": "issue_add_labels", "number": 3, "labels": ["missing"]}]
+        )
+        unknown_label = self.preflight(label_prepared)
+        unknown_label["data"]["repository"]["l0"] = None
+        result, receipt = self.execute(
+            label_prepared,
+            [(0, json.dumps(unknown_label), "", False)],
+        )
+        self.assertEqual(result, 1)
+        self.assertEqual(receipt["operations"][0]["status"], "rejected")
+
+    def test_recovery_uses_original_marker_and_prevents_duplicate_comment(self) -> None:
+        body = self.private_file("recovery-body.md", "Recover me\n")
+        original = self.prepare(
+            [{"id": "recover", "kind": "issue_comment", "number": 9, "body_file": str(body)}]
+        )
+        receipt = BATCH.base_receipt(original)
+        receipt_path = self.root / "original-receipt.json"
+        BATCH.write_private_json(receipt_path, receipt)
+        recovered = self.prepare(
+            [{"id": "recover", "kind": "issue_comment", "number": 9, "body_file": str(body)}],
+            {"manifest_sha256": original["manifest_sha256"], "receipt_file": str(receipt_path)},
+        )
+        marker = f"<!-- aidevops:batch:{original['manifest_sha256']}:recover -->"
+        self.assertIn(marker, Path(recovered["operations"][0]["body_file"]).read_text(encoding="utf-8"))
+        result, recovered_receipt = self.execute(
+            recovered,
+            [(0, json.dumps(self.preflight(recovered, marker=marker)), "", False)],
+        )
+        self.assertEqual(result, 0)
+        self.assertEqual(recovered_receipt["operations"][0]["status"], "already_succeeded")
+
+        changed = self.private_file("changed.md", "Different payload\n")
+        with self.assertRaisesRegex(BATCH.BatchError, "payload does not match"):
+            self.prepare(
+                [{"id": "recover", "kind": "issue_comment", "number": 9, "body_file": str(changed)}],
+                {"manifest_sha256": original["manifest_sha256"], "receipt_file": str(receipt_path)},
+            )
+
+        pr_body = self.private_file("pr-body.md", "Stable PR content\n")
+        original_edit = self.prepare(
+            [{"id": "edit", "kind": "pr_edit", "number": 10, "body_file": str(pr_body)}]
+        )
+        edit_receipt = BATCH.base_receipt(original_edit)
+        edit_receipt_path = self.root / "edit-receipt.json"
+        BATCH.write_private_json(edit_receipt_path, edit_receipt)
+        original_published_body = Path(original_edit["operations"][0]["body_file"]).read_text(
+            encoding="utf-8"
+        )
+        self.signature.write_text(
+            "#!/usr/bin/env bash\nprintf '%s\\n' '<!-- aidevops:sig -->' 'new canonical footer'\n",
+            encoding="utf-8",
+        )
+        recovered_edit = self.prepare(
+            [{"id": "edit", "kind": "pr_edit", "number": 10, "body_file": str(pr_body)}],
+            {
+                "manifest_sha256": original_edit["manifest_sha256"],
+                "receipt_file": str(edit_receipt_path),
+            },
+        )
+        edit_preflight = self.preflight(recovered_edit)
+        edit_preflight["data"]["repository"]["t0"]["body"] = original_published_body
+        result, recovered_edit_receipt = self.execute(
+            recovered_edit,
+            [(0, json.dumps(edit_preflight), "", False)],
+        )
+        self.assertEqual(result, 0)
+        self.assertEqual(recovered_edit_receipt["operations"][0]["status"], "already_succeeded")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add an explicit owner-only manifest path for up to ten independent issue and PR comments or metadata edits, with shared cooldown/privacy/signature policy, fresh GraphQL preflight, aliased receipts, and idempotent recovery.

## Files Changed

`.agents/scripts/gh-write-batch.py`, `.agents/scripts/gh_write_batch_graphql.py`, `.agents/scripts/shared-gh-wrappers-batch.sh`, wrapper dispatch, focused tests, and GitHub command-discipline documentation.

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — the executable batch path passed hermetic preflight/mutation transport coverage, recovery and failure-mode tests, the existing single-write suite, and the complete gh shim suite; this PR body update also exercises the managed batch path against the exact PR target.

## Qlty Smell Regression Justification

The single net-new `qlty:file-complexity` smell is confined to the batch coordinator. It implements one cohesive trust-boundary workflow: manifest validation, policy enforcement, preflight, execution, receipt classification, and recovery. The GraphQL compiler and shell orchestration were already split into dedicated modules, focused function complexity checks pass, and the new path has direct failure-mode and live runtime coverage. Accepting the +1 repository smell is preferable to fragmenting security-sensitive state transitions across more modules solely to satisfy the aggregate file metric.

## New File Smell Justification

`.agents/scripts/gh-write-batch.py` has aggregate file complexity 141 because it owns the cohesive validation and result-state machine for a high-risk publication boundary. Its GraphQL compiler and shell transport are separate, individual routines were decomposed during review, Qlty maintainability checks pass, and tests cover cooldown, privacy, authorization, preflight, partial failure, timeout, deferred execution, and recovery. The remaining aggregate smell is therefore accepted with explicit maintainer evidence.

Resolves #31593

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 2h 12m and 770,004 tokens on this with the user in an interactive session.