### PR TITLE
GH#31632: distinguish active dispatch stages

### DIFF
--- a/.agents/scripts/dispatch-stage-instrument.sh
+++ b/.agents/scripts/dispatch-stage-instrument.sh
@@ -30,8 +30,9 @@
 #     dispatch-stage-instrument.sh trim               # rotate if oversize
 #     dispatch-stage-instrument.sh clear               # wipe log
 #
-# Log format (TSV, append-only):
-#   <ISO8601_UTC>\t#<issue_number>\t<repo_slug>\t<stage_name>\t<elapsed_ms>
+# Log format (TSV, append-only). The first five fields retain the historical
+# completion format; newer records append event lineage:
+#   <ISO8601_UTC>\t#<issue>\t<repo>\t<stage>\t<elapsed_ms>\t<event>\t<attempt>\t<cycle>\t<pid>
 #
 # Override env vars:
 #   AIDEVOPS_DISPATCH_STAGES_LOG          — log path (default
@@ -52,13 +53,19 @@ _DISPATCH_STAGE_INSTRUMENT_LOADED=1
 # --- Configuration --------------------------------------------------------
 DS_LOG="${AIDEVOPS_DISPATCH_STAGES_LOG:-${HOME}/.aidevops/logs/dispatch-stages.tsv}"
 DS_LOG_MAX_LINES="${AIDEVOPS_DISPATCH_STAGES_LOG_MAX_LINES:-50000}"
+declare -a _DS_ATTEMPT_KEYS=()
+declare -a _DS_ATTEMPT_IDS=()
+declare -a _DS_ATTEMPT_COMPLETED=()
 
 # --- _ds_now_ns -----------------------------------------------------------
 # Return current time in nanoseconds. Uses bash 5+ %N when available,
 # falls back to seconds * 1e9 on macOS/bash 3.2 (no %N support).
 # Stdout: integer nanoseconds
 _ds_now_ns() {
-	[[ "${AIDEVOPS_DISPATCH_STAGES_DISABLE:-0}" == "1" ]] && { printf '0'; return 0; }
+	[[ "${AIDEVOPS_DISPATCH_STAGES_DISABLE:-0}" == "1" ]] && {
+		printf '0'
+		return 0
+	}
 	local ns
 	# Try GNU date first (supports %N)
 	ns=$(date +%s%N 2>/dev/null) || ns=""
@@ -71,6 +78,48 @@ _ds_now_ns() {
 		ns=$((s * 1000000000))
 	fi
 	printf '%s' "$ns"
+	return 0
+}
+
+_ds_attempt_id() {
+	local issue_number="$1"
+	local stage_name="$2"
+	local start_ns="$3"
+	printf '%s:%s:%s:%s' "${_PULSE_CYCLE_ID:-pid-$$}" "$issue_number" "$stage_name" "$start_ns"
+	return 0
+}
+
+_ds_normalize_stage() {
+	local stage_name="$1"
+	[[ "$stage_name" == *.* ]] || stage_name="dedup.${stage_name}"
+	printf '%s' "$stage_name"
+	return 0
+}
+
+# Record entry separately from completion so an interrupted or slow stage is
+# observable. Callers keep the start timestamp and pass it to _ds_record.
+_ds_stage_start() {
+	[[ "${AIDEVOPS_DISPATCH_STAGES_DISABLE:-0}" == "1" ]] && return 0
+	local issue_number="$1"
+	local repo_slug="$2"
+	local stage_name="$3"
+	local start_ns="$4"
+	local output_var="${5:-}"
+	local ts attempt_id cycle_id
+	stage_name=$(_ds_normalize_stage "$stage_name")
+	ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || ts="unknown"
+	_DS_ATTEMPT_SEQUENCE=$((${_DS_ATTEMPT_SEQUENCE:-0} + 1))
+	attempt_id="$(_ds_attempt_id "$issue_number" "$stage_name" "$start_ns"):${_DS_ATTEMPT_SEQUENCE}"
+	local attempt_index="${#_DS_ATTEMPT_KEYS[@]}"
+	_DS_ATTEMPT_KEYS[$attempt_index]="${issue_number}:${stage_name}:${start_ns}"
+	_DS_ATTEMPT_IDS[$attempt_index]="$attempt_id"
+	_DS_ATTEMPT_COMPLETED[$attempt_index]=0
+	[[ -n "$output_var" ]] && printf -v "$output_var" '%s' "$attempt_id"
+	cycle_id="${_PULSE_CYCLE_ID:-pid-$$}"
+	[[ "$DS_LOG" == */* ]] && mkdir -p "${DS_LOG%/*}" 2>/dev/null || true
+	printf '%s\t#%s\t%s\t%s\t0\tstart\t%s\t%s\t%s\n' \
+		"$ts" "$issue_number" "$repo_slug" "$stage_name" "$attempt_id" "$cycle_id" "$$" \
+		>>"$DS_LOG" 2>/dev/null || true
 	return 0
 }
 
@@ -92,23 +141,51 @@ _ds_record() {
 	local stage_name="$3"
 	local start_ns="$4"
 
-	local end_ns elapsed_ms ts
+	local supplied_attempt_id="${5:-${_ds_stage_attempt_id:-}}"
+	local end_ns elapsed_ms ts attempt_id cycle_id attempt_key attempt_index=-1 index
+	stage_name=$(_ds_normalize_stage "$stage_name")
 	end_ns=$(_ds_now_ns)
 	# Guard against non-numeric values (e.g., when disabled or date failed)
 	if [[ "$start_ns" =~ ^[0-9]+$ && "$end_ns" =~ ^[0-9]+$ && "$start_ns" -gt 0 ]]; then
-		elapsed_ms=$(( (end_ns - start_ns) / 1000000 ))
+		elapsed_ms=$(((end_ns - start_ns) / 1000000))
 	else
 		elapsed_ms=0
 	fi
 
 	# ISO 8601 UTC timestamp
 	ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || ts="unknown"
+	attempt_key="${issue_number}:${stage_name}:${start_ns}"
+	if [[ -n "$supplied_attempt_id" ]]; then
+		for ((index = 0; index < ${#_DS_ATTEMPT_KEYS[@]}; index++)); do
+			[[ "${_DS_ATTEMPT_IDS[$index]}" == "$supplied_attempt_id" && "${_DS_ATTEMPT_KEYS[$index]}" == "$attempt_key" ]] || continue
+			[[ "${_DS_ATTEMPT_COMPLETED[$index]}" == "1" ]] && return 0
+			attempt_index="$index"
+			break
+		done
+	fi
+	if [[ "$attempt_index" -lt 0 ]]; then
+		for ((index = 0; index < ${#_DS_ATTEMPT_KEYS[@]}; index++)); do
+			if [[ "${_DS_ATTEMPT_KEYS[$index]}" == "$attempt_key" && "${_DS_ATTEMPT_COMPLETED[$index]}" == "0" ]]; then
+				attempt_index="$index"
+			fi
+		done
+	fi
+	if [[ "$attempt_index" -ge 0 ]]; then
+		attempt_id="${_DS_ATTEMPT_IDS[$attempt_index]}"
+		_DS_ATTEMPT_COMPLETED[$attempt_index]=1
+	elif [[ " ${_DS_ATTEMPT_KEYS[*]} " == *" $attempt_key "* ]]; then
+		return 0
+	else
+		attempt_id=$(_ds_attempt_id "$issue_number" "$stage_name" "$start_ns")
+	fi
+	cycle_id="${_PULSE_CYCLE_ID:-pid-$$}"
 
 	# Ensure parent dir exists
 	[[ "$DS_LOG" == */* ]] && mkdir -p "${DS_LOG%/*}" 2>/dev/null || true
 
 	# Atomic append (short line, POSIX guarantee)
-	printf '%s\t#%s\t%s\t%s\t%s\n' "$ts" "$issue_number" "$repo_slug" "$stage_name" "$elapsed_ms" \
+	printf '%s\t#%s\t%s\t%s\t%s\tcomplete\t%s\t%s\t%s\n' \
+		"$ts" "$issue_number" "$repo_slug" "$stage_name" "$elapsed_ms" "$attempt_id" "$cycle_id" "$$" \
 		>>"$DS_LOG" 2>/dev/null || true
 	return 0
 }
@@ -132,14 +209,19 @@ _ds_report() {
 	# pre-commit positional-param validator does not flag awk's field
 	# references as bash positional params (same pattern as
 	# gh-api-instrument.sh / gh-api-aggregate.awk).
-	local awk_script
+	local awk_script report_input line report_rc=0
 	awk_script="$(dirname "${BASH_SOURCE[0]}")/dispatch-stage-aggregate.awk"
 	if [[ ! -f "$awk_script" ]]; then
 		printf 'Missing awk script: %s\n' "$awk_script" >&2
 		return 1
 	fi
-	awk -F'\t' -v cutoff="$cutoff" -f "$awk_script" "$DS_LOG"
-	return 0
+	report_input=$(mktemp "${DS_LOG}.report.XXXXXX") || return 1
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		[[ "$line" == *$'\tstart\t'* ]] || printf '%s\n' "$line" >>"$report_input"
+	done <"$DS_LOG"
+	awk -F'\t' -v cutoff="$cutoff" -f "$awk_script" "$report_input" || report_rc=$?
+	rm -f "$report_input"
+	return "$report_rc"
 }
 
 # --- _ds_trim_log ---------------------------------------------------------

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -213,7 +213,60 @@ def parse_stage(line):
         'repo': parts[2] if len(parts) > 2 else '',
         'stage': parts[3] if len(parts) > 3 else 'unknown',
         'duration_ms': int(parts[4]) if len(parts) > 4 and str(parts[4]).isdigit() else 0,
+        'event': parts[5] if len(parts) > 5 and parts[5] in {'start', 'complete'} else 'complete',
+        'attempt_id': parts[6] if len(parts) > 6 else '',
+        'cycle_id': parts[7] if len(parts) > 7 else '',
+        'owner_pid': int(parts[8]) if len(parts) > 8 and str(parts[8]).isdigit() else 0,
     }
+
+
+def process_owner_state(pid):
+    if not pid:
+        return 'unknown'
+    try:
+        os.kill(pid, 0)
+        return 'alive'
+    except ProcessLookupError:
+        return 'absent'
+    except (PermissionError, OSError):
+        return 'unknown'
+
+
+def build_stage_execution(stage_records, cycle_state):
+    completed_attempts = {
+        record['attempt_id'] for record in stage_records
+        if record['event'] == 'complete' and record['attempt_id']
+    }
+    executions = []
+    for record in stage_records:
+        if record['event'] != 'start' or not record['attempt_id']:
+            continue
+        if record['attempt_id'] in completed_attempts:
+            continue
+        owner_state = process_owner_state(record['owner_pid'])
+        cycle_supports_liveness = all((
+            cycle_state.get('availability') == 'available',
+            cycle_state.get('cycle_id') == record['cycle_id'],
+            cycle_state.get('outcome') == 'running',
+        ))
+        if owner_state == 'alive' and cycle_supports_liveness:
+            classification = 'in_flight'
+            next_action = 'recheck_owner_and_matching_completion_within_60s'
+        elif owner_state == 'absent':
+            classification = 'interrupted'
+            next_action = 'inspect_matching_cycle_terminal_evidence'
+        else:
+            classification = 'unknown'
+            next_action = 'verify_owner_process_or_cycle_lineage'
+        executions.append({
+            'issue': record['issue'],
+            'stage': record['stage'],
+            'classification': classification,
+            'age_seconds': max(0, int(now - record['ts'])),
+            'cycle_id': record['cycle_id'] or None,
+            'next_diagnostic_action': next_action,
+        })
+    return executions
 
 
 def classify_metric(item):
@@ -567,9 +620,19 @@ if canonical_reconciliation_refusal_count:
 # Keep their resource context, but never credit them as implementation workers.
 worker_metrics = [item for item in metrics if item.get('role') == 'worker']
 metric_class_counts = Counter(classify_metric(item) for item in worker_metrics)
-stage_counts = Counter(record['stage'] for record in stage_records)
-stage_timing = defaultdict(lambda: {'count': 0, 'sum_ms': 0, 'max_ms': 0})
+completed_stage_records = []
+completed_attempt_ids = set()
 for record in stage_records:
+    if record['event'] != 'complete':
+        continue
+    if record['attempt_id'] and record['attempt_id'] in completed_attempt_ids:
+        continue
+    completed_stage_records.append(record)
+    if record['attempt_id']:
+        completed_attempt_ids.add(record['attempt_id'])
+stage_counts = Counter(record['stage'] for record in completed_stage_records)
+stage_timing = defaultdict(lambda: {'count': 0, 'sum_ms': 0, 'max_ms': 0})
+for record in completed_stage_records:
     item = stage_timing[record['stage']]
     item['count'] += 1
     item['sum_ms'] += record['duration_ms']
@@ -684,6 +747,7 @@ prefetch_cache = {
 }
 health_path = os.path.join(log_dir, 'pulse-health.json')
 cycle_state = build_cycle_state(health_path)
+stage_executions = build_stage_execution(stage_records, cycle_state)
 if os.path.exists(health_path):
     try:
         with open(health_path, encoding='utf-8') as health_file:
@@ -735,9 +799,10 @@ resource_recovery = build_resource_recovery_evidence(wrapper_log_lines, worker_m
 
 result = {
     'window_seconds': window_s,
-    'dispatch_stage_events': len(stage_records),
+    'dispatch_stage_events': len(completed_stage_records),
     'dispatch_stage_counts': dict(stage_counts),
     'dispatch_stage_timing_ms': stage_timing_summary,
+    'dispatch_stage_executions': stage_executions,
     'worker_terminal_events': len(worker_metrics),
     'non_worker_terminal_events': len(metrics) - len(worker_metrics),
     'worker_result_counts': dict(metric_class_counts),
@@ -842,6 +907,7 @@ else:
     print(f'- Dispatch alive: {str(result["dispatch_alive"]).lower()}')
     print(f'- Dispatch stage events: {result["dispatch_stage_events"]}')
     print(f'- Dispatch stage counts: {json.dumps(result["dispatch_stage_counts"], sort_keys=True)}')
+    print(f'- Dispatch stages in progress or interrupted: {json.dumps(result["dispatch_stage_executions"], sort_keys=True)}')
     print(f'- Worker terminal events: {result["worker_terminal_events"]} ({result["worker_successes"]} success, {result["worker_failures_or_stalls"]} non-success)')
     print(f'- Worker outcomes: {json.dumps(result["worker_outcomes"], sort_keys=True)}')
     print(f'- Resource context: {json.dumps(result["resource_context"], sort_keys=True)}')

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1523,7 +1523,7 @@ _dispatch_dedup_check_layers() {
 	# t3043: per-sub-stage timing inside dedup_check. The outer
 	# dispatch_with_dedup records "dedup_check" as one blob; these
 	# sub-stage records let us identify which gate dominates the 235s avg.
-	local _dss_t0
+	local _dss_t0 _ds_stage_attempt_id
 
 	local target_state="" target_title=""
 	# GH#21717: normalize to uppercase — REST fallback returns lowercase "open"/"closed"
@@ -1537,6 +1537,7 @@ _dispatch_dedup_check_layers() {
 	# of assignee identity. A terminal worker draft checkpoint is the sole narrow
 	# exception: route its existing exact PR before consuming the generic hold.
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "interactive_hold" "$_dss_t0" _ds_stage_attempt_id
 	if _dispatch_interactive_hold_gate "$issue_number" "$repo_slug" "$issue_title" \
 		"$self_login" "$issue_meta_json"; then
 		_ds_record "$issue_number" "$repo_slug" "dedup.interactive_hold" "$_dss_t0"
@@ -1548,6 +1549,7 @@ _dispatch_dedup_check_layers() {
 	# than 5 GiB or 5% available. The same fail-closed policy runs at the actual
 	# worktree creation boundary, covering interactive and non-Pulse callers.
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "disk_space" "$_dss_t0" _ds_stage_attempt_id
 	local _capacity_rc=0
 	local _capacity_path="${AIDEVOPS_WORKTREE_BASE_DIR:-$HOME}"
 	aidevops_worktree_capacity_check "$_capacity_path" || _capacity_rc=$?
@@ -1555,7 +1557,7 @@ _dispatch_dedup_check_layers() {
 		if _dispatch_cleanup_disk_pressure "$issue_number" "$repo_slug" "$_capacity_path" \
 			"${AIDEVOPS_DISK_CAPACITY_REASON}" "${AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB}" \
 			"${AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT}"; then
-			_ds_record "$issue_number" "$repo_slug" "dedup.disk_space" "$_dss_t0"
+			:
 		else
 			echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: disk space critical (reason=${AIDEVOPS_DISK_CAPACITY_REASON}, available=${AIDEVOPS_DISK_CAPACITY_AVAILABLE_KB}KB/${AIDEVOPS_DISK_CAPACITY_AVAILABLE_PERCENT}%, require at least ${AIDEVOPS_MIN_WORKTREE_FREE_KB:-5242880}KB and ${AIDEVOPS_MIN_WORKTREE_FREE_PERCENT:-5}%). Run: worktree-helper.sh clean --auto --force-merged" >>"$LOGFILE"
 			_ds_record "$issue_number" "$repo_slug" "dedup.disk_space" "$_dss_t0"
@@ -1568,6 +1570,7 @@ _dispatch_dedup_check_layers() {
 	# registered git worktrees. At that scale, new worktrees risk consuming
 	# tens of GB; stale merged ones should be cleaned before adding more.
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "worktree_cap" "$_dss_t0" _ds_stage_attempt_id
 	local _wt_max=""
 	_wt_max="${AIDEVOPS_MAX_WORKTREES:-200}"
 	[[ "$_wt_max" =~ ^[1-9][0-9]*$ ]] || _wt_max=200
@@ -1579,20 +1582,25 @@ _dispatch_dedup_check_layers() {
 	_ds_record "$issue_number" "$repo_slug" "dedup.worktree_cap" "$_dss_t0"
 
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "state_check" "$_dss_t0" _ds_stage_attempt_id
 	if [[ "$target_state" != "OPEN" ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: issue state is ${target_state:-unknown}" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.state_check" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.state_check" "$_dss_t0"
 
 	# publication:pending is an unconditional hold while canonical planning is
 	# absent from the default branch. It is checked here as defence-in-depth
 	# before direct-dispatch paths can claim or launch a worker.
+	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "publication_pending" "$_dss_t0" _ds_stage_attempt_id
 	if _has_publication_pending_label "$issue_meta_json"; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: publication:pending label present" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.publication_pending" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.publication_pending" "$_dss_t0"
 
 	# GH#20219: parent-task / meta added here as defence-in-depth. The
 	# canonical parent-task guard is in dispatch-dedup-helper.sh Layer 6
@@ -1602,15 +1610,20 @@ _dispatch_dedup_check_layers() {
 	# code path that skips check_dispatch_dedup). This closes Factor 1 of
 	# the #20161 incident where a parent-task issue was dispatched despite
 	# the label being continuously present.
+	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "mgmt_label" "$_dss_t0" _ds_stage_attempt_id
 	if _has_consolidated_label "$issue_meta_json"; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: consolidated issue label present (GH#23187)" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.mgmt_label" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.mgmt_label" "$_dss_t0"
 
+	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "label_checks" "$_dss_t0" _ds_stage_attempt_id
 	if printf '%s' "$issue_meta_json" | jq -e '.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review") or index("on hold") or index("blocked") or index("parent-task") or index("meta"))' >/dev/null 2>&1; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: non-dispatchable management label present" >>"$LOGFILE"
-		_ds_record "$issue_number" "$repo_slug" "dedup.mgmt_label" "$_dss_t0"
+		_ds_record "$issue_number" "$repo_slug" "dedup.label_checks" "$_dss_t0"
 		return 1
 	fi
 
@@ -1627,6 +1640,7 @@ _dispatch_dedup_check_layers() {
 	# t1894/GH#18648: Cryptographic approval gate (ever-NMR) with
 	# review-followup exemption for bot-generated cleanup issues.
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "nmr_gate" "$_dss_t0" _ds_stage_attempt_id
 	if _check_nmr_approval_gate "$issue_number" "$repo_slug" "$issue_meta_json"; then
 		_ds_record "$issue_number" "$repo_slug" "dedup.nmr_gate" "$_dss_t0"
 		return 1
@@ -1651,6 +1665,7 @@ _dispatch_dedup_check_layers() {
 	# large-file, and footprint gates below — eliminating 1-2 extra gh calls
 	# per dispatch candidate.
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "blocked_by" "$_dss_t0" _ds_stage_attempt_id
 	local _dispatch_issue_body
 	_dispatch_issue_body=$(printf '%s' "$issue_meta_json" | jq -r '.body // ""' 2>/dev/null) || _dispatch_issue_body=""
 	if is_blocked_by_unresolved "$_dispatch_issue_body" "$repo_slug" "$issue_number"; then
@@ -1668,6 +1683,7 @@ _dispatch_dedup_check_layers() {
 	# t2996: pass meta_json through so the consolidation helper skips its
 	# `gh issue view --json labels` call (label CSV derived from JSON instead).
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "consolidation" "$_dss_t0" _ds_stage_attempt_id
 	if _issue_needs_consolidation "$issue_number" "$repo_slug" "$issue_meta_json"; then
 		_dispatch_issue_consolidation "$issue_number" "$repo_slug" "$repo_path"
 		echo "[dispatch_with_dedup] Dispatch deferred for #${issue_number} in ${repo_slug}: issue needs comment consolidation" >>"$LOGFILE"
@@ -1683,6 +1699,7 @@ _dispatch_dedup_check_layers() {
 	# t2996: pass meta_json through so the gate skips its `gh issue view --json
 	# labels` AND `--json title` calls (both derived from the bundled JSON).
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "large_file" "$_dss_t0" _ds_stage_attempt_id
 	if _issue_targets_large_files "$issue_number" "$repo_slug" "$_dispatch_issue_body" "$repo_path" "" "$issue_meta_json"; then
 		echo "[dispatch_with_dedup] Dispatch deferred for #${issue_number} in ${repo_slug}: targets large file(s), simplification gate" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.large_file" "$_dss_t0"
@@ -1695,6 +1712,7 @@ _dispatch_dedup_check_layers() {
 	# prevent CONFLICTING cascades. The check is cheap (cached per repo per
 	# cycle) and decays naturally when the blocking issue's status labels clear.
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "footprint" "$_dss_t0" _ds_stage_attempt_id
 	local _footprint_signal=""
 	_footprint_signal=$(_footprint_check_overlap "$issue_number" "$repo_slug" "$_dispatch_issue_body" 2>/dev/null) || true
 	if [[ -n "$_footprint_signal" ]]; then
@@ -1713,6 +1731,7 @@ _dispatch_dedup_check_layers() {
 	# export, those layers re-fetch the same JSON we just bundled — wasting
 	# 1-2 more gh calls under load.
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "7_layers" "$_dss_t0" _ds_stage_attempt_id
 	local _dedup_rc=0
 	local _dedup_signal=""
 	_dedup_signal=$(ISSUE_META_JSON="$issue_meta_json" DISPATCH_REPO_PATH="$repo_path" \
@@ -1738,6 +1757,7 @@ _dispatch_dedup_check_layers() {
 	# GH#22399/GH#31404: fail closed before launch, but only after dedup
 	# confirms eligibility. Never mutate author-gate labels on an active PR.
 	_dss_t0=$(_ds_now_ns)
+	_ds_stage_start "$issue_number" "$repo_slug" "external_author_gate" "$_dss_t0" _ds_stage_attempt_id
 	if _check_external_issue_author_gate "$issue_number" "$repo_slug"; then
 		_ds_record "$issue_number" "$repo_slug" "dedup.external_author_gate" "$_dss_t0"
 		return 1

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1523,7 +1523,7 @@ _dispatch_dedup_check_layers() {
 	# t3043: per-sub-stage timing inside dedup_check. The outer
 	# dispatch_with_dedup records "dedup_check" as one blob; these
 	# sub-stage records let us identify which gate dominates the 235s avg.
-	local _dss_t0 _ds_stage_attempt_id
+	local _dss_t0="" _ds_stage_attempt_id=""
 
 	local target_state="" target_title=""
 	# GH#21717: normalize to uppercase — REST fallback returns lowercase "open"/"closed"

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -16,9 +16,15 @@ import json, os, sys, time
 root = sys.argv[1]
 now = time.time()
 iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(now))
+old_iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(now - 5))
 open(os.path.join(root, 'dispatch-stages.tsv'), 'w').write(
     f'{iso}\t#1\tmarcusquinn/aidevops\tworker_launch_total\t123\n'
     f'{iso}\t#1\tmarcusquinn/aidevops\tceremony_total\t456\n'
+    f'{old_iso}\t#2\tmarcusquinn/aidevops\tdedup.nmr_gate\t0\tstart\tdead-attempt\tcycle-2\t99999999\n'
+    f'{iso}\t#4\tmarcusquinn/aidevops\tdedup.footprint\t0\tstart\tlive-attempt\tcycle-4\t{os.getppid()}\n'
+    f'{iso}\t#3\tmarcusquinn/aidevops\tdedup.label_checks\t0\tstart\tcomplete-attempt\tcycle-3\t99999999\n'
+    f'{iso}\t#3\tmarcusquinn/aidevops\tdedup.label_checks\t25\tcomplete\tcomplete-attempt\tcycle-3\t99999999\n'
+    f'{iso}\t#3\tmarcusquinn/aidevops\tdedup.label_checks\t99\tcomplete\tcomplete-attempt\tcycle-3\t99999999\n'
 )
 open(os.path.join(root, 'headless-runtime-metrics.jsonl'), 'w').write(
     json.dumps({'ts': now, 'role': 'worker', 'result': 'success', 'exit_code': 0, 'duration_ms': 1000, 'load_1min': 1.5, 'load_per_cpu': 0.2}) + '\n' +
@@ -197,6 +203,12 @@ jq -e '.pre_launch_blockers.cost_budget_exceeded == 2' "$json_output" >/dev/null
 jq -e '.pre_launch_blockers.dedup_active_claim == 1' "$json_output" >/dev/null
 jq -e '.top_pre_launch_blockers[0].reason == "cost_budget_exceeded"' "$json_output" >/dev/null
 jq -e '.dispatch_stage_timing_ms.worker_launch_total.avg_ms == 123' "$json_output" >/dev/null
+jq -e '.dispatch_stage_events == 3' "$json_output" >/dev/null
+jq -e '.dispatch_stage_counts["dedup.nmr_gate"] == null' "$json_output" >/dev/null
+jq -e '.dispatch_stage_timing_ms["dedup.label_checks"].count == 1' "$json_output" >/dev/null
+jq -e '.dispatch_stage_executions | length == 2' "$json_output" >/dev/null
+jq -e '.dispatch_stage_executions[] | select(.issue == "#2") | .classification == "interrupted" and .age_seconds >= 5 and .next_diagnostic_action == "inspect_matching_cycle_terminal_evidence"' "$json_output" >/dev/null
+jq -e '.dispatch_stage_executions[] | select(.issue == "#4") | .classification == "unknown" and .next_diagnostic_action == "verify_owner_process_or_cycle_lineage"' "$json_output" >/dev/null
 jq -e '.api_call_pressure.graphql_read_calls == 9' "$json_output" >/dev/null
 jq -e '.api_call_pressure.rest_read_calls == 8' "$json_output" >/dev/null
 jq -e '.api_call_pressure.graphql_search_calls == 11' "$json_output" >/dev/null
@@ -260,6 +272,28 @@ assert "graphql_budget_status = (" not in implementation_source
 assert 'import subprocess' not in implementation_source
 assert 'subprocess.check_output' not in implementation_source
 PY
+
+live_stage_dir="$TMP_DIR/live-stage"
+mkdir -p "$live_stage_dir"
+python3 - "$live_stage_dir" "$$" <<'PY'
+import json, os, sys, time
+root, owner_pid = sys.argv[1], sys.argv[2]
+now = time.time()
+iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(now))
+open(os.path.join(root, 'dispatch-stages.tsv'), 'w').write(
+    f'{iso}\t#9\towner/repo\tdedup.nmr_gate\t0\tstart\tslow-gate\tlive-cycle\t{owner_pid}\n'
+)
+json.dump({'cycle_state': {
+    'schema': 'aidevops.pulse-cycle-state/v1', 'cycle_id': 'live-cycle',
+    'phase': 'preflight', 'outcome': 'running', 'heartbeat_at': iso,
+    'progress': {'last_at': None, 'kinds': [], 'consecutive_no_progress_cycles': 0},
+    'blocker': {'kind': 'none', 'fingerprint': None, 'consecutive_same_cycles': 0},
+}}, open(os.path.join(root, 'pulse-health.json'), 'w'))
+PY
+live_stage_json="$TMP_DIR/live-stage.json"
+"$HELPER" --log-dir "$live_stage_dir" --repo-path "$PWD" --window 15m --json >"$live_stage_json"
+jq -e '.dispatch_stage_events == 0 and .dispatch_stage_timing_ms == {}' "$live_stage_json" >/dev/null
+jq -e '.dispatch_stage_executions[0].classification == "in_flight" and .dispatch_stage_executions[0].age_seconds >= 0 and .dispatch_stage_executions[0].next_diagnostic_action == "recheck_owner_and_matching_completion_within_60s"' "$live_stage_json" >/dev/null
 
 missing_dir="$TMP_DIR/missing-cycle-state"
 mkdir -p "$missing_dir"
@@ -339,5 +373,29 @@ AIDEVOPS_ACTIVE_WORKER_PROCESSES_OVERRIDE=0 AIDEVOPS_ZERO_WORKER_MIN_CYCLES=3 \
 jq -e '.zero_worker_underutilization.actionable == true' "$zero_json" >/dev/null
 jq -e '.zero_worker_underutilization.github_read_complete == false' "$zero_json" >/dev/null
 jq -e '.zero_worker_underutilization.classifications == {"admission_failure":1,"assignment_ownership":1,"dependency_state":1,"github_read_incomplete":1,"queue_labels":1}' "$zero_json" >/dev/null
+
+instrument_log="$TMP_DIR/instrument.tsv"
+(
+	export AIDEVOPS_DISPATCH_STAGES_LOG="$instrument_log"
+	# shellcheck source=../dispatch-stage-instrument.sh
+	source "${SCRIPT_DIR}/../dispatch-stage-instrument.sh"
+	same_start=$(_ds_now_ns)
+	outer_attempt=""
+	inner_attempt=""
+	_ds_stage_start 10 owner/repo nested_gate "$same_start" outer_attempt
+	_ds_stage_start 10 owner/repo nested_gate "$same_start" inner_attempt
+	_ds_record 10 owner/repo nested_gate "$same_start" "$inner_attempt"
+	_ds_record 10 owner/repo nested_gate "$same_start" "$inner_attempt"
+	_ds_record 10 owner/repo nested_gate "$same_start" "$outer_attempt"
+)
+python3 - "$instrument_log" <<'PY'
+import sys
+rows = [line.rstrip('\n').split('\t') for line in open(sys.argv[1], encoding='utf-8')]
+starts = [row for row in rows if row[5] == 'start']
+completions = [row for row in rows if row[5] == 'complete']
+assert len(starts) == 2 and len(completions) == 2
+assert len({row[6] for row in starts}) == 2
+assert {row[6] for row in starts} == {row[6] for row in completions}
+PY
 
 printf 'PASS pulse-current-state-helper\n'

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -586,6 +586,15 @@ assert_not_grep \
 	"10e: benign block reasons are not counted as candidate failure reasons" \
 	'dedup_active_claim \| cost_budget_exceeded' \
 	"$DISPATCH_LIB"
+assert_grep \
+	"10f: NMR gate entry is recorded before the potentially slow gate" \
+	'_ds_stage_start.*nmr_gate' \
+	"$CORE"
+assert_order \
+	"10g: NMR stage entry precedes gate execution" \
+	'_ds_stage_start.*nmr_gate' \
+	'^[[:space:]]*if _check_nmr_approval_gate' \
+	"$CORE"
 
 # --- Summary ---
 


### PR DESCRIPTION
## Summary

Record dispatch gate entry and completion with attempt/cycle lineage; classify unmatched starts as in-flight, interrupted, or unknown only from owner and cycle evidence; keep completion timings backward-compatible and deduplicated.

## Files Changed

.agents/scripts/dispatch-stage-instrument.sh, .agents/scripts/pulse-current-state.py, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/tests/test-pulse-current-state-helper.sh, .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — test-pulse-current-state-helper.sh; test-pulse-dispatch-engine-stage-wiring.sh; linters-local.sh --changed

Resolves #31632


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.344 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-sol spent 27m and 151,341 tokens on this as a headless worker.