### PR TITLE
GH#31459: align Codacy drift telemetry with effective policy

### DIFF
--- a/.agents/scripts/stats-quality-sweep-tools.sh
+++ b/.agents/scripts/stats-quality-sweep-tools.sh
@@ -388,7 +388,7 @@ _codacy_policy_drift() {
 			(.total | type == "number" and . >= 0 and . == floor))
 	' <<<"$issues_response" >/dev/null 2>&1 || return 1
 	jq -r '
-		["Bandit_B404", "ESLint8_es-x_no-modules",
+		["ESLint8_es-x_no-modules",
 		 "ESLint8_es-x_no-block-scoped-variables", "ESLint8_es-x_no-trailing-commas"] as $rules |
 		.data.counts.patterns[] | select(.id as $id | $rules | index($id)) |
 		select(.total > 0) | "  - `\(.id)`: \(.total)"

--- a/.agents/scripts/tests/test-codacy-health-sweep.sh
+++ b/.agents/scripts/tests/test-codacy-health-sweep.sh
@@ -75,6 +75,9 @@ curl() {
 		policy-drift)
 			printf '%s' '{"data":{"counts":{"patterns":[{"id":"Bandit_B404","title":"Import subprocess","total":76},{"id":"ESLint8_es-x_no-modules","total":84},{"id":"ESLint8_es-x_no-block-scoped-variables","total":56},{"id":"ESLint8_es-x_no-trailing-commas","total":40}]}}}'
 			;;
+		b404-history)
+			printf '%s' '{"data":{"counts":{"patterns":[{"id":"Bandit_B404","title":"Import subprocess","total":83}]}}}'
+			;;
 		overview-failure) return 1 ;;
 		overview-missing) printf '%s' '{"data":{"counts":{}}}' ;;
 		overview-invalid) printf '%s' '{"data":{"counts":{"patterns":[{"id":"Bandit_B404","total":"76"}]}}}' ;;
@@ -157,11 +160,15 @@ LOC=1000
 MODE="policy-drift"
 RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
 assert_contains "documented rule renders policy drift" "$RESULT" "**Analysis health**: POLICY_DRIFT"
-assert_contains "documented rule includes exact aggregate count" "$RESULT" "\`Bandit_B404\`: 76"
 assert_contains "ES modules policy drift includes exact count" "$RESULT" "\`ESLint8_es-x_no-modules\`: 84"
 assert_contains "block-scoped variables drift includes exact count" "$RESULT" "\`ESLint8_es-x_no-block-scoped-variables\`: 56"
 assert_contains "trailing commas drift includes exact count" "$RESULT" "\`ESLint8_es-x_no-trailing-commas\`: 40"
 assert_contains "drifting A is not verified at target" "$RESULT" "**Grade target**: A / UNVERIFIED"
+
+MODE="b404-history"
+RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")
+assert_contains "retained disabled B404 history does not report policy drift" "$RESULT" "**Analysis health**: HEALTHY"
+assert_contains "retained disabled B404 history preserves verified A target" "$RESULT" "**Grade target**: A / AT_TARGET"
 
 for MODE in overview-failure overview-missing overview-invalid search-page; do
 	RESULT=$(_sweep_codacy "owner/repo" "/fake/repo")

--- a/.agents/tools/code-review/codacy.md
+++ b/.agents/tools/code-review/codacy.md
@@ -102,13 +102,15 @@ patterns `ESLint8_es-x_no-modules`,
 also disabled because `.bandit` documents the narrower subprocess rules that
 remain active. Before correction, exact-SHA overview counts were 84
 (`no-modules`), 56 (`no-block-scoped-variables`), 40 (`no-trailing-commas`),
-and 83 (`B404`). A normal exact-SHA reanalysis cleared the three ESLint counts,
-but retained 83 cached B404 findings even though both the effective pattern and
-`.bandit` disable B404. This is evidence that a cache-cleared support reanalysis
-is still required for native-config policy changes; do not weaken Bandit or
-rewrite safe subprocess imports to compensate for stale derived state. Keep the
-live standard and native files aligned; changing the inert `.codacy.yml` engine
-map is not a tool-setting migration.
+and 83 (`B404`). A normal exact-SHA reanalysis cleared the three ESLint counts.
+A subsequent Codacy Support cache-cleared reanalysis still retained 83 historical
+B404 issue records even though the effective pattern endpoint and `.bandit` both
+disable B404. The issue overview therefore does not prove current policy drift
+for a disabled pattern. Use the effective pattern endpoint as the policy
+authority; do not bulk-ignore records, weaken Bandit, or rewrite safe subprocess
+imports to manipulate historical issue totals. Keep the live standard and native
+files aligned; changing the inert `.codacy.yml` engine map is not a tool-setting
+migration.
 
 ```bash
 # Commit delta statistics (new issues count + complexity delta)
@@ -160,7 +162,7 @@ The verified API v3.1.0 contracts are:
 | `HEALTHY` | The analysed SHA matches the remote default head, LOC is at least 80% of the healthy high-water sample, and overview data is valid and drift-free. | Treat the telemetry as comparable; this does not mean grade A. |
 | `STALE_ANALYSIS` | Codacy analysed a different commit from the remote default head. | Request/retry analysis; do not compare findings yet. |
 | `INDEX_DEGRADED` | Current analysed LOC is below 80% of the last healthy sample. | Investigate Codacy indexing; the healthy denominator is retained. |
-| `POLICY_DRIFT` | A documented-noise rule has a non-zero overview count. | Investigate coding-standard drift; do not change external settings from the sweep. |
+| `POLICY_DRIFT` | A monitored drift sentinel has a non-zero overview count. | Investigate coding-standard drift; do not change external settings from the sweep. |
 | `UNKNOWN` | An API, parse, remote-SHA, or state-write failure prevented a trustworthy classification. | Resolve telemetry failure and retain the previous baseline. |
 
 Healthy samples are stored atomically in `QUALITY_SWEEP_STATE_DIR` per repository.
@@ -169,10 +171,12 @@ that baseline, including on first observation. Small LOC drops retain the entire
 prior sample, so successive drops cannot gradually normalize a collapsed index.
 An intentional analysis-scope reduction requires an independently verified new
 baseline; do not erase state merely to clear an index warning.
-The documented-noise rules are `Bandit_B404`, `ESLint8_es-x_no-modules`,
+The monitored drift sentinels are `ESLint8_es-x_no-modules`,
 `ESLint8_es-x_no-block-scoped-variables`, and
 `ESLint8_es-x_no-trailing-commas`; their counts are observational evidence, not
-permission to alter Codacy, Bandit, ESLint, or exclusions.
+permission to alter Codacy, ESLint, or exclusions. `Bandit_B404` is intentionally
+disabled in both effective service policy and `.bandit`; its retained historical
+issue records do not indicate current policy drift.
 
 The separate **Grade target** is `A / AT_TARGET`, `A / BELOW_TARGET`, or
 `A / UNVERIFIED`. Only a current A with `HEALTHY` analysis is verified at target.


### PR DESCRIPTION
## Summary

Treat retained historical B404 records as non-drift after a support cache-cleared reanalysis confirmed the rule is disabled in effective policy and .bandit; retain ESLint drift sentinels.



## Files Changed

.agents/scripts/stats-quality-sweep-tools.sh, .agents/scripts/tests/test-codacy-health-sweep.sh, .agents/tools/code-review/codacy.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused Codacy health tests passed; changed-file lint passed; isolated live diagnostic reached HEALTHY and A / AT_TARGET on the second comparable sample.

Resolves #31459


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.348 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 2d 1h and 1,532,816 tokens on this with the user in an interactive session.