### PR TITLE
GH#31610: fix: allow trusted React DOM type updates

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -22,6 +22,7 @@ hono
 elysia
 @types/bun
 @types/react
+@types/react-dom
 @fontsource/dm-sans
 @fontsource/courier-prime
 @fontsource/mohave


### PR DESCRIPTION
## Summary

Allowlist @types/react-dom after verifying Dependabot PR #31606 has an exact Dependabot-authored head, dependency-only diff, and green security checks.

## Files Changed

.agents/configs/trusted-dependabot-updates.conf

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; .agents/scripts/linters-local.sh --changed

Resolves #31610


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 2m and 67,959 tokens on this as a headless worker.