### PR TITLE
GH#31618: prevent duplicate Dependabot target dispatch

### DIFF
--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -30,9 +30,13 @@ _pulse_dependabot_existing_intake_issue() {
 	# the bounded read focused on generated intake candidates.
 	issues_json=$(gh_issue_list --repo "$repo_slug" --state open \
 		--label dependencies --limit 500 \
-		--json number,body,url 2>/dev/null) || return 1
+		--json number,body,url,labels 2>/dev/null) || return 1
 	printf '%s' "$issues_json" | jq -r --arg marker "$marker" \
-		'[.[] | select((.body // "") | contains($marker))][0].url // ""' 2>/dev/null
+		'[.[]
+			| ([.labels[]?.name // ""] | unique) as $labels
+			| select(($labels | index("origin:worker")) != null)
+			| select(($labels | index("dependencies")) != null)
+			| select((.body // "") | contains($marker))][0].url // ""' 2>/dev/null
 	return $?
 }
 

--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -23,8 +23,13 @@ _pulse_dependabot_existing_intake_issue() {
 	local marker="$3"
 	local issues_json="[]"
 
+	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	# Do not use GitHub search for this identity check. Search indexing can lag
+	# issue creation, so two Pulse cycles may both observe an invented absence.
+	# The repository issue list is authoritative and the dependencies label keeps
+	# the bounded read focused on generated intake candidates.
 	issues_json=$(gh_issue_list --repo "$repo_slug" --state open \
-		--search "Dependabot PR #${pr_number} in:title" --limit 20 \
+		--label dependencies --limit 500 \
 		--json number,body,url 2>/dev/null) || return 1
 	printf '%s' "$issues_json" | jq -r --arg marker "$marker" \
 		'[.[] | select((.body // "") | contains($marker))][0].url // ""' 2>/dev/null

--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -27,16 +27,17 @@ _pulse_dependabot_existing_intake_issue() {
 	# Do not use GitHub search for this identity check. Search indexing can lag
 	# issue creation, so two Pulse cycles may both observe an invented absence.
 	# The repository issue list is authoritative and the dependencies label keeps
-	# the bounded read focused on generated intake candidates.
+	# the bounded read focused on generated intake candidates. The extra result is
+	# a truncation sentinel: a saturated read is unknown, never absence.
 	issues_json=$(gh_issue_list --repo "$repo_slug" --state open \
-		--label dependencies --limit 500 \
+		--label dependencies --limit 501 \
 		--json number,body,url,labels 2>/dev/null) || return 1
 	printf '%s' "$issues_json" | jq -r --arg marker "$marker" \
-		'[.[]
+		'if length >= 501 then error("intake lookup truncated") else [.[]
 			| ([.labels[]?.name // ""] | unique) as $labels
 			| select(($labels | index("origin:worker")) != null)
 			| select(($labels | index("dependencies")) != null)
-			| select((.body // "") | contains($marker))][0].url // ""' 2>/dev/null
+			| select((.body // "") | contains($marker))][0].url // "" end' 2>/dev/null
 	return $?
 }
 

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1653,6 +1653,11 @@ _dispatch_dedup_check_layers() {
 	_dss_t0=$(_ds_now_ns)
 	local _dispatch_issue_body
 	_dispatch_issue_body=$(printf '%s' "$issue_meta_json" | jq -r '.body // ""' 2>/dev/null) || _dispatch_issue_body=""
+	if _dedup_dependabot_intake_target "$issue_number" "$repo_slug" "$_dispatch_issue_body"; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: another issue owns the same Dependabot PR target" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.dependabot_target" "$_dss_t0"
+		return 1
+	fi
 	if is_blocked_by_unresolved "$_dispatch_issue_body" "$repo_slug" "$issue_number"; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unresolved blocked-by dependency (t1927)" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.blocked_by" "$_dss_t0"

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -177,12 +177,12 @@ _dedup_dependabot_intake_target() {
 	}
 	marker="<!-- aidevops:dependabot-pr-intake repo=${target_repo} pr=${target_pr} -->"
 	issues_json=$(gh_issue_list --repo "$repo_slug" --state open --label dependencies \
-		--limit 500 --json number,body,labels,assignees 2>/dev/null) || {
+		--limit 501 --json number,body,labels,assignees 2>/dev/null) || {
 		echo "[pulse-wrapper] Dedup: authoritative Dependabot intake lookup unavailable for #${issue_number}; blocking dispatch" >>"$LOGFILE"
 		return 0
 	}
 	owner_issue=$(printf '%s' "$issues_json" | jq -er --arg marker "$marker" '
-		[.[]
+		if length >= 501 then error("intake lookup truncated") else [.[]
 			| ([.labels[]?.name // ""] | unique) as $labels
 			| select(($labels | index("origin:worker")) != null)
 			| select(($labels | index("dependencies")) != null)
@@ -192,7 +192,7 @@ _dedup_dependabot_intake_target() {
 				| select(((.assignees // []) | length) > 0 or
 					([.labels[]?.name // ""] | any(. == "status:in-progress" or . == "status:in-review")))
 				| .number] | min) // ([$matches[].number] | min)
-		end' 2>/dev/null) || {
+		end end' 2>/dev/null) || {
 		echo "[pulse-wrapper] Dedup: invalid Dependabot intake evidence for #${issue_number}; blocking dispatch" >>"$LOGFILE"
 		return 0
 	}

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -182,7 +182,11 @@ _dedup_dependabot_intake_target() {
 		return 0
 	}
 	owner_issue=$(printf '%s' "$issues_json" | jq -er --arg marker "$marker" '
-		[.[] | select((.body // "") | contains($marker))] as $matches
+		[.[]
+			| ([.labels[]?.name // ""] | unique) as $labels
+			| select(($labels | index("origin:worker")) != null)
+			| select(($labels | index("dependencies")) != null)
+			| select((.body // "") | contains($marker))] as $matches
 		| if ($matches | length) == 0 then error("missing current intake") else
 			([$matches[]
 				| select(((.assignees // []) | length) > 0 or

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -148,6 +148,58 @@ _stale_recovery_has_worker_evidence() {
 #   1 - no duplicate (safe to dispatch)
 #######################################
 #######################################
+# Block all but one runnable issue for an authoritative Dependabot PR target.
+# Intake creation is locally serialized, but separate Pulse hosts can still
+# create issues concurrently. Elect an existing live owner first, otherwise the
+# lowest issue number. Unknown repository reads fail closed.
+# Arguments: issue_number, repo_slug, issue_body
+# Exit: 0 = blocked, 1 = current issue owns the target or is not an intake
+#######################################
+_dedup_dependabot_intake_target() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_body="$3"
+	local target_repo=""
+	local target_pr=""
+	local marker=""
+	local issues_json=""
+	local owner_issue=""
+
+	if [[ "$issue_body" =~ aidevops:dependabot-pr-intake[[:space:]]repo=([^[:space:]]+)[[:space:]]pr=([0-9]+) ]]; then
+		target_repo="${BASH_REMATCH[1]}"
+		target_pr="${BASH_REMATCH[2]}"
+	else
+		return 1
+	fi
+	[[ "$target_repo" == "$repo_slug" ]] || {
+		echo "[pulse-wrapper] Dedup: Dependabot intake #${issue_number} target repository mismatch; blocking dispatch" >>"$LOGFILE"
+		return 0
+	}
+	marker="<!-- aidevops:dependabot-pr-intake repo=${target_repo} pr=${target_pr} -->"
+	issues_json=$(gh_issue_list --repo "$repo_slug" --state open --label dependencies \
+		--limit 500 --json number,body,labels,assignees 2>/dev/null) || {
+		echo "[pulse-wrapper] Dedup: authoritative Dependabot intake lookup unavailable for #${issue_number}; blocking dispatch" >>"$LOGFILE"
+		return 0
+	}
+	owner_issue=$(printf '%s' "$issues_json" | jq -er --arg marker "$marker" '
+		[.[] | select((.body // "") | contains($marker))] as $matches
+		| if ($matches | length) == 0 then error("missing current intake") else
+			([$matches[]
+				| select(((.assignees // []) | length) > 0 or
+					([.labels[]?.name // ""] | any(. == "status:in-progress" or . == "status:in-review")))
+				| .number] | min) // ([$matches[].number] | min)
+		end' 2>/dev/null) || {
+		echo "[pulse-wrapper] Dedup: invalid Dependabot intake evidence for #${issue_number}; blocking dispatch" >>"$LOGFILE"
+		return 0
+	}
+	if [[ "$owner_issue" != "$issue_number" ]]; then
+		echo "[pulse-wrapper] Dedup: Dependabot PR #${target_pr} intake #${issue_number} blocked by target owner #${owner_issue}" >>"$LOGFILE"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Layer 1 (GH#6696): in-flight dispatch ledger check.
 # Catches workers in the 10-15 min gap between dispatch and PR creation.
 # Arguments: issue_number, repo_slug

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -35,8 +35,8 @@ _is_authentic_dependabot_pr() {
 	local repo_slug="$2"
 	local pr_author="$3"
 	local expected_head_sha="$4"
-	[[ "$AUTHENTIC" -eq 1 && "$pr_number" == "30038" && "$repo_slug" == "owner/repo" \
-		&& "$pr_author" == "app/dependabot" && "$expected_head_sha" == "head-current" ]]
+	[[ "$AUTHENTIC" -eq 1 && "$pr_number" == "30038" && "$repo_slug" == "owner/repo" &&
+		"$pr_author" == "app/dependabot" && "$expected_head_sha" == "head-current" ]]
 	return $?
 }
 
@@ -124,7 +124,7 @@ test_creates_worker_ready_issue() {
 
 test_reuses_existing_issue() {
 	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/issue-list-args"
-	OPEN_ISSUES_JSON='[{"number":42,"url":"https://github.com/owner/repo/issues/42","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->"}]'
+	OPEN_ISSUES_JSON='[{"number":42,"url":"https://github.com/owner/repo/issues/42","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"dependencies"}]}]'
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "terminal-ci-failure"
 	[[ ! -e "${TEST_ROOT}/create-args" ]]
 	if grep -q -- '--search' "${TEST_ROOT}/issue-list-args"; then
@@ -139,14 +139,23 @@ test_target_level_dispatch_dedup() {
 	local marker='<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->'
 	local current_body="$marker"
 
-	OPEN_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","assignees":[{"login":"runner"}],"labels":[{"name":"status:in-progress"}]},{"number":43,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","assignees":[],"labels":[{"name":"status:available"}]}]'
+	OPEN_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","assignees":[{"login":"runner"}],"labels":[{"name":"origin:worker"},{"name":"dependencies"},{"name":"status:in-progress"}]},{"number":43,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","assignees":[],"labels":[{"name":"origin:worker"},{"name":"dependencies"},{"name":"status:available"}]}]'
 	_dedup_dependabot_intake_target "43" "owner/repo" "$current_body"
 	if _dedup_dependabot_intake_target "42" "owner/repo" "$current_body"; then
 		return 1
 	fi
 
-	OPEN_ISSUES_JSON='[{"number":43,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30039 -->","assignees":[],"labels":[{"name":"status:available"}]}]'
+	OPEN_ISSUES_JSON='[{"number":43,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30039 -->","assignees":[],"labels":[{"name":"origin:worker"},{"name":"dependencies"},{"name":"status:available"}]}]'
 	if _dedup_dependabot_intake_target "43" "owner/repo" '<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30039 -->'; then
+		return 1
+	fi
+	return 0
+}
+
+test_untrusted_marker_does_not_own_target() {
+	OPEN_ISSUES_JSON='[{"number":41,"url":"https://github.com/owner/repo/issues/41","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","assignees":[{"login":"runner"}],"labels":[{"name":"dependencies"},{"name":"status:in-progress"}]},{"number":42,"url":"https://github.com/owner/repo/issues/42","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","assignees":[],"labels":[{"name":"origin:worker"},{"name":"dependencies"},{"name":"status:available"}]}]'
+	if _dedup_dependabot_intake_target "42" "owner/repo" \
+		'<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->'; then
 		return 1
 	fi
 	return 0
@@ -342,7 +351,7 @@ _is_authentic_dependabot_pr() {
 
 gh_issue_list() {
 	if [[ -f "${SHARED_STATE}/created" ]]; then
-		printf '%s\n' '[{"number":42,"url":"https://github.com/owner/repo/issues/42","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->"}]'
+		printf '%s\n' '[{"number":42,"url":"https://github.com/owner/repo/issues/42","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"dependencies"}]}]'
 	else
 		printf '%s\n' '[]'
 	fi
@@ -403,6 +412,8 @@ main() {
 	printf 'PASS concurrent routes converge on one issue\n'
 	test_target_level_dispatch_dedup
 	printf 'PASS same-target intake dispatch elects one live owner\n'
+	test_untrusted_marker_does_not_own_target
+	printf 'PASS untrusted marker cannot own an intake target\n'
 	test_target_lookup_failure_blocks_dispatch
 	printf 'PASS unknown target lookup fails closed\n'
 	return 0

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -131,7 +131,7 @@ test_reuses_existing_issue() {
 		return 1
 	fi
 	assert_file_contains "intake lookup uses authoritative labeled issue list" \
-		"${TEST_ROOT}/issue-list-args" "--label dependencies --limit 500"
+		"${TEST_ROOT}/issue-list-args" "--label dependencies --limit 501"
 	return $?
 }
 
@@ -163,6 +163,16 @@ test_untrusted_marker_does_not_own_target() {
 
 test_target_lookup_failure_blocks_dispatch() {
 	gh_issue_list() { return 1; }
+	_dedup_dependabot_intake_target "43" "owner/repo" \
+		'<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->'
+	return $?
+}
+
+test_saturated_target_lookup_blocks_dispatch() {
+	gh_issue_list() {
+		jq -nc '[range(501) | {number: ., body: "", labels: [], assignees: []}]'
+		return 0
+	}
 	_dedup_dependabot_intake_target "43" "owner/repo" \
 		'<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->'
 	return $?
@@ -416,6 +426,8 @@ main() {
 	printf 'PASS untrusted marker cannot own an intake target\n'
 	test_target_lookup_failure_blocks_dispatch
 	printf 'PASS unknown target lookup fails closed\n'
+	test_saturated_target_lookup_blocks_dispatch
+	printf 'PASS saturated target lookup fails closed\n'
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -42,6 +42,7 @@ _is_authentic_dependabot_pr() {
 
 gh_issue_list() {
 	local args=" $* "
+	printf '%s\n' "$*" >>"${TEST_ROOT}/issue-list-args"
 	if [[ "$args" == *" --state closed "* ]]; then
 		printf '%s\n' "$CLOSED_ISSUES_JSON"
 	else
@@ -122,10 +123,39 @@ test_creates_worker_ready_issue() {
 }
 
 test_reuses_existing_issue() {
-	rm -f "${TEST_ROOT}/create-args"
+	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/issue-list-args"
 	OPEN_ISSUES_JSON='[{"number":42,"url":"https://github.com/owner/repo/issues/42","body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->"}]'
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "terminal-ci-failure"
 	[[ ! -e "${TEST_ROOT}/create-args" ]]
+	if grep -q -- '--search' "${TEST_ROOT}/issue-list-args"; then
+		return 1
+	fi
+	assert_file_contains "intake lookup uses authoritative labeled issue list" \
+		"${TEST_ROOT}/issue-list-args" "--label dependencies --limit 500"
+	return $?
+}
+
+test_target_level_dispatch_dedup() {
+	local marker='<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->'
+	local current_body="$marker"
+
+	OPEN_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","assignees":[{"login":"runner"}],"labels":[{"name":"status:in-progress"}]},{"number":43,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","assignees":[],"labels":[{"name":"status:available"}]}]'
+	_dedup_dependabot_intake_target "43" "owner/repo" "$current_body"
+	if _dedup_dependabot_intake_target "42" "owner/repo" "$current_body"; then
+		return 1
+	fi
+
+	OPEN_ISSUES_JSON='[{"number":43,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30039 -->","assignees":[],"labels":[{"name":"status:available"}]}]'
+	if _dedup_dependabot_intake_target "43" "owner/repo" '<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30039 -->'; then
+		return 1
+	fi
+	return 0
+}
+
+test_target_lookup_failure_blocks_dispatch() {
+	gh_issue_list() { return 1; }
+	_dedup_dependabot_intake_target "43" "owner/repo" \
+		'<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->'
 	return $?
 }
 
@@ -353,6 +383,8 @@ main() {
 	trap teardown_test_env EXIT
 	# shellcheck source=../pulse-dependabot-intake.sh
 	source "$INTAKE_SCRIPT"
+	# shellcheck source=../pulse-dispatch-dedup-layers.sh
+	source "${SCRIPT_DIR}/../pulse-dispatch-dedup-layers.sh"
 	test_creates_worker_ready_issue
 	test_reuses_existing_issue
 	printf 'PASS existing intake is idempotent\n'
@@ -369,6 +401,10 @@ main() {
 	printf 'PASS dry-run performs no GitHub write\n'
 	test_concurrent_routes_create_once
 	printf 'PASS concurrent routes converge on one issue\n'
+	test_target_level_dispatch_dedup
+	printf 'PASS same-target intake dispatch elects one live owner\n'
+	test_target_lookup_failure_blocks_dispatch
+	printf 'PASS unknown target lookup fails closed\n'
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Use authoritative labeled issue reads for intake identity and elect one live or lowest-numbered issue per Dependabot PR before dispatch.

## Files Changed

.agents/scripts/pulse-dependabot-intake.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/pulse-dispatch-dedup-layers.sh, .agents/scripts/tests/test-pulse-dependabot-intake.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-pulse-dependabot-intake.sh; ShellCheck for all changed shell files

Resolves #31618


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.343 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol spent 9m and 129,152 tokens on this as a headless worker.