### PR TITLE
GH#31633: recover direct-merge completion

### DIFF
--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -2051,9 +2051,12 @@ cmd_complete() {
 	fi
 	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$PR_NUMBER") || return 1
 	if [[ -f "$receipt_path" ]]; then
+		# A merged direct-completion receipt can belong to the merge executor rather
+		# than this initialized-only executor. Finalize through the same canonical
+		# terminal-evidence path as `finalize-receipt` so immutable receipt identity
+		# remains preserved instead of requiring the current process identity.
 		full_loop_finalize_cleanup_receipt "$repo" "$PR_NUMBER" \
-			"${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" "$current_root" "$current_branch" \
-			"$owner_pid" "$owner_session" || {
+			"${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" || {
 			print_error "Cannot finalize durable deferred-cleanup handoff"
 			return 1
 		}
@@ -2061,8 +2064,7 @@ cmd_complete() {
 		"$owner_pid" "$owner_session" "${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" >/dev/null; then
 		# A merge process may have created the receipt after the existence check.
 		full_loop_finalize_cleanup_receipt "$repo" "$PR_NUMBER" \
-			"${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" "$current_root" "$current_branch" \
-			"$owner_pid" "$owner_session" || {
+			"${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" || {
 			print_error "Cannot persist durable deferred-cleanup handoff"
 			return 1
 		}

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -374,11 +374,17 @@ test_cmd_merge_defers_current_linked_worktree() {
 		 and (.owner.pid | type == "number") and (.owner.process_identity | length > 0)' \
 		"$receipt_path" >/dev/null || rc=1
 	cmd_record_no_release "123" "example/repo" >/dev/null || rc=1
+	# An initialized-only direct-completion executor differs from the merge
+	# executor that owns the existing receipt. Completion must preserve that
+	# immutable owner evidence and converge through canonical finalization.
+	jq '.owner.session = "merge-executor-session"' "$receipt_path" >"${receipt_path}.tmp" || rc=1
+	mv "${receipt_path}.tmp" "$receipt_path" || rc=1
 	cmd_complete >/dev/null || rc=1
 	jq -e '
 		.executor_completion_state == "COMPLETE"
 		and .resource_cleanup_state == "CLEANUP_DEFERRED"
 		and .release_status == "not-requested"
+		and .owner.session == "merge-executor-session"
 	' "$receipt_path" >/dev/null || rc=1
 	cp "$receipt_path" "${TEST_ROOT}/completed-receipt.json"
 	cmd_complete >/dev/null || rc=1


### PR DESCRIPTION
## Summary

Reuse canonical receipt finalization when initialized-only completion encounters an existing direct-merge receipt, preserving immutable receipt ownership.

## Files Changed

.agents/scripts/full-loop-helper-state.sh, .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — bash .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh; bash .agents/scripts/tests/test-full-loop-completion-evidence.sh; shellcheck targeted scripts; .agents/scripts/linters-local.sh --changed

Resolves #31633


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.344 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 3m and 77,700 tokens on this as a headless worker.