### PR TITLE
GH#31617: make Pulse productivity evidence bounded and actionable

### DIFF
--- a/.agents/reference/diagnostics-discipline.md
+++ b/.agents/reference/diagnostics-discipline.md
@@ -63,3 +63,38 @@ For provider/model/account questions, use `worker-activity-helper.sh providers -
 - Listing aggregate failure-mode counts ("66 circuit-breaker trips in 48h") without checking whether they fired in the last 10 min.
 
 This rule sits alongside t3215 (canonical sources) and t2204 (attribution before verification) — all three fire at the diagnosis-publish step, all three demand evidence-then-claim.
+
+## Actionable productivity measurements
+
+Use `pulse-check-helper.sh report --window 15m --since 6h --budget 60 --verify-delivery`
+for a bounded combined observation. The default collection budget is 45 seconds;
+each component also has a ceiling. The report returns partial evidence rather
+than waiting indefinitely. `collection` records component state and elapsed
+seconds; a timeout is missing evidence, not zero activity or an empty queue.
+
+- **Capacity:** active processes are a local snapshot. Missing maximum/free-slot
+  evidence remains unknown, not a claim that capacity equals current activity.
+  A cycle heartbeat outside the requested window is stale; its retained progress
+  history cannot trigger current under-utilisation conclusions.
+- **Work supply:** inventory coverage and dependency/progress enrichment are
+  separate. Partial counts do not establish the total ready backlog. Issue entries
+  are not independent work targets: duplicate intakes can name the same PR, and
+  assigned work may have a live owner. Verify both before filling slots.
+- **Flow:** use stage durations and their sample counts to locate admission delays.
+  Nested stage times overlap; do not sum them into an invented end-to-end latency.
+  Compare current launches/completions with ready supply and live ownership before
+  attributing a quiet interval to a broken dispatcher.
+- **Delivery:** optional GitHub verification reports deliveries independently of
+  local terminal attempt records. A blocked attempt may later produce a merged
+  PR; multiple attempts may contribute to one delivery. Do not divide these
+  unmatched counts into a success percentage. Existing compatibility percentage
+  fields remain null until a matched cohort is available; runtime handoff rate
+  retains its own terminal-attempt denominator.
+- **Next action:** insufficient independent authorized supply calls for reviewing
+  existing plans and blockers, not manufacturing tasks. Ready work with idle slots
+  calls for tracing admission. High occupancy with low delivery calls for reviewing
+  progress, quality and integration waits. Include evidence gaps and the next
+  bounded verification, rather than declaring health from occupancy alone.
+
+The objective is verified useful delivery with less user time and avoidable cost,
+not maximum processes, comments, attempts, or tokens.

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -31,6 +31,8 @@ COMMAND="report"
 WINDOW="15m"
 SINCE="24h"
 RECENT_SINCE="1h"
+REPORT_BUDGET_SECONDS="${PULSE_CHECK_REPORT_BUDGET_SECONDS:-45}"
+VERIFY_DELIVERY=0
 APPLY_REPO="${PULSE_CHECK_APPLY_REPO:-}"
 JSON_OUTPUT=0
 APPLY_MODE=0
@@ -52,6 +54,8 @@ Options:
   --window <15m|30m|1h>       Current-state window (default: ${WINDOW})
   --since <1h|6h|24h|48h|7d> Historical worker summary window (default: ${SINCE})
   --recent <1h|6h|24h>       Recent worker outcome window (default: ${RECENT_SINCE})
+  --budget <seconds>         Collection deadline; missing evidence stays unknown (default: ${REPORT_BUDGET_SECONDS})
+  --verify-delivery          Also verify GitHub delivery counts within the collection deadline
   --repo <owner/repo>        Repo for --apply self-improvement issues
   --max-issues <N>           Per-repo auto-dispatch issue scan limit (default: ${MAX_ISSUES_PER_REPO})
   --available-threshold <N>  Queue depth threshold for underfill findings (default: ${AVAILABLE_THRESHOLD})
@@ -81,6 +85,8 @@ _parse_args() {
 		--window) WINDOW="$next"; shift 2 ;;
 		--since) SINCE="$next"; shift 2 ;;
 		--recent) RECENT_SINCE="$next"; shift 2 ;;
+		--budget) REPORT_BUDGET_SECONDS="$next"; shift 2 ;;
+		--verify-delivery) VERIFY_DELIVERY=1; shift ;;
 		--repo) APPLY_REPO="$next"; shift 2 ;;
 		--max-issues) MAX_ISSUES_PER_REPO="$next"; shift 2 ;;
 		--available-threshold) AVAILABLE_THRESHOLD="$next"; shift 2 ;;
@@ -103,6 +109,7 @@ _validate_numeric_options() {
 	[[ "$NMR_INACTIVE_MINUTES" =~ ^[0-9]+$ ]] || NMR_INACTIVE_MINUTES=10080
 	[[ "$FAILURE_FAMILY_THRESHOLD" =~ ^[0-9]+$ ]] || FAILURE_FAMILY_THRESHOLD=3
 	[[ "$FAILURE_FAMILY_RECOVERY_SECONDS" =~ ^[0-9]+$ ]] || FAILURE_FAMILY_RECOVERY_SECONDS=86400
+	[[ "$REPORT_BUDGET_SECONDS" =~ ^[1-9][0-9]*$ ]] || REPORT_BUDGET_SECONDS=45
 	return 0
 }
 
@@ -111,13 +118,26 @@ _run_json_helper() {
 	shift
 
 	local output=""
-	local rc=0
-	output=$("$@" 2>/dev/null) || rc=$?
-	if [[ "$rc" -ne 0 || -z "$output" ]] || ! printf '%s' "$output" | jq empty >/dev/null 2>&1; then
-		printf '%s\n' "$fallback_json"
-		return 0
+	local rc=0 started="$SECONDS" state="ok"
+	local remaining=$((_PULSE_CHECK_REPORT_DEADLINE - SECONDS))
+	local component_budget="${_PULSE_CHECK_COMPONENT_BUDGET:-10}"
+	if [[ "$remaining" -le 0 ]]; then
+		state="deadline_exhausted"
+	else
+		[[ "$remaining" -lt "$component_budget" ]] && component_budget="$remaining"
+		output=$(timeout_sec "$component_budget" "$@" 2>/dev/null) || rc=$?
+		if [[ "$rc" -eq 124 ]]; then
+			state="timed_out"
+		elif [[ "$rc" -ne 0 ]]; then
+			state="failed"
+		elif [[ -z "$output" ]] || ! printf '%s' "$output" | jq -e 'type == "object"' >/dev/null 2>&1; then
+			state="invalid_json"
+		fi
 	fi
-	printf '%s\n' "$output"
+	[[ "$state" == "ok" ]] || output="$fallback_json"
+	printf '%s' "$output" | jq --arg state "$state" --argjson rc "$rc" \
+		--argjson elapsed "$((SECONDS - started))" \
+		'. + {_collection:{state:$state,exit_code:$rc,elapsed_seconds:$elapsed}}'
 	return 0
 }
 
@@ -132,7 +152,8 @@ _scan_auto_dispatch_queue() {
 		PULSE_CHECK_MAX_ISSUES_PER_REPO="$MAX_ISSUES_PER_REPO" \
 		PULSE_CHECK_OLD_AVAILABLE_MINUTES="$OLD_AVAILABLE_MINUTES" \
 		PULSE_CHECK_NMR_INACTIVE_MINUTES="$NMR_INACTIVE_MINUTES" \
-		python3 "$QUEUE_SCANNER"
+		_PULSE_CHECK_COMPONENT_BUDGET=25 \
+		_run_json_helper '{"aggregate":{},"error":"queue_collection_unavailable"}' python3 "$QUEUE_SCANNER"
 	return 0
 }
 
@@ -145,6 +166,8 @@ _collect_report_json() {
 	local api_budget="{}"
 	local queue="{}"
 	local pulse_health="{}"
+	local delivery='{"_collection":{"state":"not_requested"}}'
+	_PULSE_CHECK_REPORT_DEADLINE=$((SECONDS + REPORT_BUDGET_SECONDS))
 
 	current_state=$(_run_json_helper '{}' "$CURRENT_STATE_HELPER" --window "$WINDOW" --json)
 	if [[ -f "$PULSE_HEALTH_FILE" ]]; then
@@ -153,8 +176,6 @@ _collect_report_json() {
 	fi
 	worker_summary=$(_run_json_helper '{}' "$WORKER_ACTIVITY_HELPER" summary --since "$SINCE" --json --no-pr-check)
 	worker_recent=$(_run_json_helper '{}' "$WORKER_ACTIVITY_HELPER" summary --since "$RECENT_SINCE" --json --no-pr-check)
-	providers=$(_run_json_helper '{}' "$WORKER_ACTIVITY_HELPER" providers --since "$RECENT_SINCE" --json)
-	runner_health=$(_run_json_helper '{}' "$RUNNER_HEALTH_HELPER" diagnose --json)
 	api_budget=$(_run_json_helper '{}' "$PULSE_DIAGNOSE_HELPER" api-budget --json)
 	local rest_admission="{}"
 	rest_admission=$(_run_json_helper '{}' python3 "${SCRIPT_DIR}/gh_transport_budget.py" status)
@@ -168,6 +189,15 @@ _collect_report_json() {
 	else
 		queue=$(_scan_auto_dispatch_queue)
 	fi
+	# Optional diagnostics must not consume the ready-work inventory budget.
+	if [[ "$VERIFY_DELIVERY" -eq 1 && "$skip_queue_scan" != "1" ]]; then
+		delivery=$(_PULSE_CHECK_COMPONENT_BUDGET=20 _run_json_helper '{}' \
+			"$WORKER_ACTIVITY_HELPER" summary --since "$SINCE" --json --pr-check)
+	elif [[ "$VERIFY_DELIVERY" -eq 1 ]]; then
+		delivery='{"_collection":{"state":"api_cooldown_active"}}'
+	fi
+	providers=$(_run_json_helper '{}' "$WORKER_ACTIVITY_HELPER" providers --since "$RECENT_SINCE" --json)
+	runner_health=$(_run_json_helper '{}' "$RUNNER_HEALTH_HELPER" diagnose --json)
 
 	if [[ ! -f "$REPORT_FILTER" ]]; then
 		print_error "pulse-check: report filter not found: ${REPORT_FILTER}"
@@ -187,6 +217,7 @@ _collect_report_json() {
 		--argjson runner "$runner_health" \
 		--argjson api "$api_budget" \
 		--argjson queue "$queue" \
+		--argjson delivery "$delivery" \
 		-f "$REPORT_FILTER"
 	return 0
 }
@@ -196,14 +227,18 @@ _render_text_report() {
 	printf '%s' "$report_json" | jq -r '
 		def percent_text: if . == null then "n/a" else (. | tostring) + "%" end;
 		def unknown: "unknown";
+		def count_text: if . == null then unknown else tostring end;
 		"Pulse Check — " + .generated_at,
 		"",
 		"## Current utilisation",
-		"- Active workers: " + (.summary.active_workers | tostring) + " / " + (.summary.max_workers | tostring) + " (available slots: " + (.summary.available_slots | tostring) + ")",
-		"- Auto-dispatch queue: " + (.summary.auto_dispatch_available_unassigned | tostring) + " available (" + (.summary.auto_dispatch_eligible_available_unassigned | tostring) + " label-eligible; launch admission not verified) / " + (.summary.auto_dispatch_open | tostring) + " open across " + (.queue.repos | tostring) + " pulse repos",
+		"- Active workers: " + (.summary.active_workers | count_text) + " / " + (.summary.max_workers | count_text) + " (available slots: " + (.summary.available_slots | count_text) + ")",
+		"- Auto-dispatch queue: " + (.summary.auto_dispatch_available_unassigned | count_text) + " available (" + (.summary.auto_dispatch_eligible_available_unassigned | count_text) + " label-eligible; launch admission not verified) / " + (.summary.auto_dispatch_open | count_text) + " open across " + (.queue.repos | count_text) + " pulse repos",
 		"- Queue scan state: " + (.summary.auto_dispatch_scan_state // "scanned"),
-		"- Current window launches: " + (.summary.worker_launches_in_window | tostring) + "; terminal worker events: " + (.summary.worker_terminal_events_in_window | tostring),
-		"- Recent worker metric events: " + (.summary.recent_worker_events | tostring) + "; " + .inputs.historical_window + " runtime handoff rate: " + (.summary.historical_runtime_handoff_rate | percent_text) + "; delivered success rate: " + (.summary.historical_delivery_success_rate | percent_text),
+		"- Queue coverage: " + (.queue.repos_scanned | count_text) + "/" + (.queue.repos | count_text) + " repositories; counts are " + .summary.queue_counts_basis + ", not independent work targets",
+		"- Collection evidence: " + (.collection | tojson),
+		"- Current window launches: " + (.summary.worker_launches_in_window | count_text) + "; terminal worker events: " + (.summary.worker_terminal_events_in_window | count_text),
+		"- Recent worker metric events: " + (.summary.recent_worker_events | count_text) + "; " + .inputs.historical_window + " runtime handoff rate: " + (.summary.historical_runtime_handoff_rate | percent_text),
+		"- Verified deliveries in " + .inputs.historical_window + ": " + (.summary.historical_worker_delivered_successes | count_text) + " (" + .summary.delivery_measurement_state + "; independent of the local attempt cohort)",
 		"- GraphQL: " + (.summary.graphql_budget_status // unknown),
 		"- REST transport admission: " + ((.summary.rest_admission // {state:"unknown"}) | tojson),
 		"- Current launch blockers: " + ((.current_state.top_pre_launch_blockers // []) | tojson),
@@ -218,7 +253,7 @@ _render_text_report() {
 		"## Evidence commands",
 		"- pulse-current-state-helper.sh --window " + .inputs.current_window + " --json",
 		"- worker-activity-helper.sh summary --since " + .inputs.recent_window + " --json --no-pr-check",
-		"- worker-activity-helper.sh summary --since " + .inputs.historical_window + " --json --no-pr-check",
+		"- worker-activity-helper.sh summary --since " + .inputs.historical_window + " --json --pr-check",
 		"- worker-activity-helper.sh live-workers",
 		"- pulse-diagnose-helper.sh cycle-health --window 1h",
 		"",

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -148,11 +148,20 @@ _scan_auto_dispatch_queue() {
 		return 0
 	fi
 
+	local remaining=$((_PULSE_CHECK_REPORT_DEADLINE - SECONDS))
+	local queue_budget="${PULSE_CHECK_QUEUE_BUDGET_SECONDS:-20}"
+	[[ "$queue_budget" =~ ^[1-9][0-9]*$ ]] || queue_budget=20
+	if [[ "$remaining" -le 2 ]]; then
+		queue_budget=1
+	elif [[ "$queue_budget" -gt $((remaining - 2)) ]]; then
+		queue_budget=$((remaining - 2))
+	fi
 	PULSE_CHECK_REPOS_JSON="$REPOS_JSON" \
 		PULSE_CHECK_MAX_ISSUES_PER_REPO="$MAX_ISSUES_PER_REPO" \
 		PULSE_CHECK_OLD_AVAILABLE_MINUTES="$OLD_AVAILABLE_MINUTES" \
 		PULSE_CHECK_NMR_INACTIVE_MINUTES="$NMR_INACTIVE_MINUTES" \
-		_PULSE_CHECK_COMPONENT_BUDGET=25 \
+		PULSE_CHECK_QUEUE_BUDGET_SECONDS="$queue_budget" \
+		_PULSE_CHECK_COMPONENT_BUDGET="$((queue_budget + 2))" \
 		_run_json_helper '{"aggregate":{},"error":"queue_collection_unavailable"}' python3 "$QUEUE_SCANNER"
 	return 0
 }
@@ -171,7 +180,7 @@ _collect_report_json() {
 
 	current_state=$(_run_json_helper '{}' "$CURRENT_STATE_HELPER" --window "$WINDOW" --json)
 	if [[ -f "$PULSE_HEALTH_FILE" ]]; then
-		pulse_health=$(jq -c . "$PULSE_HEALTH_FILE" 2>/dev/null || printf '{}')
+		pulse_health=$(jq -c 'if type == "object" then . else {} end' "$PULSE_HEALTH_FILE" 2>/dev/null || printf '{}')
 		current_state=$(printf '%s' "$current_state" | jq -c --argjson health "$pulse_health" '. + {pulse_health: $health}' 2>/dev/null || printf '%s' "$current_state")
 	fi
 	worker_summary=$(_run_json_helper '{}' "$WORKER_ACTIVITY_HELPER" summary --since "$SINCE" --json --no-pr-check)

--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -14,6 +14,7 @@ import shutil
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
+from functools import lru_cache
 from typing import Any, Optional
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
@@ -173,7 +174,9 @@ def _load_repos(repos_json: pathlib.Path) -> tuple[list[dict[str, Any]], str]:
     return repos, ""
 
 
+@lru_cache(maxsize=None)
 def _fetch_repo_issues(slug: str, max_issues: int) -> Optional[list[dict[str, Any]]]:
+    """Reuse the same bounded inventory during this report's enrichment pass."""
     issues: Optional[list[dict[str, Any]]] = None
     cmd = [
         "gh", "issue", "list",
@@ -269,12 +272,9 @@ def _scan_repo(
     max_issues: int,
     now: dt.datetime,
     old_minutes: int,
-    issues: Optional[list[dict[str, Any]]] = None,
-    prefetched: bool = False,
 ) -> None:
     slug = str(repo.get("slug") or "")
-    if not prefetched:
-        issues = _fetch_repo_issues(slug, max_issues)
+    issues = _fetch_repo_issues(slug, max_issues)
     if issues is None:
         aggregate[GH_ERRORS_KEY] += 1
         return
@@ -325,11 +325,11 @@ def main() -> int:
     # Inventory all repositories before spending the remaining budget on
     # dependency/progress enrichment. Independent reads retain gh admission.
     with ThreadPoolExecutor(max_workers=4) as pool:
-        inventories = list(pool.map(_fetch_repo_issues,
-                                    [str(repo.get("slug") or "") for repo in repos],
-                                    [max_issues] * len(repos)))
-    for repo, issues in zip(repos, inventories):
-        _scan_repo(aggregate, repo, max_issues, now, old_minutes, issues, prefetched=True)
+        list(pool.map(_fetch_repo_issues,
+                      [str(repo.get("slug") or "") for repo in repos],
+                      [max_issues] * len(repos)))
+    for repo in repos:
+        _scan_repo(aggregate, repo, max_issues, now, old_minutes)
 
     error = "queue_budget_exhausted" if time.monotonic() >= dependency_scan.QUERY_DEADLINE else ""
     _emit(aggregate, error=error, scanned_at=now.isoformat())

--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -11,8 +11,9 @@ import os
 import pathlib
 import re
 import shutil
-import subprocess
 import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
@@ -62,6 +63,8 @@ def _int_from_env(name: str, default: int) -> int:
 def _empty_aggregate() -> dict[str, int]:
     return {
         "repos": 0,
+        "repos_scanned": 0,
+        "dependency_unknown": 0,
         "auto_dispatch_open": 0,
         "available_unassigned": 0,
         "eligible_available_unassigned": 0,
@@ -181,24 +184,9 @@ def _fetch_repo_issues(slug: str, max_issues: int) -> Optional[list[dict[str, An
         "--json", "number,title,body,labels,assignees,createdAt,updatedAt",
     ]
     if _valid_repo_slug(slug):
-        try:
-            # Fixed argv, shell=False, validated owner/repo slug.
-            completed = subprocess.run(  # nosec B603
-                cmd,
-                text=True,
-                capture_output=True,
-                timeout=30,
-                check=False,
-            )
-        except (OSError, subprocess.SubprocessError):
-            completed = None
-        if completed is not None and completed.returncode == 0:
-            try:
-                parsed = json.loads(completed.stdout or "[]")
-            except json.JSONDecodeError:
-                parsed = None
-            if isinstance(parsed, list):
-                issues = [issue for issue in parsed if isinstance(issue, dict)]
+        parsed = _run_gh_json(cmd)
+        if isinstance(parsed, list):
+            issues = [issue for issue in parsed if isinstance(issue, dict)]
     return issues
 
 
@@ -281,12 +269,16 @@ def _scan_repo(
     max_issues: int,
     now: dt.datetime,
     old_minutes: int,
+    issues: Optional[list[dict[str, Any]]] = None,
+    prefetched: bool = False,
 ) -> None:
     slug = str(repo.get("slug") or "")
-    issues = _fetch_repo_issues(slug, max_issues)
+    if not prefetched:
+        issues = _fetch_repo_issues(slug, max_issues)
     if issues is None:
         aggregate[GH_ERRORS_KEY] += 1
         return
+    aggregate["repos_scanned"] += 1
     if len(issues) > max_issues:
         aggregate[GH_ERRORS_KEY] += 1
         issues = issues[:max_issues]
@@ -294,7 +286,11 @@ def _scan_repo(
         inconsistent, scan_error = _dependency_diagnostic(slug, issue)
         issue["dependency_inconsistent"] = inconsistent
         aggregate[GH_ERRORS_KEY] += int(scan_error)
-        _count_durable_progress(aggregate, slug, issue, now)
+        aggregate["dependency_unknown"] += int(scan_error)
+        if dependency_scan.QUERY_DEADLINE is None or time.monotonic() < dependency_scan.QUERY_DEADLINE:
+            _count_durable_progress(aggregate, slug, issue, now)
+        else:
+            aggregate["durable_progress_unknown"] += 1
     repo_available = sum(
         int(_count_issue(aggregate, issue, now, old_minutes))
         for issue in issues
@@ -324,10 +320,19 @@ def main() -> int:
         return 0
 
     now = dt.datetime.now(dt.timezone.utc)
-    for repo in repos:
-        _scan_repo(aggregate, repo, max_issues, now, old_minutes)
+    budget = max(1, _int_from_env("PULSE_CHECK_QUEUE_BUDGET_SECONDS", 20))
+    dependency_scan.QUERY_DEADLINE = time.monotonic() + budget
+    # Inventory all repositories before spending the remaining budget on
+    # dependency/progress enrichment. Independent reads retain gh admission.
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        inventories = list(pool.map(_fetch_repo_issues,
+                                    [str(repo.get("slug") or "") for repo in repos],
+                                    [max_issues] * len(repos)))
+    for repo, issues in zip(repos, inventories):
+        _scan_repo(aggregate, repo, max_issues, now, old_minutes, issues, prefetched=True)
 
-    _emit(aggregate, scanned_at=now.isoformat())
+    error = "queue_budget_exhausted" if time.monotonic() >= dependency_scan.QUERY_DEADLINE else ""
+    _emit(aggregate, error=error, scanned_at=now.isoformat())
     return 0
 
 

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -19,7 +19,14 @@ def non_failure_handoff_family:
   and ((.examples // []) | length) > 0
   and all(.examples[]?; .result == "post_pr_handoff" and (.exit_code // 1) == 0);
 
-(($current.active_worker_processes // $current.pulse_health.workers_active // null) | capacity_number) as $active_worker_processes |
+(try ($window | capture("^(?<value>[0-9]+)(?<unit>[smhd])$")
+  | (.value | tonumber) * ({s:1,m:60,h:3600,d:86400}[.unit])) catch null) as $window_seconds |
+(try ($current.pulse_health.timestamp | fromdateiso8601) catch null) as $health_timestamp |
+(if $health_timestamp == null then null else now - $health_timestamp end) as $health_age |
+($health_age != null and $window_seconds != null and $health_age >= 0 and $health_age <= $window_seconds) as $health_fresh |
+($current.active_worker_processes | capacity_number) as $process_workers |
+((if $health_fresh then $current.pulse_health.workers_active else null end) | capacity_number) as $health_workers |
+($process_workers // $health_workers) as $active_worker_processes |
 (($current.pulse_gauges.dispatch_capacity_final_max_workers // $current.pulse_health.workers_max // null) | capacity_number) as $raw_max_workers |
 ($current.current_state_guardrails.available_slots_last // $current.pulse_gauges.pulse_dispatch_guardrail_available_slots // (if ($current.pulse_health.workers_max // null) == null or $active_worker_processes == null then null else ([($current.pulse_health.workers_max | number_or_zero) - $active_worker_processes, 0] | max) end)) as $raw_available_slots |
 ($raw_available_slots | capacity_number) as $available_slots |
@@ -88,10 +95,13 @@ end) as $max_workers |
   summary: {
     max_workers: $max_workers,
     active_workers: $active_workers,
-    active_workers_source: (if $active_workers == null then "unavailable" elif $active_worker_processes == null then "capacity_gauge" else "process_scan" end),
+    active_workers_source: (if $process_workers != null then "process_scan" elif $health_workers != null then "pulse_health_snapshot" elif $active_workers != null then "capacity_gauge" else "unavailable" end),
+    max_workers_source: (if ($current.pulse_gauges.dispatch_capacity_final_max_workers | capacity_number) != null then "capacity_gauge" elif ($current.pulse_health.workers_max | capacity_number) != null then "pulse_health_configured_snapshot" elif $max_workers != null then "inferred_from_observed_slots" else "unavailable" end),
+    health_snapshot_fresh: $health_fresh,
+    health_snapshot_age_seconds: (if $health_age == null then null else ($health_age | floor) end),
     inferred_active_workers: $inferred_active_workers,
     available_slots: $effective_available_slots,
-    capacity_state: (if $max_workers == null or $effective_available_slots == null then "unknown" else "observed" end),
+    capacity_state: (if $max_workers == null or $effective_available_slots == null then "unknown" elif $raw_max_workers != null and ($current.pulse_gauges.dispatch_capacity_final_max_workers | capacity_number) == null then "configured_snapshot" else "observed" end),
     cycle_state_freshness: ($current.cycle_state.availability // "unavailable"),
     dispatch_alive: (if $current.dispatch_alive == null then null else $dispatch_alive end),
     dispatch_stage_events: ($current.dispatch_stage_events // null),

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -1,4 +1,6 @@
 def number_or_zero: (tonumber? // 0);
+def capacity_number:
+  (tonumber? // null) | if type == "number" and . >= 0 and floor == . then . else null end;
 
 def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
   id: $id,
@@ -17,18 +19,18 @@ def non_failure_handoff_family:
   and ((.examples // []) | length) > 0
   and all(.examples[]?; .result == "post_pr_handoff" and (.exit_code // 1) == 0);
 
-(if ($current.active_worker_processes // $current.pulse_health.workers_active // null) == null then null else ($current.active_worker_processes // $current.pulse_health.workers_active | number_or_zero) end) as $active_worker_processes |
-($current.pulse_gauges.dispatch_capacity_final_max_workers // $current.pulse_health.workers_max // null) as $raw_max_workers |
+(($current.active_worker_processes // $current.pulse_health.workers_active // null) | capacity_number) as $active_worker_processes |
+(($current.pulse_gauges.dispatch_capacity_final_max_workers // $current.pulse_health.workers_max // null) | capacity_number) as $raw_max_workers |
 ($current.current_state_guardrails.available_slots_last // $current.pulse_gauges.pulse_dispatch_guardrail_available_slots // (if ($current.pulse_health.workers_max // null) == null or $active_worker_processes == null then null else ([($current.pulse_health.workers_max | number_or_zero) - $active_worker_processes, 0] | max) end)) as $raw_available_slots |
-($raw_available_slots // 0 | number_or_zero) as $available_slots |
+($raw_available_slots | capacity_number) as $available_slots |
 (if $raw_max_workers == null then
-  (if $active_worker_processes == null then $available_slots else ($active_worker_processes + $available_slots) end)
+  (if $active_worker_processes == null or $available_slots == null then null else ($active_worker_processes + $available_slots) end)
 else
-  ($raw_max_workers | number_or_zero)
+  $raw_max_workers
 end) as $max_workers |
-([$max_workers - $available_slots, 0] | max) as $inferred_active_workers |
+(if $max_workers == null or $available_slots == null then null else ([$max_workers - $available_slots, 0] | max) end) as $inferred_active_workers |
 (if $active_worker_processes == null then $inferred_active_workers else $active_worker_processes end) as $active_workers |
-(if $active_worker_processes == null then $available_slots else ([$max_workers - $active_worker_processes, 0] | max) end) as $effective_available_slots |
+(if $active_worker_processes == null or $max_workers == null then $available_slots else ([$max_workers - $active_worker_processes, 0] | max) end) as $effective_available_slots |
 ($queue.aggregate.available_unassigned // 0 | number_or_zero) as $available_issues |
 ($queue.aggregate.eligible_available_unassigned // $queue.aggregate.available_unassigned // 0 | number_or_zero) as $eligible_issues |
 ($queue.aggregate.excluded_persistent_dashboard // 0 | number_or_zero) as $excluded_persistent_dashboard |
@@ -50,7 +52,7 @@ end) as $max_workers |
 ($summary.metrics.total // 0 | number_or_zero) as $hist_total |
 ($summary.metrics.terminal_session_total // $summary.metrics.total // 0 | number_or_zero) as $hist_terminal_total |
 ($summary.metrics.runtime_handoffs // $summary.metrics.succeeded // 0 | number_or_zero) as $hist_handoffs |
-($summary.delivery_stages // {}) as $hist_delivery |
+(if ($delivery._collection.state // "") == "ok" then ($delivery.delivery_stages // {}) else ($summary.delivery_stages // {}) end) as $hist_delivery |
 (if $hist_delivery.delivered_successes == null then null else ($hist_delivery.delivered_successes | number_or_zero) end) as $hist_delivered |
 ($summary.metrics.failure_families // [] | map(select(non_failure_handoff_family | not))) as $failure_families |
 ($recent_summary.metrics.failure_families // [] | map(select(non_failure_handoff_family | not))) as $recent_failure_families |
@@ -73,37 +75,54 @@ end) as $max_workers |
 {
   generated_at: (now | todateiso8601),
   inputs: {current_window: $window, historical_window: $since, recent_window: $recent},
+  collection: {
+    current: ($current._collection // {state:"unknown"}),
+    history: ($summary._collection // {state:"unknown"}),
+    recent: ($recent_summary._collection // {state:"unknown"}),
+    api: ($api._collection // {state:"unknown"}),
+    queue: ($queue._collection // {state:"unknown"}),
+    delivery: ($delivery._collection // {state:"not_requested"}),
+    providers: ($providers._collection // {state:"unknown"}),
+    runner: ($runner._collection // {state:"unknown"})
+  },
   summary: {
     max_workers: $max_workers,
     active_workers: $active_workers,
-    active_workers_source: (if $active_worker_processes == null then "capacity_gauge" else "process_scan" end),
+    active_workers_source: (if $active_workers == null then "unavailable" elif $active_worker_processes == null then "capacity_gauge" else "process_scan" end),
     inferred_active_workers: $inferred_active_workers,
     available_slots: $effective_available_slots,
-    dispatch_alive: $dispatch_alive,
-    dispatch_stage_events: ($current.dispatch_stage_events // 0),
-    worker_launches_in_window: $spawned,
-    worker_terminal_events_in_window: $current_terminal_events,
+    capacity_state: (if $max_workers == null or $effective_available_slots == null then "unknown" else "observed" end),
+    cycle_state_freshness: ($current.cycle_state.availability // "unavailable"),
+    dispatch_alive: (if $current.dispatch_alive == null then null else $dispatch_alive end),
+    dispatch_stage_events: ($current.dispatch_stage_events // null),
+    worker_launches_in_window: (if $current.worker_outcomes.spawned == null then null else $spawned end),
+    worker_terminal_events_in_window: (if $current.worker_terminal_events == null then null else $current_terminal_events end),
     worker_launch_validation_failures_in_window: $launch_validation_failed,
-    recent_worker_events: $recent_total,
-    historical_worker_events: $hist_total,
+    recent_worker_events: (if $recent_summary.metrics.total == null then null else $recent_total end),
+    historical_worker_events: (if $summary.metrics.total == null then null else $hist_total end),
     historical_worker_runtime_handoffs: $hist_handoffs,
     historical_runtime_handoff_rate: (if $hist_terminal_total > 0 then (($hist_handoffs / $hist_terminal_total) * 100 | floor) else null end),
     historical_worker_delivered_successes: $hist_delivered,
-    historical_delivery_success_rate: (if $hist_terminal_total > 0 and $hist_delivered != null then (($hist_delivered / $hist_terminal_total) * 100 | floor) else null end),
+    historical_delivery_success_rate: null,
+    delivery_measurement_state: ($hist_delivery.check_state // $delivery._collection.state // "unavailable"),
+    delivery_rate_basis: "unavailable_without_matched_attempt_cohort",
     historical_worker_successes: $hist_delivered,
-    historical_success_rate: (if $hist_terminal_total > 0 and $hist_delivered != null then (($hist_delivered / $hist_terminal_total) * 100 | floor) else null end),
-    auto_dispatch_open: ($queue.aggregate.auto_dispatch_open // 0),
-    auto_dispatch_available_unassigned: $available_issues,
-    auto_dispatch_eligible_available_unassigned: $eligible_issues,
+    historical_success_rate: null,
+    auto_dispatch_open: ($queue.aggregate.auto_dispatch_open // null),
+    auto_dispatch_available_unassigned: (if $queue.aggregate.available_unassigned == null then null else $available_issues end),
+    auto_dispatch_eligible_available_unassigned: (if $queue.aggregate.available_unassigned == null then null else $eligible_issues end),
     auto_dispatch_excluded_persistent_dashboard: $excluded_persistent_dashboard,
     auto_dispatch_available_old: $old_available,
     auto_dispatch_dependency_inconsistent_available: $dependency_inconsistent,
     auto_dispatch_repos_with_available: ($queue.aggregate.repos_with_available // 0),
     auto_dispatch_scan_errors: $gh_errors,
-    auto_dispatch_scan_state: (if $queue_error == "" then "scanned" else $queue_error end),
+    auto_dispatch_scan_state: (if $queue_error != "" then $queue_error elif $gh_errors > 0 then "partial" else "scanned" end),
+    auto_dispatch_scan_complete: $queue_scan_complete,
+    queue_counts_basis: (if $queue_scan_complete then "complete_inventory" elif $queue.aggregate.auto_dispatch_open == null then "unavailable" else "partial_observation" end),
     graphql_budget_status: ($current.graphql_budget_status // "unknown"),
     rest_admission: ($api.rest_admission // {state:"unknown"}),
     eligibility_basis: "labels_and_dependencies_not_launch_admission",
+    parallelism_basis: "issue_entries_not_deduplicated_work_targets",
     secondary_cooldown_state: $secondary_cooldown_state,
     secondary_cooldown_active: $secondary_cooldown_active,
     runner_health: ($runner.finding // "unknown"),
@@ -374,7 +393,7 @@ end) as $max_workers |
         "medium";
         "Auto-dispatch queue scan was skipped or incomplete";
         [("queue_scan_state=" + $queue_error)];
-        "Re-run pulse-check after API cooldown clears before making queue-depth or underfill claims.";
+        "Inspect collection timings and queue coverage; distinguish deadline exhaustion from API cooldown. Retry only missing evidence within an explicit budget before making queue-depth or underfill claims.";
         false
       )
     else empty end,
@@ -398,16 +417,7 @@ end) as $max_workers |
         false
       )
     else empty end,
-    if ($hist_terminal_total >= 10 and $hist_delivered != null and (($hist_delivered * 100) / $hist_terminal_total) < 70) then
-      finding(
-        "worker-delivery-rate-regression";
-        "medium";
-        "Historical worker delivered-success rate is below the productivity target";
-        [("delivered_success_rate_percent=" + (((($hist_delivered * 100) / $hist_terminal_total) | floor) | tostring)), ("delivered_successes=" + ($hist_delivered | tostring)), ("terminal_session_outcomes=" + ($hist_terminal_total | tostring))];
-        "Compare runtime handoffs, opened PRs, merged PRs, and solved issues with worker-activity-helper summary --pr-check before changing dispatch capacity.";
-        false
-      )
-    else empty end
+    empty
     ,
     ($failure_families[] as $family
       | $family

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -149,6 +149,16 @@ def valid_cycle_state_contract(state):
     return valid_terminal_cycle_state(state, progress, blocker)
 
 
+def cycle_state_problem(state):
+    if not isinstance(state, dict):
+        return 'malformed', 'cycle-state-object'
+    if not valid_cycle_state_contract(state):
+        return 'malformed', 'cycle-state-contract'
+    if parse_time(state['heartbeat_at']) > now:
+        return 'unavailable', 'future-heartbeat'
+    return None
+
+
 def build_cycle_state(path):
     try:
         with open(path, encoding='utf-8') as handle:
@@ -162,14 +172,12 @@ def build_cycle_state(path):
     state = health.get('cycle_state')
     if state is None:
         return unavailable_cycle_state('unavailable')
-    if not isinstance(state, dict) or not valid_cycle_state_contract(state):
-        reason = 'cycle-state-object' if not isinstance(state, dict) else 'cycle-state-contract'
-        return unavailable_cycle_state('malformed', reason)
+    problem = cycle_state_problem(state)
+    if problem:
+        return unavailable_cycle_state(*problem)
     progress = state['progress']
     blocker = state['blocker']
     heartbeat_age = now - parse_time(state['heartbeat_at'])
-    if heartbeat_age < 0:
-        return unavailable_cycle_state('unavailable', 'future-heartbeat')
     return {
         'availability': 'available' if heartbeat_age <= window_s else 'stale',
         'heartbeat_age_seconds': int(heartbeat_age),

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -167,8 +167,13 @@ def build_cycle_state(path):
         return unavailable_cycle_state('malformed', reason)
     progress = state['progress']
     blocker = state['blocker']
+    heartbeat_age = now - parse_time(state['heartbeat_at'])
+    if heartbeat_age < 0:
+        return unavailable_cycle_state('unavailable', 'future-heartbeat')
     return {
-        'availability': 'available',
+        'availability': 'available' if heartbeat_age <= window_s else 'stale',
+        'heartbeat_age_seconds': int(heartbeat_age),
+        'freshness_window_seconds': window_s,
         'schema': state['schema'],
         'cycle_id': state['cycle_id'],
         'phase': state['phase'],

--- a/.agents/scripts/pulse_check_dependencies.py
+++ b/.agents/scripts/pulse_check_dependencies.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import time
 from typing import Any, Optional
+
+QUERY_DEADLINE: Optional[float] = None
 
 NATIVE_ABSENT = "absent"
 NATIVE_CLEAR = "clear"
@@ -27,9 +30,12 @@ def _issue_labels(issue: dict[str, Any]) -> set[str]:
 
 
 def _run_gh_json(cmd: list[str]) -> Optional[Any]:
+    timeout = 30.0 if QUERY_DEADLINE is None else min(30.0, QUERY_DEADLINE - time.monotonic())
+    if timeout <= 0:
+        return None
     try:
         completed = subprocess.run(  # nosec B603
-            cmd, text=True, capture_output=True, timeout=30, check=False
+            cmd, text=True, capture_output=True, timeout=timeout, check=False
         )
     except (OSError, subprocess.SubprocessError):
         return None

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -134,6 +134,10 @@ cat >"${TEST_ROOT}/worker-activity.sh" <<'SH'
 #!/usr/bin/env bash
 cmd="${1:-}"
 shift || true
+if [[ " $* " == *" --pr-check "* ]]; then
+  printf '%s\n' '{"delivery_stages":{"delivered_successes":30,"pr_merged":30,"check_state":"ok"}}'
+  exit 0
+fi
 if [[ "$cmd" == "providers" ]]; then
   cat <<'JSON'
 {"provider_diagnostics":{"provider_model_usage":[],"recent_events":[],"account_pool":[{"provider":"openai","total":1,"available":1,"capacity_slots":24,"active_idle":1,"rate_limited":0,"auth_errors":0}]}}
@@ -219,6 +223,9 @@ if [[ " $* " == *" api -i /repos/"*"/collaborators/fixture-user/permission "* ||
   exit 0
 fi
 if [[ " $* " == *" api graphql "* ]]; then
+  if [[ "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "slow-dependency-scan" ]]; then
+    sleep 5
+  fi
   if [[ "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "dependency-scan-error" ]]; then
     printf 'simulated dependency lookup failure\n' >&2
     exit 1
@@ -392,6 +399,30 @@ HANDOFF_RATE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.historical_runtime_hand
 assert_eq "json runtime handoff rate uses terminal session denominator" "90" "$HANDOFF_RATE"
 SUCCESS_RATE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.historical_success_rate')
 assert_eq "json delivered success rate is unknown without GitHub delivery check" "null" "$SUCCESS_RATE"
+DELIVERY_JSON=$(env "${COMMON_ENV[@]}" "$HELPER" json --verify-delivery 2>&1)
+assert_eq "explicit delivery verification exposes observed GitHub deliveries" "30" "$(printf '%s' "$DELIVERY_JSON" | jq -r '.summary.historical_worker_delivered_successes')"
+assert_eq "independent delivery counts never create a 300 percent attempt success rate" "null" "$(printf '%s' "$DELIVERY_JSON" | jq -r '.summary.historical_delivery_success_rate')"
+assert_eq "delivery verification retains local terminal handoff denominator" "90" "$(printf '%s' "$DELIVERY_JSON" | jq -r '.summary.historical_runtime_handoff_rate')"
+assert_eq "delivery collection records verified state" "ok" "$(printf '%s' "$DELIVERY_JSON" | jq -r '.collection.delivery.state')"
+
+cat >"${TEST_ROOT}/slow-current.sh" <<'SH'
+#!/usr/bin/env bash
+sleep 10
+printf '{}\n'
+SH
+chmod +x "${TEST_ROOT}/slow-current.sh"
+bounded_start="$SECONDS"
+BOUNDED_JSON=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/slow-current.sh" "$HELPER" json --budget 2 2>&1)
+assert_eq "slow collector returns a timed-out evidence record" "timed_out" "$(printf '%s' "$BOUNDED_JSON" | jq -r '.collection.current.state')"
+assert_eq "timed-out collector does not invent active worker count" "null" "$(printf '%s' "$BOUNDED_JSON" | jq -r '.summary.active_workers')"
+assert_eq "overall report deadline returns before the slow child completes" "true" "$([[ $((SECONDS - bounded_start)) -lt 9 ]] && printf true || printf false)"
+assert_eq "uncollected queue is explicitly unavailable" "queue_collection_unavailable" "$(printf '%s' "$BOUNDED_JSON" | jq -r '.summary.auto_dispatch_scan_state')"
+
+PARTIAL_JSON=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=slow-dependency-scan" "PULSE_CHECK_QUEUE_BUDGET_SECONDS=1" "$HELPER" json 2>&1)
+assert_eq "slow enrichment retains all repository inventories" "2" "$(printf '%s' "$PARTIAL_JSON" | jq -r '.queue.repos_scanned')"
+assert_eq "slow enrichment retains observed open issue counts" "6" "$(printf '%s' "$PARTIAL_JSON" | jq -r '.queue.auto_dispatch_open')"
+assert_eq "queue deadline is explicit instead of empty output" "queue_budget_exhausted" "$(printf '%s' "$PARTIAL_JSON" | jq -r '.summary.auto_dispatch_scan_state')"
+assert_eq "unknown dependency evidence is counted" "true" "$(printf '%s' "$PARTIAL_JSON" | jq -r '.queue.dependency_unknown > 0')"
 HANDOFF_FAMILY_JSON=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_HANDOFF_FAILURE_FIXTURE=yes" "$HELPER" json 2>&1)
 assert_eq "post-PR handoff family is absent from remediation candidates" "0" \
 	"$(printf '%s' "$HANDOFF_FAMILY_JSON" | jq -r '.failure_family_remediation | length')"
@@ -547,8 +578,10 @@ JSON
 SH
 chmod +x "${TEST_ROOT}/current-state-active-no-gauge.sh"
 JSON_ACTIVE_NO_GAUGE_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-active-no-gauge.sh" "$HELPER" json 2>&1)
-assert_eq "json falls back to process count when capacity gauge is absent" "2" "$(printf '%s' "$JSON_ACTIVE_NO_GAUGE_OUT" | jq -r '.summary.max_workers')"
-assert_eq "json absent capacity gauge avoids impossible active over max report" "Active workers: 2 / 2" "$(env "${COMMON_ENV[@]}" "PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-active-no-gauge.sh" "$HELPER" report 2>&1 | grep -o 'Active workers: [0-9] / [0-9]')"
+assert_eq "json preserves unknown maximum when capacity gauge is absent" "null" "$(printf '%s' "$JSON_ACTIVE_NO_GAUGE_OUT" | jq -r '.summary.max_workers')"
+assert_eq "json does not equate unknown capacity with zero free slots" "null" "$(printf '%s' "$JSON_ACTIVE_NO_GAUGE_OUT" | jq -r '.summary.available_slots')"
+assert_eq "json retains the independently observed worker count" "2" "$(printf '%s' "$JSON_ACTIVE_NO_GAUGE_OUT" | jq -r '.summary.active_workers')"
+assert_contains "text explicitly reports unknown capacity" "Active workers: 2 / unknown" "$(env "${COMMON_ENV[@]}" "PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-active-no-gauge.sh" "$HELPER" report 2>&1)"
 
 cat >"${TEST_ROOT}/pulse-health.json" <<'JSON'
 {"workers_active":1,"workers_max":2}

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -407,7 +407,7 @@ assert_eq "delivery collection records verified state" "ok" "$(printf '%s' "$DEL
 
 cat >"${TEST_ROOT}/slow-current.sh" <<'SH'
 #!/usr/bin/env bash
-sleep 10
+sleep "${PULSE_CHECK_FIXTURE_DELAY:-10}"
 printf '{}\n'
 SH
 chmod +x "${TEST_ROOT}/slow-current.sh"
@@ -417,6 +417,14 @@ assert_eq "slow collector returns a timed-out evidence record" "timed_out" "$(pr
 assert_eq "timed-out collector does not invent active worker count" "null" "$(printf '%s' "$BOUNDED_JSON" | jq -r '.summary.active_workers')"
 assert_eq "overall report deadline returns before the slow child completes" "true" "$([[ $((SECONDS - bounded_start)) -lt 9 ]] && printf true || printf false)"
 assert_eq "uncollected queue is explicitly unavailable" "queue_collection_unavailable" "$(printf '%s' "$BOUNDED_JSON" | jq -r '.summary.auto_dispatch_scan_state')"
+assert_eq "missing current measurements are not zero launches" "null" "$(printf '%s' "$BOUNDED_JSON" | jq -r '.summary.worker_launches_in_window')"
+assert_eq "missing queue measurements are not zero open work" "null" "$(printf '%s' "$BOUNDED_JSON" | jq -r '.summary.auto_dispatch_open')"
+
+NESTED_JSON=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/slow-current.sh" \
+	"PULSE_CHECK_FIXTURE_DELAY=2" "PULSE_CHECK_QUEUE_FIXTURE=slow-dependency-scan" "$HELPER" json --budget 8 2>&1)
+assert_eq "nested queue deadline returns valid partial JSON before outer kill" "ok" "$(printf '%s' "$NESTED_JSON" | jq -r '.collection.queue.state')"
+assert_eq "nested deadline preserves collected inventories" "2" "$(printf '%s' "$NESTED_JSON" | jq -r '.queue.repos_scanned')"
+assert_eq "nested deadline marks incomplete enrichment" "queue_budget_exhausted" "$(printf '%s' "$NESTED_JSON" | jq -r '.summary.auto_dispatch_scan_state')"
 
 PARTIAL_JSON=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=slow-dependency-scan" "PULSE_CHECK_QUEUE_BUDGET_SECONDS=1" "$HELPER" json 2>&1)
 assert_eq "slow enrichment retains all repository inventories" "2" "$(printf '%s' "$PARTIAL_JSON" | jq -r '.queue.repos_scanned')"
@@ -583,9 +591,7 @@ assert_eq "json does not equate unknown capacity with zero free slots" "null" "$
 assert_eq "json retains the independently observed worker count" "2" "$(printf '%s' "$JSON_ACTIVE_NO_GAUGE_OUT" | jq -r '.summary.active_workers')"
 assert_contains "text explicitly reports unknown capacity" "Active workers: 2 / unknown" "$(env "${COMMON_ENV[@]}" "PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-active-no-gauge.sh" "$HELPER" report 2>&1)"
 
-cat >"${TEST_ROOT}/pulse-health.json" <<'JSON'
-{"workers_active":1,"workers_max":2}
-JSON
+jq -n '{workers_active:1,workers_max:2,timestamp:(now | todateiso8601)}' >"${TEST_ROOT}/pulse-health.json"
 cat >"${TEST_ROOT}/current-state-active-health-only.sh" <<'SH'
 #!/usr/bin/env bash
 cat <<'JSON'
@@ -606,6 +612,18 @@ JSON_ACTIVE_HEALTH_OUT=$(env "${COMMON_ENV[@]}" \
 	"PULSE_CHECK_PULSE_HEALTH_FILE=${TEST_ROOT}/pulse-health.json" "$HELPER" json 2>&1)
 assert_eq "json falls back to pulse health max when capacity gauge is absent" "2" "$(printf '%s' "$JSON_ACTIVE_HEALTH_OUT" | jq -r '.summary.max_workers')"
 assert_eq "json derives available slots from pulse health when gauge is absent" "1" "$(printf '%s' "$JSON_ACTIVE_HEALTH_OUT" | jq -r '.summary.available_slots')"
+assert_eq "fresh health count is named as a snapshot not a process scan" "pulse_health_snapshot" "$(printf '%s' "$JSON_ACTIVE_HEALTH_OUT" | jq -r '.summary.active_workers_source')"
+assert_eq "health maximum is characterized as configured snapshot" "pulse_health_configured_snapshot" "$(printf '%s' "$JSON_ACTIVE_HEALTH_OUT" | jq -r '.summary.max_workers_source')"
+for health_age in stale missing future; do
+	jq -n --arg age "$health_age" '{workers_active:1,workers_max:2,
+      timestamp:(if $age == "missing" then null elif $age == "stale" then (now - 3600 | todateiso8601) else (now + 3600 | todateiso8601) end)}' >"${TEST_ROOT}/pulse-health.json"
+	HEALTH_UNKNOWN_JSON=$(env "${COMMON_ENV[@]}" \
+		"PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-active-health-only.sh" \
+		"PULSE_CHECK_PULSE_HEALTH_FILE=${TEST_ROOT}/pulse-health.json" "$HELPER" json 2>&1)
+	assert_eq "$health_age health snapshot does not supply current workers" "null" "$(printf '%s' "$HEALTH_UNKNOWN_JSON" | jq -r '.summary.active_workers')"
+	assert_eq "$health_age health snapshot does not supply free slots" "null" "$(printf '%s' "$HEALTH_UNKNOWN_JSON" | jq -r '.summary.available_slots')"
+	assert_eq "$health_age health snapshot retains separately identified configured maximum" "2" "$(printf '%s' "$HEALTH_UNKNOWN_JSON" | jq -r '.summary.max_workers')"
+done
 
 cat >"${TEST_ROOT}/current-state-shortfall.sh" <<'SH'
 #!/usr/bin/env bash

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -267,6 +267,17 @@ missing_json="$TMP_DIR/missing-cycle-state.json"
 "$HELPER" --log-dir "$missing_dir" --repo-path "$PWD" --window 15m --json >"$missing_json"
 jq -e '.cycle_state.availability == "unavailable"' "$missing_json" >/dev/null
 
+jq '.cycle_state.heartbeat_at = ((now - 1800) | todateiso8601)' \
+	"$TMP_DIR/pulse-health.json" >"$missing_dir/pulse-health.json"
+"$HELPER" --log-dir "$missing_dir" --repo-path "$PWD" --window 15m --json >"$missing_json"
+jq -e '.cycle_state.availability == "stale" and .cycle_state.heartbeat_age_seconds >= 1800
+  and .cycle_state.freshness_window_seconds == 900
+  and .zero_worker_underutilization.actionable == false' "$missing_json" >/dev/null
+jq '.cycle_state.heartbeat_at = ((now + 3600) | todateiso8601)' \
+	"$TMP_DIR/pulse-health.json" >"$missing_dir/pulse-health.json"
+"$HELPER" --log-dir "$missing_dir" --repo-path "$PWD" --window 15m --json >"$missing_json"
+jq -e '.cycle_state.availability == "unavailable" and .cycle_state.reason == "future-heartbeat"' "$missing_json" >/dev/null
+
 upstream_mismatch_dir="$TMP_DIR/upstream-mismatch"
 mkdir -p "$upstream_mismatch_dir"
 printf 'ERROR Refusing reconciliation: HEAD is not exact origin/main SHA private-sha\n' >"$upstream_mismatch_dir/pulse-wrapper.log"


### PR DESCRIPTION
## Summary

- Bound productivity collection and return component timings, timeout states and partial queue coverage instead of silent hangs.
- Inventory repositories with four bounded independent reads before dependency/progress enrichment; preserve existing GitHub admission and ownership gates.
- Keep absent capacity unknown, reject stale/future cycle and health snapshots as current occupancy, and identify configured maximums separately.
- Add optional `--verify-delivery` without dividing independently observed GitHub deliveries by local terminal attempts.
- Document how to turn supply, admission, integration and missing-evidence measurements into the next bounded action.

Resolves #31617

## Files and reference patterns

Existing collector, queue, dependency, current-state and jq report paths are modified: `.agents/scripts/pulse-check-helper.sh`, `pulse-check-queue-scan.py`, `pulse_check_dependencies.py`, `pulse-current-state.py`, and `pulse-check-report.jq`. Existing tests `test-pulse-check-helper.sh` and `test-pulse-current-state-helper.sh` cover the changes. `.agents/reference/diagnostics-discipline.md` explains scope and interpretation. No new runner, database, daemon or always-loaded rules.

## Runtime Testing

- **Risk:** medium; runtime-verified read-only production diagnostics plus existing isolated failure fixtures.
- `bash .agents/scripts/tests/test-pulse-check-helper.sh`:162 assertions passed.
- `bash .agents/scripts/tests/test-pulse-current-state-helper.sh`:passed.
- `bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh`:23 tests passed.
- `bash .agents/scripts/linters-local.sh --changed`:all required local checks passed; existing formatting advisory remains.
- Real `pulse-check-helper.sh json --budget 60 --window 15m --since 6h --verify-delivery` returned usable evidence in approximately43 seconds:21/21 repository inventories, explicitly incomplete enrichment, a10-second API collector timeout, and two verified deliveries independently of one terminal local attempt. This is one observation, not a benchmark or a sustained throughput claim.

## Review and safety

Independent review found nested-deadline loss of partial output and stale health-snapshot fallback; both were corrected and covered by focused regressions. Re-review found no remaining blocking defect. Current-state, missing-capacity, incomplete-scan and trust/permission tests remain fail-closed.

The live queue also exposed duplicate Dependabot intake targeting the same PR. Ownership changed before mutation, so no live worker was closed or displaced. Independent follow-up #31618 tracks that defect; this PR does not claim it solved or count issue entries as independent work targets.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 2d 15h and 6,940,689 tokens on this with the user in an interactive session.