### PR TITLE
GH#31612: allow trusted secretlint updates

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -35,6 +35,7 @@ elysia
 @fontsource/ubuntu
 @fontsource/ubuntu-mono
 @secretlint/secretlint-rule-preset-recommend
+secretlint
 typescript
 npm_and_yarn:fast-uri
 actions:actions/checkout

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -587,6 +587,20 @@ test_repository_allows_secretlint_recommend() {
 	return 0
 }
 
+test_repository_allows_secretlint() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "bun" "secretlint"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits Secretlint Bun updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits Secretlint Bun updates" 1
+	return 0
+}
+
 test_repository_allows_trusted_actions() {
 	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
 	local dependency_name=""
@@ -693,6 +707,7 @@ main() {
 	test_repository_allows_fontsource_inter
 	test_repository_allows_fontsource_source_serif_4
 	test_repository_allows_secretlint_recommend
+	test_repository_allows_secretlint
 	test_repository_allows_trusted_actions
 	test_trusted_dependabot_can_be_approved
 	test_review_bot_failure_is_ignored_when_other_checks_green


### PR DESCRIPTION
Resolves #31612. Allow the verified Secretlint 13 Dependabot update through the narrow trusted-dependency policy and cover it with the existing policy test. Testing: bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; shellcheck .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh. <!-- aidevops:origin:worker --> <!-- aidevops:sig --> --- [aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 17m and 96,281 tokens on this as a headless worker.
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 19m and 98,523 tokens on this as a headless worker.