### PR TITLE
GH#31608: trust React DOM Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -22,6 +22,7 @@ hono
 elysia
 @types/bun
 @types/react
+@types/react-dom
 @fontsource/dm-sans
 @fontsource/courier-prime
 @fontsource/mohave

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -461,6 +461,20 @@ test_repository_allows_types_bun() {
 	return 0
 }
 
+test_repository_allows_types_react_dom() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "" "@types/react-dom"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits @types/react-dom updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits @types/react-dom updates" 1
+	return 0
+}
+
 test_repository_allows_hono() {
 	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
 
@@ -684,6 +698,7 @@ main() {
 	test_trusted_actions_dependabot_passes
 	test_unallowlisted_dependency_fails
 	test_repository_allows_types_bun
+	test_repository_allows_types_react_dom
 	test_repository_allows_hono
 	test_repository_allows_vite_react_plugin
 	test_repository_allows_elysia


### PR DESCRIPTION
Allows the verified @types/react-dom patch update for the trusted Dependabot path and adds coverage. Resolves #31608. <!-- aidevops:origin:worker --> <!-- aidevops:sig --> aidevops.sh v3.32.343 Overall, gpt-5.6-terra spent 20m and 119,352 tokens on this as a headless worker.
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 21m and 121,856 tokens on this as a headless worker.