### PR TITLE
GH#31621: fix: make merge PR listing deadline-aware

### DIFF
--- a/.agents/scripts/pulse-merge-pass.sh
+++ b/.agents/scripts/pulse-merge-pass.sh
@@ -743,15 +743,15 @@ _pmp_run_stuck_diagnostics_for_repos() {
 _pmp_log_repo_timing_rows() {
 	local primary_rows="$1"
 	local diagnostic_rows="$2"
-	local repo_slug="" total_s=0 list_s=0 mergeability_s=0 ruleset_s=0 branch_protection_s=0
+	local repo_slug="" total_s=0 list_s=0 mergeability_s=0 ruleset_s=0 branch_protection_s=0 list_state="complete"
 	local merged=0 closed=0 failed=0 pr_count=0 stuck_s=0
 
-	while IFS='|' read -r repo_slug total_s list_s mergeability_s ruleset_s branch_protection_s merged closed failed pr_count; do
+	while IFS='|' read -r repo_slug total_s list_s mergeability_s ruleset_s branch_protection_s merged closed failed pr_count list_state; do
 		[[ -n "$repo_slug" ]] || continue
 		stuck_s=$(_pmp_diagnostic_seconds_for_repo "$diagnostic_rows" "$repo_slug")
 		[[ "$total_s" =~ ^[0-9]+$ ]] || total_s=0
 		total_s=$((total_s + stuck_s))
-		_pmp_log_repo_timing_summary "$repo_slug" "$total_s" "$list_s" "$mergeability_s" "$ruleset_s" "$branch_protection_s" "$stuck_s" "$merged" "$closed" "$failed" "$pr_count"
+		_pmp_log_repo_timing_summary "$repo_slug" "$total_s" "$list_s" "$mergeability_s" "$ruleset_s" "$branch_protection_s" "$stuck_s" "$merged" "$closed" "$failed" "$pr_count" "$list_state"
 	done <<<"$primary_rows"
 	return 0
 }
@@ -825,7 +825,7 @@ _pmp_process_merge_repo_for_pass() {
 	fi
 
 	local repo_merged=0 repo_closed=0 repo_failed=0 _mr_repo_pr_count=0
-	local _mr_repo_list_s=0 _mr_repo_mergeability_s=0 _mr_repo_ruleset_s=0 _mr_repo_branch_protection_s=0
+	local _mr_repo_list_s=0 _mr_repo_mergeability_s=0 _mr_repo_ruleset_s=0 _mr_repo_branch_protection_s=0 _mr_repo_list_state="complete"
 	local _mr_repo_start _mr_repo_total_s=0
 	_mr_repo_start=$(_pmp_now_epoch)
 
@@ -835,7 +835,7 @@ _pmp_process_merge_repo_for_pass() {
 	_pmp_add_counter_var "$total_closed_var" "$repo_closed"
 	_pmp_add_counter_var "$total_failed_var" "$repo_failed"
 	_pmp_add_elapsed_seconds _mr_repo_total_s "$_mr_repo_start"
-	_PMP_LAST_REPO_TIMING_ROW="${repo_slug}|${_mr_repo_total_s}|${_mr_repo_list_s}|${_mr_repo_mergeability_s}|${_mr_repo_ruleset_s}|${_mr_repo_branch_protection_s}|${repo_merged}|${repo_closed}|${repo_failed}|${_mr_repo_pr_count}"
+	_PMP_LAST_REPO_TIMING_ROW="${repo_slug}|${_mr_repo_total_s}|${_mr_repo_list_s}|${_mr_repo_mergeability_s}|${_mr_repo_ruleset_s}|${_mr_repo_branch_protection_s}|${repo_merged}|${repo_closed}|${repo_failed}|${_mr_repo_pr_count}|${_mr_repo_list_state}"
 	if [[ "$_mr_repo_rc" -eq 5 ]]; then
 		echo "[pulse-wrapper] Deterministic merge pass paused mid-repo ${repo_slug}; PR cursor persisted" >>"$logfile"
 		printf -v "$completed_all_var" '%s' '0'

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -524,6 +524,56 @@ _pmp_record_processed_pr_result() {
 }
 
 #######################################
+# Resolve the merge pass's list-specific read timeout. PR-list reads need more
+# headroom than ordinary point reads, but must remain inside the pass deadline.
+#######################################
+_pmp_merge_pr_list_timeout_seconds() {
+	local timeout_seconds="${PULSE_MERGE_PR_LIST_TIMEOUT_SECONDS:-45}"
+	local deadline="${_PMP_MERGE_PASS_DEADLINE_EPOCH:-0}"
+	local now_epoch="" remaining_seconds=""
+	[[ "$timeout_seconds" =~ ^[0-9]+$ && "$timeout_seconds" -ge 1 && "$timeout_seconds" -le 120 ]] || timeout_seconds=45
+	if [[ "$deadline" =~ ^[0-9]+$ && "$deadline" -gt 0 ]]; then
+		now_epoch=$(_pmp_now_epoch)
+		remaining_seconds=$((deadline - now_epoch))
+		[[ "$remaining_seconds" -ge 1 ]] || return 1
+		[[ "$remaining_seconds" -lt "$timeout_seconds" ]] && timeout_seconds="$remaining_seconds"
+	fi
+	printf '%s' "$timeout_seconds"
+	return 0
+}
+
+_pmp_fetch_ready_pr_list() {
+	local repo_slug="$1"
+	local timeout_seconds="$2"
+	local error_file="$3"
+	if declare -F pulse_pr_list_get >/dev/null 2>&1; then
+		AIDEVOPS_GH_READ_TIMEOUT="$timeout_seconds" pulse_pr_list_get --repo "$repo_slug" --state open \
+			--json "$(_pulse_merge_ready_pr_json_fields)" --limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$error_file"
+		return $?
+	fi
+	AIDEVOPS_GH_READ_TIMEOUT="$timeout_seconds" gh_pr_list --repo "$repo_slug" --state open \
+		--json "$(_pulse_merge_ready_pr_json_fields)" --limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$error_file"
+	return $?
+}
+
+#######################################
+# Record elapsed PR-list time and whether the observed list was authoritative.
+#######################################
+_pmp_record_pr_list_timing() {
+	local timing_prefix="$1"
+	local list_start="$2"
+	local list_complete="$3"
+	[[ -n "$timing_prefix" ]] || return 0
+	_pmp_add_elapsed_seconds "${timing_prefix}list_s" "$list_start"
+	if [[ "$list_complete" -eq 1 ]]; then
+		printf -v "${timing_prefix}list_state" '%s' 'complete'
+	else
+		printf -v "${timing_prefix}list_state" '%s' 'incomplete'
+	fi
+	return 0
+}
+
+#######################################
 # Merge ready PRs for a single repo.
 #
 # Fetches the PR list for the repo, iterates, and delegates each PR
@@ -546,31 +596,31 @@ _merge_ready_prs_for_repo() {
 	local _timing_prefix="${6:-}"
 
 	local merged=0 closed=0 failed=0
-	local pr_json="" pr_merge_err="" _list_start="" pr_count=""
+	local pr_json="" pr_merge_err="" _list_start="" pr_count="" pr_list_timeout="" pr_list_rc=0
 	local pr_list_complete=1 outcomes_complete=1
 	_list_start=$(_pmp_now_epoch)
-	pr_merge_err=$(mktemp)
-	if declare -F pulse_pr_list_get >/dev/null 2>&1; then
-		pr_json=$(pulse_pr_list_get --repo "$repo_slug" --state open \
-			--json "$(_pulse_merge_ready_pr_json_fields)" \
-			--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json=""
-	else
-		pr_json=$(gh_pr_list --repo "$repo_slug" --state open \
-			--json "$(_pulse_merge_ready_pr_json_fields)" \
-			--limit "$PULSE_MERGE_BATCH_LIMIT" 2>"$pr_merge_err") || pr_json=""
+	if ! pr_list_timeout=$(_pmp_merge_pr_list_timeout_seconds); then
+		_pmp_record_pr_list_timing "$_timing_prefix" "$_list_start" 0
+		if [[ -n "$_pr_count_var" ]]; then
+			[[ "$_pr_count_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+			printf -v "$_pr_count_var" '%s' '0'
+		fi
+		eval "${_merged_var}=0; ${_closed_var}=0; ${_failed_var}=0"
+		return 5
 	fi
-	if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
+	pr_merge_err=$(mktemp)
+	pr_json=$(_pmp_fetch_ready_pr_list "$repo_slug" "$pr_list_timeout" "$pr_merge_err") || pr_list_rc=$?
+	if [[ "$pr_list_rc" -ne 0 || -z "$pr_json" || "$pr_json" == "null" ]]; then
 		local _pr_merge_err_msg
 		_pr_merge_err_msg=$(cat "$pr_merge_err" 2>/dev/null || echo "unknown error")
-		echo "[pulse-wrapper] _process_merge_batch: pulse_pr_list_get FAILED for ${repo_slug}: ${_pr_merge_err_msg}" >>"$LOGFILE"
+		echo "[pulse-wrapper] _process_merge_batch: pulse_pr_list_get FAILED for ${repo_slug}: list_state=incomplete rc=${pr_list_rc} timeout_s=${pr_list_timeout}: ${_pr_merge_err_msg}" >>"$LOGFILE"
 		pr_json="[]"
 		pr_list_complete=0
 	fi
 	rm -f "$pr_merge_err"
-	[[ -n "$_timing_prefix" ]] && _pmp_add_elapsed_seconds "${_timing_prefix}list_s" "$_list_start"
-
 	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || { pr_count=0; pr_list_complete=0; }
-	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+	[[ "$pr_count" =~ ^[0-9]+$ ]] || { pr_count=0; pr_list_complete=0; }
+	_pmp_record_pr_list_timing "$_timing_prefix" "$_list_start" "$pr_list_complete"
 	if [[ -n "$_pr_count_var" ]]; then
 		[[ "$_pr_count_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
 		printf -v "$_pr_count_var" '%s' "$pr_count"

--- a/.agents/scripts/pulse-merge-timing.sh
+++ b/.agents/scripts/pulse-merge-timing.sh
@@ -65,7 +65,8 @@ _pmp_log_repo_timing_summary() {
 	local closed="${9:-0}"
 	local failed="${10:-0}"
 	local pr_count="${11:-0}"
+	local list_state="${12:-complete}"
 
-	echo "[pulse-wrapper] deterministic_merge_pass timing: repo=${repo_slug} total_s=${total_s} list_s=${list_s} mergeability_s=${mergeability_s} ruleset_s=${ruleset_s} branch_protection_s=${branch_protection_s} stuck_detector_s=${stuck_detector_s} merged=${merged} closed=${closed} failed=${failed} prs=${pr_count}" >>"$logfile"
+	echo "[pulse-wrapper] deterministic_merge_pass timing: repo=${repo_slug} total_s=${total_s} list_s=${list_s} list_state=${list_state} mergeability_s=${mergeability_s} ruleset_s=${ruleset_s} branch_protection_s=${branch_protection_s} stuck_detector_s=${stuck_detector_s} merged=${merged} closed=${closed} failed=${failed} prs=${pr_count}" >>"$logfile"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-timing-summary.sh
+++ b/.agents/scripts/tests/test-pulse-merge-timing-summary.sh
@@ -114,12 +114,51 @@ if [[ "$(grep -c 'deterministic_merge_pass timing: repo=' "$LOGFILE")" -ne 2 ]];
 fi
 
 for repo in owner/alpha owner/beta; do
-  if ! grep -qE "deterministic_merge_pass timing: repo=${repo} .*list_s=[0-9]+ .*mergeability_s=[0-9]+ .*ruleset_s=[0-9]+ .*branch_protection_s=[0-9]+ .*stuck_detector_s=[0-9]+" "$LOGFILE"; then
+	if ! grep -qE "deterministic_merge_pass timing: repo=${repo} .*list_s=[0-9]+ list_state=complete .*mergeability_s=[0-9]+ .*ruleset_s=[0-9]+ .*branch_protection_s=[0-9]+ .*stuck_detector_s=[0-9]+" "$LOGFILE"; then
     printf 'FAIL: missing structured timing summary for %s\n' "$repo"
     cat "$LOGFILE"
     exit 1
   fi
 done
+
+LIST_TIMEOUT_FILE="${TEST_ROOT}/list-timeout"
+pulse_pr_list_get() {
+	printf '%s' "${AIDEVOPS_GH_READ_TIMEOUT:-unset}" >"$LIST_TIMEOUT_FILE"
+	printf '%s' 'request timed out' >&2
+	return 124
+}
+failed_merged=0 failed_closed=0 failed_count=0 failed_pr_count=0
+failed_list_s=0 failed_list_state="complete"
+_merge_ready_prs_for_repo "owner/failure" failed_merged failed_closed failed_count failed_pr_count "failed_"
+if [[ "$(<"$LIST_TIMEOUT_FILE")" != "45" ]]; then
+	printf 'FAIL: merge PR list did not receive its list-specific 45s timeout\n'
+	exit 1
+fi
+if [[ "$failed_list_state" != "incomplete" || "$failed_pr_count" -ne 0 ]]; then
+	printf 'FAIL: failed PR list was not recorded as incomplete with zero observed PRs\n'
+	exit 1
+fi
+_pmp_log_repo_timing_summary "owner/failure" 0 "$failed_list_s" 0 0 0 0 0 0 0 "$failed_pr_count" "$failed_list_state"
+if ! grep -q 'deterministic_merge_pass timing: repo=owner/failure .*list_state=incomplete' "$LOGFILE"; then
+	printf 'FAIL: missing explicit incomplete PR-list timing telemetry\n'
+	exit 1
+fi
+
+_pmp_now_epoch() { printf '100'; }
+_PMP_MERGE_PASS_DEADLINE_EPOCH=110
+if [[ "$(_pmp_merge_pr_list_timeout_seconds)" != "10" ]]; then
+	printf 'FAIL: PR-list timeout was not clamped to the remaining pass deadline\n'
+	exit 1
+fi
+rm -f "$LIST_TIMEOUT_FILE"
+_PMP_MERGE_PASS_DEADLINE_EPOCH=100
+expired_rc=0
+_merge_ready_prs_for_repo "owner/expired" failed_merged failed_closed failed_count failed_pr_count "failed_" || expired_rc=$?
+if [[ "$expired_rc" -ne 5 || -f "$LIST_TIMEOUT_FILE" || "$failed_list_state" != "incomplete" ]]; then
+	printf 'FAIL: expired deadline did not pause before the PR-list provider call\n'
+	exit 1
+fi
+_PMP_MERGE_PASS_DEADLINE_EPOCH=0
 
 if ! grep -q 'deterministic_merge_pass timing: total_s=' "$LOGFILE"; then
   printf 'FAIL: missing overall deterministic_merge_pass timing summary\n'


### PR DESCRIPTION
## Summary

Implementation for issue #31621.

## Files Changed

.agents/scripts/pulse-merge-pass.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge-timing.sh, .agents/scripts/tests/test-pulse-merge-timing-summary.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #31621


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.344 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 58m and 420,691 tokens on this with the user in an interactive session.