### PR TITLE
fix: preserve open issue-linked pull requests

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -477,7 +477,7 @@ _parse_commit_and_pr_args() {
 	while [[ "$index" -lt "${#args[@]}" ]]; do
 		arg="${args[$index]}"
 		case "$arg" in
-		--issue | --message | --title | --summary | --testing | --risk-level | --testing-level | --decisions | --label | --proof-pr | --task-id)
+		--issue | --message | --title | --summary | --testing | --risk-level | --testing-level | --decisions | --label | --proof-pr | --task-id | --replace-pr | --replacement-reason)
 			if [[ $((index + 1)) -ge ${#args[@]} ]]; then
 				print_error "${arg} requires a value"
 				return 1
@@ -529,6 +529,14 @@ _parse_commit_and_pr_args() {
 			;;
 		--task-id)
 			bookkeeping_task_id="$value"
+			index=$((index + 2))
+			;;
+		--replace-pr)
+			replacement_pr="$value"
+			index=$((index + 2))
+			;;
+		--replacement-reason)
+			replacement_reason="$value"
 			index=$((index + 2))
 			;;
 		--completion-bookkeeping)
@@ -1369,6 +1377,7 @@ _build_pr_body() {
 	local requested_risk="${7:-}"
 	local requested_testing_level="${8:-}"
 	local base_ref="${9:-}"
+	local replacement_note="${10:-}"
 	local runtime_risk=""
 	local testing_level=""
 
@@ -1378,6 +1387,11 @@ _build_pr_body() {
 	printf '%s\n' "## Summary
 
 ${summary_what:-Implementation for issue #${issue_number}.}
+
+${replacement_note:+## Replacement Audit
+
+${replacement_note}
+}
 
 ## Files Changed
 
@@ -1655,6 +1669,24 @@ _reconcile_pr_origin_label() {
 # GH#26045: After extracting the PR number, verify/re-apply the current session
 # origin label via set_origin_label so recovered partial-success PRs cannot remain
 # unlabeled and unroutable by pulse CI/review repair workers.
+_create_or_continue_pr() {
+	local continuation_pr="$1"
+	local repo="$2"
+	local pr_title="$3"
+	local pr_body="$4"
+	local origin_label="$5"
+	shift 5
+	if [[ -n "$continuation_pr" ]]; then
+		print_info "Continuing existing issue-linked PR #${continuation_pr} at the final creation boundary"
+		_reconcile_pr_origin_label "$continuation_pr" "$repo" "${origin_label#origin:}" || return 1
+		_reconcile_recovered_pr_metadata "$continuation_pr" "$repo" "$pr_title" "$pr_body" || return 1
+		printf '%s\n' "$continuation_pr"
+		return 0
+	fi
+	_create_pr "$repo" "$pr_title" "$pr_body" "$origin_label" "$@"
+	return $?
+}
+
 _create_pr() {
 	local repo="$1" pr_title="$2" pr_body="$3" origin_label="$4"
 	shift 4

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -61,6 +61,9 @@ source "${SCRIPT_DIR}/full-loop-helper-risk.sh"
 # shellcheck source=./full-loop-helper-commit.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/full-loop-helper-commit.sh"
+# shellcheck source=./issue-open-pr-guard.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/issue-open-pr-guard.sh"
 
 # shellcheck source=./full-loop-helper-merge.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
@@ -90,6 +93,7 @@ cmd_commit_and_pr() {
 	local issue_number="" commit_message="" pr_title="" summary_what="" summary_testing="" summary_decisions=""
 	local runtime_risk="" testing_level=""
 	local completion_bookkeeping=0 bookkeeping_proof_pr="" bookkeeping_task_id=""
+	local replacement_pr="" replacement_reason=""
 	local -a extra_labels=()
 	local allow_parent_close=0
 	local skip_hooks=0 skip_rebase=0
@@ -99,6 +103,12 @@ cmd_commit_and_pr() {
 	# Validate inputs and detect repo/branch (sets $repo and $branch in this scope)
 	local repo="" branch="" base_branch="" base_ref=""
 	_validate_commit_and_pr_inputs "$issue_number" "$commit_message" || return 1
+	if [[ -n "$replacement_pr" || -n "$replacement_reason" ]]; then
+		if [[ ! "$replacement_pr" =~ ^[1-9][0-9]*$ || ${#replacement_reason} -lt 20 ]]; then
+			print_error "Explicit replacement requires --replace-pr N and --replacement-reason with at least 20 characters"
+			return 1
+		fi
+	fi
 	_validate_explicit_pr_metadata "$runtime_risk" "$testing_level" || return 1
 	_validate_completion_bookkeeping_request "$completion_bookkeeping" "$bookkeeping_proof_pr" \
 		"$bookkeeping_task_id" "$allow_parent_close" "$repo" \
@@ -107,6 +117,24 @@ cmd_commit_and_pr() {
 	base_ref="origin/${base_branch}"
 	_validate_pending_runtime_metadata "$runtime_risk" "$testing_level" \
 		"$summary_testing" "$summary_what" "$base_ref" || return 1
+	local parent_issue=0
+	_issue_has_parent_task_label "$issue_number" "$repo" && parent_issue=1
+	if [[ "$parent_issue" -eq 0 ]]; then
+		local initial_open_pr_guard_rc=0
+		issue_open_pr_guard_check "$issue_number" "$repo" "$branch" \
+			"$replacement_pr" "$replacement_reason" 0 || initial_open_pr_guard_rc=$?
+		case "$initial_open_pr_guard_rc" in
+		0 | 3) ;;
+		1)
+			print_error "Issue #${issue_number} already has open PR #${ISSUE_OPEN_PR_NUMBER}; continue branch '${ISSUE_OPEN_PR_HEAD_REF}' or use an explicit audited replacement"
+			return 1
+			;;
+		*)
+			print_error "Open-PR linkage evidence is unavailable or ambiguous for issue #${issue_number}; refusing PR workflow"
+			return 1
+			;;
+		esac
+	fi
 
 	_stage_and_commit "$commit_message" || return 1
 	# GH#27902: WIP commits are durable checkpoints, not publishable history.
@@ -167,7 +195,11 @@ cmd_commit_and_pr() {
 		print_info "Issue #${issue_number} has parent-task label — using 'For' keyword (t2242)"
 	fi
 
-	pr_body=$(_build_pr_body "$issue_number" "$summary_what" "$summary_testing" "$files_changed" "$sig_footer" "$closing_keyword" "$runtime_risk" "$testing_level" "$base_ref") || return 1
+	local replacement_note=""
+	if [[ -n "$replacement_pr" ]]; then
+		replacement_note="This explicitly justified replacement preserves open PR #${replacement_pr}. Rationale: ${replacement_reason}"
+	fi
+	pr_body=$(_build_pr_body "$issue_number" "$summary_what" "$summary_testing" "$files_changed" "$sig_footer" "$closing_keyword" "$runtime_risk" "$testing_level" "$base_ref" "$replacement_note") || return 1
 
 	# t2046: parent-task keyword guard — prevent Resolves/Closes/Fixes on
 	# parent-task issues. The parent must stay open until all phase children merge.
@@ -195,7 +227,6 @@ cmd_commit_and_pr() {
 		print_error "Aborting: dispatch claim no longer valid for #${issue_number} (t1955)"
 		return 1
 	}
-
 	# t2091: Guard against filing PRs on already-closed issues.
 	# A worker racing an interactive session may finish implementation after
 	# the issue was already resolved. Opening a PR against a closed issue
@@ -233,9 +264,28 @@ Worker aborted PR creation: issue #${issue_number} was already closed by the tim
 	fi
 
 	_push_branch "$branch" "$skip_hooks" || return 1
+	local continuation_pr=""
+	if [[ "$parent_issue" -eq 0 ]]; then
+		local final_open_pr_guard_rc=0
+		issue_open_pr_guard_check "$issue_number" "$repo" "$branch" \
+			"$replacement_pr" "$replacement_reason" 1 || final_open_pr_guard_rc=$?
+		case "$final_open_pr_guard_rc" in
+		0) ;;
+		3) continuation_pr="$ISSUE_OPEN_PR_NUMBER" ;;
+		1)
+			print_error "Aborting duplicate PR creation: open PR #${ISSUE_OPEN_PR_NUMBER} remains durable work, or its head is not preserved by this replacement"
+			return 1
+			;;
+		*)
+			print_error "Aborting PR creation: final open-PR linkage evidence is unavailable or ambiguous"
+			return 1
+			;;
+		esac
+	fi
 
 	local pr_number=""
-	pr_number=$(_create_pr "$repo" "$pr_title" "$pr_body" "$origin_label" "${extra_labels[@]+"${extra_labels[@]}"}") || return 1
+	pr_number=$(_create_or_continue_pr "$continuation_pr" "$repo" "$pr_title" "$pr_body" \
+		"$origin_label" "${extra_labels[@]+"${extra_labels[@]}"}") || return 1
 	# A worker PR is only eligible for the worker-briefed merge path when GitHub
 	# can associate it with the issue that dispatched the worker. Creation should
 	# already preserve this body, but recover from partial GraphQL writes before

--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -282,8 +282,76 @@ _isc_handle_existing_claim_ownership() {
 	esac
 }
 
+_isc_guard_existing_open_pr() {
+	local issue="$1"
+	local slug="$2"
+	local replacement_pr="$3"
+	local replacement_reason="$4"
+	local claim_metadata="$5"
+	local user="$6"
+	local current_branch=""
+	local open_pr_guard_rc=0
+	local parent_issue=0
+
+	current_branch=$(git branch --show-current 2>/dev/null || true)
+	printf '%s' "$claim_metadata" | jq -e \
+		'any(.labels[]?; .name == "parent-task" or .name == "meta")' >/dev/null 2>&1 && parent_issue=1
+	if [[ "$parent_issue" -eq 0 ]]; then
+		issue_open_pr_guard_check "$issue" "$slug" "$current_branch" \
+			"$replacement_pr" "$replacement_reason" 0 "" "$user" || open_pr_guard_rc=$?
+	fi
+	case "$open_pr_guard_rc" in
+	0 | 3) ;;
+	1)
+		_isc_err "claim: issue #$issue already has open PR #${ISSUE_OPEN_PR_NUMBER}; continue branch '${ISSUE_OPEN_PR_HEAD_REF}' instead of taking over ownership"
+		return 1
+		;;
+	*)
+		_isc_err "claim: open-PR linkage evidence unavailable or ambiguous for #$issue; refusing ownership mutation"
+		return 1
+		;;
+	esac
+	if [[ -n "$replacement_pr" && "$replacement_pr" == "$ISSUE_OPEN_PR_NUMBER" ]]; then
+		local replacement_marker="<!-- aidevops:replacement-pr original=${replacement_pr} -->"
+		if ! printf '%s' "$claim_metadata" | jq -e --arg marker "$replacement_marker" \
+			'any(.comments[]?; (.body // "") | contains($marker))' >/dev/null 2>&1; then
+			gh_issue_comment "$issue" --repo "$slug" --body "${replacement_marker}
+Explicit replacement authorized for open PR #${replacement_pr}. Rationale: ${replacement_reason}. The replacement must preserve the original PR head before PR creation." >/dev/null || return 1
+		fi
+	fi
+	return 0
+}
+
+_isc_validate_claim_request() {
+	local issue="$1"
+	local slug="$2"
+	local replacement_pr="$3"
+	local replacement_reason="$4"
+	local implementing="$5"
+	if [[ -z "$issue" || -z "$slug" ]]; then
+		_isc_err "claim: <issue> and <slug> are required"
+		_isc_err "usage: interactive-session-helper.sh claim <issue> <slug> [--worktree PATH] [--implementing] [--defer-comment]"
+		return 2
+	fi
+	if [[ ! "$issue" =~ ^[0-9]+$ ]]; then
+		_isc_err "claim: <issue> must be numeric (got: $issue)"
+		return 2
+	fi
+	if [[ -n "$replacement_pr" || -n "$replacement_reason" ]] &&
+		[[ ! "$replacement_pr" =~ ^[1-9][0-9]*$ || ${#replacement_reason} -lt 20 ]]; then
+		_isc_err "claim: explicit replacement requires --replace-pr N and a rationale of at least 20 characters"
+		return 2
+	fi
+	if [[ "${AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION:-0}" == "1" && $implementing -eq 0 ]]; then
+		_isc_err "claim: interactive issue implementation requires --implementing; refusing worker-claim routing"
+		return 2
+	fi
+	return 0
+}
+
 _isc_cmd_claim() {
 	local issue="" slug="" worktree_path="" implementing=0 defer_comment=0
+	local replacement_pr="" replacement_reason=""
 
 	# Parse positional + flags
 	while [[ $# -gt 0 ]]; do
@@ -305,6 +373,14 @@ _isc_cmd_claim() {
 			defer_comment=1
 			shift
 			;;
+		--replace-pr)
+			replacement_pr="${2:-}"
+			shift 2
+			;;
+		--replacement-reason)
+			replacement_reason="${2:-}"
+			shift 2
+			;;
 		-h | --help)
 			_isc_cmd_help
 			return 0
@@ -322,21 +398,7 @@ _isc_cmd_claim() {
 		esac
 	done
 
-	if [[ -z "$issue" || -z "$slug" ]]; then
-		_isc_err "claim: <issue> and <slug> are required"
-		_isc_err "usage: interactive-session-helper.sh claim <issue> <slug> [--worktree PATH] [--implementing] [--defer-comment]"
-		return 2
-	fi
-
-	if [[ ! "$issue" =~ ^[0-9]+$ ]]; then
-		_isc_err "claim: <issue> must be numeric (got: $issue)"
-		return 2
-	fi
-
-	if [[ "${AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION:-0}" == "1" && $implementing -eq 0 ]]; then
-		_isc_err "claim: interactive issue implementation requires --implementing; refusing worker-claim routing"
-		return 2
-	fi
+	_isc_validate_claim_request "$issue" "$slug" "$replacement_pr" "$replacement_reason" "$implementing" || return $?
 	_isc_validate_worktree_origin "$slug" "$worktree_path" || return 1
 
 	local user
@@ -354,6 +416,8 @@ _isc_cmd_claim() {
 		_isc_err "claim: ownership metadata unavailable for #$issue; no stamp written"
 		return 1
 	fi
+	_isc_guard_existing_open_pr "$issue" "$slug" "$replacement_pr" \
+		"$replacement_reason" "$claim_metadata" "$user" || return 1
 	local ownership_rc=0
 	_isc_handle_existing_claim_ownership "$issue" "$slug" "$worktree_path" "$user" \
 		"$defer_comment" "$implementing" "$claim_metadata" || ownership_rc=$?

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -58,6 +58,9 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=./issue-open-pr-guard.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/issue-open-pr-guard.sh"
 
 set -euo pipefail
 

--- a/.agents/scripts/interactive-start-helper.sh
+++ b/.agents/scripts/interactive-start-helper.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 _usage() {
 	cat <<'EOF'
-Usage: interactive-start-helper.sh --issue N --repo owner/repo --task "description" [--auto-dispatch] [--background]
+Usage: interactive-start-helper.sh --issue N --repo owner/repo --task "description" [--auto-dispatch] [--background] [--replace-pr N --replacement-reason "reason"]
 
 Claims the issue for interactive implementation, runs the pre-edit loop check,
 validates and enters the linked worktree selected by pre-edit, refreshes the
@@ -126,6 +126,8 @@ _interactive_start_parse_args() {
 	_INTERACTIVE_START_TASK=""
 	_INTERACTIVE_START_AUTO_DISPATCH=0
 	_INTERACTIVE_START_BACKGROUND=0
+	_INTERACTIVE_START_REPLACEMENT_PR=""
+	_INTERACTIVE_START_REPLACEMENT_REASON=""
 	_INTERACTIVE_START_HELP_REQUESTED=0
 	_INTERACTIVE_START_SOURCE_PATHS=()
 	while [[ $# -gt 0 ]]; do
@@ -160,6 +162,22 @@ _interactive_start_parse_args() {
 			shift
 			;;
 		--auto-dispatch) _INTERACTIVE_START_AUTO_DISPATCH=1 ;;
+		--replace-pr)
+			[[ $# -gt 0 ]] || {
+				printf 'ERROR: --replace-pr requires a value\n' >&2
+				return 2
+			}
+			_INTERACTIVE_START_REPLACEMENT_PR="$1"
+			shift
+			;;
+		--replacement-reason)
+			[[ $# -gt 0 ]] || {
+				printf 'ERROR: --replacement-reason requires a value\n' >&2
+				return 2
+			}
+			_INTERACTIVE_START_REPLACEMENT_REASON="$1"
+			shift
+			;;
 		--source-path)
 			if [[ $# -eq 0 || -z "$1" || "$1" == /* || "$1" == ".." || "$1" == ../* || "$1" == */../* || "$1" == */.. ]]; then
 				printf 'ERROR: --source-path requires a repository-relative candidate\n' >&2
@@ -183,6 +201,12 @@ _interactive_start_parse_args() {
 	if [[ -z "$_INTERACTIVE_START_ISSUE" || -z "$_INTERACTIVE_START_REPO" || -z "$_INTERACTIVE_START_TASK" ]]; then
 		_usage >&2
 		return 2
+	fi
+	if [[ -n "$_INTERACTIVE_START_REPLACEMENT_PR" || -n "$_INTERACTIVE_START_REPLACEMENT_REASON" ]]; then
+		if [[ ! "$_INTERACTIVE_START_REPLACEMENT_PR" =~ ^[1-9][0-9]*$ || ${#_INTERACTIVE_START_REPLACEMENT_REASON} -lt 20 ]]; then
+			printf 'ERROR: explicit replacement requires --replace-pr N and a rationale of at least 20 characters\n' >&2
+			return 2
+		fi
 	fi
 	return 0
 }
@@ -232,12 +256,17 @@ main() {
 	local task="$_INTERACTIVE_START_TASK"
 	local auto_dispatch="$_INTERACTIVE_START_AUTO_DISPATCH"
 	local background="$_INTERACTIVE_START_BACKGROUND"
+	local replacement_pr="$_INTERACTIVE_START_REPLACEMENT_PR"
+	local replacement_reason="$_INTERACTIVE_START_REPLACEMENT_REASON"
 	# Reaching this entrypoint means the issue is being implemented locally.
 	# Export the marker so asynchronous local children inherit that authority.
 	export AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION=1
 	# Retain --auto-dispatch for CLI compatibility; takeover is now unconditional.
 	: "$auto_dispatch"
 	local initial_claim_args=(claim "$issue" "$repo" --implementing --defer-comment)
+	if [[ -n "$replacement_pr" || -n "$replacement_reason" ]]; then
+		initial_claim_args+=(--replace-pr "$replacement_pr" --replacement-reason "$replacement_reason")
+	fi
 	if ! interactive-session-helper.sh "${initial_claim_args[@]}"; then
 		printf 'ERROR: initial interactive claim failed for #%s in %s\n' "$issue" "$repo" >&2
 		return 1
@@ -254,6 +283,9 @@ main() {
 	local worktree_path=""
 	worktree_path=$(_interactive_start_resolve_worktree "$pre_edit_output") || return 1
 	local refresh_claim_args=(claim "$issue" "$repo" --implementing --worktree "$worktree_path")
+	if [[ -n "$replacement_pr" || -n "$replacement_reason" ]]; then
+		refresh_claim_args+=(--replace-pr "$replacement_pr" --replacement-reason "$replacement_reason")
+	fi
 	if ! interactive-session-helper.sh "${refresh_claim_args[@]}"; then
 		printf 'ERROR: interactive claim refresh failed; recoverable worktree: %s\n' "$worktree_path" >&2
 		return 1

--- a/.agents/scripts/issue-open-pr-guard.sh
+++ b/.agents/scripts/issue-open-pr-guard.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Preserve durable issue-linked work before ownership or PR creation changes.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+[[ -n "${_ISSUE_OPEN_PR_GUARD_LOADED:-}" ]] && return 0
+_ISSUE_OPEN_PR_GUARD_LOADED=1
+
+ISSUE_OPEN_PR_NUMBER=""
+ISSUE_OPEN_PR_HEAD_REF=""
+ISSUE_OPEN_PR_HEAD_SHA=""
+ISSUE_OPEN_PR_AUTHOR=""
+ISSUE_OPEN_PR_HEAD_REPO=""
+
+_issue_open_pr_guard_reset() {
+	ISSUE_OPEN_PR_NUMBER=""
+	ISSUE_OPEN_PR_HEAD_REF=""
+	ISSUE_OPEN_PR_HEAD_SHA=""
+	ISSUE_OPEN_PR_AUTHOR=""
+	ISSUE_OPEN_PR_HEAD_REPO=""
+	return 0
+}
+
+# Resolve same-repository open PRs from GitHub's authoritative closing-issue
+# projection. The bounded complete snapshot includes drafts and conflicted PRs.
+# Returns 0 for exactly one open PR, 1 for none, and 2 when evidence is
+# unavailable, malformed, or ambiguous. Details are exposed in globals.
+issue_open_pr_guard_resolve() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local open_pr_json=""
+	local open_pr_count=0
+	local matches_json=""
+	local match_count=0
+	local string_type="string"
+
+	_issue_open_pr_guard_reset
+	[[ "$issue_number" =~ ^[1-9][0-9]*$ && "$repo_slug" == */* ]] || return 2
+	open_pr_json=$(gh pr list --repo "$repo_slug" --state open --limit 1000 \
+		--json number,headRefName,headRefOid,headRepository,author,closingIssuesReferences,isDraft 2>/dev/null) || return 2
+	printf '%s' "$open_pr_json" | jq -e --arg string_type "$string_type" '
+		type == "array" and all(.[];
+			(.number | type) == "number" and (.headRefName | type) == $string_type and
+			(.headRefOid | type) == $string_type and (.author.login | type) == $string_type and
+			(.headRepository.nameWithOwner | type) == $string_type and
+			(.closingIssuesReferences | type) == "array" and
+			(.closingIssuesReferences | length) < 100)
+	' >/dev/null 2>&1 || return 2
+	open_pr_count=$(printf '%s' "$open_pr_json" | jq -r 'length' 2>/dev/null) || return 2
+	[[ "$open_pr_count" -lt 1000 ]] || return 2
+	matches_json=$(printf '%s' "$open_pr_json" | jq -c --argjson issue "$issue_number" --arg repo "$repo_slug" '
+		[.[] | select(any(.closingIssuesReferences[]?;
+			.number == $issue and
+			((.repository.owner.login + "/" + .repository.name) | ascii_downcase) == ($repo | ascii_downcase)))]
+	' 2>/dev/null) || return 2
+	match_count=$(printf '%s' "$matches_json" | jq -r 'length' 2>/dev/null) || return 2
+	[[ "$match_count" -eq 0 ]] && return 1
+	[[ "$match_count" -eq 1 ]] || return 2
+	ISSUE_OPEN_PR_NUMBER=$(printf '%s' "$matches_json" | jq -r '.[0].number')
+	ISSUE_OPEN_PR_HEAD_REF=$(printf '%s' "$matches_json" | jq -r '.[0].headRefName')
+	ISSUE_OPEN_PR_HEAD_SHA=$(printf '%s' "$matches_json" | jq -r '.[0].headRefOid')
+	ISSUE_OPEN_PR_AUTHOR=$(printf '%s' "$matches_json" | jq -r '.[0].author.login')
+	ISSUE_OPEN_PR_HEAD_REPO=$(printf '%s' "$matches_json" | jq -r '.[0].headRepository.nameWithOwner')
+	return 0
+}
+
+_issue_open_pr_guard_local_repo() {
+	local origin_url=""
+	origin_url=$(git remote get-url origin 2>/dev/null) || return 1
+	origin_url=${origin_url%.git}
+	case "$origin_url" in
+	https://github.com/*) printf '%s' "${origin_url#https://github.com/}" ;;
+	git@github.com:*) printf '%s' "${origin_url#git@github.com:}" ;;
+	ssh://git@github.com/*) printf '%s' "${origin_url#ssh://git@github.com/}" ;;
+	ssh://git@github.com:22/*) printf '%s' "${origin_url#ssh://git@github.com:22/}" ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+# Returns 0 when fresh work or an explicit replacement is safe, 3 when the
+# current actor/repository/branch continues the linked PR, 1 for a durable-work
+# conflict, and 2 for incomplete evidence.
+issue_open_pr_guard_check() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local current_branch="${3:-}"
+	local replacement_pr="${4:-}"
+	local replacement_reason="${5:-}"
+	local require_ancestry="${6:-0}"
+	local current_head_repo="${7:-}"
+	local current_actor="${8:-}"
+	local resolve_rc=0
+	local normalized_current_repo=""
+	local normalized_pr_repo=""
+	local normalized_current_actor=""
+	local normalized_pr_author=""
+
+	issue_open_pr_guard_resolve "$issue_number" "$repo_slug" || resolve_rc=$?
+	if [[ "$resolve_rc" -eq 1 ]]; then
+		[[ -z "$replacement_pr" && -z "$replacement_reason" ]] && return 0
+		return 2
+	fi
+	[[ "$resolve_rc" -eq 0 ]] || return 2
+	if [[ -n "$current_branch" && "$current_branch" == "$ISSUE_OPEN_PR_HEAD_REF" ]]; then
+		if [[ -z "$current_head_repo" ]]; then
+			current_head_repo=$(_issue_open_pr_guard_local_repo 2>/dev/null) || return 2
+		fi
+		if [[ -z "$current_actor" ]]; then
+			current_actor=$(gh api user --jq '.login // empty' 2>/dev/null) || return 2
+			[[ -n "$current_actor" ]] || return 2
+		fi
+		normalized_current_repo=$(printf '%s' "$current_head_repo" | tr '[:upper:]' '[:lower:]')
+		normalized_pr_repo=$(printf '%s' "$ISSUE_OPEN_PR_HEAD_REPO" | tr '[:upper:]' '[:lower:]')
+		normalized_current_actor=$(printf '%s' "$current_actor" | tr '[:upper:]' '[:lower:]')
+		normalized_pr_author=$(printf '%s' "$ISSUE_OPEN_PR_AUTHOR" | tr '[:upper:]' '[:lower:]')
+		if [[ "$normalized_current_repo" == "$normalized_pr_repo" &&
+			"$normalized_current_actor" == "$normalized_pr_author" ]]; then
+			return 3
+		fi
+	fi
+
+	if [[ "$replacement_pr" == "$ISSUE_OPEN_PR_NUMBER" && ${#replacement_reason} -ge 20 ]]; then
+		if [[ "$require_ancestry" -eq 1 ]]; then
+			git cat-file -e "${ISSUE_OPEN_PR_HEAD_SHA}^{commit}" 2>/dev/null || return 2
+			git merge-base --is-ancestor "$ISSUE_OPEN_PR_HEAD_SHA" HEAD 2>/dev/null || return 1
+		fi
+		return 0
+	fi
+	return 1
+}

--- a/.agents/scripts/tests/test-full-loop-closed-issue-bookkeeping.sh
+++ b/.agents/scripts/tests/test-full-loop-closed-issue-bookkeeping.sh
@@ -55,6 +55,7 @@ eval "$(extract_function "$COMMIT_HELPER" _validate_completion_bookkeeping_paths
 eval "$(extract_function "$COMMIT_HELPER" _validate_completion_bookkeeping_todo)"
 eval "$(extract_function "$COMMIT_HELPER" _validate_completion_bookkeeping_pr_body)"
 eval "$(extract_function "$COMMIT_HELPER" _validate_closed_issue_completion_bookkeeping)"
+eval "$(extract_function "$COMMIT_HELPER" _create_or_continue_pr)"
 eval "$(extract_function "$MAIN_HELPER" cmd_commit_and_pr)"
 
 _FULL_LOOP_TRUE="true"
@@ -251,6 +252,10 @@ _issue_has_parent_task_label() {
 	local repo_slug="$2"
 	[[ -n "$issue_number" && -n "$repo_slug" ]] || return 1
 	return 1
+}
+
+issue_open_pr_guard_check() {
+	return 0
 }
 
 _validate_worker_claim() {

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -168,7 +168,20 @@ auth)
 		fi
 		exit 0
 		;;
-issue)
+	pr)
+		if [[ "$2" == "list" ]]; then
+			if [[ -n "${STUB_OPEN_PR_ISSUE:-}" ]]; then
+				printf '[{"number":77,"headRefName":"feature/existing","headRefOid":"1111111111111111111111111111111111111111","headRepository":{"nameWithOwner":"%s/%s"},"author":{"login":"other-human"},"closingIssuesReferences":[{"number":%s,"repository":{"owner":{"login":"%s"},"name":"%s"}}],"isDraft":false}]\n' \
+					"${STUB_OPEN_PR_OWNER:-regress}" "${STUB_OPEN_PR_REPO:-test}" "$STUB_OPEN_PR_ISSUE" \
+					"${STUB_OPEN_PR_OWNER:-regress}" "${STUB_OPEN_PR_REPO:-test}"
+			else
+				printf '[]\n'
+			fi
+			exit 0
+		fi
+		exit 1
+		;;
+	issue)
 	case "$2" in
 	view)
 		# GH#20946 PR #20977 review: STUB_GH_VIEW_FAILS=1 simulates a gh lookup
@@ -744,6 +757,24 @@ else
 		"(rc=$takeover_rc owner=$takeover_owner stamp=$([[ -f "$takeover_stamp" ]] && echo yes || echo no) log=$(tr '\n' '|' <"$STUB_LOG") out=${takeover_out:0:120})"
 fi
 
+# --- Case (d2b): an old foreign claim with a linked open PR is durable work ---
+rm -f "${claim_dir}"/*.json 2>/dev/null || true
+: >"$STUB_LOG"
+old_claim_time=$(date -u -v-3H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '3 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+printf '{"state":"OPEN","labels":[{"name":"status:in-review"}],"assignees":[{"login":"other-human"}],"comments":[{"author":{"login":"other-human"},"createdAt":"%s","body":"> Interactive session claimed by @other-human on other-host."}]}\n' \
+	"$old_claim_time" >"${STUB_STATE_DIR}/56007.json"
+open_pr_out=$(STUB_OPEN_PR_ISSUE=56007 "$HELPER_PATH" claim 56007 regress/test --implementing --worktree /tmp/replacement-wt 2>&1)
+open_pr_rc=$?
+open_pr_stamp="${claim_dir}/regress-test-56007.json"
+if [[ $open_pr_rc -eq 1 && ! -f "$open_pr_stamp" ]] &&
+	! grep -q 'issue edit 56007' "$STUB_LOG" &&
+	printf '%s' "$open_pr_out" | grep -q "already has open PR #77"; then
+	print_result "old foreign claim with fresh open PR blocks interactive takeover" 0
+else
+	print_result "old foreign claim with fresh open PR blocks interactive takeover" 1 \
+		"(rc=$open_pr_rc stamp=$([[ -f "$open_pr_stamp" ]] && echo yes || echo no) out=${open_pr_out:0:180})"
+fi
+
 # --- Case (d3): a recent compatible foreign interactive claim is protected ---
 rm -f "${claim_dir}"/*.json 2>/dev/null || true
 : >"$STUB_LOG"
@@ -969,6 +1000,7 @@ rm -f "${claim_dir}"/*.json 2>/dev/null || true
 : >"$STUB_LOG"
 
 ad_pt_out=$(STUB_ISSUE_HAS_IN_REVIEW=0 STUB_ISSUE_HAS_AUTO_DISPATCH=1 STUB_ISSUE_HAS_PARENT_TASK=1 STUB_GH_MODE=online \
+	STUB_OPEN_PR_ISSUE=60003 STUB_OPEN_PR_OWNER=carveout STUB_OPEN_PR_REPO=test \
 	"$HELPER_PATH" claim 60003 carveout/test --worktree /tmp/carveout-wt 2>&1)
 ad_pt_rc=$?
 

--- a/.agents/scripts/tests/test-interactive-start-helper.sh
+++ b/.agents/scripts/tests/test-interactive-start-helper.sh
@@ -153,6 +153,16 @@ assert_log_line "claim cwd=${linked_worktree} marker=1 args=claim 43 owner/repo 
 assert_log_line "full-loop cwd=${linked_worktree} marker=1 args=start GH#43 queued fix --background"
 
 : >"$call_log"
+(
+	cd "$linked_worktree" || exit 1
+	PRE_EDIT_MODE=linked-current PATH="${stub_dir}:$PATH" \
+		"$helper" --issue 46 --repo owner/repo --task "replace abandoned work" \
+		--replace-pr 77 --replacement-reason "The existing implementation cannot satisfy the current API contract." </dev/null
+) || fail "explicit replacement issue start failed"
+assert_log_line "claim cwd=${linked_worktree} marker=1 args=claim 46 owner/repo --implementing --defer-comment --replace-pr 77 --replacement-reason The existing implementation cannot satisfy the current API contract."
+assert_log_line "claim cwd=${linked_worktree} marker=1 args=claim 46 owner/repo --implementing --worktree ${linked_worktree} --replace-pr 77 --replacement-reason The existing implementation cannot satisfy the current API contract."
+
+: >"$call_log"
 if STUB_CLAIM_FAILS=1 PATH="${stub_dir}:$PATH" \
 	"$helper" --issue 31317 --repo owner/repo --task "failed claim" </dev/null >/dev/null 2>&1; then
 	fail "failed initial claim reached success"

--- a/.agents/scripts/tests/test-issue-open-pr-guard.sh
+++ b/.agents/scripts/tests/test-issue-open-pr-guard.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+STUB_BIN="${TEST_ROOT}/bin"
+mkdir -p "$STUB_BIN"
+
+cat >"${STUB_BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1 $2 $3" == "pr list --repo" ]]; then
+	case "${STUB_CASE:-none}" in
+	missing) exit 1 ;;
+	none | historical) printf '[]\n' ;;
+	multiple)
+		printf '[{"number":77,"headRefName":"feature/existing","headRefOid":"%s","headRepository":{"nameWithOwner":"%s"},"author":{"login":"alice"},"closingIssuesReferences":[{"number":42,"repository":{"owner":{"login":"owner"},"name":"repo"}}],"isDraft":false},{"number":78,"headRefName":"feature/other","headRefOid":"2222222222222222222222222222222222222222","headRepository":{"nameWithOwner":"owner/repo"},"author":{"login":"bob"},"closingIssuesReferences":[{"number":42,"repository":{"owner":{"login":"owner"},"name":"repo"}}],"isDraft":true}]\n' "${STUB_HEAD_SHA:-1111111111111111111111111111111111111111}" "${STUB_HEAD_REPO:-owner/repo}"
+		;;
+	*)
+		printf '[{"number":77,"headRefName":"feature/existing","headRefOid":"%s","headRepository":{"nameWithOwner":"%s"},"author":{"login":"alice"},"closingIssuesReferences":[{"number":42,"repository":{"owner":{"login":"owner"},"name":"repo"}}],"isDraft":false}]\n' "${STUB_HEAD_SHA:-1111111111111111111111111111111111111111}" "${STUB_HEAD_REPO:-owner/repo}"
+		;;
+	esac
+	exit 0
+fi
+exit 1
+STUB
+chmod +x "${STUB_BIN}/gh"
+
+# shellcheck source=../issue-open-pr-guard.sh
+source "${SCRIPT_DIR_TEST}/issue-open-pr-guard.sh"
+# shellcheck source=../full-loop-helper-commit.sh
+source "${SCRIPT_DIR_TEST}/full-loop-helper-commit.sh"
+
+failures=0
+assert_rc() {
+	local name="$1" expected="$2"
+	shift 2
+	local actual=0
+	PATH="${STUB_BIN}:$PATH" "$@" || actual=$?
+	if [[ "$actual" -eq "$expected" ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s expected=%s actual=%s\n' "$name" "$expected" "$actual"
+		failures=$((failures + 1))
+	fi
+}
+
+check_in_repo() {
+	local repo_path="$1"
+	shift
+	(
+		cd "$repo_path" || exit 2
+		issue_open_pr_guard_check "$@"
+	)
+}
+
+STUB_CASE=none assert_rc 'PR-less issue is allowed' 0 issue_open_pr_guard_check 42 owner/repo feature/new '' '' 0 owner/repo
+STUB_CASE=none assert_rc 'replacement cannot name a nonexistent open PR' 2 issue_open_pr_guard_check 42 owner/repo feature/new 77 'The old approach cannot satisfy the verified API contract.' 0 owner/repo
+STUB_CASE=open assert_rc 'foreign open PR blocks fresh branch' 1 issue_open_pr_guard_check 42 owner/repo feature/new '' '' 0 owner/repo
+STUB_CASE=open assert_rc 'same PR branch continues idempotently' 3 issue_open_pr_guard_check 42 owner/repo feature/existing '' '' 0 owner/repo alice
+STUB_CASE=open assert_rc 'same repo and branch cannot impersonate another PR author' 1 issue_open_pr_guard_check 42 owner/repo feature/existing '' '' 0 owner/repo bob
+STUB_CASE=open STUB_HEAD_REPO=fork/repo assert_rc 'fork PR with same ref does not impersonate local continuation' 1 issue_open_pr_guard_check 42 owner/repo feature/existing '' '' 0 owner/repo alice
+STUB_CASE=open STUB_HEAD_REPO=fork/repo assert_rc 'matching fork remote continues its own PR' 3 issue_open_pr_guard_check 42 owner/repo feature/existing '' '' 0 fork/repo alice
+STUB_CASE=open assert_rc 'short replacement rationale is rejected' 1 issue_open_pr_guard_check 42 owner/repo feature/new 77 short
+STUB_CASE=open assert_rc 'explicit audited replacement is allowed before ancestry gate' 0 issue_open_pr_guard_check 42 owner/repo feature/new 77 'The old approach cannot satisfy the verified API contract.'
+STUB_CASE=historical assert_rc 'closed historical PR does not block' 0 issue_open_pr_guard_check 42 owner/repo feature/new '' '' 0 owner/repo
+STUB_CASE=missing assert_rc 'missing linkage evidence fails closed' 2 issue_open_pr_guard_check 42 owner/repo feature/new '' '' 0 owner/repo
+STUB_CASE=multiple assert_rc 'multiple linked open PRs fail closed as ambiguous' 2 issue_open_pr_guard_check 42 owner/repo feature/new '' '' 0 owner/repo
+
+GIT_FIXTURE="${TEST_ROOT}/repo"
+mkdir -p "$GIT_FIXTURE"
+git -C "$GIT_FIXTURE" init -q
+git -C "$GIT_FIXTURE" config user.email test@example.invalid
+git -C "$GIT_FIXTURE" config user.name Test
+printf 'original\n' >"${GIT_FIXTURE}/original.txt"
+git -C "$GIT_FIXTURE" add original.txt
+git -C "$GIT_FIXTURE" commit -qm original
+export STUB_HEAD_SHA
+STUB_HEAD_SHA=$(git -C "$GIT_FIXTURE" rev-parse HEAD)
+printf 'replacement\n' >"${GIT_FIXTURE}/replacement.txt"
+git -C "$GIT_FIXTURE" add replacement.txt
+git -C "$GIT_FIXTURE" commit -qm replacement
+STUB_CASE=open assert_rc 'replacement preserves original head ancestry' 0 check_in_repo "$GIT_FIXTURE" 42 owner/repo feature/new 77 'The old approach cannot satisfy the verified API contract.' 1
+git -C "$GIT_FIXTURE" checkout --orphan unrelated -q
+git -C "$GIT_FIXTURE" rm -rf . -q
+printf 'unrelated\n' >"${GIT_FIXTURE}/unrelated.txt"
+git -C "$GIT_FIXTURE" add unrelated.txt
+git -C "$GIT_FIXTURE" commit -qm unrelated
+STUB_CASE=open assert_rc 'replacement rejects discarded original commits' 1 check_in_repo "$GIT_FIXTURE" 42 owner/repo feature/new 77 'The old approach cannot satisfy the verified API contract.' 1
+
+guard_lines=$(grep -n '^[[:space:]]*issue_open_pr_guard_check ' "${SCRIPT_DIR_TEST}/full-loop-helper.sh" | cut -d: -f1)
+initial_guard_line="${guard_lines%%$'\n'*}"
+final_guard_line="${guard_lines##*$'\n'}"
+stage_line=$(grep -n '^[[:space:]]*_stage_and_commit ' "${SCRIPT_DIR_TEST}/full-loop-helper.sh" | cut -d: -f1)
+push_line=$(grep -n '^[[:space:]]*_push_branch ' "${SCRIPT_DIR_TEST}/full-loop-helper.sh" | cut -d: -f1)
+create_line=$(grep -n '^[[:space:]]*pr_number=.*_create_or_continue_pr ' "${SCRIPT_DIR_TEST}/full-loop-helper.sh" | cut -d: -f1)
+if [[ "$initial_guard_line" -lt "$stage_line" && "$push_line" -lt "$final_guard_line" && "$final_guard_line" -lt "$create_line" ]]; then
+	printf 'PASS full-loop revalidates linked PRs at the final creation boundary\n'
+else
+	printf 'FAIL full-loop guard ordering initial=%s stage=%s push=%s final=%s create=%s\n' \
+		"$initial_guard_line" "$stage_line" "$push_line" "$final_guard_line" "$create_line"
+	failures=$((failures + 1))
+fi
+
+CONTINUATION_LOG="${TEST_ROOT}/continuation.log"
+print_info() { return 0; }
+_reconcile_pr_origin_label() { printf 'origin %s %s %s\n' "$1" "$2" "$3" >>"$CONTINUATION_LOG"; }
+_reconcile_recovered_pr_metadata() { printf 'metadata %s %s %s %s\n' "$1" "$2" "$3" "$4" >>"$CONTINUATION_LOG"; }
+_create_pr() { printf 'create\n' >>"$CONTINUATION_LOG"; printf '99\n'; }
+: >"$CONTINUATION_LOG"
+continued_pr=$(_create_or_continue_pr 77 owner/repo title body origin:interactive)
+if [[ "$continued_pr" == "77" ]] &&
+	grep -q '^origin 77 owner/repo interactive$' "$CONTINUATION_LOG" &&
+	grep -q '^metadata 77 owner/repo title body$' "$CONTINUATION_LOG" &&
+	! grep -q '^create$' "$CONTINUATION_LOG"; then
+	printf 'PASS final-boundary continuation reconciles without creating a PR\n'
+else
+	printf 'FAIL final-boundary continuation result=%s log=%s\n' "$continued_pr" "$(tr '\n' '|' <"$CONTINUATION_LOG")"
+	failures=$((failures + 1))
+fi
+
+if [[ "$failures" -ne 0 ]]; then
+	exit 1
+fi
+printf 'PASS issue open PR guard regression suite\n'


### PR DESCRIPTION
## Summary

Prevent interactive ownership takeover and duplicate PR creation when an issue already has durable open PR work; require audited, ancestry-preserving replacement when explicitly justified.



## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/interactive-session-helper-commands.sh, .agents/scripts/interactive-session-helper.sh, .agents/scripts/interactive-start-helper.sh, .agents/scripts/issue-open-pr-guard.sh, .agents/scripts/tests/test-full-loop-closed-issue-bookkeeping.sh, .agents/scripts/tests/test-interactive-session-claim.sh, .agents/scripts/tests/test-interactive-start-helper.sh, .agents/scripts/tests/test-issue-open-pr-guard.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Changed-file lint; open-PR guard, interactive claim/start, closed-issue bookkeeping, runtime-risk, create-alias, and WIP-finalization regression suites.

Resolves #31660


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.348 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 35m and 172,111 tokens on this as a headless worker.
