### PR TITLE
GH#31652: fix release-blocking js-yaml audit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,7 +69,7 @@
   "overrides": {
     "esbuild": "0.28.1",
     "fast-uri": "3.1.7",
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "nanoid": "3.3.18",
     "postcss": "8.5.23",
   },
@@ -344,7 +344,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
+    "js-yaml": ["js-yaml@4.3.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "overrides": {
     "esbuild": "0.28.1",
     "fast-uri": "3.1.7",
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "nanoid": "3.3.18",
     "postcss": "8.5.23"
   },


### PR DESCRIPTION
## Summary

Raise the existing js-yaml override from 4.3.1 to 4.3.2 so Dependency Security no longer reports GHSA-2883-xcg3-v3hh during the authorized v3.32.347 publication.

## Files Changed

bun.lock, package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bun install --frozen-lockfile --ignore-scripts; bun audit (0 vulnerabilities); bun test (96 passed, 0 failed); root typecheck/test and gui-api tests via project validator; changed-file linters; git diff --check.

Resolves #31652


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.346 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 1h and 494,276 tokens on this with the user in an interactive session.