### PR TITLE
GH#31662: protect Pulse cooldown recovery windows

### DIFF
--- a/.agents/reference/github-api-transport.md
+++ b/.agents/reference/github-api-transport.md
@@ -202,6 +202,20 @@ deferred while quota expires unused. Do not claim throughput improvement from
 unit tests or fewer requests alone. Existing freshness/trust checks and optional
 benchmark comparability rules remain unchanged.
 
+Pulse idle backoff evaluates its local interval before the optional
+available-work Search probe. A normal cycle therefore does not spend a
+pre-backoff Search request. When local state already calls for a skipped cycle,
+an active shared secondary cooldown or its recovery ramp suppresses that
+optional probe so interactive authority checks receive the recovery window.
+Timeouts, other request errors, and malformed counts remain unknown rather than
+becoming an empty queue, so the watchdog-protected cycle fails open. A proven
+unattempted local transport deferral (exit 75) instead retains the prior local
+skip decision and reschedules without a backend request. Successful eligible-work
+evidence still resets idle backoff. Cooldown diagnostics retain only sanitized
+method, endpoint/query shape, operation, wrapper, and Pulse-stage attribution.
+Rollback should revert the idle-gate ordering while leaving the shared cooldown
+enabled.
+
 ## Durable PR wake hints
 
 `pulse-merge-dirty-queue.py` stores repo/PR identifiers, generation, wake and

--- a/.agents/scripts/gh-transport-controls.sh
+++ b/.agents/scripts/gh-transport-controls.sh
@@ -37,7 +37,12 @@ _gh_transport_record_error() {
 	response="${response}$(<"$error_file")"
 	AIDEVOPS_GH_COOLDOWN_NO_PROBE=1 \
 		_gh_secondary_cooldown_record_if_needed "$rc" "$response" \
-		"GH-CLI" "unknown" "" "transport" "gh" "${AIDEVOPS_PULSE_STAGE:-unknown}"
+		"${AIDEVOPS_GH_COOLDOWN_METHOD:-GH-CLI}" \
+		"${AIDEVOPS_GH_COOLDOWN_ENDPOINT:-unknown}" \
+		"${AIDEVOPS_GH_COOLDOWN_QUERY:-}" \
+		"${AIDEVOPS_GH_COOLDOWN_OPERATION:-transport}" \
+		"${AIDEVOPS_GH_COOLDOWN_WRAPPER:-gh}" \
+		"${AIDEVOPS_GH_COOLDOWN_STAGE:-${AIDEVOPS_PULSE_STAGE:-unknown}}"
 	return 0
 }
 

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -200,7 +200,7 @@ _pulse_available_auto_dispatch_work_exists() {
 	local _timeout_secs="${AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK_TIMEOUT:-30}"
 	[[ "$_timeout_secs" =~ ^[1-9][0-9]*$ ]] || _timeout_secs=30
 	if ! declare -F timeout_sec >/dev/null 2>&1; then
-		printf '[pulse-wrapper] Idle available-work check has no timeout helper; proceeding without idle backoff (GH#27769)\n' \
+		printf '[pulse-wrapper] Idle available-work check has no timeout helper; preserving unknown work state (GH#27769)\n' \
 			>>"${WRAPPER_LOGFILE:-/dev/null}"
 		return 124
 	fi
@@ -217,16 +217,37 @@ _pulse_available_auto_dispatch_work_exists() {
 		fi
 		_count=""
 		_query_rc=0
-		_count=$(timeout_sec "$_remaining" gh api -X GET search/issues \
+		_count=$(AIDEVOPS_GH_COOLDOWN_METHOD=GET \
+			AIDEVOPS_GH_COOLDOWN_ENDPOINT=/search/issues \
+			AIDEVOPS_GH_COOLDOWN_QUERY="q=repo:${_slug}&per_page=1" \
+			AIDEVOPS_GH_COOLDOWN_OPERATION=idle_available_work \
+			AIDEVOPS_GH_COOLDOWN_WRAPPER=pulse-wrapper.sh \
+			AIDEVOPS_GH_COOLDOWN_STAGE=idle-backoff-availability \
+			timeout_sec "$_remaining" gh api -X GET search/issues \
 			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available -label:publication:pending -label:needs-maintainer-review -label:needs-maintainer-permissions -label:infrastructure no:assignee" \
 			-f per_page=1 \
 			--jq '.total_count // 0' 2>/dev/null) || _query_rc=$?
-		if [[ "$_query_rc" -eq 124 ]]; then
-			printf '[pulse-wrapper] Idle available-work check timed out after %ss; proceeding without idle backoff (GH#27769)\n' \
-				"$_timeout_secs" >>"${WRAPPER_LOGFILE:-/dev/null}"
-			return 124
+		if [[ "$_query_rc" -ne 0 ]]; then
+			if [[ "$_query_rc" -eq 124 ]]; then
+				printf '[pulse-wrapper] Idle available-work check timed out after %ss; preserving unknown work state (GH#27769)\n' \
+					"$_timeout_secs" >>"${WRAPPER_LOGFILE:-/dev/null}"
+			elif [[ "$_query_rc" -eq 75 ]]; then
+				printf '[pulse-wrapper] Idle available-work check deferred by transport admission; rescheduling with local backoff (GH#31662)\n' \
+					>>"${WRAPPER_LOGFILE:-/dev/null}"
+			else
+				printf '[pulse-wrapper] Idle available-work check unavailable (rc=%s); preserving unknown work state (GH#31662)\n' \
+					"$_query_rc" >>"${WRAPPER_LOGFILE:-/dev/null}"
+			fi
+			case "$_query_rc" in
+			75 | 124) return "$_query_rc" ;;
+			*) return 2 ;;
+			esac
 		fi
-		[[ "$_count" =~ ^[0-9]+$ ]] || _count=0
+		if ! [[ "$_count" =~ ^[0-9]+$ ]]; then
+			printf '[pulse-wrapper] Idle available-work check returned malformed evidence; preserving unknown work state (GH#31662)\n' \
+				>>"${WRAPPER_LOGFILE:-/dev/null}"
+			return 2
+		fi
 		if [[ "$_count" -gt 0 ]]; then
 			echo "[pulse-wrapper] Idle backoff bypass: eligible auto-dispatch work is visible in ${_slug} (GH#22631)" >>"$WRAPPER_LOGFILE"
 			return 0
@@ -238,37 +259,52 @@ _pulse_available_auto_dispatch_work_exists() {
 _pulse_check_idle_backoff_gate() {
 	local _ib_helper="${SCRIPT_DIR}/pulse-idle-backoff-helper.sh"
 	[[ -x "$_ib_helper" ]] || return 0
-	local _ib_available_work=0
-	local _ib_available_work_rc=0
-	if _pulse_available_auto_dispatch_work_exists; then
-		_ib_available_work=1
-	else
-		_ib_available_work_rc=$?
-		# Unknown work state must not suppress the watchdog-protected cycle.
-		[[ "$_ib_available_work_rc" -eq 124 ]] && return 0
-	fi
 	local _ib_ts_file="${HOME}/.aidevops/logs/pulse-wrapper-last-run.ts"
 	local _ib_last=0
 	if [[ -f "$_ib_ts_file" ]]; then
 		read -r _ib_last <"$_ib_ts_file" || [[ -n "$_ib_last" ]] || _ib_last=0
 		[[ "$_ib_last" =~ ^[0-9]+$ ]] || _ib_last=0
 	fi
-	# Helper convention: exit 0 = "skip this cycle", exit 1 = "proceed".
-	# Mirrors should-skip semantics so the helper composes naturally with
-	# `if helper should-skip; then return; fi` at the call site.
-	if AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK="$_ib_available_work" "$_ib_helper" should-skip "$_ib_last" >/dev/null 2>&1; then
-		local _ib_state="" _ib_count="" _ib_interval=""
-		_ib_state=$("$_ib_helper" state 2>/dev/null || echo '{}')
-		_ib_count=$(echo "$_ib_state" | jq -r '.consecutive_idle // 0' 2>/dev/null || echo "0")
-		_ib_interval=$(echo "$_ib_state" | jq -r '.current_effective_interval_s // 90' 2>/dev/null || echo "90")
-		echo "[pulse-wrapper] Idle backoff: skipping cycle (consecutive_idle=${_ib_count}, effective_interval=${_ib_interval}s) (t3027)" >>"$WRAPPER_LOGFILE"
-		_PULSE_HEALTH_IDLE_CYCLE_SKIPPED=$((${_PULSE_HEALTH_IDLE_CYCLE_SKIPPED:-0} + 1))
-		if declare -F pulse_stats_increment >/dev/null 2>&1; then
-			pulse_stats_increment "pulse_idle_cycle_skipped" 2>/dev/null || true
-		fi
-		return 1
+	# Do not spend a Search request until local state has already decided this
+	# cycle would be skipped. During a secondary hold or its recovery ramp, keep
+	# this optional wake-up probe quiet so interactive authority checks get the
+	# recovery window. The normal cycle remains fail-open when no backoff applies.
+	if ! AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK=0 "$_ib_helper" should-skip "$_ib_last" >/dev/null 2>&1; then
+		return 0
 	fi
-	return 0
+	if declare -F _gh_secondary_cooldown_active >/dev/null 2>&1 && _gh_secondary_cooldown_active; then
+		printf '[pulse-wrapper] Idle backoff: skipping availability probe during shared GitHub cooldown (GH#31662)\n' \
+			>>"${WRAPPER_LOGFILE:-/dev/null}"
+	elif declare -F _gh_secondary_read_ramp_phase >/dev/null 2>&1 && [[ -n "$(_gh_secondary_read_ramp_phase 2>/dev/null || true)" ]]; then
+		printf '[pulse-wrapper] Idle backoff: skipping availability probe during GitHub recovery ramp (GH#31662)\n' \
+			>>"${WRAPPER_LOGFILE:-/dev/null}"
+	elif _pulse_available_auto_dispatch_work_exists; then
+		AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK=1 "$_ib_helper" should-skip "$_ib_last" >/dev/null 2>&1 || true
+		return 0
+	else
+		local _ib_available_work_rc=$?
+		if [[ "$_ib_available_work_rc" -eq 75 ]]; then
+			printf '[pulse-wrapper] Idle backoff: transport deferred optional availability; retaining local skip decision (GH#31662)\n' \
+				>>"${WRAPPER_LOGFILE:-/dev/null}"
+		elif [[ "$_ib_available_work_rc" -ne 1 ]]; then
+			printf '[pulse-wrapper] Idle backoff: availability remains unknown (rc=%s); bypassing local skip decision (GH#31662)\n' \
+				"$_ib_available_work_rc" >>"${WRAPPER_LOGFILE:-/dev/null}"
+			# Timeouts, malformed evidence, and attempted request failures remain
+			# fail-open for watchdog/liveness. A proven unattempted local transport
+			# deferral (75) is the only query result that reschedules this skipped cycle.
+			return 0
+		fi
+	fi
+	local _ib_state="" _ib_count="" _ib_interval=""
+	_ib_state=$("$_ib_helper" state 2>/dev/null || echo '{}')
+	_ib_count=$(echo "$_ib_state" | jq -r '.consecutive_idle // 0' 2>/dev/null || echo "0")
+	_ib_interval=$(echo "$_ib_state" | jq -r '.current_effective_interval_s // 90' 2>/dev/null || echo "90")
+	echo "[pulse-wrapper] Idle backoff: skipping cycle (consecutive_idle=${_ib_count}, effective_interval=${_ib_interval}s) (t3027)" >>"$WRAPPER_LOGFILE"
+	_PULSE_HEALTH_IDLE_CYCLE_SKIPPED=$((${_PULSE_HEALTH_IDLE_CYCLE_SKIPPED:-0} + 1))
+	if declare -F pulse_stats_increment >/dev/null 2>&1; then
+		pulse_stats_increment "pulse_idle_cycle_skipped" 2>/dev/null || true
+	fi
+	return 1
 }
 
 _pulse_refresh_supervisor_circuit_breaker() {

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -289,6 +289,11 @@ export PATH="${SCRIPT_DIR}:${PATH}"
 # BASH_SOURCE[1] and re-exec the wrong script. (GH#19632)
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
+# GH#31662: the pre-cycle idle gate reads shared cooldown/recovery state
+# locally so optional Search probes cannot consume the interactive recovery
+# window. The include guard keeps later transport sourcing idempotent.
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/shared-gh-secondary-cooldown.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/config-helper.sh" 2>/dev/null || true
 # shellcheck source=/dev/null

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -97,7 +97,7 @@ reset_case() {
 	rm -f "${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE}.primary-core" "${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE}.primary-graphql" "${AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE}.primary-code_search"
 	rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE"
 	rm -f "$AIDEVOPS_GH_READ_RAMP_STATE_FILE"
-	unset GH_SECONDARY_FAIL GH_REST_CORE_403_FAIL GH_CORE_RATE_LIMIT_RESET GH_SEARCH_RATE_LIMIT_RESET GH_HEADER_LIMIT_FAIL GH_GENERIC_403_FAIL GH_ABUSE_403_FAIL GH_PRIMARY_REMAINING_ZERO_FAIL GH_PRIMARY_REMAINING_ZERO_SUCCESS GH_LARGE_SUCCESS AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_LINES AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_BYTES AIDEVOPS_GH_READ_RAMP_BUDGET AIDEVOPS_GH_READ_RAMP_BOOT_SECS AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS AIDEVOPS_GH_READ_RAMP_OVERRIDE AIDEVOPS_GH_AUTH_MODE AIDEVOPS_GH_AUTH_PRINCIPAL AIDEVOPS_GH_COOLDOWN_OPERATION AIDEVOPS_GH_COOLDOWN_WRAPPER AIDEVOPS_GH_COOLDOWN_STAGE AIDEVOPS_GH_API_POOL AIDEVOPS_GH_ROUTE_DECISION 2>/dev/null || true
+	unset GH_SECONDARY_FAIL GH_REST_CORE_403_FAIL GH_CORE_RATE_LIMIT_RESET GH_SEARCH_RATE_LIMIT_RESET GH_HEADER_LIMIT_FAIL GH_GENERIC_403_FAIL GH_ABUSE_403_FAIL GH_PRIMARY_REMAINING_ZERO_FAIL GH_PRIMARY_REMAINING_ZERO_SUCCESS GH_LARGE_SUCCESS AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_LINES AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_BYTES AIDEVOPS_GH_READ_RAMP_BUDGET AIDEVOPS_GH_READ_RAMP_BOOT_SECS AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS AIDEVOPS_GH_READ_RAMP_OVERRIDE AIDEVOPS_GH_AUTH_MODE AIDEVOPS_GH_AUTH_PRINCIPAL AIDEVOPS_GH_COOLDOWN_METHOD AIDEVOPS_GH_COOLDOWN_ENDPOINT AIDEVOPS_GH_COOLDOWN_QUERY AIDEVOPS_GH_COOLDOWN_OPERATION AIDEVOPS_GH_COOLDOWN_WRAPPER AIDEVOPS_GH_COOLDOWN_STAGE AIDEVOPS_GH_API_POOL AIDEVOPS_GH_ROUTE_DECISION 2>/dev/null || true
 	_GH_SECONDARY_COOLDOWN_LOGGED_ACTIVE=0
 	_GH_SECONDARY_COOLDOWN_LOGGED_RAMP=0
 	_gh_secondary_system_boot_ts() { return 1; }
@@ -558,6 +558,24 @@ test_all_primary_resources_remain_isolated() {
 	return 0
 }
 
+test_transport_preserves_sanitized_caller_context() {
+	local error_file="${TMP_HOME}/transport-error" response=""
+	reset_case
+	: >"$error_file"
+	response=$(printf 'HTTP/2 403\r\nX-RateLimit-Remaining: 14\r\nX-RateLimit-Resource: search\r\n\r\n{"message":"secondary rate limit"}\n')
+	AIDEVOPS_GH_COOLDOWN_METHOD=GET \
+		AIDEVOPS_GH_COOLDOWN_ENDPOINT=/search/issues \
+		AIDEVOPS_GH_COOLDOWN_QUERY='q=private-value&per_page=1' \
+		AIDEVOPS_GH_COOLDOWN_OPERATION=idle_available_work \
+		AIDEVOPS_GH_COOLDOWN_WRAPPER=pulse-wrapper.sh \
+		AIDEVOPS_GH_COOLDOWN_STAGE=idle-backoff-availability \
+		_gh_transport_record_error 1 "$error_file" "$response"
+	jq -e '.diagnostic.method == "GET" and .diagnostic.endpoint == "/search/issues" and .diagnostic.query_shape == "q=<redacted>&per_page=<redacted>" and .diagnostic.operation == "idle_available_work" and .diagnostic.wrapper == "pulse-wrapper.sh" and .diagnostic.pulse_stage == "idle-backoff-availability"' \
+		"$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null
+	printf 'PASS transport cooldown records sanitized originating context\n'
+	return 0
+}
+
 test_secondary_response_writes_cooldown
 test_header_response_writes_retry_after_cooldown
 test_generic_403_diagnostic_distinguishes_forbidden
@@ -581,3 +599,4 @@ test_read_ramp_does_not_defer_writes
 test_primary_search_isolation
 test_search_expiry_and_secondary_precedence
 test_all_primary_resources_remain_isolated
+test_transport_preserves_sanitized_caller_context

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -34,13 +34,27 @@ mkdir -p "$SCRIPT_DIR"
 : >"$WRAPPER_LOGFILE"
 
 GH_QUERY_FILE="${TMP}/query.txt"
+GH_CONTEXT_FILE="${TMP}/context.txt"
+GH_CALL_COUNT_FILE="${TMP}/gh-call-count.txt"
 TIMEOUT_CALL_FILE="${TMP}/timeout.txt"
 export GH_QUERY_FILE
+export GH_CONTEXT_FILE
+export GH_CALL_COUNT_FILE
 export TIMEOUT_CALL_FILE
 export TIMEOUT_MODE="pass"
+export GH_OUTPUT="0"
+export IDLE_DECISION="skip"
+printf '0\n' >"$GH_CALL_COUNT_FILE"
 gh() {
+	local call_count=""
+	call_count=$(<"$GH_CALL_COUNT_FILE")
+	printf '%s\n' "$((call_count + 1))" >"$GH_CALL_COUNT_FILE"
 	printf '%s\n' "$*" >"$GH_QUERY_FILE"
-	printf '0\n'
+	printf '%s|%s|%s|%s|%s|%s\n' \
+		"${AIDEVOPS_GH_COOLDOWN_METHOD:-}" "${AIDEVOPS_GH_COOLDOWN_ENDPOINT:-}" \
+		"${AIDEVOPS_GH_COOLDOWN_QUERY:-}" "${AIDEVOPS_GH_COOLDOWN_OPERATION:-}" \
+		"${AIDEVOPS_GH_COOLDOWN_WRAPPER:-}" "${AIDEVOPS_GH_COOLDOWN_STAGE:-}" >"$GH_CONTEXT_FILE"
+	printf '%s\n' "$GH_OUTPUT"
 	return 0
 }
 
@@ -51,6 +65,12 @@ timeout_sec() {
 	if [[ "$TIMEOUT_MODE" == "timeout" ]]; then
 		return 124
 	fi
+	if [[ "$TIMEOUT_MODE" == "deferred" ]]; then
+		return 75
+	fi
+	if [[ "$TIMEOUT_MODE" == "error" ]]; then
+		return 1
+	fi
 	"$@"
 	return $?
 }
@@ -58,7 +78,11 @@ timeout_sec() {
 cat >"${SCRIPT_DIR}/pulse-idle-backoff-helper.sh" <<'EOF'
 #!/usr/bin/env bash
 case "${1:-}" in
-should-skip) exit 0 ;;
+should-skip)
+	[[ "${AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK:-0}" != "1" ]] || exit 1
+	[[ "${IDLE_DECISION:-skip}" != "proceed" ]] || exit 1
+	exit 0
+	;;
 state)
 	printf '{"consecutive_idle":2,"current_effective_interval_s":120}\n'
 	exit 0
@@ -124,6 +148,12 @@ else
 	fail "idle-work query excludes unpublished planning issues" "query=$(<"$GH_QUERY_FILE")"
 fi
 
+if [[ "$(<"$GH_CONTEXT_FILE")" == 'GET|/search/issues|q=repo:owner/repo&per_page=1|idle_available_work|pulse-wrapper.sh|idle-backoff-availability' ]]; then
+	pass "idle-work query carries sanitized cooldown attribution context"
+else
+	fail "idle-work query carries sanitized cooldown attribution context" "context=$(<"$GH_CONTEXT_FILE")"
+fi
+
 timeout_value=$(<"$TIMEOUT_CALL_FILE")
 if grep -q 'AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK_TIMEOUT:-30' "$SOURCE_SCRIPT" &&
 	[[ "$timeout_value" =~ ^[0-9]+$ ]] &&
@@ -146,9 +176,9 @@ else
 fi
 
 if _pulse_check_idle_backoff_gate; then
-	pass "idle-work timeout bypasses idle backoff"
+	pass "idle-work timeout preserves unknown and fails open"
 else
-	fail "idle-work timeout bypasses idle backoff"
+	fail "idle-work timeout preserves unknown and fails open"
 fi
 
 if grep -q 'timed out after 30s' "$WRAPPER_LOGFILE"; then
@@ -156,6 +186,99 @@ if grep -q 'timed out after 30s' "$WRAPPER_LOGFILE"; then
 else
 	fail "idle-work timeout is logged"
 fi
+
+export TIMEOUT_MODE="deferred"
+if _pulse_available_auto_dispatch_work_exists; then
+	fail "idle-work transport deferral preserves status"
+else
+	query_rc=$?
+	if [[ "$query_rc" -eq 75 ]]; then
+		pass "idle-work transport deferral preserves status"
+	else
+		fail "idle-work transport deferral preserves status" "rc=${query_rc}"
+	fi
+fi
+
+export TIMEOUT_MODE="pass"
+export GH_OUTPUT="malformed"
+if _pulse_available_auto_dispatch_work_exists; then
+	fail "idle-work malformed response remains unknown"
+else
+	query_rc=$?
+	if [[ "$query_rc" -eq 2 ]]; then
+		pass "idle-work malformed response remains unknown"
+	else
+		fail "idle-work malformed response remains unknown" "rc=${query_rc}"
+	fi
+fi
+
+export TIMEOUT_MODE="error"
+if _pulse_available_auto_dispatch_work_exists; then
+	fail "attempted query failure maps to typed unknown"
+else
+	query_rc=$?
+	if [[ "$query_rc" -eq 2 ]]; then
+		pass "attempted query failure maps to typed unknown"
+	else
+		fail "attempted query failure maps to typed unknown" "rc=${query_rc}"
+	fi
+fi
+
+export GH_OUTPUT="0"
+export IDLE_DECISION="proceed"
+printf '0\n' >"$GH_CALL_COUNT_FILE"
+if _pulse_check_idle_backoff_gate && [[ "$(<"$GH_CALL_COUNT_FILE")" -eq 0 ]]; then
+	pass "normal cycle avoids unnecessary pre-backoff Search"
+else
+	fail "normal cycle avoids unnecessary pre-backoff Search" "calls=$(<"$GH_CALL_COUNT_FILE")"
+fi
+
+export IDLE_DECISION="skip"
+printf '0\n' >"$GH_CALL_COUNT_FILE"
+_gh_secondary_read_ramp_phase() { printf 'cooldown-recovery\n'; }
+if _pulse_check_idle_backoff_gate; then
+	fail "recovery ramp keeps optional availability probe quiet"
+elif [[ "$(<"$GH_CALL_COUNT_FILE")" -eq 0 ]]; then
+	pass "recovery ramp keeps optional availability probe quiet"
+else
+	fail "recovery ramp keeps optional availability probe quiet" "calls=$(<"$GH_CALL_COUNT_FILE")"
+fi
+unset -f _gh_secondary_read_ramp_phase
+
+printf '0\n' >"$GH_CALL_COUNT_FILE"
+_gh_secondary_cooldown_active() { return 0; }
+if _pulse_check_idle_backoff_gate; then
+	fail "active cooldown keeps optional availability probe quiet"
+elif [[ "$(<"$GH_CALL_COUNT_FILE")" -eq 0 ]]; then
+	pass "active cooldown keeps optional availability probe quiet"
+else
+	fail "active cooldown keeps optional availability probe quiet" "calls=$(<"$GH_CALL_COUNT_FILE")"
+fi
+unset -f _gh_secondary_cooldown_active
+
+export TIMEOUT_MODE="deferred"
+if _pulse_check_idle_backoff_gate; then
+	fail "transport deferral retains prior local backoff decision"
+else
+	pass "transport deferral retains prior local backoff decision"
+fi
+export TIMEOUT_MODE="pass"
+
+export TIMEOUT_MODE="error"
+if _pulse_check_idle_backoff_gate; then
+	pass "attempted query failure preserves unknown and fails open"
+else
+	fail "attempted query failure preserves unknown and fails open"
+fi
+export TIMEOUT_MODE="pass"
+
+export GH_OUTPUT="1"
+if _pulse_check_idle_backoff_gate; then
+	pass "visible work still bypasses active idle backoff"
+else
+	fail "visible work still bypasses active idle backoff"
+fi
+export GH_OUTPUT="0"
 
 : >"$EVIDENCE_FILE"
 : >"$EVIDENCE_TIMESTAMP_FILE"


### PR DESCRIPTION
## Summary

Move the optional idle-work Search behind local backoff, suppress it during shared cooldown recovery, preserve typed unknown/error states, and attach sanitized transport attribution.



## Files Changed

.agents/reference/github-api-transport.md, .agents/scripts/gh-transport-controls.sh, .agents/scripts/pulse-wrapper-cycle-gates.sh, .agents/scripts/pulse-wrapper.sh, .agents/scripts/tests/test-gh-secondary-cooldown.sh, .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with Pulse cycle-gate, idle-backoff, dry-run bootstrap, and GitHub cooldown suites; ShellCheck and changed-file linters pass.

Resolves #31662


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.348 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 52m and 390,984 tokens on this with the user in an interactive session.