### PR TITLE
GH#31601: feat: add wait-aware bounded operation status

### DIFF
--- a/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
@@ -24,6 +24,7 @@ import {
 import { resolveSessionOwnedWorktreeRoot } from "./gpt-image-worktree.mjs";
 
 const MAX_OPERATIONS = 24;
+const MAX_STATUS_WAIT_MS = 60 * 1000;
 const MAX_OUTPUT_LINES = 500;
 const SUPERVISOR_PATH = fileURLToPath(new URL("./bounded-operation-supervisor.mjs", import.meta.url));
 const SUPERVISOR_RUNTIME = "node";
@@ -67,9 +68,25 @@ export class BoundedInteractiveOperationManager {
     for (const stream of [child.stdout, child.stderr]) {
       stream?.on("data", (chunk) => {
         appendCapture(operation, chunk);
-        observeProgress(operation, chunk, this.now);
+        if (observeProgress(operation, chunk, this.now)) this.notifyStatusWaiters(operation);
       });
     }
+  }
+
+  statusVersion(operation) {
+    return `${operation.state}:${operation.restorationState}:${operation.progressEvents}`;
+  }
+
+  notifyStatusWaiters(operation) {
+    const version = this.statusVersion(operation);
+    for (const waiter of operation.statusWaiters) {
+      if (waiter.version === version) continue;
+      waiter.finish();
+    }
+  }
+
+  clearStatusWaiters(operation) {
+    for (const waiter of operation.statusWaiters) waiter.finish();
   }
 
   spawnOwned(operation, command, stage) {
@@ -142,6 +159,7 @@ export class BoundedInteractiveOperationManager {
       restorationTimer: null,
       budgetTimer: null,
       killTimer: null,
+      statusWaiters: new Set(),
     };
     this.operations.set(operation.id, operation);
 
@@ -151,6 +169,7 @@ export class BoundedInteractiveOperationManager {
       child.once("exit", () => { operation.childExited = true; });
       child.once("spawn", () => {
         operation.state = "running";
+        this.notifyStatusWaiters(operation);
         operation.budgetTimer = this.setTimer(() => this.requestTermination(operation, "timed_out"), operation.budgetMs);
         resolve();
       });
@@ -173,6 +192,7 @@ export class BoundedInteractiveOperationManager {
     if (!canTerminate(operation)) return false;
     operation.disposition = disposition;
     operation.state = disposition === "cancelled" ? "cancelling" : "timing_out";
+    this.notifyStatusWaiters(operation);
     operation.processSignal = "SIGTERM";
     const signalled = this.kill(operation.child, "SIGTERM");
     return signalled;
@@ -194,6 +214,7 @@ export class BoundedInteractiveOperationManager {
   async runRestoration(operation) {
     operation.state = "restoring";
     operation.restorationState = "running";
+    this.notifyStatusWaiters(operation);
     await new Promise((resolve) => {
       let settled = false;
       const finish = (state, code = null) => {
@@ -203,6 +224,7 @@ export class BoundedInteractiveOperationManager {
         operation.restorationChild = null;
         operation.restorationExit = Number.isInteger(code) ? code : null;
         operation.restorationState = state;
+        this.notifyStatusWaiters(operation);
         resolve();
       };
       const child = this.spawnOwned(operation, operation.restorationCommand, "restoration");
@@ -211,6 +233,7 @@ export class BoundedInteractiveOperationManager {
       child.once("exit", () => { operation.restorationChildExited = true; });
       operation.restorationTimer = this.setTimer(() => {
         operation.restorationState = "timing_out";
+        this.notifyStatusWaiters(operation);
         if (!operation.restorationChildExited && child.exitCode === null && child.signalCode === null) {
           this.kill(child, "SIGTERM");
         }
@@ -229,6 +252,7 @@ export class BoundedInteractiveOperationManager {
       ? "restoration_failed"
       : operation.disposition;
     operation.state = "finalizing";
+    this.notifyStatusWaiters(operation);
     try {
       operation.outputID = await this.recordOutput(Buffer.concat(operation.output), {
         exitCode: operation.processExit,
@@ -239,6 +263,7 @@ export class BoundedInteractiveOperationManager {
     }
     operation.output = [];
     operation.state = finalState;
+    this.notifyStatusWaiters(operation);
     if (operation.ownerDeleted) this.operations.delete(operation.id);
   }
 
@@ -251,8 +276,28 @@ export class BoundedInteractiveOperationManager {
     return operation;
   }
 
-  status(id, context = {}) {
-    return this.receipt(this.ownedOperation(id, context));
+  status(id, context = {}, requested = {}) {
+    const operation = this.ownedOperation(id, context);
+    const waitMs = Number(requested.waitMs ?? 0);
+    if (!Number.isSafeInteger(waitMs) || waitMs < 0 || waitMs > MAX_STATUS_WAIT_MS) {
+      throw new Error("status wait must be an integer from 0 to 60000 milliseconds");
+    }
+    if (waitMs === 0 || !["starting", "running", "cancelling", "timing_out", "restoring", "finalizing"].includes(operation.state)) {
+      return this.receipt(operation);
+    }
+    return new Promise((resolve) => {
+      const waiter = {
+        version: this.statusVersion(operation),
+        finish: () => {
+          if (!operation.statusWaiters.delete(waiter)) return;
+          this.clearTimer(waiter.timer);
+          resolve(this.receipt(operation));
+        },
+        timer: null,
+      };
+      operation.statusWaiters.add(waiter);
+      waiter.timer = this.setTimer(waiter.finish, waitMs);
+    });
   }
 
   async output(id, context = {}, requested = {}) {
@@ -306,6 +351,7 @@ export class BoundedInteractiveOperationManager {
   }
 
   dispose() {
+    for (const operation of this.operations.values()) this.clearStatusWaiters(operation);
     disposeOperations(this.operations, this.kill, this.clearTimer);
     this.recordOutput.dispose?.();
     this.readOutput.dispose?.();

--- a/.agents/plugins/opencode-aidevops/bounded-operation-runtime.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-operation-runtime.mjs
@@ -20,6 +20,7 @@ export function appendCapture(operation, chunk) {
 export function observeProgress(operation, chunk, now) {
   const text = `${operation.progressRemainder}${String(chunk)}`;
   const lines = text.split(/\r?\n/);
+  let observed = false;
   operation.progressRemainder = lines.pop() || "";
   if (Buffer.byteLength(operation.progressRemainder) > MAX_PROGRESS_REMAINDER_BYTES) {
     operation.progressRemainder = operation.progressRemainder.slice(-MAX_PROGRESS_REMAINDER_BYTES);
@@ -28,8 +29,10 @@ export function observeProgress(operation, chunk, now) {
     if (/^AIDEVOPS_PROGRESS:\s*\S/.test(line)) {
       operation.lastMeaningfulProgressAt = now();
       operation.progressEvents += 1;
+      observed = true;
     }
   }
+  return observed;
 }
 
 export function signalSupervisor(child) {

--- a/.agents/plugins/opencode-aidevops/bounded-operation-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-operation-tool.mjs
@@ -11,12 +11,13 @@ export function createBoundedInteractiveOperationTool(tool, z, manager) {
   return tool({
     description:
       "Start, inspect, retrieve output from, or cancel a bounded long-running command without blocking the interactive session. " +
-      "Use start for operations expected to exceed the progress interval, call status periodically, then use output with the operation ID after it reaches a terminal state. " +
+      "Use start for operations expected to exceed the progress interval; status can wait up to 60 seconds for progress or a lifecycle transition; then use output with the operation ID after it reaches a terminal state. " +
       "Commands are argv arrays, remain confined to the active project root, and must not daemonize or create a new process session. " +
       "Cancellation is session-owned and restoration evidence remains explicit.",
     args: {
       action: z.enum(["start", "status", "output", "cancel"]),
       operation_id: z.string().optional(),
+      wait_seconds: z.number().optional(),
       output_offset: z.number().optional(),
       output_limit: z.number().optional(),
       command: z.array(z.string()).optional(),
@@ -39,7 +40,9 @@ export function createBoundedInteractiveOperationTool(tool, z, manager) {
             restorationCommand: args.restoration_command,
           }, context);
         } else if (args.action === "status") {
-          receipt = manager.status(args.operation_id, context);
+          receipt = await manager.status(args.operation_id, context, {
+            waitMs: Number(args.wait_seconds ?? 0) * 1000,
+          });
         } else if (args.action === "output") {
           receipt = await manager.output(args.operation_id, context, {
             offset: args.output_offset,

--- a/.agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs
@@ -106,6 +106,61 @@ describe("bounded interactive operations", () => {
     assert.equal(JSON.stringify(result).includes("phase-one"), false);
   });
 
+  test("wait-aware status returns on progress, terminal state, or its bound", async () => {
+    const instance = manager();
+    const progressing = await instance.start({
+      command: [process.execPath, "-e", "setTimeout(() => console.log('AIDEVOPS_PROGRESS: ready'), 40); setTimeout(() => process.exit(0), 250)"],
+      budgetMs: 1000,
+      progressIntervalMs: 500,
+    }, owner);
+    const progressStarted = Date.now();
+    const progress = await instance.status(progressing.operation_id, owner, { waitMs: 500 });
+    assert.equal(progress.state, "running");
+    assert.equal(progress.progress_events, 1);
+    assert.ok(Date.now() - progressStarted < 400, "progress did not wake status promptly");
+    const completed = await instance.status(progressing.operation_id, owner, { waitMs: 500 });
+    assert.ok(["finalizing", "succeeded"].includes(completed.state));
+    assert.equal((await terminal(instance, progressing.operation_id)).state, "succeeded");
+
+    const quiet = await instance.start({
+      command: [process.execPath, "-e", "setTimeout(() => process.exit(0), 500)"],
+      budgetMs: 1000,
+    }, owner);
+    const boundStarted = Date.now();
+    const bounded = await instance.status(quiet.operation_id, owner, { waitMs: 30 });
+    assert.equal(bounded.state, "running");
+    assert.ok(Date.now() - boundStarted >= 20, "status returned before its wait bound");
+    instance.cancel(quiet.operation_id, owner);
+    await terminal(instance, quiet.operation_id);
+  });
+
+  test("wait-aware status preserves immediate, ownership, cancellation, and tool behavior", async () => {
+    const instance = manager();
+    const started = await instance.start({
+      command: [process.execPath, "-e", "setTimeout(() => {}, 1000)"],
+      budgetMs: 1000,
+    }, owner);
+    assert.equal(instance.status(started.operation_id, owner).state, "running");
+    assert.throws(() => instance.status(started.operation_id, owner, { waitMs: 60001 }), /0 to 60000/);
+    assert.throws(() => instance.status(started.operation_id, { sessionID: "ses_other" }, { waitMs: 20 }), /owner mismatch/);
+
+    const waiting = instance.status(started.operation_id, owner, { waitMs: 500 });
+    instance.cancel(started.operation_id, owner);
+    assert.equal((await waiting).state, "cancelling");
+
+    const schemaNode = { optional() { return this; } };
+    const z = { enum: () => schemaNode, string: () => schemaNode, number: () => schemaNode, array: () => schemaNode };
+    const tool = createBoundedInteractiveOperationTool((definition) => definition, z, instance);
+    const toolResult = JSON.parse(await tool.execute({
+      action: "status",
+      operation_id: started.operation_id,
+      wait_seconds: 1,
+    }, owner));
+    assert.ok(["cancelling", "finalizing", "cancelled"].includes(toolResult.state), JSON.stringify(toolResult));
+    assert.equal(toolResult.schema, "aidevops.interactive-operation/v1");
+    await terminal(instance, started.operation_id);
+  });
+
   test("an outside cwd requires a session-owned worktree resolution before spawn", async () => {
     const linked = mkdtempSync(join(tmpdir(), "aidevops-bounded-linked-"));
     let resolution;
@@ -236,6 +291,24 @@ describe("bounded interactive operations", () => {
     const timedRestoreResult = await terminal(instance, timedRestore.operation_id);
     assert.equal(timedRestoreResult.state, "restoration_failed");
     assert.equal(timedRestoreResult.restoration_state, "timed_out");
+  });
+
+  test("wait-aware status wakes when restoration reaches its timeout", async () => {
+    const instance = manager({ kill: () => false });
+    const started = await instance.start({
+      command: [process.execPath, "-e", "process.exit(0)"],
+      restorationCommand: [process.execPath, "-e", "setTimeout(() => process.exit(0), 200)"],
+      budgetMs: 1000,
+      restorationBudgetMs: 30,
+    }, owner);
+    const deadline = Date.now() + 1000;
+    while (instance.status(started.operation_id, owner).state !== "restoring" && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    const result = await instance.status(started.operation_id, owner, { waitMs: 500 });
+    assert.equal(result.state, "restoring");
+    assert.equal(result.restoration_state, "timing_out");
+    assert.equal((await terminal(instance, started.operation_id)).state, "restoration_failed");
   });
 
   test("expired generations and private command data stay isolated", async () => {

--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -70,10 +70,11 @@ canonical help command instead of repeating the full catalogue.
 
 OpenCode exposes `aidevops_bounded_operation` for a command expected to outlast
 the next useful progress update. Start it with argv arrays rather than shell
-text, retain the opaque `operation_id`, and poll `status` no later than the
-configured progress interval. The start action returns after the owned process
-spawns, so the primary session remains available for progress reports and
-scoped cancellation.
+text and retain the opaque `operation_id`. Status accepts an optional
+`wait_seconds` value from 1 to 60 and returns early when meaningful progress or
+a lifecycle transition occurs; omit it for an immediate snapshot. The start
+action returns after the owned process spawns, so the primary session remains
+available for progress reports and scoped cancellation.
 
 The receipt distinguishes running, failed, timed-out, cancelled, and
 restoration-failed states. `AIDEVOPS_PROGRESS: ...` lines count as explicit


### PR DESCRIPTION
## Summary

Implementation for issue #31601.

## Files Changed

.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs, .agents/plugins/opencode-aidevops/bounded-operation-runtime.mjs, .agents/plugins/opencode-aidevops/bounded-operation-tool.mjs, .agents/plugins/opencode-aidevops/tests/test-bounded-interactive-operation.mjs, .agents/reference/context-efficient-output.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #31601


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.345 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 2h 46m and 470,024 tokens on this with the user in an interactive session.