### PR TITLE
GH#31652: fix Dependabot worker intake dispatch loops

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -161,7 +161,8 @@ _brief_requires_files_scope() {
 		return 1
 	fi
 
-	printf '%s' "$issue_body" | grep -qE '<!-- aidevops:generator=[a-z0-9_-]+[^>]* cited_file=[^ >]+'
+	printf '%s' "$issue_body" | grep -qE \
+		'<!-- aidevops:generator=[a-z0-9_-]+[^>]* cited_file=[^ >]+|<!-- aidevops:dependabot-pr-intake[[:space:]]'
 	return $?
 }
 

--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -17,6 +17,41 @@ _pulse_dependabot_intake_marker() {
 	return 0
 }
 
+# Build executable scope from the authentic source PR's exact current diff.
+# The identity gate runs first; this second read binds the scope to the same
+# head and rejects paths that cannot be represented safely in Markdown.
+_pulse_dependabot_intake_scope_lines() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="$3"
+	local scope_json=""
+	local scope_head=""
+	local paths=""
+	local path=""
+
+	scope_json=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+		--json headRefOid,files 2>/dev/null) || return 1
+	scope_head=$(printf '%s' "$scope_json" | jq -r '.headRefOid // ""' 2>/dev/null) || return 1
+	[[ "$scope_head" == "$expected_head_sha" ]] || return 1
+	paths=$(printf '%s' "$scope_json" | jq -er '
+		if ((.files | type) != "array") or (.files | length) == 0
+		then error("Dependabot diff files unavailable")
+		else .files[] | .path
+		end' 2>/dev/null) || return 1
+
+	# shellcheck disable=SC2016 # Literal Markdown scope declaration.
+	printf '%s\n' '- EDIT: `.agents/configs/trusted-dependabot-updates.conf`'
+	while IFS= read -r path; do
+		case "$path" in
+		"" | /* | ../* | */../* | */.. | *'`'*) return 1 ;;
+		esac
+		[[ "$path" != *$'\r'* ]] || return 1
+		# shellcheck disable=SC2016 # Literal Markdown code-span delimiters.
+		printf -- '- EDIT: `%s`\n' "$path"
+	done <<<"$paths"
+	return 0
+}
+
 _pulse_dependabot_existing_intake_issue() {
 	local pr_number="$1"
 	local repo_slug="$2"
@@ -137,6 +172,7 @@ _pulse_dependabot_intake_body() {
 	local head_sha="$3"
 	local reason="$4"
 	local marker="$5"
+	local scope_lines="$6"
 
 	cat <<-EOF
 		## Dependabot PR worker intake
@@ -156,10 +192,12 @@ _pulse_dependabot_intake_body() {
 		update is unsafe or intentionally deferred, apply an explicit maintainer-review hold
 		with rationale. Close or supersede the source PR only after preserving this evidence.
 
-		### Files and patterns
+		### Files Scope
 
-		Start from the source PR diff. Dependency manifests, lockfiles, workflow references,
-		and exact failing test paths are intentionally unknown until inspection. Follow the
+		${scope_lines}
+
+		Start from the source PR diff. The exact observed paths above and the narrow trusted
+		dependency policy are the initial executable boundary. Follow the
 		trusted boundary in \`.agents/scripts/trusted-dependabot-lib.sh\` and the repair-routing
 		pattern in \`.agents/scripts/pulse-merge-process.sh::_route_pr_to_fix_worker\`.
 
@@ -188,19 +226,19 @@ _pulse_dependabot_acquire_intake_lock() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local output_var="$3"
-	local lock_dir=""
+	local lock_path=""
 	local lock_pid=""
 	local stale_dir=""
 	local attempt=0
 
-	lock_dir=$(_pulse_dependabot_intake_lock_dir "$pr_number" "$repo_slug") || return 1
-	mkdir -p "${lock_dir%/*}" 2>/dev/null || return 1
-	while ! mkdir "$lock_dir" 2>/dev/null; do
+	lock_path=$(_pulse_dependabot_intake_lock_dir "$pr_number" "$repo_slug") || return 1
+	mkdir -p "${lock_path%/*}" 2>/dev/null || return 1
+	while ! mkdir "$lock_path" 2>/dev/null; do
 		lock_pid=""
-		[[ -f "${lock_dir}/pid" ]] && lock_pid=$(<"${lock_dir}/pid")
+		[[ -f "${lock_path}/pid" ]] && lock_pid=$(<"${lock_path}/pid")
 		if [[ "$lock_pid" =~ ^[1-9][0-9]*$ ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
-			stale_dir="${lock_dir}.stale.$$"
-			if mv "$lock_dir" "$stale_dir" 2>/dev/null; then
+			stale_dir="${lock_path}.stale.$$"
+			if mv "$lock_path" "$stale_dir" 2>/dev/null; then
 				rm -rf "$stale_dir"
 				continue
 			fi
@@ -209,11 +247,11 @@ _pulse_dependabot_acquire_intake_lock() {
 		[[ "$attempt" -lt 300 ]] || return 1
 		sleep 0.1
 	done
-	printf '%s\n' "$$" >"${lock_dir}/pid" 2>/dev/null || {
-		rmdir "$lock_dir" 2>/dev/null || true
+	printf '%s\n' "$$" >"${lock_path}/pid" 2>/dev/null || {
+		rmdir "$lock_path" 2>/dev/null || true
 		return 1
 	}
-	printf -v "$output_var" '%s' "$lock_dir"
+	printf -v "$output_var" '%s' "$lock_path"
 	return 0
 }
 
@@ -242,6 +280,7 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 	local issue_output=""
 	local lock_dir=""
 	local hold_rc=0
+	local scope_lines=""
 
 	case "$reason" in
 	policy-ineligible | terminal-ci-failure | merge-conflict) ;;
@@ -291,6 +330,12 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: existing worker issue ${existing_url}" >>"$LOGFILE"
 		return 0
 	fi
+	scope_lines=$(_pulse_dependabot_intake_scope_lines \
+		"$pr_number" "$repo_slug" "$expected_head_sha") || {
+		_pulse_dependabot_release_intake_lock "$lock_dir" || true
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: exact-head Files Scope unavailable; failing before issue creation" >>"$LOGFILE"
+		return 1
+	}
 
 	temp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
 	mkdir -p "$temp_dir" 2>/dev/null || {
@@ -301,7 +346,7 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 		_pulse_dependabot_release_intake_lock "$lock_dir" || true
 		return 1
 	}
-	_pulse_dependabot_intake_body "$pr_number" "$repo_slug" "$expected_head_sha" "$reason" "$marker" >"$body_file" || {
+	_pulse_dependabot_intake_body "$pr_number" "$repo_slug" "$expected_head_sha" "$reason" "$marker" "$scope_lines" >"$body_file" || {
 		rm -f "$body_file"
 		_pulse_dependabot_release_intake_lock "$lock_dir" || true
 		return 1

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -727,6 +727,46 @@ test_generated_implementation_brief_with_scope_allows_dispatch() {
 	return 0
 }
 
+test_dependabot_intake_without_scope_blocks_before_worker() {
+	setup_test_env
+	create_gh_stub_generated_brief_body '<!-- aidevops:dependabot-pr-intake repo=marcusquinn/aidevops pr=31609 -->
+## Dependabot PR worker intake
+Inspect and repair the dependency update.'
+
+	local rc=0 output=""
+	output=$("$HELPER_SCRIPT" validate "31652" "marcusquinn/aidevops" 2>&1) || rc=$?
+
+	if [[ "$rc" -eq 30 ]] && [[ "$output" == *"brief-defect"* ]]; then
+		print_result "malformed Dependabot intake blocks before worker launch" 0
+	else
+		print_result "malformed Dependabot intake blocks before worker launch" 1 "Expected typed exit 30, got ${rc}: ${output}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_dependabot_intake_with_scope_allows_dispatch() {
+	setup_test_env
+	# shellcheck disable=SC2016 # Literal Markdown code span in fixture.
+	create_gh_stub_generated_brief_body '<!-- aidevops:dependabot-pr-intake repo=marcusquinn/aidevops pr=31609 -->
+### Files Scope
+
+- EDIT: `.github/workflows/code-quality.yml`'
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "31652" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "Dependabot intake with canonical scope remains dispatchable" 0
+	else
+		print_result "Dependabot intake with canonical scope remains dispatchable" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 test_planning_only_generated_brief_without_scope_allows_dispatch() {
 	setup_test_env
 	# shellcheck disable=SC2016 # literal generated issue body
@@ -1133,6 +1173,8 @@ main() {
 	test_bypass_env_var
 	test_generated_implementation_brief_without_scope_blocks_dispatch
 	test_generated_implementation_brief_with_scope_allows_dispatch
+	test_dependabot_intake_without_scope_blocks_before_worker
+	test_dependabot_intake_with_scope_allows_dispatch
 	test_planning_only_generated_brief_without_scope_allows_dispatch
 	test_zero_progress_meta_recovered_blocks_dispatch
 	test_zero_progress_meta_recovered_readonly_allows_dispatch_without_write

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -12,6 +12,7 @@ CLOSED_ISSUES_JSON="[]"
 AUTHENTIC=1
 PR_LABELS=""
 PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[{"name":"needs-maintainer-review"}]}'
+PR_SCOPE_JSON='{"headRefOid":"head-current","files":[{"path":"package.json"},{"path":"bun.lock"}]}'
 PR_VIEW_FAIL=0
 SUPERSEDING_PR=""
 
@@ -53,7 +54,9 @@ gh_issue_list() {
 
 gh_pr_view() {
 	[[ "$PR_VIEW_FAIL" -eq 0 ]] || return 1
-	if [[ " $* " == *" --json state,headRefOid,labels "* ]]; then
+	if [[ " $* " == *" --json headRefOid,files "* ]]; then
+		printf '%s\n' "$PR_SCOPE_JSON"
+	elif [[ " $* " == *" --json state,headRefOid,labels "* ]]; then
 		printf '%s\n' "$PR_FINAL_JSON"
 	else
 		printf '%s\n' "$PR_LABELS"
@@ -118,7 +121,42 @@ test_creates_worker_ready_issue() {
 	[[ -f "${TEST_ROOT}/create-args" ]] || return 1
 	assert_file_contains "worker issue has auto-dispatch ownership" "${TEST_ROOT}/create-args" "auto-dispatch,origin:worker,tier:standard,dependencies"
 	assert_file_contains "worker issue cites source PR" "${TEST_ROOT}/created-body" "Source PR: https://github.com/owner/repo/pull/30038"
+	assert_file_contains "worker issue has canonical Files Scope" "${TEST_ROOT}/created-body" "### Files Scope"
+	# shellcheck disable=SC2016 # Literal Markdown scope declarations.
+	assert_file_contains "worker issue scopes the exact source diff" "${TEST_ROOT}/created-body" '- EDIT: `package.json`'
+	# shellcheck disable=SC2016 # Literal Markdown scope declarations.
+	assert_file_contains "worker issue permits narrow trust-policy repair" "${TEST_ROOT}/created-body" '- EDIT: `.agents/configs/trusted-dependabot-updates.conf`'
 	assert_file_contains "worker issue carries idempotency marker" "${TEST_ROOT}/created-body" "aidevops:dependabot-pr-intake repo=owner/repo pr=30038"
+	return 0
+}
+
+test_scope_read_fails_closed_on_head_drift() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/create-args"
+	OPEN_ISSUES_JSON="[]"
+	AUTHENTIC=1
+	PR_LABELS=""
+	PR_SCOPE_JSON='{"headRefOid":"head-new","files":[{"path":"package.json"}]}'
+	_pulse_route_dependabot_pr_to_worker_issue \
+		"30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 1 ]] || return 1
+	[[ ! -e "${TEST_ROOT}/create-args" ]] || return 1
+	assert_file_contains "head drift blocks intake creation" "$LOGFILE" "exact-head Files Scope unavailable"
+	PR_SCOPE_JSON='{"headRefOid":"head-current","files":[{"path":"package.json"},{"path":"bun.lock"}]}'
+	return 0
+}
+
+test_scope_read_rejects_unsafe_markdown_path() {
+	local scope_output=""
+
+	PR_SCOPE_JSON='{"headRefOid":"head-current","files":[{"path":"docs/unsafe`path.md"}]}'
+	if scope_output=$(_pulse_dependabot_intake_scope_lines "30038" "owner/repo" "head-current"); then
+		printf 'FAIL unsafe Markdown path was accepted: %s\n' "$scope_output" >&2
+		return 1
+	fi
+	PR_SCOPE_JSON='{"headRefOid":"head-current","files":[{"path":"package.json"},{"path":"bun.lock"}]}'
+	printf 'PASS unsafe Markdown path fails closed\n'
 	return 0
 }
 
@@ -377,7 +415,11 @@ gh_create_issue() {
 }
 
 gh_pr_view() {
-	printf '%s\n' ''
+	if [[ " $* " == *" --json headRefOid,files "* ]]; then
+		printf '%s\n' '{"headRefOid":"head-current","files":[{"path":"package.json"}]}'
+	else
+		printf '%s\n' ''
+	fi
 	return 0
 }
 
@@ -405,6 +447,8 @@ main() {
 	# shellcheck source=../pulse-dispatch-dedup-layers.sh
 	source "${SCRIPT_DIR}/../pulse-dispatch-dedup-layers.sh"
 	test_creates_worker_ready_issue
+	test_scope_read_fails_closed_on_head_drift
+	test_scope_read_rejects_unsafe_markdown_path
 	test_reuses_existing_issue
 	printf 'PASS existing intake is idempotent\n'
 	test_rejects_unverified_author

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -894,7 +894,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qlty CLI
-      uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
+      uses: qltysh/qlty-action/install@08a0a862c159eae9b9003081da6663d96efef637 # v2.3.0
 
     - name: Qlty smells check (diff mode)
       run: |
@@ -932,7 +932,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qlty CLI
-      uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
+      uses: qltysh/qlty-action/install@08a0a862c159eae9b9003081da6663d96efef637 # v2.3.0
 
     - name: Qlty smell threshold check
       run: |

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -289,7 +289,7 @@ jobs:
             }
       
       - name: Run OpenCode Agent
-        uses: anomalyco/opencode/github@ef2880f379129aa048be9e9353e30aa168d42c17 # v1.18.23
+        uses: anomalyco/opencode/github@774cc7c1914e4329eefde5a669f938b0cf566661 # v1.18.26
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Install Qlty CLI
         if: steps.brief.outputs.exists == 'true'
-        uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
+        uses: qltysh/qlty-action/install@08a0a862c159eae9b9003081da6663d96efef637 # v2.3.0
 
       - name: Install verification dependencies
         if: steps.brief.outputs.exists == 'true'

--- a/.github/workflows/qlty-new-file-gate.yml
+++ b/.github/workflows/qlty-new-file-gate.yml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Qlty CLI
-        uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
+        uses: qltysh/qlty-action/install@08a0a862c159eae9b9003081da6663d96efef637 # v2.3.0
 
       - name: Run new-file gate helper
         id: scan

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -115,7 +115,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Qlty CLI
-        uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
+        uses: qltysh/qlty-action/install@08a0a862c159eae9b9003081da6663d96efef637 # v2.3.0
 
       - name: Run qlty regression diff
         id: diff

--- a/.github/workflows/ratchet-post-merge.yml
+++ b/.github/workflows/ratchet-post-merge.yml
@@ -53,7 +53,7 @@ jobs:
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Install Qlty CLI
-        uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
+        uses: qltysh/qlty-action/install@08a0a862c159eae9b9003081da6663d96efef637 # v2.3.0
 
       - name: Compute smell count and ratchet if reduced
         env:


### PR DESCRIPTION
## Summary

Generate canonical exact-head Files Scope for Pulse-created Dependabot intake, preflight malformed legacy intake, release intake locks correctly, and carry the verified action updates from source PR #31609.

## Files Changed

.agents/scripts/pre-dispatch-validator-helper.sh, .agents/scripts/pulse-dependabot-intake.sh, .agents/scripts/tests/test-pre-dispatch-validator.sh, .agents/scripts/tests/test-pulse-dependabot-intake.sh, .github/workflows/code-quality.yml, .github/workflows/opencode-agent.yml, .github/workflows/post-merge-verify.yml, .github/workflows/qlty-new-file-gate.yml, .github/workflows/qlty-regression.yml, .github/workflows/ratchet-post-merge.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Dependabot intake regression suite (23 checks), pre-dispatch validator suite (34 tests), ShellCheck, changed-file linters, exact-head drift and unsafe-path fixtures, review evidence aa75809969b7918cfbea44b4a588d4baebbef77299ac02c8be60a4ddc69296a8.

Resolves #31652


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.346 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 29m and 354,748 tokens on this with the user in an interactive session.