### PR TITLE
GH#31613: trust react-icons Dependabot update

### DIFF
--- a/.agents/configs/trusted-dependabot-updates.conf
+++ b/.agents/configs/trusted-dependabot-updates.conf
@@ -18,6 +18,7 @@ pip:pyarrow
 vite
 @vitejs/plugin-react
 react
+react-icons
 hono
 elysia
 @types/bun

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -475,6 +475,20 @@ test_repository_allows_hono() {
 	return 0
 }
 
+test_repository_allows_react_icons() {
+	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
+
+	unset AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF
+	if _trusted_dependabot_dependency_allowed "bun" "react-icons"; then
+		export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+		print_result "repository allowlist permits react-icons Bun updates" 0
+		return 0
+	fi
+	export AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF="$fixture_allowlist"
+	print_result "repository allowlist permits react-icons Bun updates" 1
+	return 0
+}
+
 test_repository_allows_vite_react_plugin() {
 	local fixture_allowlist="$AIDEVOPS_TRUSTED_DEPENDABOT_UPDATES_CONF"
 
@@ -685,6 +699,7 @@ main() {
 	test_unallowlisted_dependency_fails
 	test_repository_allows_types_bun
 	test_repository_allows_hono
+	test_repository_allows_react_icons
 	test_repository_allows_vite_react_plugin
 	test_repository_allows_elysia
 	test_repository_allows_fontsource_ubuntu

--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
         "@fontsource/zilla-slab": "5.3.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "react-icons": "5.6.0",
+        "react-icons": "5.7.0",
       },
     },
   },
@@ -416,7 +416,7 @@
 
     "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
-    "react-icons": ["react-icons@5.6.0", "", { "peerDependencies": { "react": "*" } }, "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA=="],
+    "react-icons": ["react-icons@5.7.0", "", { "peerDependencies": { "react": "*" } }, "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw=="],
 
     "read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
 

--- a/packages/gui-web/package.json
+++ b/packages/gui-web/package.json
@@ -24,7 +24,7 @@
     "@fontsource/zilla-slab": "5.3.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "react-icons": "5.6.0"
+    "react-icons": "5.7.0"
   },
   "scripts": {
     "dev": "vite --host 127.0.0.1",


### PR DESCRIPTION
Resolves #31613

## Summary

- Replaced the verified React Icons Dependabot update with a trusted, maintainable policy entry.
- Bumped @aidevops/gui-web from react-icons 5.6.0 to 5.7.0 and regenerated Bun lock metadata.
- Added an exact allowlist regression test.

## Runtime Testing

- self-assessed: dependency-policy and GUI package update; focused install, tests, typecheck, and production build completed.

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 17m and 232,667 tokens on this as a headless worker.
