### PR TITLE
GH#31653: honor repository bases in changed lint mode

### DIFF
--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -32,9 +32,11 @@
 #
 # Execution flags:
 #   --changed           Changed-file scope (default; safety gates still run)
+#   --base-ref REF      Compare changed files with REF (no fetch or ref mutation)
 #   --no-cache          Do not reuse broad/advisory gate cache entries
 #   --full              Release-boundary path: run every gate without cache/time-budget downgrade
 #   --strict            Make ratchet failures and broad-gate timeouts blocking
+#   --help, -h          Show this usage without running quality gates
 # Ratchet flags:
 #   --update-baseline   Record only same/lower committed compatibility counts
 #   --init-baseline     Same as --update-baseline (alias for first-time setup)
@@ -124,8 +126,23 @@ collect_shell_files() {
 }
 
 _linters_local_base_ref() {
+	local requested_ref="${LINTERS_LOCAL_BASE_REF:-}"
+	local default_ref=""
 	local base_ref=""
-	base_ref=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null || true)
+
+	if [[ -z "$requested_ref" ]]; then
+		default_ref=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+		requested_ref="$default_ref"
+	fi
+	if [[ -z "$requested_ref" ]]; then
+		printf 'Error: cannot resolve the changed-file base from origin/HEAD; use --base-ref REF.\n' >&2
+		return 1
+	fi
+	base_ref=$(git merge-base HEAD "$requested_ref" 2>/dev/null || true)
+	if [[ -z "$base_ref" ]]; then
+		printf 'Error: changed-file base ref is not resolvable from HEAD: %s\n' "$requested_ref" >&2
+		return 1
+	fi
 	printf '%s\n' "$base_ref"
 	return 0
 }
@@ -141,7 +158,7 @@ _linters_local_prepare_changed_inventory() {
 		return 0
 	fi
 	local base_ref=""
-	base_ref=$(_linters_local_base_ref)
+	base_ref=$(_linters_local_base_ref) || return $?
 	lint_changed_files "$base_ref"
 	return 0
 }
@@ -162,17 +179,55 @@ _collect_changed_shell_files() {
 	return 0
 }
 
+_linters_local_usage() {
+	cat <<'EOF'
+Usage: linters-local.sh [OPTIONS]
+
+Run local quality gates. Changed-file scope is the default.
+
+Options:
+  --changed, --fast-pr  Run changed-file safety gates (default)
+  --base-ref REF        Compare changed files with REF without fetching
+  --no-cache            Disable broad/advisory gate cache reuse
+  --full                Run every release-boundary gate without cache
+  --strict              Make ratchet failures and broad timeouts blocking
+  --update-baseline     Update compatible ratchet baseline counts
+  --init-baseline       Alias for --update-baseline
+  --migrate-baseline    Allow an explicit ratchet baseline migration
+  --dry-run             Report ratchet baseline changes without writing
+  -h, --help            Show this help and exit
+EOF
+	return 0
+}
+
 _linters_local_parse_args() {
-	local arg
 	export LINTERS_LOCAL_CACHE_ENABLED=true
 	export LINTERS_LOCAL_FULL=false
 	export LINTERS_LOCAL_CHANGED=true
 	export LINTERS_LOCAL_MODE="$LINTERS_LOCAL_MODE_CHANGED"
-	for arg in "$@"; do
-		case "$arg" in
+	export LINTERS_LOCAL_HELP=false
+	while [[ "$#" -gt 0 ]]; do
+		case "$1" in
 		--changed | --fast-pr)
 			export LINTERS_LOCAL_CHANGED=true
 			export LINTERS_LOCAL_MODE="$LINTERS_LOCAL_MODE_CHANGED"
+			;;
+		--base-ref)
+			if [[ "$#" -lt 2 || -z "$2" || "$2" == -* ]]; then
+				printf 'Error: --base-ref requires a Git ref argument.\n' >&2
+				_linters_local_usage >&2
+				return 2
+			fi
+			export LINTERS_LOCAL_BASE_REF="$2"
+			shift
+			;;
+		--base-ref=*)
+			if [[ -z "${1#--base-ref=}" ]]; then
+				printf 'Error: --base-ref requires a Git ref argument.\n' >&2
+				_linters_local_usage >&2
+				return 2
+			fi
+			export LINTERS_LOCAL_BASE_REF="${1#--base-ref=}"
 			;;
 		--no-cache)
 			export LINTERS_LOCAL_CACHE_ENABLED=false
@@ -198,13 +253,27 @@ _linters_local_parse_args() {
 		--dry-run)
 			export RATCHET_DRY_RUN=true
 			;;
+		-h | --help)
+			export LINTERS_LOCAL_HELP=true
+			_linters_local_usage
+			return 0
+			;;
+		*)
+			printf 'Error: unknown option: %s\n' "$1" >&2
+			_linters_local_usage >&2
+			return 2
+			;;
 		esac
+		shift
 	done
 	return 0
 }
 
 main() {
-	_linters_local_parse_args "$@"
+	local parse_rc=0
+	_linters_local_parse_args "$@" || parse_rc=$?
+	[[ "$parse_rc" -eq 0 ]] || return "$parse_rc"
+	[[ "${LINTERS_LOCAL_HELP:-false}" == "true" ]] && return 0
 
 	print_header
 

--- a/.agents/scripts/tests/test-linters-local-changed-mode.sh
+++ b/.agents/scripts/tests/test-linters-local-changed-mode.sh
@@ -194,7 +194,7 @@ create_changed_mode_fixture() {
 	git -C "$repo" commit -qm "feature"
 	printf 'staged\n' >"${repo}/staged.txt"
 	git -C "$repo" add staged.txt
-	printf 'unstaged\n' >>"${repo}/feature.txt"
+	printf 'unstaged\n' >>"${repo}/common.txt"
 	printf 'untracked\n' >"${repo}/untracked.txt"
 	return 0
 }
@@ -263,6 +263,7 @@ test_changed_inventory_uses_remote_default() {
 	inventory=$(changed_inventory_for_repo "$repo")
 	assert_inventory_contains "$inventory" "feature.txt" "develop base includes committed feature change"
 	assert_inventory_contains "$inventory" "staged.txt" "develop base retains staged changes"
+	assert_inventory_contains "$inventory" "common.txt" "develop base retains unstaged changes"
 	assert_inventory_contains "$inventory" "untracked.txt" "develop base retains untracked changes"
 	assert_inventory_excludes "$inventory" "develop-baseline.txt" "develop base excludes integration history"
 	assert_inventory_excludes "$inventory" "main-only.txt" "develop base excludes divergent main history"
@@ -341,6 +342,13 @@ test_help_and_invalid_arguments() {
 		print_result "missing --base-ref argument exits 2" 0
 	else
 		print_result "missing --base-ref argument exits 2" 1 "rc=$rc output=$output"
+	fi
+	rc=0
+	output=$(cd "$outside_repo" && PATH="/usr/bin:/bin" bash "${REPO_ROOT}/.agents/scripts/linters-local.sh" --base-ref refs/heads/missing 2>&1) || rc=$?
+	if [[ "$rc" -ne 0 && "$output" == *"not resolvable from HEAD"* && "$output" != *"ALL LOCAL CHECKS"* ]]; then
+		print_result "unresolvable explicit base fails before gates" 0
+	else
+		print_result "unresolvable explicit base fails before gates" 1 "rc=$rc output=$output"
 	fi
 	rm -rf "$outside_repo"
 	return 0

--- a/.agents/scripts/tests/test-linters-local-changed-mode.sh
+++ b/.agents/scripts/tests/test-linters-local-changed-mode.sh
@@ -140,6 +140,81 @@ assert_summary_contains() {
 	return 0
 }
 
+assert_inventory_contains() {
+	local inventory="$1"
+	local expected="$2"
+	local name="$3"
+	if printf '%s\n' "$inventory" | grep -qxF "$expected"; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "inventory: ${inventory//$'\n'/, }"
+	fi
+	return 0
+}
+
+assert_inventory_excludes() {
+	local inventory="$1"
+	local unexpected="$2"
+	local name="$3"
+	if ! printf '%s\n' "$inventory" | grep -qxF "$unexpected"; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "inventory: ${inventory//$'\n'/, }"
+	fi
+	return 0
+}
+
+create_changed_mode_fixture() {
+	local repo="$1"
+	git -C "$repo" init -q
+	git -C "$repo" config user.email test@example.invalid
+	git -C "$repo" config user.name "Fixture User"
+	printf 'common\n' >"${repo}/common.txt"
+	git -C "$repo" add common.txt
+	git -C "$repo" commit -qm "common"
+	local common_sha=""
+	common_sha=$(git -C "$repo" rev-parse HEAD)
+
+	git -C "$repo" branch -M main
+	printf 'main only\n' >"${repo}/main-only.txt"
+	git -C "$repo" add main-only.txt
+	git -C "$repo" commit -qm "main only"
+	git -C "$repo" update-ref refs/remotes/origin/main HEAD
+
+	git -C "$repo" checkout -qb develop "$common_sha"
+	printf 'develop baseline\n' >"${repo}/develop-baseline.txt"
+	git -C "$repo" add develop-baseline.txt
+	git -C "$repo" commit -qm "develop baseline"
+	git -C "$repo" update-ref refs/remotes/origin/develop HEAD
+	git -C "$repo" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+
+	git -C "$repo" checkout -qb feature
+	printf 'feature commit\n' >"${repo}/feature.txt"
+	git -C "$repo" add feature.txt
+	git -C "$repo" commit -qm "feature"
+	printf 'staged\n' >"${repo}/staged.txt"
+	git -C "$repo" add staged.txt
+	printf 'unstaged\n' >>"${repo}/feature.txt"
+	printf 'untracked\n' >"${repo}/untracked.txt"
+	return 0
+}
+
+changed_inventory_for_repo() {
+	local repo="$1"
+	local explicit_ref="${2:-}"
+	(
+		cd "$repo" || exit 1
+		LINT_CHANGED_FILES_READY=false
+		LINT_CHANGED_FILES=""
+		LINTERS_LOCAL_MODE=changed
+		LINTERS_LOCAL_BASE_REF="$explicit_ref"
+		if ! _linters_local_prepare_changed_inventory; then
+			return 1
+		fi
+		printf '%s\n' "$LINT_CHANGED_FILES"
+	)
+}
+
 test_changed_mode_gate_set() {
 	LINTERS_LOCAL_MODE="changed"
 	ALL_SH_FILES=(".agents/scripts/linters-local.sh")
@@ -180,9 +255,104 @@ test_mode_defaults_and_full_override() {
 	return 0
 }
 
+test_changed_inventory_uses_remote_default() {
+	local repo=""
+	repo=$(mktemp -d)
+	create_changed_mode_fixture "$repo"
+	local inventory=""
+	inventory=$(changed_inventory_for_repo "$repo")
+	assert_inventory_contains "$inventory" "feature.txt" "develop base includes committed feature change"
+	assert_inventory_contains "$inventory" "staged.txt" "develop base retains staged changes"
+	assert_inventory_contains "$inventory" "untracked.txt" "develop base retains untracked changes"
+	assert_inventory_excludes "$inventory" "develop-baseline.txt" "develop base excludes integration history"
+	assert_inventory_excludes "$inventory" "main-only.txt" "develop base excludes divergent main history"
+	rm -rf "$repo"
+	return 0
+}
+
+test_explicit_base_override() {
+	local repo=""
+	repo=$(mktemp -d)
+	create_changed_mode_fixture "$repo"
+	git -C "$repo" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+	local inventory=""
+	inventory=$(changed_inventory_for_repo "$repo" origin/develop)
+	assert_inventory_excludes "$inventory" "develop-baseline.txt" "explicit base overrides remote default"
+	_linters_local_parse_args --base-ref origin/develop
+	if [[ "${LINTERS_LOCAL_BASE_REF:-}" == "origin/develop" ]]; then
+		print_result "--base-ref parses its argument" 0
+	else
+		print_result "--base-ref parses its argument" 1 "base=${LINTERS_LOCAL_BASE_REF:-unset}"
+	fi
+	rm -rf "$repo"
+	return 0
+}
+
+test_main_base_and_missing_ref() {
+	local repo=""
+	repo=$(mktemp -d)
+	create_changed_mode_fixture "$repo"
+	git -C "$repo" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+	git -C "$repo" reset --hard -q
+	git -C "$repo" clean -fdq
+	git -C "$repo" checkout -q main
+	git -C "$repo" checkout -qb main-feature
+	printf 'main feature\n' >"${repo}/main-feature.txt"
+	git -C "$repo" add main-feature.txt
+	git -C "$repo" commit -qm "main feature"
+	local inventory=""
+	inventory=$(changed_inventory_for_repo "$repo")
+	assert_inventory_contains "$inventory" "main-feature.txt" "main default includes feature change"
+	assert_inventory_excludes "$inventory" "main-only.txt" "main default excludes base history"
+	git -C "$repo" symbolic-ref --delete refs/remotes/origin/HEAD
+	local error_output=""
+	local rc=0
+	error_output=$(changed_inventory_for_repo "$repo" 2>&1) || rc=$?
+	if [[ "$rc" -ne 0 && "$error_output" == *"use --base-ref REF"* ]]; then
+		print_result "missing default ref fails with override guidance" 0
+	else
+		print_result "missing default ref fails with override guidance" 1 "rc=$rc output=$error_output"
+	fi
+	rm -rf "$repo"
+	return 0
+}
+
+test_help_and_invalid_arguments() {
+	local outside_repo=""
+	outside_repo=$(mktemp -d)
+	local output=""
+	local rc=0
+	output=$(cd "$outside_repo" && PATH="/usr/bin:/bin" bash "${REPO_ROOT}/.agents/scripts/linters-local.sh" --help 2>&1) || rc=$?
+	if [[ "$rc" -eq 0 && "$output" == *"Usage: linters-local.sh"* && "$output" != *"Local Linters - Fast"* ]]; then
+		print_result "--help exits before inventory and gates outside Git" 0
+	else
+		print_result "--help exits before inventory and gates outside Git" 1 "rc=$rc output=$output"
+	fi
+	rc=0
+	output=$(cd "$outside_repo" && PATH="/usr/bin:/bin" bash "${REPO_ROOT}/.agents/scripts/linters-local.sh" --unknown-option 2>&1) || rc=$?
+	if [[ "$rc" -eq 2 && "$output" == *"unknown option"* && "$output" != *"Local Linters - Fast"* ]]; then
+		print_result "unknown option exits 2 before gates" 0
+	else
+		print_result "unknown option exits 2 before gates" 1 "rc=$rc output=$output"
+	fi
+	rc=0
+	output=$(cd "$outside_repo" && PATH="/usr/bin:/bin" bash "${REPO_ROOT}/.agents/scripts/linters-local.sh" --base-ref 2>&1) || rc=$?
+	if [[ "$rc" -eq 2 && "$output" == *"requires a Git ref"* ]]; then
+		print_result "missing --base-ref argument exits 2" 0
+	else
+		print_result "missing --base-ref argument exits 2" 1 "rc=$rc output=$output"
+	fi
+	rm -rf "$outside_repo"
+	return 0
+}
+
 main() {
 	test_changed_mode_gate_set
 	test_mode_defaults_and_full_override
+	test_changed_inventory_uses_remote_default
+	test_explicit_base_override
+	test_main_base_and_missing_ref
+	test_help_and_invalid_arguments
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then
 		return 1


### PR DESCRIPTION
## Summary

Resolve changed-file scope from origin/HEAD or an explicit --base-ref, and make help and invalid arguments exit before gates

## Files Changed

.agents/scripts/linters-local.sh, .agents/scripts/tests/test-linters-local-changed-mode.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck and focused changed-mode regression suite pass

Resolves #31653


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.346 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 10m and 98,256 tokens on this as a headless worker.