### PR TITLE
GH#31620: ignore superseded Dependabot check cancellations

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -690,6 +690,21 @@ test_non_review_failure_blocks_required_check_bypass() {
 	return 0
 }
 
+test_superseded_non_review_cancel_does_not_block_required_check_bypass() {
+	local fixture_tmp="${TEST_ROOT}/pr-with-superseded-cancel.json"
+
+	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
+	jq '.statusCheckRollup += [{"name":"Framework Validation","conclusion":"CANCELLED","status":"COMPLETED"}]' \
+		"${TEST_ROOT}/pr.json" >"$fixture_tmp"
+	mv "$fixture_tmp" "${TEST_ROOT}/pr.json"
+	if _trusted_dependabot_non_review_checks_green "24473" "owner/repo"; then
+		print_result "superseded non-review cancellation does not block Dependabot required-check bypass" 0
+		return 0
+	fi
+	print_result "superseded non-review cancellation does not block Dependabot required-check bypass" 1 "Expected a same-name successful check to supersede cancellation. Log: $(<"$LOGFILE")"
+	return 0
+}
+
 main() {
 	setup_test_env
 	trap teardown_test_env EXIT
@@ -728,6 +743,7 @@ main() {
 	test_review_bot_failure_is_ignored_when_other_checks_green
 	test_precomputed_status_rollup_skips_graphql
 	test_non_review_failure_blocks_required_check_bypass
+	test_superseded_non_review_cancel_does_not_block_required_check_bypass
 
 	printf '\nTests run: %s\n' "$TESTS_RUN"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/trusted-dependabot-lib.sh
+++ b/.agents/scripts/trusted-dependabot-lib.sh
@@ -399,8 +399,13 @@ _trusted_dependabot_non_review_checks_green() {
 		def is_review_gate: ((check_label | test("(^|/ )review-bot-gate$|^review-bot-gate$"; "i")) or ((.workflowName // "") == "Review Bot Gate"));
 		def passish: (up(.conclusion) == "SUCCESS" or up(.conclusion) == "NEUTRAL" or up(.conclusion) == "SKIPPED" or up(.state) == "SUCCESS");
 		def pendingish: (up(.status) == "QUEUED" or up(.status) == "IN_PROGRESS" or up(.state) == "PENDING" or up(.state) == "EXPECTED" or ((up(.conclusion) == "") and (up(.state) != "SUCCESS") and (up(.status) != "COMPLETED")));
-		[([.statusCheckRollup[]? | select(is_review_gate | not)] | length),
-		 ([.statusCheckRollup[]? | select((is_review_gate | not) and (pendingish or (passish | not)))] | length)] | @tsv
+		. as $rollup
+		| def superseded_cancel: (
+			up(.conclusion) == "CANCELLED"
+			and (. as $check | any($rollup.statusCheckRollup[]?; check_label == ($check | check_label) and passish))
+		);
+		[([$rollup.statusCheckRollup[]? | select(is_review_gate | not)] | length),
+		 ([$rollup.statusCheckRollup[]? | select((is_review_gate | not) and (pendingish or ((passish or superseded_cancel) | not)))] | length)] | @tsv
 	' 2>/dev/null) || return 1
 	read -r non_review_count blocker_count <<<"$result"
 	[[ "$non_review_count" =~ ^[0-9]+$ && "$blocker_count" =~ ^[0-9]+$ ]] || return 1


### PR DESCRIPTION
## Summary

Treat a cancelled non-review check as non-blocking only when the same check label has a passing terminal result, preventing duplicate cancelled workflow runs from creating false Dependabot CI intake.

## Files Changed

.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, .agents/scripts/trusted-dependabot-lib.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash -n .agents/scripts/trusted-dependabot-lib.sh .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh (34 tests passed); pre-commit ShellCheck and shell validation passed

Resolves #31620


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 3m and 98,307 tokens on this as a headless worker.