### PR TITLE
GH#31621: retry timed-out Pulse PR lists

### DIFF
--- a/.agents/scripts/pulse-pr-list-cache.sh
+++ b/.agents/scripts/pulse-pr-list-cache.sh
@@ -178,9 +178,21 @@ pulse_pr_list_get() {
 		printf '%s' "$cached_output"
 		return 0
 	fi
-	local output=""
-	output="$(gh_pr_list "$@")"
-	local rc=$?
+	local output="" rc=0 attempt=1
+	# A timed-out list is not equivalent to an empty repository. Retry once so a
+	# transient slow GraphQL/REST response cannot silently skip this merge pass.
+	while :; do
+		if output="$(gh_pr_list "$@")"; then
+			rc=0
+		else
+			rc=$?
+		fi
+		if [[ "$rc" -ne 124 || "$attempt" -ge 2 ]]; then
+			break
+		fi
+		printf '[pulse-wrapper] pulse_pr_list_get: timed out; retrying PR list (attempt %s/2)\n' "$attempt" >&2
+		attempt=$((attempt + 1))
+	done
 	if [[ "$rc" -eq 0 ]]; then
 		_pulse_pr_list_cache_put "$output" "$@"
 		printf '%s' "$output"

--- a/.agents/scripts/tests/test-pulse-pr-list-cache.sh
+++ b/.agents/scripts/tests/test-pulse-pr-list-cache.sh
@@ -44,6 +44,10 @@ gh_pr_list_cache_invalidate_repo() {
 
 gh_pr_list() {
 	printf '%s\n' "$*" >>"$GH_CALLS"
+	if [[ -n "${PULSE_TEST_TIMEOUT_MARKER:-}" && -f "$PULSE_TEST_TIMEOUT_MARKER" ]]; then
+		rm -f "$PULSE_TEST_TIMEOUT_MARKER"
+		return 124
+	fi
 	if [[ "${PULSE_TEST_EMPTY_OUTPUT:-0}" == "1" ]]; then
 		return 0
 	fi
@@ -56,6 +60,19 @@ source "${SCRIPTS_DIR}/pulse-pr-list-cache.sh"
 
 export PULSE_PR_LIST_PROVIDER_CACHE_DIR="${TMP_DIR}/cache"
 export PULSE_PR_LIST_PROVIDER_CACHE_TTL=3600
+
+: >"$GH_CALLS"
+export PULSE_TEST_TIMEOUT_MARKER="${TMP_DIR}/timeout-once"
+: >"$PULSE_TEST_TIMEOUT_MARKER"
+retry_output=$(pulse_pr_list_get --repo owner/retry --state open --json number --limit 10)
+unset PULSE_TEST_TIMEOUT_MARKER
+retry_backend_calls=$(grep -cF -- '--repo owner/retry --state open --json number --limit 10' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$retry_output" == '[{"number":1,"reviewDecision":"APPROVED","headRefOid":"abc123"}]' && "$retry_backend_calls" == "2" ]]; then
+	pass "provider retries a timed-out PR list instead of treating it as empty"
+else
+	fail "provider retries a timed-out PR list instead of treating it as empty" \
+		"output=${retry_output} backend_calls=${retry_backend_calls} calls=$(<"$GH_CALLS")"
+fi
 
 first_output=$(pulse_pr_list_get --repo owner/repo --state open --json number,reviewDecision,headRefOid --limit 200)
 second_output=$(pulse_pr_list_get --repo owner/repo --state open --json number,reviewDecision,headRefOid --limit 200)


### PR DESCRIPTION
## Summary

Retries a timed-out cached PR-list provider call once instead of treating it as an empty repository.

## Files Changed

.agents/scripts/pulse-pr-list-cache.sh, .agents/scripts/tests/test-pulse-pr-list-cache.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-pr-list-cache.sh; bash .agents/scripts/tests/test-pulse-merge-timing-summary.sh; shellcheck .agents/scripts/pulse-pr-list-cache.sh .agents/scripts/tests/test-pulse-pr-list-cache.sh

Resolves #31621


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 5m and 100,492 tokens on this as a headless worker.