### PR TITLE
GH#31640: propagate aidevops tool command failures

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -187,6 +187,20 @@ function run(cmd, timeout = 5000) {
 }
 
 /**
+ * Run a shell command while preserving failures for user-facing tool calls.
+ * @param {string} cmd
+ * @param {number} [timeout=5000]
+ * @returns {string}
+ */
+function runChecked(cmd, timeout = 5000) {
+  return execSync(cmd, {
+    encoding: "utf-8",
+    timeout,
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+}
+
+/**
  * Read a file if it exists, or return empty string.
  * @param {string} filepath
  * @returns {string}
@@ -393,6 +407,7 @@ export async function AidevopsPlugin({ directory, client }) {
   });
   process.once("exit", () => boundedOperationManager.dispose());
   const baseTools = createTools(SCRIPTS_DIR, run, {
+    aidevopsRun: runChecked,
     sessionOrigin: process.env.AIDEVOPS_SESSION_ORIGIN,
     poolToolFactory: () => createPoolTool(client),
     imageFetch: IMAGE_FETCH,

--- a/.agents/plugins/opencode-aidevops/tests/test-aidevops-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-aidevops-tool.mjs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createTools } from "../tools.mjs";
+
+function aidevopsTool(run) {
+  return createTools("/tmp/aidevops-test-scripts", () => "", { aidevopsRun: run }).aidevops;
+}
+
+test("aidevops tool returns command output", async () => {
+  const tool = aidevopsTool((command, timeout) => {
+    assert.equal(command, "aidevops status");
+    assert.equal(timeout, 15000);
+    return "healthy";
+  });
+
+  assert.equal(await tool.execute({ command: "status" }), "healthy");
+});
+
+test("aidevops tool distinguishes successful empty output", async () => {
+  const tool = aidevopsTool(() => "");
+
+  assert.equal(await tool.execute({ command: "status" }), "Command completed: aidevops status");
+});
+
+test("aidevops tool rejects non-zero command exits with stderr", async () => {
+  const tool = aidevopsTool(() => {
+    const error = new Error("command failed");
+    error.status = 1;
+    error.stderr = Buffer.from("This command must be run with sudo");
+    throw error;
+  });
+
+  await assert.rejects(
+    tool.execute({ command: "approve permissions issue 123 owner/repo --request perm-0000000000000000" }),
+    /aidevops command failed \(exit 1\): This command must be run with sudo/,
+  );
+});
+
+test("aidevops tool reports timeouts without fabricating success", async () => {
+  const tool = aidevopsTool(() => {
+    const error = new Error("spawn timeout");
+    error.code = "ETIMEDOUT";
+    throw error;
+  });
+
+  await assert.rejects(tool.execute({ command: "status" }), /aidevops command failed \(timed out\)/);
+});
+
+test("aidevops tool redacts and bounds failure diagnostics", async () => {
+  const tool = aidevopsTool(() => {
+    const error = new Error("command failed");
+    error.status = 2;
+    error.stderr = `API_TOKEN=unsafe-value ${"x".repeat(5000)}`;
+    throw error;
+  });
+
+  await assert.rejects(tool.execute({ command: "status" }), (error) => {
+    assert.match(error.message, /API_TOKEN=\[redacted-credential\]/);
+    assert.doesNotMatch(error.message, /unsafe-value/);
+    assert.ok(error.message.length < 4200);
+    return true;
+  });
+});
+
+test("aidevops tool redacts complete diagnostics before bounding them", async () => {
+  const tool = aidevopsTool(() => {
+    const error = new Error("command failed");
+    error.status = 2;
+    error.stderr = `${"x".repeat(4000)}-----BEGIN PRIVATE KEY-----\nsensitive\n-----END PRIVATE KEY-----`;
+    throw error;
+  });
+
+  await assert.rejects(tool.execute({ command: "status" }), (error) => {
+    assert.match(error.message, /\[redacted-private-key\]/);
+    assert.doesNotMatch(error.message, /BEGIN PRIVATE KEY|sensitive/);
+    assert.ok(error.message.length < 4200);
+    return true;
+  });
+});

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -7,6 +7,7 @@ import { createPreEditCheckTool } from "./pre-edit-check-tool.mjs";
 import { BoundedInteractiveOperationManager } from "./bounded-interactive-operation.mjs";
 import { createOutputSandboxReader, createOutputSandboxRecorder } from "./bounded-operation-output.mjs";
 import { createBoundedInteractiveOperationTool } from "./bounded-operation-tool.mjs";
+import { scrubCredentials } from "./quality-hooks-output-scrub.mjs";
 
 const FALLBACK_SCHEMA_NODE = {
   _zod: {},
@@ -121,8 +122,24 @@ function createAidevopsTool(run) {
         return `Error: command contains disallowed characters. Only alphanumeric, spaces, hyphens, underscores, dots, slashes, colons, # and @ are permitted.`;
       }
       const cmd = `aidevops ${rawCmd}`;
-      const result = run(cmd, 15000);
-      return result || `Command completed: ${cmd}`;
+      try {
+        const result = run(cmd, 15000);
+        return result || `Command completed: ${cmd}`;
+      } catch (error) {
+        const exitCode = Number.isInteger(error?.status) ? error.status : null;
+        const reason = exitCode !== null
+          ? `exit ${exitCode}`
+          : error?.code === "ETIMEDOUT"
+            ? "timed out"
+            : error?.signal
+              ? `signal ${error.signal}`
+              : "execution error";
+        const stderr = Buffer.isBuffer(error?.stderr)
+          ? error.stderr.toString("utf8")
+          : String(error?.stderr || "");
+        const detail = scrubCredentials(stderr.trim()).scrubbed.slice(0, 4096);
+        throw new Error(`aidevops command failed (${reason})${detail ? `: ${detail}` : ""}`);
+      }
     },
   });
 }
@@ -217,7 +234,7 @@ function createMemoryTool(scriptsDir, run) {
  *
  * @param {string} scriptsDir - Path to scripts directory
  * @param {function} run - Shell command runner
- * @param {{preEditTimeoutMs?: number, workerWorktree?: string, sessionOrigin?: string, poolToolFactory?: function, mcpClient?: object, mcpDirectory?: string, managedMcpNames?: string[], managedMcpWorkspaces?: object, boundedOperationManager?: object}} [options] - Tool-specific test/runtime overrides
+ * @param {{aidevopsRun?: function, preEditTimeoutMs?: number, workerWorktree?: string, sessionOrigin?: string, poolToolFactory?: function, mcpClient?: object, mcpDirectory?: string, managedMcpNames?: string[], managedMcpWorkspaces?: object, boundedOperationManager?: object}} [options] - Tool-specific test/runtime overrides
  * @returns {Record<string, object>}
  */
 export function createTools(scriptsDir, run, options = {}) {
@@ -230,7 +247,7 @@ export function createTools(scriptsDir, run, options = {}) {
   });
 
   const tools = {
-    aidevops: createAidevopsTool(run),
+    aidevops: createAidevopsTool(options.aidevopsRun || run),
     gpt_image_generate: createGptImageTool(tool, z, {
       scriptsDir,
       env: options.env,


### PR DESCRIPTION
## Summary

Preserve checked command execution failures in the OpenCode aidevops tool, report exit/timeout diagnostics, and redact and bound stderr before surfacing it.

## Files Changed

.agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/tests/test-aidevops-tool.mjs, .agents/plugins/opencode-aidevops/tools.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused aidevops tool tests pass (6/6); OpenCode plugin suite passes (856/856 after npm ci); changed-file local linters pass; closeout bundle c0c57b3c023244e1d3fad3982d8db12d9143433d0cd2c394c279b4467b2f17c6 is clean.

Resolves #31640


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.345 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 32m and 301,709 tokens on this with the user in an interactive session.