### PR TITLE
GH#31597: complete approved maintainer review fixes

### DIFF
--- a/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
@@ -24,6 +24,7 @@ import {
 import { resolveSessionOwnedWorktreeRoot } from "./gpt-image-worktree.mjs";
 
 const MAX_OPERATIONS = 24;
+const MAX_OUTPUT_LINES = 500;
 const SUPERVISOR_PATH = fileURLToPath(new URL("./bounded-operation-supervisor.mjs", import.meta.url));
 const SUPERVISOR_RUNTIME = "node";
 
@@ -36,6 +37,9 @@ export class BoundedInteractiveOperationManager {
     this.now = options.now || Date.now;
     this.makeID = options.makeID || (() => `op_${this.now()}_${randomBytes(6).toString("hex")}`);
     this.recordOutput = options.recordOutput || (async () => "");
+    this.readOutput = options.readOutput || (async () => {
+      throw new Error("stored output retrieval is unavailable");
+    });
     this.kill = options.kill || signalSupervisor;
     this.killGraceMs = options.killGraceMs ?? 500;
     this.setTimer = options.setTimer || setTimeout;
@@ -251,6 +255,32 @@ export class BoundedInteractiveOperationManager {
     return this.receipt(this.ownedOperation(id, context));
   }
 
+  async output(id, context = {}, requested = {}) {
+    const operation = this.ownedOperation(id, context);
+    if (["starting", "running", "cancelling", "timing_out", "restoring", "finalizing"].includes(operation.state)) {
+      throw new Error("stored output is available only after the operation reaches a terminal state");
+    }
+    if (!operation.outputID) throw new Error("stored output is unavailable");
+    const offset = Number(requested.offset ?? 1);
+    const limit = Number(requested.limit ?? 120);
+    if (!Number.isSafeInteger(offset) || offset < 1) throw new Error("output offset must be a positive integer");
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_OUTPUT_LINES) {
+      throw new Error(`output limit must be an integer from 1 to ${MAX_OUTPUT_LINES}`);
+    }
+    const result = await this.readOutput(operation.outputID, { offset, limit });
+    return {
+      schema: "aidevops.interactive-operation-output/v1",
+      operation_id: operation.id,
+      state: operation.state,
+      output_id: operation.outputID,
+      offset,
+      limit,
+      output: result.output,
+      output_redacted: Boolean(result.redacted),
+      output_truncated: Boolean(result.truncated),
+    };
+  }
+
   cancel(id, context = {}) {
     const operation = this.ownedOperation(id, context);
     if (!["running", "starting"].includes(operation.state)) return this.receipt(operation);
@@ -278,5 +308,6 @@ export class BoundedInteractiveOperationManager {
   dispose() {
     disposeOperations(this.operations, this.kill, this.clearTimer);
     this.recordOutput.dispose?.();
+    this.readOutput.dispose?.();
   }
 }

--- a/.agents/plugins/opencode-aidevops/bounded-operation-output.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-operation-output.mjs
@@ -3,6 +3,14 @@
 
 import { spawn } from "node:child_process";
 
+const MAX_READ_BYTES = 128 * 1024;
+
+function captureBounded(current, chunk) {
+  if (Buffer.byteLength(current) >= MAX_READ_BYTES) return current;
+  const remaining = MAX_READ_BYTES - Buffer.byteLength(current);
+  return current + Buffer.from(chunk).subarray(0, remaining).toString("utf8");
+}
+
 export function createOutputSandboxRecorder(helperPath, spawnImpl = spawn, timeoutMs = 5000) {
   const activeChildren = new Set();
   const recorder = (content, evidence = {}) => new Promise((resolve) => {
@@ -41,4 +49,51 @@ export function createOutputSandboxRecorder(helperPath, spawnImpl = spawn, timeo
     activeChildren.clear();
   };
   return recorder;
+}
+
+export function createOutputSandboxReader(helperPath, spawnImpl = spawn, timeoutMs = 5000) {
+  const activeChildren = new Set();
+  const reader = (outputID, { offset, limit }) => new Promise((resolve, reject) => {
+    const child = spawnImpl("bash", [
+      helperPath, "show", outputID, "--offset", String(offset), "--limit", String(limit),
+    ], { stdio: ["ignore", "pipe", "pipe"] });
+    activeChildren.add(child);
+    let stdout = "";
+    let stderr = "";
+    let truncated = false;
+    let settled = false;
+    const finish = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      activeChildren.delete(child);
+      if (error) reject(error);
+      else resolve({ output: stdout, redacted: /redacted before storage/i.test(stderr), truncated });
+    };
+    const timer = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      finish(new Error("stored output retrieval timed out"));
+    }, timeoutMs);
+    child.stdout?.on("data", (chunk) => {
+      const next = captureBounded(stdout, chunk);
+      if (Buffer.byteLength(next) < Buffer.byteLength(stdout) + Buffer.byteLength(chunk)) truncated = true;
+      stdout = next;
+    });
+    child.stderr?.on("data", (chunk) => { stderr = captureBounded(stderr, chunk); });
+    child.once("error", () => finish(new Error("stored output retrieval is unavailable")));
+    child.once("close", (code) => {
+      if (code !== 0) {
+        finish(new Error(stderr.trim() || "stored output is unavailable"));
+        return;
+      }
+      finish();
+    });
+  });
+  reader.dispose = () => {
+    for (const child of activeChildren) {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    }
+    activeChildren.clear();
+  };
+  return reader;
 }

--- a/.agents/plugins/opencode-aidevops/bounded-operation-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-operation-tool.mjs
@@ -10,13 +10,15 @@ function responseError(message) {
 export function createBoundedInteractiveOperationTool(tool, z, manager) {
   return tool({
     description:
-      "Start, inspect, or cancel a bounded long-running command without blocking the interactive session. " +
-      "Use start for operations expected to exceed the progress interval, then call status periodically. " +
+      "Start, inspect, retrieve output from, or cancel a bounded long-running command without blocking the interactive session. " +
+      "Use start for operations expected to exceed the progress interval, call status periodically, then use output with the operation ID after it reaches a terminal state. " +
       "Commands are argv arrays, remain confined to the active project root, and must not daemonize or create a new process session. " +
       "Cancellation is session-owned and restoration evidence remains explicit.",
     args: {
-      action: z.enum(["start", "status", "cancel"]),
+      action: z.enum(["start", "status", "output", "cancel"]),
       operation_id: z.string().optional(),
+      output_offset: z.number().optional(),
+      output_limit: z.number().optional(),
       command: z.array(z.string()).optional(),
       cwd: z.string().optional(),
       budget_seconds: z.number().optional(),
@@ -38,6 +40,11 @@ export function createBoundedInteractiveOperationTool(tool, z, manager) {
           }, context);
         } else if (args.action === "status") {
           receipt = manager.status(args.operation_id, context);
+        } else if (args.action === "output") {
+          receipt = await manager.output(args.operation_id, context, {
+            offset: args.output_offset,
+            limit: args.output_limit,
+          });
         } else if (args.action === "cancel") {
           receipt = manager.cancel(args.operation_id, context);
         } else {

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -64,7 +64,7 @@ import { createSubagentCancellationReceipt } from "./subagent-cancellation-recei
 import {
   BoundedInteractiveOperationManager,
 } from "./bounded-interactive-operation.mjs";
-import { createOutputSandboxRecorder } from "./bounded-operation-output.mjs";
+import { createOutputSandboxReader, createOutputSandboxRecorder } from "./bounded-operation-output.mjs";
 import { createRoutingFeedbackHandler } from "./routing-feedback-handler.mjs";
 import { createSessionBoundaryAdvisory } from "./session-boundary-advisory.mjs";
 import { createProviderErrorHandler } from "./provider-error-diagnostics.mjs";
@@ -389,6 +389,7 @@ export async function AidevopsPlugin({ directory, client }) {
     projectRoot: directory,
     scriptsDir: SCRIPTS_DIR,
     recordOutput: createOutputSandboxRecorder(join(SCRIPTS_DIR, "output-sandbox-helper.sh")),
+    readOutput: createOutputSandboxReader(join(SCRIPTS_DIR, "output-sandbox-helper.sh")),
   });
   process.once("exit", () => boundedOperationManager.dispose());
   const baseTools = createTools(SCRIPTS_DIR, run, {

--- a/.agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs
@@ -7,8 +7,11 @@ import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { BoundedInteractiveOperationManager } from "../bounded-interactive-operation.mjs";
+import { createOutputSandboxReader, createOutputSandboxRecorder } from "../bounded-operation-output.mjs";
+import { createBoundedInteractiveOperationTool } from "../bounded-operation-tool.mjs";
 
 const root = mkdtempSync(join(tmpdir(), "aidevops-bounded-operation-"));
 const owner = { sessionID: "ses_owner" };
@@ -28,6 +31,11 @@ function manager(options = {}) {
       recorded.push({ content: String(content), evidence });
       return `out_fixture_${recorded.length}`;
     },
+    readOutput: async (outputID, bounds) => ({
+      output: `${bounds.offset}: output for ${outputID}\n`,
+      redacted: false,
+      truncated: false,
+    }),
     ...options,
   });
   managers.push(instance);
@@ -250,6 +258,58 @@ describe("bounded interactive operations", () => {
     }, owner);
     await terminal(instance, newlineFree.operation_id);
     assert.ok(instance.operations.get(newlineFree.operation_id).progressRemainder.length <= 4096);
+  });
+
+  test("terminal output retrieval is bounded and session-owned", async () => {
+    const instance = manager();
+    const started = await instance.start({
+      command: [process.execPath, "-e", "console.log('retrieval-proof')"],
+      budgetMs: 1000,
+    }, owner);
+    await assert.rejects(instance.output(started.operation_id, owner), /only after.*terminal/i);
+    await terminal(instance, started.operation_id);
+
+    const result = await instance.output(started.operation_id, owner, { offset: 2, limit: 10 });
+    assert.equal(result.schema, "aidevops.interactive-operation-output/v1");
+    assert.equal(result.output, `2: output for ${result.output_id}\n`);
+    assert.equal(result.offset, 2);
+    assert.equal(result.limit, 10);
+    await assert.rejects(instance.output(started.operation_id, { sessionID: "ses_other" }), /owner mismatch/);
+    await assert.rejects(instance.output(started.operation_id, owner, { offset: 0 }), /positive integer/);
+    await assert.rejects(instance.output(started.operation_id, owner, { limit: 501 }), /1 to 500/);
+
+    const schemaNode = { optional() { return this; } };
+    const z = { enum: () => schemaNode, string: () => schemaNode, number: () => schemaNode, array: () => schemaNode };
+    const tool = createBoundedInteractiveOperationTool((definition) => definition, z, instance);
+    const toolResult = JSON.parse(await tool.execute({
+      action: "output",
+      operation_id: started.operation_id,
+      output_offset: 3,
+      output_limit: 4,
+    }, owner));
+    assert.equal(toolResult.output, `3: output for ${toolResult.output_id}\n`);
+  });
+
+  test("the sandbox adapter retrieves stored output without exposing its path", async () => {
+    const helper = fileURLToPath(new URL("../../../scripts/output-sandbox-helper.sh", import.meta.url));
+    const previousDirectory = process.env.AIDEVOPS_OUTPUT_SANDBOX_DIR;
+    process.env.AIDEVOPS_OUTPUT_SANDBOX_DIR = join(root, "output-sandbox");
+    const recorder = createOutputSandboxRecorder(helper);
+    const reader = createOutputSandboxReader(helper);
+    try {
+      const outputID = await recorder(Buffer.from("first\nsecond\n"), { exitCode: 0 });
+      assert.match(outputID, /^out_/);
+      const result = await reader(outputID, { offset: 2, limit: 1 });
+      assert.equal(result.output, "2: second\n");
+      assert.equal(result.redacted, false);
+      assert.equal(result.output.includes(process.env.AIDEVOPS_OUTPUT_SANDBOX_DIR), false);
+      await assert.rejects(reader("out_missing", { offset: 1, limit: 1 }), /output not found/);
+    } finally {
+      recorder.dispose();
+      reader.dispose();
+      if (previousDirectory === undefined) delete process.env.AIDEVOPS_OUTPUT_SANDBOX_DIR;
+      else process.env.AIDEVOPS_OUTPUT_SANDBOX_DIR = previousDirectory;
+    }
   });
 
   test("session deletion cancels only operations owned by that session", async () => {

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -5,7 +5,7 @@ import { createGptImageTool } from "./gpt-image-tool.mjs";
 import { createMcpActivationTool } from "./mcp-activation-tool.mjs";
 import { createPreEditCheckTool } from "./pre-edit-check-tool.mjs";
 import { BoundedInteractiveOperationManager } from "./bounded-interactive-operation.mjs";
-import { createOutputSandboxRecorder } from "./bounded-operation-output.mjs";
+import { createOutputSandboxReader, createOutputSandboxRecorder } from "./bounded-operation-output.mjs";
 import { createBoundedInteractiveOperationTool } from "./bounded-operation-tool.mjs";
 
 const FALLBACK_SCHEMA_NODE = {
@@ -226,6 +226,7 @@ export function createTools(scriptsDir, run, options = {}) {
     projectRoot: options.projectRoot || process.cwd(),
     scriptsDir,
     recordOutput: createOutputSandboxRecorder(join(scriptsDir, "output-sandbox-helper.sh")),
+    readOutput: createOutputSandboxReader(join(scriptsDir, "output-sandbox-helper.sh")),
   });
 
   const tools = {

--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -83,6 +83,12 @@ terminal command path, and its exit remains independently visible. Raw output
 is represented only by an opaque output ID when terminal evidence storage is
 available.
 
+After a terminal receipt reports `evidence_state: recorded`, retrieve a bounded
+slice through the same native tool with action `output`, the receipt's
+`operation_id`, and optional `output_offset`/`output_limit` values. Retrieval is
+terminal-only, limited to 500 lines per call, and revalidates session ownership;
+callers cannot use a bare output ID to bypass the operation generation.
+
 Cancellation is restricted to the runtime session that started the operation
 and signals only the retained detached process group. The implementation is an
 OpenCode process-lifetime adapter, not a durable scheduler: restarting or

--- a/.agents/reference/repo-organization.md
+++ b/.agents/reference/repo-organization.md
@@ -75,6 +75,11 @@ aidevops repos migrate-layout rollback --receipt <receipt-id> --confirm <receipt
 
 `plan` is non-mutating. It inventories dirty state, branches, stashes,
 submodules, linked worktrees, registrations, local consumers, and collisions.
+Its summary also reports active-path consumers and the exact confirmed apply
+command to resume. When a source or destination is active, save a session
+checkpoint with `/checkpoint`, exit every process using either path, restart
+from outside both paths, and run that resume command. The migration does not
+create compatibility symlinks for a live process.
 Explicit `initialized_repos[].path` entries remain excluded unless planning uses
 `--include-registered-paths`; that approval is recorded in the content-hashed
 plan. Apply rechecks the complete before-state, rejects cross-device moves and

--- a/.agents/scripts/full-loop-helper-commit-validators.sh
+++ b/.agents/scripts/full-loop-helper-commit-validators.sh
@@ -115,7 +115,7 @@ _validator_scopes() {
 			_validator_all_workspace_scopes "$workspace_patterns"
 			return $?
 		fi
-		if ! _validator_workspace_matches "$scope" "$workspace_patterns"; then
+		if ! _validator_workspace_matches "$scope" "$workspace_patterns" && ! _validator_package_has_check "$scope/package.json"; then
 			print_error "[validators] cannot map changed Node file to a declared workspace: $changed_file"
 			print_error "[validators] add a package-level check script or correct package.json workspaces before publication"
 			return 1
@@ -137,6 +137,7 @@ _validator_select_script() {
 	format) candidates=$'format:check\ncheck:format\nprettier:check' ;;
 	lint) candidates=$'lint:check\nlint' ;;
 	typecheck) candidates=$'typecheck\ncheck:types\ntsc' ;;
+	test) candidates='test' ;;
 	esac
 	while IFS= read -r script_name; do
 		if jq -e --arg s "$script_name" '.scripts[$s] // empty' "$package_json" >/dev/null 2>&1; then
@@ -149,7 +150,7 @@ _validator_select_script() {
 
 _validator_package_has_check() {
 	local package_json="$1" phase=""
-	for phase in format lint typecheck; do
+	for phase in format lint typecheck test; do
 		_validator_select_script "$package_json" "$phase" >/dev/null && return 0
 	done
 	return 1
@@ -181,7 +182,7 @@ _run_scoped_node_checks() {
 		scope_label="$scope"
 	fi
 	local phase="" script_name="" check_count=0 command_rc=0 check_index=0
-	for phase in format lint typecheck; do
+	for phase in format lint typecheck test; do
 		script_name=$(_validator_select_script "$package_json" "$phase") || continue
 		check_count=$((check_count + 1))
 		check_index=$((check_index + 1))

--- a/.agents/scripts/repo_layout_migrate.py
+++ b/.agents/scripts/repo_layout_migrate.py
@@ -11,6 +11,7 @@ import importlib.util
 import json
 import os
 import re
+import shlex
 import shutil
 import sqlite3
 import stat
@@ -591,13 +592,29 @@ def plan_command(args: argparse.Namespace) -> int:
     if any(item["source_device"] != item["destination_device"] for item in repositories):
         raise MigrationError("Cross-device move detected; no plan was written")
     atomic_write(output, canonical_bytes(plan))
+    active_path_consumers = len(active_path_matches(plan))
+    resume_command = shlex.join(
+        [
+            "aidevops",
+            "repos",
+            "migrate-layout",
+            "apply",
+            "--plan",
+            str(output),
+            "--confirm",
+            plan["plan_sha256"],
+        ]
+    )
     print(
         json.dumps(
             {
+                "active_path_consumers": active_path_consumers,
+                "active_path_handoff_required": active_path_consumers > 0,
                 "plan": str(output),
                 "plan_sha256": plan["plan_sha256"],
                 "moves": len(repositories),
                 "exclusions": len(exclusions),
+                "resume_command": resume_command,
             },
             sort_keys=True,
         )
@@ -882,8 +899,8 @@ def release_lock(lock: Path) -> None:
         pass
 
 
-def assert_no_active_path(plan: dict[str, Any]) -> None:
-    """Reject observed process working directories below a planned path."""
+def active_path_matches(plan: dict[str, Any]) -> set[Path]:
+    """Return observed process working directories below a planned path."""
     current = Path.cwd().resolve()
     active_directories = [current]
     lsof = shutil.which("lsof")
@@ -904,14 +921,26 @@ def assert_no_active_path(plan: dict[str, Any]) -> None:
                 )
         except (OSError, subprocess.TimeoutExpired):
             pass
+    matches: set[Path] = set()
     for item in plan["repositories"]:
         source = Path(item["source"])
         destination = Path(item["destination"])
         for active in active_directories:
             if path_is_inside(source, active) or path_is_inside(destination, active):
-                raise MigrationError(
-                    "Active-path ambiguity: a process cwd is inside a planned repository"
-                )
+                matches.add(active)
+    return matches
+
+
+def assert_no_active_path(plan: dict[str, Any], resume_command: str) -> None:
+    """Reject active paths with a safe checkpoint-and-restart handoff."""
+    if not active_path_matches(plan):
+        return
+    raise MigrationError(
+        "Active-path ambiguity: a process cwd is inside a planned repository. "
+        "Run /checkpoint, exit every process using the source or destination, "
+        "restart from a directory outside both paths, then resume with: "
+        f"{resume_command}"
+    )
 
 
 def validate_repository_plan(
@@ -1412,7 +1441,19 @@ def apply_command(args: argparse.Namespace) -> int:
         if "migration:complete" in completed:
             print(json.dumps(receipt_status(receipt_id, receipt_dir, journal), sort_keys=True))
             return 0
-        assert_no_active_path(plan)
+        resume_command = shlex.join(
+            [
+                "aidevops",
+                "repos",
+                "migrate-layout",
+                "apply",
+                "--plan",
+                str(plan_path),
+                "--confirm",
+                args.confirm,
+            ]
+        )
+        assert_no_active_path(plan, resume_command)
         validate_apply_repositories(plan, completed, events)
         validate_consumers(plan, completed, events)
         context = (journal, events, completed)
@@ -1991,7 +2032,19 @@ def rollback_command(args: argparse.Namespace) -> int:
         if "migration:rolled-back" in completed:
             print(json.dumps(receipt_status(receipt_id, directory, journal), sort_keys=True))
             return 0
-        assert_no_active_path(plan)
+        resume_arguments = [
+            "aidevops",
+            "repos",
+            "migrate-layout",
+            "rollback",
+            "--receipt",
+            args.receipt,
+            "--confirm",
+            args.confirm,
+        ]
+        if args.state_dir:
+            resume_arguments.extend(["--state-dir", args.state_dir])
+        assert_no_active_path(plan, shlex.join(resume_arguments))
         for index in reversed(range(len(plan["consumers"].get("markers", [])))):
             key = f"consumer:marker:{index}"
             event = event_for_key(events, key)

--- a/.agents/scripts/tests/test-aidevops-repos-help.sh
+++ b/.agents/scripts/tests/test-aidevops-repos-help.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/aidevops-repos-help.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="${TEST_ROOT}/home"
+CONFIG_DIR="${HOME}/.config/aidevops"
+REPOS_FILE="${CONFIG_DIR}/repos.json"
+FIRST_REPO="${TEST_ROOT}/first"
+SECOND_REPO="${TEST_ROOT}/second"
+mkdir -p "$CONFIG_DIR" "$FIRST_REPO" "$SECOND_REPO"
+
+write_fixture() {
+	jq -n --arg first "$FIRST_REPO" --arg second "$SECOND_REPO" \
+		'{initialized_repos: [{path: $first, custom: "preserved"}, {path: $second}]}' >"$REPOS_FILE"
+}
+
+fail() {
+	printf 'FAIL %s\n' "$1"
+	exit 1
+}
+
+for action in remove rm; do
+	for help_arg in help -h --help; do
+		write_fixture
+		cp "$REPOS_FILE" "${REPOS_FILE}.before"
+		output=$(bash "$REPO_ROOT/aidevops.sh" repos "$action" "$help_arg") || fail "$action $help_arg returned non-zero"
+		[[ "$output" == *"Usage: aidevops repos remove"* ]] || fail "$action $help_arg omitted scoped usage"
+		cmp -s "$REPOS_FILE" "${REPOS_FILE}.before" || fail "$action $help_arg changed the registry"
+		[[ ! -e "${REPOS_FILE}.tmp" ]] || fail "$action $help_arg left a temporary registry"
+	done
+done
+
+write_fixture
+bash "$REPO_ROOT/aidevops.sh" repos remove "$FIRST_REPO" >/dev/null
+[[ "$(jq '.initialized_repos | length' "$REPOS_FILE")" -eq 1 ]] || fail "valid removal changed the wrong number of entries"
+[[ "$(jq -r '.initialized_repos[0].path' "$REPOS_FILE")" == "$SECOND_REPO" ]] || fail "valid removal did not preserve the unrelated entry"
+
+cp "$REPOS_FILE" "${REPOS_FILE}.before"
+if bash "$REPO_ROOT/aidevops.sh" repos remove "${TEST_ROOT}/missing" >/dev/null 2>&1; then
+	fail "missing repository reported successful removal"
+fi
+cmp -s "$REPOS_FILE" "${REPOS_FILE}.before" || fail "missing repository changed the registry"
+[[ ! -e "${REPOS_FILE}.tmp" ]] || fail "missing repository left a temporary registry"
+
+printf 'PASS repos remove help is read-only and removals report truthful outcomes\n'

--- a/.agents/scripts/tests/test-full-loop-project-validators-shell-only.sh
+++ b/.agents/scripts/tests/test-full-loop-project-validators-shell-only.sh
@@ -317,6 +317,29 @@ else
 	print_result "mutating-only scripts fail with scoped-check guidance" 1 "rc=${case8_rc}, calls=$(wc -l <"$NPM_CALL_LOG" 2>/dev/null || printf 0)"
 fi
 
+# Case 9: a nested package with its own check-only test script remains a valid
+# validation scope even when it is intentionally outside the root workspaces.
+NESTED_PACKAGE_REPO="${TEST_ROOT}/nested-package"
+make_workspace_repo "$NESTED_PACKAGE_REPO"
+NPM_CALL_LOG="${TEST_ROOT}/npm-nested-package.log"
+export NPM_CALL_LOG NPM_FAKE_ACTION='' NPM_FAKE_RC=0
+(
+	cd "$NESTED_PACKAGE_REPO" || exit 1
+	mkdir -p .agents/plugins/example
+	printf '%s\n' '{"scripts":{"test":"node --test tests/*.mjs"}}' >.agents/plugins/example/package.json
+	printf '%s\n' 'export const example = true;' >.agents/plugins/example/index.mjs
+	git add .agents/plugins/example
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'add nested package'
+	PATH="${FAKE_BIN}:$PATH" _run_project_validators 0
+)
+case9_rc=$?
+if [[ "$case9_rc" -eq 0 && $(wc -l <"$NPM_CALL_LOG") -eq 1 ]] &&
+	grep -q '/.agents/plugins/example|run test' "$NPM_CALL_LOG" && ! grep -q '/packages/' "$NPM_CALL_LOG"; then
+	print_result "nested package test script defines a focused validation scope" 0
+else
+	print_result "nested package test script defines a focused validation scope" 1 "rc=${case9_rc}, calls=$(wc -l <"$NPM_CALL_LOG" 2>/dev/null || printf 0)"
+fi
+
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1
 exit 0

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -839,9 +839,27 @@ _repos_remove() {
 		print_error "jq required for repo management"
 		return 1
 	}
+	local match_count
+	match_count=$(jq --arg path "$repo_path" '[.initialized_repos[]? | select(.path == $path)] | length' "$REPOS_FILE") || return 1
+	if [[ "$match_count" -eq 0 ]]; then
+		print_error "Repository is not registered: $repo_path"
+		return 1
+	fi
 	local temp_file="${REPOS_FILE}.tmp"
-	jq --arg path "$repo_path" '.initialized_repos |= map(select(.path != $path))' "$REPOS_FILE" >"$temp_file" && mv "$temp_file" "$REPOS_FILE"
+	if ! jq --arg path "$repo_path" '.initialized_repos |= map(select(.path != $path))' "$REPOS_FILE" >"$temp_file"; then
+		rm -f "$temp_file"
+		return 1
+	fi
+	mv "$temp_file" "$REPOS_FILE" || return 1
 	print_success "Removed $repo_path from registry"
+	return 0
+}
+
+_repos_remove_usage() {
+	echo "Usage: aidevops repos remove [repo-path]"
+	echo ""
+	echo "Remove the selected repository from the aidevops registry."
+	echo "When repo-path is omitted, use the current Git repository."
 	return 0
 }
 
@@ -907,7 +925,12 @@ cmd_repos() {
 		shift
 		_repos_add "$@"
 		;;
-	remove | rm) _repos_remove "${2:-}" ;;
+	remove | rm)
+		case "${2:-}" in
+		help | -h | --help) _repos_remove_usage ;;
+		*) _repos_remove "${2:-}" ;;
+		esac
+		;;
 	clean) _repos_clean ;;
 	migrate-layout)
 		shift

--- a/tests/test-repo-layout-migrate.py
+++ b/tests/test-repo-layout-migrate.py
@@ -322,7 +322,21 @@ class RepoLayoutMigrationTest(unittest.TestCase):
         self.destination.rmdir()
         self.destination.parent.rmdir()
 
-        summary = self._plan()
+        active_plan = self._run(
+            "plan",
+            "--workspace",
+            str(self.workspace),
+            "--output",
+            str(self.plan),
+            "--repos-json",
+            str(self.repos_json),
+            "--include-registered-paths",
+            cwd=self.source,
+        )
+        summary = json.loads(active_plan.stdout)
+        self.assertTrue(summary["active_path_handoff_required"])
+        self.assertGreaterEqual(summary["active_path_consumers"], 1)
+        self.assertIn("migrate-layout apply", summary["resume_command"])
         active = self._run(
             "apply",
             "--plan",
@@ -334,6 +348,8 @@ class RepoLayoutMigrationTest(unittest.TestCase):
         )
         self.assertEqual(active.returncode, 2)
         self.assertIn("Active-path ambiguity", active.stderr)
+        self.assertIn("Run /checkpoint", active.stderr)
+        self.assertIn(summary["resume_command"], active.stderr)
         self.assertTrue(self.source.is_dir())
 
     def test_refusal_for_unexpected_linked_pointer(self) -> None:


### PR DESCRIPTION
## Summary

Add safe repository-rename restart handoffs, native session-owned bounded-output retrieval, side-effect-free repos remove help with truthful no-match handling, and focused validation for nested Node packages.

## Files Changed

.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs, .agents/plugins/opencode-aidevops/bounded-operation-output.mjs, .agents/plugins/opencode-aidevops/bounded-operation-tool.mjs, .agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs, .agents/plugins/opencode-aidevops/tools.mjs, .agents/reference/context-efficient-output.md, .agents/reference/repo-organization.md, .agents/scripts/full-loop-helper-commit-validators.sh, .agents/scripts/repo_layout_migrate.py, .agents/scripts/tests/test-aidevops-repos-help.sh, .agents/scripts/tests/test-full-loop-project-validators-shell-only.sh, aidevops.sh, tests/test-repo-layout-migrate.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — disposable migration apply/refusal/rollback fixtures, native operation lifecycle and sandbox retrieval integration tests, an isolated HOME registry mutation fixture, nested-package validator fixtures, the OpenCode plugin test suite, ShellCheck, and changed-file lint.

Resolves #31597
Resolves #31598
Resolves #31599

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 1h 15m and 505,454 tokens on this with the user in an interactive session.
