### PR TITLE
GH#31668: Reconcile disabled Pulse LaunchAgents during setup

### DIFF
--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -232,9 +232,12 @@ _pulse_launchd_supervisor_disabled() {
 	command -v launchctl >/dev/null 2>&1 || return 1
 	disabled_state=$(launchctl print-disabled "gui/$(id -u)" 2>/dev/null) || return 1
 	while IFS= read -r disabled_line; do
-		if [[ "$disabled_line" == *"$pulse_label"* && "$disabled_line" == *"=> true"* ]]; then
-			return 0
-		fi
+		# launchctl uses boolean or named states depending on macOS version.
+		# Match the complete label, not a watchdog/sidecar sharing its prefix.
+		disabled_line="${disabled_line//[[:space:]]/}"
+		case "$disabled_line" in
+		"\"${pulse_label}\"=>true" | "\"${pulse_label}\"=>disabled" | "${pulse_label}=>true" | "${pulse_label}=>disabled") return 0 ;;
+		esac
 	done <<<"$disabled_state"
 	return 1
 }
@@ -852,7 +855,7 @@ _reconcile_managed() {
 		return 1
 	fi
 
-	if [[ "${AIDEVOPS_PULSE_MANAGED_ENABLED:-false}" != "true" ]]; then
+	if [[ "${AIDEVOPS_PULSE_MANAGED_ENABLED:-false}" != "true" || -f "$HOME/.aidevops/logs/pulse-session.stop" ]]; then
 		supervisor_disabled=true
 	elif _pulse_launchd_supervisor_disabled; then
 		supervisor_disabled=true

--- a/.agents/scripts/setup/modules/schedulers-pulse.sh
+++ b/.agents/scripts/setup/modules/schedulers-pulse.sh
@@ -593,7 +593,7 @@ _install_supervisor_pulse() {
 	mkdir -p "$HOME/.aidevops/logs"
 
 	if [[ "$_os" == "Darwin" ]]; then
-		_install_pulse_launchd "$pulse_label" "$wrapper_script" "$opencode_bin" "$_pulse_installed"
+		_install_pulse_launchd "$pulse_label" "$wrapper_script" "$opencode_bin" "$_pulse_installed" || return 1
 		return 0
 	fi
 
@@ -686,6 +686,8 @@ _pulse_runtime_pin_preserves_scheduler() {
 
 setup_supervisor_pulse() {
 	local _os="$1"
+	# Never retain a previous successful install decision after a failed retry.
+	PULSE_ENABLED="false"
 
 	# Record template hash so auto-update can detect drift between
 	# schedulers.sh and the installed plists on macOS (t2119).
@@ -712,6 +714,12 @@ setup_supervisor_pulse() {
 
 	local _do_install
 	_do_install=$(_determine_pulse_install "$_pulse_user_config" "$wrapper_script")
+	# Session stop takes precedence over persisted consent during updates. Only
+	# an explicit Pulse start may remove this flag, not scheduler reconciliation.
+	if [[ -f "$HOME/.aidevops/logs/pulse-session.stop" ]]; then
+		_do_install=false
+		print_info "Supervisor pulse remains stopped by explicit session request"
+	fi
 
 	local _pulse_lower
 	_pulse_lower=$(echo "$_pulse_user_config" | tr '[:upper:]' '[:lower:]')
@@ -733,7 +741,7 @@ setup_supervisor_pulse() {
 		if [[ "$_pin_scheduler_rc" -eq 0 ]]; then
 			print_info "Supervisor pulse scheduler preserved while its bounded runtime pin is active"
 		elif [[ "$_pin_scheduler_rc" -eq 1 ]]; then
-			_install_supervisor_pulse "$_os" "$pulse_label" "$wrapper_script" "$opencode_bin" "$_pulse_installed"
+			_install_supervisor_pulse "$_os" "$pulse_label" "$wrapper_script" "$opencode_bin" "$_pulse_installed" || return 1
 		else
 			print_error "Supervisor pulse scheduler refused an invalid runtime pin"
 			return 1
@@ -913,7 +921,35 @@ PLIST
 	return 0
 }
 
-# Install supervisor pulse via launchd (macOS)
+# Only the consent-gated Pulse installer may clear a persistent disabled
+# override. Shared scheduler installation must not re-enable unrelated jobs.
+_install_authorized_pulse_launchd() {
+	local pulse_label="$1"
+	local pulse_plist="$2"
+	local pulse_plist_content="$3"
+	local domain
+	command -v launchctl >/dev/null 2>&1 || return 1
+	domain="gui/$(id -u)"
+
+	if ! launchctl enable "${domain}/${pulse_label}"; then
+		print_error "Failed to enable Pulse LaunchAgent ${domain}/${pulse_label}; inspect launchctl print-disabled ${domain}"
+		return 1
+	fi
+	_launchd_install_if_changed "$pulse_label" "$pulse_plist" "$pulse_plist_content" || return 1
+	# Legacy load can return success without registering the service. Bootstrap
+	# only when absent; unchanged loaded jobs retain their StartInterval timing.
+	if ! launchctl print "${domain}/${pulse_label}" >/dev/null 2>&1; then
+		launchctl bootstrap "$domain" "$pulse_plist" || return 1
+	fi
+	if ! launchctl print "${domain}/${pulse_label}" >/dev/null 2>&1; then
+		# shell-portability: ignore next — diagnostic text, not command execution
+		print_error "Pulse LaunchAgent is not registered: launchctl print ${domain}/${pulse_label}"
+		return 1
+	fi
+	return 0
+}
+
+# Install supervisor pulse via launchd (macOS), after effective consent checks.
 _install_pulse_launchd() {
 	local pulse_label="$1"
 	local wrapper_script="$2"
@@ -955,7 +991,7 @@ _install_pulse_launchd() {
 	# _launchd_install_if_changed handles unload-before-replace only when content
 	# has changed, and writes atomically via tmp+rename (see setup.sh).
 	# shell-portability: ignore next — _install_pulse_launchd is macOS-only (launchd)
-	if _launchd_install_if_changed "$pulse_label" "$pulse_plist" "$pulse_plist_content"; then
+	if _install_authorized_pulse_launchd "$pulse_label" "$pulse_plist" "$pulse_plist_content"; then
 		if [[ "$_pulse_installed" == "true" ]]; then
 			print_info "Supervisor pulse updated (launchd config regenerated, every ${_interval_label})"
 		else
@@ -964,7 +1000,8 @@ _install_pulse_launchd() {
 		# Log any user-provided env var overrides that were injected (GH#20563 / t2759)
 		_log_plist_env_overrides "$pulse_label"
 	else
-		print_warning "Failed to load supervisor pulse LaunchAgent"
+		print_error "Failed to load supervisor pulse LaunchAgent; inspect launchd errors and retry aidevops setup --scope pulse"
+		return 1
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-launchd-setup.sh
+++ b/.agents/scripts/tests/test-pulse-launchd-setup.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# GH#31668: source-backed Pulse installer/launchd regression tests. No live jobs.
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_REPO_ROOT="$(cd "$TEST_SCRIPT_DIR/../../.." && pwd)"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+setup_fixture() {
+	HOME=$(mktemp -d)
+	export HOME
+	trap 'rm -rf "$HOME"' EXIT
+	mkdir -p "$HOME/.aidevops/agents/scripts" "$HOME/.aidevops/logs" "$HOME/Library/LaunchAgents"
+	touch "$HOME/.aidevops/agents/scripts/pulse-wrapper.sh"
+	# shellcheck source=../setup/_scheduler_runtime.sh
+	source "$TEST_REPO_ROOT/.agents/scripts/setup/_scheduler_runtime.sh"
+	# shellcheck source=../setup/modules/schedulers-pulse.sh
+	source "$TEST_REPO_ROOT/.agents/scripts/setup/modules/schedulers-pulse.sh"
+	# shellcheck source=../pulse-lifecycle-helper.sh
+	source "$TEST_REPO_ROOT/.agents/scripts/pulse-lifecycle-helper.sh"
+	NON_INTERACTIVE=true
+	AIDEVOPS_PULSE_OS_NAME=Darwin
+	TEST_LABEL=com.aidevops.aidevops-supervisor-pulse
+	TEST_CONSENT=true
+	TEST_DISABLED=true
+	TEST_LOADED=false
+	TEST_FAIL_ENABLE=false
+	TEST_FAIL_BOOTSTRAP=false
+	TEST_BOOTSTRAP_NOOP=false
+	TEST_LOAD_NOOP=false
+	TEST_EVENTS="$HOME/events"
+	: >"$TEST_EVENTS"
+	TEST_PLIST="$HOME/Library/LaunchAgents/$TEST_LABEL.plist"
+	printf 'fixture plist\n' >"$TEST_PLIST"
+	print_info() {
+		printf '%s\n' "$*"
+		return 0
+	}
+	print_warning() {
+		printf '%s\n' "$*"
+		return 0
+	}
+	print_error() {
+		printf '%s\n' "$*"
+		return 0
+	}
+	_resolve_pulse_consent() {
+		printf '%s' "$TEST_CONSENT"
+		return 0
+	}
+	_schedulers_record_template_hash() { return 0; }
+	_resolve_pulse_runtime_binary() { return 0; }
+	_pulse_runtime_pin_preserves_scheduler() { return 1; }
+	_is_pulse_installed() { [[ "$TEST_LOADED" == true ]]; }
+	_generate_pulse_plist_content() {
+		printf 'fixture plist'
+		return 0
+	}
+	_read_pulse_interval_seconds() {
+		printf '120'
+		return 0
+	}
+	_log_plist_env_overrides() { return 0; }
+	_uninstall_pulse() {
+		printf 'uninstall\n' >>"$TEST_EVENTS"
+		return 0
+	}
+	return 0
+}
+
+launchctl() {
+	printf '%s\n' "$1" >>"$TEST_EVENTS"
+	case "$1" in
+	enable)
+		[[ "$TEST_FAIL_ENABLE" == false ]] || return 1
+		TEST_DISABLED=false
+		;;
+	list)
+		[[ "$TEST_LOADED" == false ]] || printf '%s\n' "$TEST_LABEL"
+		;;
+	print)
+		[[ "$TEST_LOADED" == true ]] || return 1
+		printf 'state = waiting\n'
+		;;
+	print-disabled) printf '"%s" => %s\n' "$TEST_LABEL" "$TEST_DISABLED" ;;
+	load)
+		# Legacy load may succeed without registering a disabled service.
+		if [[ "$TEST_DISABLED" == false && "$TEST_LOAD_NOOP" == false ]]; then
+			TEST_LOADED=true
+		fi
+		;;
+	bootstrap)
+		[[ "$TEST_DISABLED" == false && "$TEST_FAIL_BOOTSTRAP" == false ]] || return 1
+		[[ "$TEST_BOOTSTRAP_NOOP" == true ]] || TEST_LOADED=true
+		;;
+	unload | bootout) TEST_LOADED=false ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+test_disabled_converges() {
+	setup_supervisor_pulse Darwin || return 1
+	[[ "$TEST_DISABLED" == false && "$TEST_LOADED" == true && "$PULSE_ENABLED" == true ]] || return 1
+	local first_mutation
+	first_mutation=$(awk '/^(enable|load|bootstrap)$/ {print; exit}' "$TEST_EVENTS")
+	[[ "$first_mutation" == enable ]]
+}
+
+test_disabled_loaded_preserves_timing() {
+	TEST_LOADED=true
+	setup_supervisor_pulse Darwin || return 1
+	[[ "$TEST_DISABLED" == false && "$PULSE_ENABLED" == true ]] || return 1
+	! grep -Eq '^(unload|bootout|bootstrap|load|kickstart)$' "$TEST_EVENTS"
+}
+
+test_repeat_preserves_timing() {
+	test_disabled_converges || return 1
+	: >"$TEST_EVENTS"
+	setup_supervisor_pulse Darwin || return 1
+	! grep -Eq '^(unload|bootout|bootstrap|load|kickstart)$' "$TEST_EVENTS"
+}
+
+test_load_noop_bootstraps() {
+	TEST_LOAD_NOOP=true
+	test_disabled_converges || return 1
+	grep -q '^bootstrap$' "$TEST_EVENTS"
+}
+
+test_enable_failure() {
+	TEST_FAIL_ENABLE=true
+	PULSE_ENABLED=true
+	if setup_supervisor_pulse Darwin; then return 1; fi
+	[[ "$PULSE_ENABLED" == false && "$TEST_DISABLED" == true ]] || return 1
+	! grep -Eq '^(load|bootstrap)$' "$TEST_EVENTS"
+}
+
+test_bootstrap_failure_retry() {
+	TEST_LOAD_NOOP=true
+	TEST_FAIL_BOOTSTRAP=true
+	if setup_supervisor_pulse Darwin; then return 1; fi
+	[[ "$PULSE_ENABLED" == false && "$TEST_LOADED" == false ]] || return 1
+	TEST_FAIL_BOOTSTRAP=false
+	test_disabled_converges
+}
+
+test_bootstrap_noop_fails() {
+	TEST_LOAD_NOOP=true
+	TEST_BOOTSTRAP_NOOP=true
+	if setup_supervisor_pulse Darwin; then return 1; fi
+	[[ "$PULSE_ENABLED" == false && "$TEST_LOADED" == false ]]
+}
+
+test_consent_false() {
+	TEST_CONSENT=false
+	setup_supervisor_pulse Darwin || return 1
+	[[ "$PULSE_ENABLED" == false && "$TEST_DISABLED" == true ]] || return 1
+	! grep -Eq '^(enable|load|bootstrap)$' "$TEST_EVENTS"
+}
+
+test_consent_false_cleanup() {
+	TEST_LOADED=true
+	test_consent_false || return 1
+	grep -q '^uninstall$' "$TEST_EVENTS"
+}
+
+test_stop_wins() {
+	touch "$HOME/.aidevops/logs/pulse-session.stop"
+	setup_supervisor_pulse Darwin || return 1
+	[[ "$PULSE_ENABLED" == false && "$TEST_DISABLED" == true ]] || return 1
+	[[ -f "$HOME/.aidevops/logs/pulse-session.stop" ]] || return 1
+	! grep -Eq '^(enable|load|bootstrap)$' "$TEST_EVENTS"
+}
+
+test_disabled_parser() {
+	local state
+	for state in true disabled; do
+		TEST_DISABLED="$state"
+		_pulse_launchd_supervisor_disabled || return 1
+	done
+	for state in false enabled; do
+		TEST_DISABLED="$state"
+		if _pulse_launchd_supervisor_disabled; then return 1; fi
+	done
+	TEST_DISABLED=disabled
+	TEST_LABEL=com.aidevops.aidevops-supervisor-pulse-watchdog
+	if _pulse_launchd_supervisor_disabled; then return 1; fi
+	return 0
+}
+
+test_failure_does_not_report_enabled() {
+	TEST_LOAD_NOOP=true
+	TEST_FAIL_BOOTSTRAP=true
+	if setup_supervisor_pulse Darwin >"$HOME/setup-output" 2>&1; then return 1; fi
+	grep -q 'retry aidevops setup --scope pulse' "$HOME/setup-output" || return 1
+	! grep -Eq 'Supervisor pulse (enabled|updated)' "$HOME/setup-output"
+}
+
+test_reconcile_respects_stop() {
+	touch "$HOME/.aidevops/logs/pulse-session.stop"
+	_PULSE_AGENTS_DIR="$TEST_REPO_ROOT/.agents"
+	AIDEVOPS_RUNTIME_TRANSITION_LOCK_DIR="$HOME/runtime-lock"
+	AIDEVOPS_PULSE_MANAGED_ENABLED=true
+	TEST_DISABLED=false
+	_pulse_refresh_active_runtime() { return 0; }
+	_stop_reconciliation_processes() {
+		printf 'stop\n' >>"$TEST_EVENTS"
+		return 0
+	}
+	_pulse_reconciliation_pids_raw() { return 0; }
+	_pulse_start_managed() {
+		printf 'start\n' >>"$TEST_EVENTS"
+		return 1
+	}
+	_reconcile_managed || return 1
+	grep -q '^stop$' "$TEST_EVENTS" || return 1
+	[[ ! -d "$AIDEVOPS_RUNTIME_TRANSITION_LOCK_DIR" ]] || return 1
+	! grep -q '^start$' "$TEST_EVENTS"
+}
+
+main() {
+	local test_name output
+	for test_name in test_disabled_converges test_disabled_loaded_preserves_timing \
+		test_repeat_preserves_timing test_load_noop_bootstraps test_enable_failure \
+		test_bootstrap_failure_retry test_bootstrap_noop_fails test_consent_false \
+		test_consent_false_cleanup test_stop_wins test_disabled_parser \
+		test_failure_does_not_report_enabled test_reconcile_respects_stop; do
+		TESTS_RUN=$((TESTS_RUN + 1))
+		if output=$(setup_fixture && "$test_name"); then
+			printf 'PASS %s\n' "$test_name"
+		else
+			TESTS_FAILED=$((TESTS_FAILED + 1))
+			printf 'FAIL %s\n%s\n' "$test_name" "$output"
+		fi
+	done
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+}
+
+main "$@"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -121,6 +121,14 @@ jobs:
 
     - name: Install Bubblewrap
       run: |
+        # Bubblewrap comes from Ubuntu, not the runner's browser/vendor repos.
+        # Keep unrelated mirror/signature failures out of boundary verification.
+        for source_file in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+          [ -e "$source_file" ] || continue
+          if grep -qE 'packages[.]microsoft[.]com|dl[.]google[.]com/linux/chrome' "$source_file"; then
+            sudo mv "$source_file" "${source_file}.disabled"
+          fi
+        done
         sudo apt-get update -qq
         sudo apt-get install -y bubblewrap
 
@@ -499,8 +507,8 @@ jobs:
       # 22.04+ ships shfmt in the default apt repos; --to-json is stable since
       # v3.0.0 so the packaged version is fine. Hosted runner images can carry
       # third-party apt sources that fail independently of this repo; remove the
-      # known failing Microsoft package source before apt update so shfmt install
-      # is not blocked by unrelated 403/signature errors.
+      # unused Microsoft/Chrome package sources before apt update so shfmt install
+      # is not blocked by unrelated 403/signature/hash-mismatch errors.
       run: |
         # Keep each network-bound apt phase within a five-minute budget. The
         # heartbeat makes a slow runner distinguishable from a silent stall.
@@ -536,7 +544,7 @@ jobs:
 
         for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
           [ -e "$source_file" ] || continue
-          if grep -q 'packages.microsoft.com' "$source_file"; then
+          if grep -qE 'packages[.]microsoft[.]com|dl[.]google[.]com/linux/chrome' "$source_file"; then
             sudo mv "$source_file" "${source_file}.disabled"
           fi
         done


### PR DESCRIPTION
## Summary

Repair persistent launchd disabled overrides only in consent-authorized Pulse setup; verify exact service registration, propagate installer failures, and preserve explicit session stops and loaded-job timer idempotency. Recognize both launchctl disabled-state formats with exact-label matching.

An additional, separate CI-repair commit isolates the two Ubuntu dependency-bootstrap steps from unused Chrome/Microsoft apt sources. The initial run and failed-job retry both hit the same Chrome repository hash mismatch before analysis could execute. This extends the workflow's existing vendor-source isolation; Ubuntu package signature/hash verification and all check commands remain unchanged.

## Files Changed

- `.agents/scripts/pulse-lifecycle-helper.sh`
- `.agents/scripts/setup/modules/schedulers-pulse.sh`
- `.agents/scripts/tests/test-pulse-launchd-setup.sh`
- `.github/workflows/code-quality.yml` — bounded CI bootstrap repair required to execute the merge gates.

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified. 86 focused tests passed: `test-pulse-launchd-setup.sh` (13), `test-launchd-install-if-changed.sh` (14), `test-pulse-lifecycle-helper.sh` (56), and `test-setup-noninteractive-supervisor-pulse.sh` (3).
- Real macOS launchd used a unique temporary label and inert wrapper: persistent disable → production Pulse installer → registered service → managed kickstart with new fixture-runtime PID proof. Cleanup verified; no live Pulse service touched.
- Pulse changed-file lint passed; the remaining shfmt advisory concerns pre-existing formatting outside changed lines. `actionlint .github/workflows/code-quality.yml` passed for the CI repair.

## Review and Scope

The shared scheduler loader is unchanged. Source-backed tests cover partial failures/retries, consent and explicit-stop precedence, exact disabled-state parsing, and unchanged-loaded timing. Direct closeout plus independent standard-tier advisory found no material Pulse defects. The CI repair preserves the checks themselves and only removes unused third-party source files from ephemeral runner provisioning.

Release/publication is not requested.

Resolves #31668

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.349 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 45m and 253,165 tokens on this with the user in an interactive session.