### PR TITLE
fix: enforce qlty regression quality gate

### DIFF
--- a/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
@@ -22,9 +22,13 @@ import {
   trimTerminalOperations,
 } from "./bounded-operation-runtime.mjs";
 import {
+  attachOperationOutput,
   cancelOperation,
+  clearOperationStatusWaiters,
+  notifyOperationStatusWaiters,
   operationOutput,
   operationStatus,
+  operationStatusVersion,
 } from "./bounded-operation-access.mjs";
 import { resolveSessionOwnedWorktreeRoot } from "./gpt-image-worktree.mjs";
 
@@ -48,6 +52,8 @@ export class BoundedInteractiveOperationManager {
     this.killGraceMs = options.killGraceMs ?? 500;
     this.setTimer = options.setTimer || setTimeout;
     this.clearTimer = options.clearTimer || clearTimeout;
+    this.appendCapture = appendCapture;
+    this.observeProgress = observeProgress;
     this.supervisorRuntime = options.supervisorRuntime || SUPERVISOR_RUNTIME;
     this.operations = new Map();
   }
@@ -68,28 +74,19 @@ export class BoundedInteractiveOperationManager {
   }
 
   attachOutput(operation, child) {
-    for (const stream of [child.stdout, child.stderr]) {
-      stream?.on("data", (chunk) => {
-        appendCapture(operation, chunk);
-        if (observeProgress(operation, chunk, this.now)) this.notifyStatusWaiters(operation);
-      });
-    }
+    attachOperationOutput(this, operation, child);
   }
 
   statusVersion(operation) {
-    return `${operation.state}:${operation.restorationState}:${operation.progressEvents}`;
+    return operationStatusVersion(operation);
   }
 
   notifyStatusWaiters(operation) {
-    const version = this.statusVersion(operation);
-    for (const waiter of operation.statusWaiters) {
-      if (waiter.version === version) continue;
-      waiter.finish();
-    }
+    notifyOperationStatusWaiters(this, operation);
   }
 
   clearStatusWaiters(operation) {
-    for (const waiter of operation.statusWaiters) waiter.finish();
+    clearOperationStatusWaiters(operation);
   }
 
   spawnOwned(operation, command, stage) {

--- a/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
@@ -21,11 +21,14 @@ import {
   signalSupervisor,
   trimTerminalOperations,
 } from "./bounded-operation-runtime.mjs";
+import {
+  cancelOperation,
+  operationOutput,
+  operationStatus,
+} from "./bounded-operation-access.mjs";
 import { resolveSessionOwnedWorktreeRoot } from "./gpt-image-worktree.mjs";
 
 const MAX_OPERATIONS = 24;
-const MAX_STATUS_WAIT_MS = 60 * 1000;
-const MAX_OUTPUT_LINES = 500;
 const SUPERVISOR_PATH = fileURLToPath(new URL("./bounded-operation-supervisor.mjs", import.meta.url));
 const SUPERVISOR_RUNTIME = "node";
 
@@ -277,60 +280,15 @@ export class BoundedInteractiveOperationManager {
   }
 
   status(id, context = {}, requested = {}) {
-    const operation = this.ownedOperation(id, context);
-    const waitMs = Number(requested.waitMs ?? 0);
-    if (!Number.isSafeInteger(waitMs) || waitMs < 0 || waitMs > MAX_STATUS_WAIT_MS) {
-      throw new Error("status wait must be an integer from 0 to 60000 milliseconds");
-    }
-    if (waitMs === 0 || !["starting", "running", "cancelling", "timing_out", "restoring", "finalizing"].includes(operation.state)) {
-      return this.receipt(operation);
-    }
-    return new Promise((resolve) => {
-      const waiter = {
-        version: this.statusVersion(operation),
-        finish: () => {
-          if (!operation.statusWaiters.delete(waiter)) return;
-          this.clearTimer(waiter.timer);
-          resolve(this.receipt(operation));
-        },
-        timer: null,
-      };
-      operation.statusWaiters.add(waiter);
-      waiter.timer = this.setTimer(waiter.finish, waitMs);
-    });
+    return operationStatus(this, id, context, requested);
   }
 
   async output(id, context = {}, requested = {}) {
-    const operation = this.ownedOperation(id, context);
-    if (["starting", "running", "cancelling", "timing_out", "restoring", "finalizing"].includes(operation.state)) {
-      throw new Error("stored output is available only after the operation reaches a terminal state");
-    }
-    if (!operation.outputID) throw new Error("stored output is unavailable");
-    const offset = Number(requested.offset ?? 1);
-    const limit = Number(requested.limit ?? 120);
-    if (!Number.isSafeInteger(offset) || offset < 1) throw new Error("output offset must be a positive integer");
-    if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_OUTPUT_LINES) {
-      throw new Error(`output limit must be an integer from 1 to ${MAX_OUTPUT_LINES}`);
-    }
-    const result = await this.readOutput(operation.outputID, { offset, limit });
-    return {
-      schema: "aidevops.interactive-operation-output/v1",
-      operation_id: operation.id,
-      state: operation.state,
-      output_id: operation.outputID,
-      offset,
-      limit,
-      output: result.output,
-      output_redacted: Boolean(result.redacted),
-      output_truncated: Boolean(result.truncated),
-    };
+    return operationOutput(this, id, context, requested);
   }
 
   cancel(id, context = {}) {
-    const operation = this.ownedOperation(id, context);
-    if (!["running", "starting"].includes(operation.state)) return this.receipt(operation);
-    if (!this.requestTermination(operation, "cancelled")) throw new Error("owned process could not be signalled");
-    return this.receipt(operation);
+    return cancelOperation(this, id, context);
   }
 
   handleEvent(input) {

--- a/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-interactive-operation.mjs
@@ -14,9 +14,7 @@ import {
   withinRoot,
 } from "./bounded-operation-values.mjs";
 import {
-  appendCapture,
   disposeOperations,
-  observeProgress,
   operationReceipt,
   signalSupervisor,
   trimTerminalOperations,
@@ -52,8 +50,6 @@ export class BoundedInteractiveOperationManager {
     this.killGraceMs = options.killGraceMs ?? 500;
     this.setTimer = options.setTimer || setTimeout;
     this.clearTimer = options.clearTimer || clearTimeout;
-    this.appendCapture = appendCapture;
-    this.observeProgress = observeProgress;
     this.supervisorRuntime = options.supervisorRuntime || SUPERVISOR_RUNTIME;
     this.operations = new Map();
   }

--- a/.agents/plugins/opencode-aidevops/bounded-operation-access.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-operation-access.mjs
@@ -5,6 +5,31 @@ const ACTIVE_STATES = ["starting", "running", "cancelling", "timing_out", "resto
 const MAX_OUTPUT_LINES = 500;
 const MAX_STATUS_WAIT_MS = 60 * 1000;
 
+export function attachOperationOutput(manager, operation, child) {
+  for (const stream of [child.stdout, child.stderr]) {
+    stream?.on("data", (chunk) => {
+      manager.appendCapture(operation, chunk);
+      if (manager.observeProgress(operation, chunk, manager.now)) manager.notifyStatusWaiters(operation);
+    });
+  }
+}
+
+export function operationStatusVersion(operation) {
+  return `${operation.state}:${operation.restorationState}:${operation.progressEvents}`;
+}
+
+export function notifyOperationStatusWaiters(manager, operation) {
+  const version = manager.statusVersion(operation);
+  for (const waiter of operation.statusWaiters) {
+    if (waiter.version === version) continue;
+    waiter.finish();
+  }
+}
+
+export function clearOperationStatusWaiters(operation) {
+  for (const waiter of operation.statusWaiters) waiter.finish();
+}
+
 export function operationStatus(manager, id, context = {}, requested = {}) {
   const operation = manager.ownedOperation(id, context);
   const waitMs = Number(requested.waitMs ?? 0);

--- a/.agents/plugins/opencode-aidevops/bounded-operation-access.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-operation-access.mjs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2026 Marcus Quinn
 
+import { appendCapture, observeProgress } from "./bounded-operation-runtime.mjs";
+
 const ACTIVE_STATES = ["starting", "running", "cancelling", "timing_out", "restoring", "finalizing"];
 const MAX_OUTPUT_LINES = 500;
 const MAX_STATUS_WAIT_MS = 60 * 1000;
@@ -8,8 +10,8 @@ const MAX_STATUS_WAIT_MS = 60 * 1000;
 export function attachOperationOutput(manager, operation, child) {
   for (const stream of [child.stdout, child.stderr]) {
     stream?.on("data", (chunk) => {
-      manager.appendCapture(operation, chunk);
-      if (manager.observeProgress(operation, chunk, manager.now)) manager.notifyStatusWaiters(operation);
+      appendCapture(operation, chunk);
+      if (observeProgress(operation, chunk, manager.now)) manager.notifyStatusWaiters(operation);
     });
   }
 }

--- a/.agents/plugins/opencode-aidevops/bounded-operation-access.mjs
+++ b/.agents/plugins/opencode-aidevops/bounded-operation-access.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+const ACTIVE_STATES = ["starting", "running", "cancelling", "timing_out", "restoring", "finalizing"];
+const MAX_OUTPUT_LINES = 500;
+const MAX_STATUS_WAIT_MS = 60 * 1000;
+
+export function operationStatus(manager, id, context = {}, requested = {}) {
+  const operation = manager.ownedOperation(id, context);
+  const waitMs = Number(requested.waitMs ?? 0);
+  if (!Number.isSafeInteger(waitMs) || waitMs < 0 || waitMs > MAX_STATUS_WAIT_MS) {
+    throw new Error("status wait must be an integer from 0 to 60000 milliseconds");
+  }
+  if (waitMs === 0 || !ACTIVE_STATES.includes(operation.state)) return manager.receipt(operation);
+  return new Promise((resolve) => {
+    const waiter = {
+      version: manager.statusVersion(operation),
+      finish: () => {
+        if (!operation.statusWaiters.delete(waiter)) return;
+        manager.clearTimer(waiter.timer);
+        resolve(manager.receipt(operation));
+      },
+      timer: null,
+    };
+    operation.statusWaiters.add(waiter);
+    waiter.timer = manager.setTimer(waiter.finish, waitMs);
+  });
+}
+
+export async function operationOutput(manager, id, context = {}, requested = {}) {
+  const operation = manager.ownedOperation(id, context);
+  if (ACTIVE_STATES.includes(operation.state)) {
+    throw new Error("stored output is available only after the operation reaches a terminal state");
+  }
+  if (!operation.outputID) throw new Error("stored output is unavailable");
+  const offset = Number(requested.offset ?? 1);
+  const limit = Number(requested.limit ?? 120);
+  if (!Number.isSafeInteger(offset) || offset < 1) throw new Error("output offset must be a positive integer");
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_OUTPUT_LINES) {
+    throw new Error(`output limit must be an integer from 1 to ${MAX_OUTPUT_LINES}`);
+  }
+  const result = await manager.readOutput(operation.outputID, { offset, limit });
+  return {
+    schema: "aidevops.interactive-operation-output/v1",
+    operation_id: operation.id,
+    state: operation.state,
+    output_id: operation.outputID,
+    offset,
+    limit,
+    output: result.output,
+    output_redacted: Boolean(result.redacted),
+    output_truncated: Boolean(result.truncated),
+  };
+}
+
+export function cancelOperation(manager, id, context = {}) {
+  const operation = manager.ownedOperation(id, context);
+  if (!["running", "starting"].includes(operation.state)) return manager.receipt(operation);
+  if (!manager.requestTermination(operation, "cancelled")) {
+    throw new Error("owned process could not be signalled");
+  }
+  return manager.receipt(operation);
+}

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -80,6 +80,34 @@ function isSafeCommand(command) {
   return /^[a-zA-Z0-9 _\-./:#@]+$/.test(command);
 }
 
+function aidevopsFailureReason(error) {
+  if (Number.isInteger(error?.status)) return `exit ${error.status}`;
+  if (error?.code === "ETIMEDOUT") return "timed out";
+  if (error?.signal) return `signal ${error.signal}`;
+  return "execution error";
+}
+
+function aidevopsFailureDetail(error) {
+  const stderr = Buffer.isBuffer(error?.stderr)
+    ? error.stderr.toString("utf8")
+    : String(error?.stderr || "");
+  return scrubCredentials(stderr.trim()).scrubbed.slice(0, 4096);
+}
+
+function executeAidevopsCommand(run, rawCommand) {
+  const rawCmd = String(rawCommand);
+  if (!isSafeCommand(rawCmd)) {
+    return "Error: command contains disallowed characters. Only alphanumeric, spaces, hyphens, underscores, dots, slashes, colons, # and @ are permitted.";
+  }
+  const cmd = `aidevops ${rawCmd}`;
+  try {
+    return run(cmd, 15000) || `Command completed: ${cmd}`;
+  } catch (error) {
+    const detail = aidevopsFailureDetail(error);
+    throw new Error(`aidevops command failed (${aidevopsFailureReason(error)})${detail ? `: ${detail}` : ""}`);
+  }
+}
+
 /**
  * Validate memory tool arguments before invoking the shell helper.
  * @param {object} args
@@ -117,29 +145,7 @@ function createAidevopsTool(run) {
       command: z.string().describe('aidevops command and arguments, e.g. "status" or "repos"'),
     },
     async execute(args) {
-      const rawCmd = String(args.command || args);
-      if (!isSafeCommand(rawCmd)) {
-        return `Error: command contains disallowed characters. Only alphanumeric, spaces, hyphens, underscores, dots, slashes, colons, # and @ are permitted.`;
-      }
-      const cmd = `aidevops ${rawCmd}`;
-      try {
-        const result = run(cmd, 15000);
-        return result || `Command completed: ${cmd}`;
-      } catch (error) {
-        const exitCode = Number.isInteger(error?.status) ? error.status : null;
-        const reason = exitCode !== null
-          ? `exit ${exitCode}`
-          : error?.code === "ETIMEDOUT"
-            ? "timed out"
-            : error?.signal
-              ? `signal ${error.signal}`
-              : "execution error";
-        const stderr = Buffer.isBuffer(error?.stderr)
-          ? error.stderr.toString("utf8")
-          : String(error?.stderr || "");
-        const detail = scrubCredentials(stderr.trim()).scrubbed.slice(0, 4096);
-        throw new Error(`aidevops command failed (${reason})${detail ? `: ${detail}` : ""}`);
-      }
+      return executeAidevopsCommand(run, args.command || args);
     },
   });
 }

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -25,13 +25,9 @@ on:
     # in-flight required check before job-level guards could skip them. Docs-only
     # PRs observed 15+ cancelled runs per workflow, which `gh pr checks`
     # then surfaces as `fail` (it displays `cancelled` conclusions as
-    # `fail` in its TSV output). Filtering docs-only at the trigger
-    # level reduces no-op runs; keeping cancel-in-progress disabled prevents
-    # label events on mixed PRs from cancelling required checks. In-workflow
-    # `detect-scope` still runs as a belt-and-suspenders check.
-    paths-ignore:
-      - '**/*.md'
-      - 'todo/**'
+    # `fail` in its TSV output). Keep the workflow trigger unconditional so the
+    # stable required-check summary below is always published; `detect-scope`
+    # avoids the expensive Qlty scan for docs-only and unrelated label events.
 
 permissions:
   pull-requests: write
@@ -205,3 +201,26 @@ jobs:
           fi
           echo "::error::Qlty smell regression detected (exit $EXIT_CODE). Add the 'ratchet-bump' label to override if justified (maintainer only)."
           exit 1
+
+  required-check:
+    name: Qlty Regression Gate
+    runs-on: ubuntu-latest
+    needs: [detect-scope, qlty-diff]
+    if: always()
+    env:
+      SCOPE_RESULT: ${{ needs.detect-scope.result }}
+      SHOULD_SCAN: ${{ needs.detect-scope.outputs.should_scan }}
+      DIFF_RESULT: ${{ needs.qlty-diff.result }}
+    steps:
+      - name: Publish stable regression verdict
+        run: |
+          set -euo pipefail
+          if [ "$SCOPE_RESULT" = "failure" ] || [ "$SCOPE_RESULT" = "cancelled" ]; then
+            echo "::error::Qlty scope detection did not complete successfully ($SCOPE_RESULT)."
+            exit 1
+          fi
+          if [ "$SHOULD_SCAN" = "true" ] && [ "$DIFF_RESULT" != "success" ]; then
+            echo "::error::Qlty regression scan did not pass ($DIFF_RESULT)."
+            exit 1
+          fi
+          echo "Qlty regression gate passed (scope=$SHOULD_SCAN, diff=$DIFF_RESULT)."


### PR DESCRIPTION
## Summary

- Remove the three Qlty smells that pushed main from the 77-smell baseline to 80.
- Split bounded-operation access concerns and aidevops command failure formatting without changing behavior.
- Publish an always-terminal Qlty Regression Gate check so branch protection can enforce the delta gate, including docs-only and unrelated-label events.

## Root Cause

The absolute threshold correctly detected 80 smells against a baseline of 77. Two function-complexity smells were introduced in PR #31648 even though its Qlty Smell Regression check failed; that check was not required by branch protection, so the merge gate ignored it. One earlier file-complexity smell in `bounded-interactive-operation.mjs` consumed the final baseline slot. Subsequent PRs inherited a permanently red absolute check.

## Testing

- OpenCode plugin suite: 858/858 passing after `npm ci`.
- Focused aidevops and bounded-operation tests: 18/18 passing.
- Qlty 0.643.0 targeted scan: zero smells in the three refactored modules.
- Qlty 0.643.0 repository scan: 69 non-duplication smells; with the stable eight-duplicate baseline this is 77 (the configured threshold). A local warmed full scan reported 75 due to Qlty duplicate-cluster variance, also within threshold.
- `actionlint .github/workflows/qlty-regression.yml`.
- `.agents/scripts/linters-local.sh --changed`.

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified through the full OpenCode plugin test suite and exact pinned Qlty CLI scans.

## Decisions

The absolute threshold remains unchanged at 77. After this workflow lands, branch protection will require the new stable Qlty Regression Gate context so future smell-increasing PRs cannot merge merely because the regression workflow is optional.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.349 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 37m and 248,860 tokens on this with the user in an interactive session.