### PR TITLE
GH#31669: keep Pulse discovery and PR verification productive

### DIFF
--- a/.agents/reference/github-api-transport.md
+++ b/.agents/reference/github-api-transport.md
@@ -207,6 +207,10 @@ discovery. A normal cycle therefore spends no pre-backoff discovery request.
 The wake hint uses one REST repository-issues page, server-filtered by open state,
 both dispatch labels and no assignee, instead of Search. Client filtering excludes
 PRs, unpublished work, maintainer/permission holds and infrastructure advisories.
+It also mirrors the dispatcher's hard management/status exclusions: persistent
+audit/supervisor tickets, parents, held, consolidated and completed work cannot
+continually reset idle backoff just because stale availability labels remain.
+The hint still grants no launch authority; fresh dispatch gates remain canonical.
 A full page with no eligible issue is incomplete evidence, not an empty queue;
 normal cycle discovery handles it without unbounded optional pagination. This
 removes the recurring availability Search producer, not GitHub's secondary limit.

--- a/.agents/reference/github-api-transport.md
+++ b/.agents/reference/github-api-transport.md
@@ -202,19 +202,35 @@ deferred while quota expires unused. Do not claim throughput improvement from
 unit tests or fewer requests alone. Existing freshness/trust checks and optional
 benchmark comparability rules remain unchanged.
 
-Pulse idle backoff evaluates its local interval before the optional
-available-work Search probe. A normal cycle therefore does not spend a
-pre-backoff Search request. When local state already calls for a skipped cycle,
+Pulse idle backoff evaluates its local interval before optional available-work
+discovery. A normal cycle therefore spends no pre-backoff discovery request.
+The wake hint uses one REST repository-issues page, server-filtered by open state,
+both dispatch labels and no assignee, instead of Search. Client filtering excludes
+PRs, unpublished work, maintainer/permission holds and infrastructure advisories.
+A full page with no eligible issue is incomplete evidence, not an empty queue;
+normal cycle discovery handles it without unbounded optional pagination. This
+removes the recurring availability Search producer, not GitHub's secondary limit.
+When local state already calls for a skipped cycle,
 an active shared secondary cooldown or its recovery ramp suppresses that
 optional probe so interactive authority checks receive the recovery window.
-Timeouts, other request errors, and malformed counts remain unknown rather than
+Timeouts, other request errors, and malformed/incomplete pages remain unknown rather than
 becoming an empty queue, so the watchdog-protected cycle fails open. A proven
 unattempted local transport deferral (exit 75) instead retains the prior local
 skip decision and reschedules without a backend request. Successful eligible-work
 evidence still resets idle backoff. Cooldown diagnostics retain only sanitized
 method, endpoint/query shape, operation, wrapper, and Pulse-stage attribution.
-Rollback should revert the idle-gate ordering while leaving the shared cooldown
-enabled.
+Remaining-quota headers retain their value in event and state metadata regardless
+of header casing; a missing value stays unknown. Positive primary quota never
+overrides a genuine secondary response. Rollback may revert the query change,
+but must preserve the local-first idle ordering and shared cooldown.
+
+Fresh PR-readiness reads preserve transport cooldown, recovery-ramp and local
+admission diagnostics across command substitution. Those outcomes defer merge
+without generating a false CI failure; timeouts, malformed responses and other
+failed reads remain indeterminate. No additional retry, cached authorization or
+alternate transport is introduced. Continuous interactive development and useful
+worker delivery within finite GitHub/AI allowances remain the objective, rather
+than either maximum request volume or minimum request count in isolation.
 
 ## Durable PR wake hints
 

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -26,6 +26,8 @@ _FULL_LOOP_COMMIT_LIB_LOADED=1
 _FULL_LOOP_CHECK_PENDING="pending"
 _FULL_LOOP_CHECK_INDETERMINATE="indeterminate"
 _FULL_LOOP_CHECK_DEFERRED="api-deferred"
+_FULL_LOOP_ERROR_COOLDOWN="github-api-cooldown"
+_FULL_LOOP_ERROR_READ_DEFERRED="github-api-read-deferred"
 _FULL_LOOP_TRUE="true"
 FULL_LOOP_COMPLETION_BOOKKEEPING_AUDIT=""
 FULL_LOOP_COMPLETION_BOOKKEEPING_FILES=""
@@ -150,21 +152,21 @@ _full_loop_query_required_checks() {
 		return 1
 	fi
 	if [[ "$required_checks_stderr" == *"error_kind=github-api-cooldown"* ]]; then
-		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="github-api-cooldown"
+		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="$_FULL_LOOP_ERROR_COOLDOWN"
 		FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="unknown"
 		if [[ "$required_checks_stderr" =~ expires_at=([0-9]+) ]]; then
 			FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="${BASH_REMATCH[1]}"
 		fi
-		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="github-api-cooldown"
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="$_FULL_LOOP_ERROR_COOLDOWN"
 		if [[ "$FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL" =~ ^[0-9]+$ ]]; then
 			FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="GitHub API cooldown is active until epoch ${FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL}"
 		else
 			FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="GitHub API cooldown is active"
 		fi
 	elif [[ "$required_checks_stderr" == *"error_kind=github-api-read-deferred"* ]]; then
-		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="github-api-read-deferred"
+		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="$_FULL_LOOP_ERROR_READ_DEFERRED"
 		FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="retry-when-capacity-returns"
-		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="github-api-read-deferred"
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="$_FULL_LOOP_ERROR_READ_DEFERRED"
 		FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="GitHub API read capacity is deferred; preserve the PR and retry when capacity returns"
 	fi
 
@@ -201,7 +203,7 @@ _full_loop_review_bot_gate_helper_path() {
 # activity can otherwise leave the benchmark attempt unattributed.
 # Args: $1=pr_number, $2=repo_slug
 # Output: gh-pr-view-compatible readiness JSON
-# Returns: 0=complete exact-cost snapshot, 1=API/validation failure
+# Returns: 0=complete exact-cost snapshot, otherwise transport/validation failure
 #######################################
 _full_loop_pr_readiness_json_graphql() {
 	local pr_number="$1"
@@ -227,7 +229,7 @@ _full_loop_pr_readiness_json_graphql() {
 				}
 			}
 			rateLimit { cost }
-		}' 2>/dev/null) || return 1
+		}') || return $?
 
 	pr_json=$(printf '%s' "$response" | jq -ce --arg string_type "$jq_string_type" '
 		select(((.errors // []) | type) == "array")
@@ -244,6 +246,46 @@ _full_loop_pr_readiness_json_graphql() {
 	' 2>/dev/null) || return 1
 	printf '%s\n' "$pr_json"
 	return 0
+}
+
+# Capture at the caller boundary: command substitution cannot propagate blocker
+# globals. Keep transport evidence distinct without replaying a readiness read.
+_full_loop_read_pr_readiness() {
+	local pr_number="$1" repo="$2"
+	local error_file="" diagnostics="" read_rc=0
+	FULL_LOOP_PR_READINESS_JSON=""
+	FULL_LOOP_PRE_MERGE_BLOCKER_KIND=""
+	FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL=""
+	error_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-pr-readiness.XXXXXX") || return 1
+	FULL_LOOP_PR_READINESS_JSON=$(_full_loop_pr_readiness_json_graphql "$pr_number" "$repo" 2>"$error_file") || read_rc=$?
+	diagnostics=$(<"$error_file")
+	rm -f "$error_file"
+	[[ "$read_rc" -ne 0 ]] || return 0
+	FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="readiness-unavailable"
+	FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="PR readiness read failed (exit ${read_rc})"
+	if _full_loop_local_admission_evidence "$diagnostics"; then
+		: # Existing typed local-admission evidence owns the reason and deadline.
+	elif [[ "$diagnostics" == *'error_kind=github-api-cooldown'* ||
+		"$diagnostics" == *'[gh-cooldown] secondary-rate-limit active=true'* ||
+		"$diagnostics" == *'[gh-cooldown] primary-'*' active=true'* ]]; then
+		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="$_FULL_LOOP_ERROR_COOLDOWN"
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="$FULL_LOOP_PRE_MERGE_BLOCKER_KIND"
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="GitHub API cooldown is active"
+		if [[ "$diagnostics" =~ expires_at=([0-9]+) ]]; then
+			FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="${BASH_REMATCH[1]}"
+			FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL+=" until epoch ${BASH_REMATCH[1]}"
+		fi
+	elif [[ "$diagnostics" == *'[gh-cooldown] read-ramp active=true'* ||
+		"$diagnostics" == *'error_kind=github-api-read-deferred'* ]]; then
+		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="$_FULL_LOOP_ERROR_READ_DEFERRED"
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="$FULL_LOOP_PRE_MERGE_BLOCKER_KIND"
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="GitHub API read capacity is deferred (recovery/admission)"
+	elif [[ "$read_rc" -eq 124 ]]; then
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="readiness-timeout"
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="PR readiness read timed out; evidence remains unknown"
+	fi
+	_full_loop_record_check_read_failure "$pr_number" ""
+	return 1
 }
 
 _full_loop_reconcile_stale_coderabbit_review() {
@@ -263,10 +305,11 @@ _full_loop_reconcile_stale_coderabbit_review() {
 		print_error "PR #${pr_number} retains changes-requested review state; automatic reconciliation was not authorized"
 		return 1
 	fi
-	refreshed_json=$(_full_loop_pr_readiness_json_graphql "$pr_number" "$repo") || {
+	_full_loop_read_pr_readiness "$pr_number" "$repo" || {
 		print_error "Cannot refresh PR #${pr_number} after CodeRabbit reconciliation"
 		return 1
 	}
+	refreshed_json="$FULL_LOOP_PR_READINESS_JSON"
 	if [[ "$(printf '%s' "$refreshed_json" | jq -r '.headRefOid // empty')" != "$expected_head" ]]; then
 		print_error "PR #${pr_number} head changed during CodeRabbit reconciliation"
 		return 1
@@ -300,10 +343,8 @@ _full_loop_verify_pr_readiness() {
 	local verified_head=""
 	local review_decision=""
 
-	pr_json=$(_full_loop_pr_readiness_json_graphql "$pr_number" "$repo") || {
-		print_error "Cannot read PR #${pr_number} readiness evidence"
-		return 1
-	}
+	_full_loop_read_pr_readiness "$pr_number" "$repo" || return 1
+	pr_json="$FULL_LOOP_PR_READINESS_JSON"
 	verified_head=$(printf '%s' "$pr_json" | jq -r '.headRefOid // empty')
 	review_decision=$(printf '%s' "$pr_json" | jq -r '(.reviewDecision // "") | ascii_upcase')
 	if [[ "$review_decision" == "CHANGES_REQUESTED" && -n "$verified_head" ]]; then

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -206,7 +206,7 @@ _pulse_available_auto_dispatch_work_exists() {
 	fi
 
 	local _deadline=$((SECONDS + _timeout_secs))
-	local _slug="" _count="" _query_rc=0 _remaining=0
+	local _slug="" _page="" _count="" _query_rc=0 _remaining=0
 	while IFS= read -r _slug; do
 		[[ -n "$_slug" ]] || continue
 		_remaining=$((_deadline - SECONDS))
@@ -217,16 +217,18 @@ _pulse_available_auto_dispatch_work_exists() {
 		fi
 		_count=""
 		_query_rc=0
-		_count=$(AIDEVOPS_GH_COOLDOWN_METHOD=GET \
-			AIDEVOPS_GH_COOLDOWN_ENDPOINT=/search/issues \
-			AIDEVOPS_GH_COOLDOWN_QUERY="q=repo:${_slug}&per_page=1" \
+		# This is a repository-scoped existence hint, not a search problem. Avoid
+		# the Search endpoint implicated in recurring secondary holds (GH#31669).
+		# Bound discovery to one page; a saturated excluded page remains unknown.
+		_page=$(AIDEVOPS_GH_COOLDOWN_METHOD=GET \
+			AIDEVOPS_GH_COOLDOWN_ENDPOINT="/repos/${_slug}/issues" \
+			AIDEVOPS_GH_COOLDOWN_QUERY="state=open&labels=auto-dispatch,status:available&assignee=none&per_page=100" \
 			AIDEVOPS_GH_COOLDOWN_OPERATION=idle_available_work \
 			AIDEVOPS_GH_COOLDOWN_WRAPPER=pulse-wrapper.sh \
 			AIDEVOPS_GH_COOLDOWN_STAGE=idle-backoff-availability \
-			timeout_sec "$_remaining" gh api -X GET search/issues \
-			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available -label:publication:pending -label:needs-maintainer-review -label:needs-maintainer-permissions -label:infrastructure no:assignee" \
-			-f per_page=1 \
-			--jq '.total_count // 0' 2>/dev/null) || _query_rc=$?
+			timeout_sec "$_remaining" gh api -X GET "repos/${_slug}/issues" \
+			-f state=open -f labels=auto-dispatch,status:available \
+			-f assignee=none -f per_page=100 2>/dev/null) || _query_rc=$?
 		if [[ "$_query_rc" -ne 0 ]]; then
 			if [[ "$_query_rc" -eq 124 ]]; then
 				printf '[pulse-wrapper] Idle available-work check timed out after %ss; preserving unknown work state (GH#27769)\n' \
@@ -243,8 +245,21 @@ _pulse_available_auto_dispatch_work_exists() {
 			*) return 2 ;;
 			esac
 		fi
-		if ! [[ "$_count" =~ ^[0-9]+$ ]]; then
-			printf '[pulse-wrapper] Idle available-work check returned malformed evidence; preserving unknown work state (GH#31662)\n' \
+		if ! _count=$(printf '%s' "$_page" | jq -er '
+			def is_array: type == "array";
+			def valid: type == "object" and (.state | type) == "string"
+				and (.assignees | is_array) and (.labels | is_array)
+				and all(.labels[]; type == "object" and (.name | type) == "string");
+			def eligible: .pull_request == null and .state == "open" and (.assignees | length) == 0
+				and any(.labels[]; .name == "auto-dispatch")
+				and any(.labels[]; .name == "status:available")
+				and all(.labels[]; .name != "publication:pending" and .name != "needs-maintainer-review"
+					and .name != "needs-maintainer-permissions" and .name != "infrastructure");
+			if (is_array | not) or (all(.[]; valid) | not) then error("invalid issue page")
+			elif any(.[]; eligible) then 1
+			elif length < 100 then 0
+			else error("incomplete issue page") end' 2>/dev/null); then
+			printf '[pulse-wrapper] Idle available-work check returned malformed or incomplete evidence; preserving unknown work state (GH#31669)\n' \
 				>>"${WRAPPER_LOGFILE:-/dev/null}"
 			return 2
 		fi
@@ -265,7 +280,7 @@ _pulse_check_idle_backoff_gate() {
 		read -r _ib_last <"$_ib_ts_file" || [[ -n "$_ib_last" ]] || _ib_last=0
 		[[ "$_ib_last" =~ ^[0-9]+$ ]] || _ib_last=0
 	fi
-	# Do not spend a Search request until local state has already decided this
+	# Do not spend a discovery request until local state has already decided this
 	# cycle would be skipped. During a secondary hold or its recovery ramp, keep
 	# this optional wake-up probe quiet so interactive authority checks get the
 	# recovery window. The normal cycle remains fail-open when no backoff applies.

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -250,11 +250,14 @@ _pulse_available_auto_dispatch_work_exists() {
 			def valid: type == "object" and (.state | type) == "string"
 				and (.assignees | is_array) and (.labels | is_array)
 				and all(.labels[]; type == "object" and (.name | type) == "string");
+			# Mirror the hard management/status exclusions in pulse-dispatch-core.sh.
+			def held_labels: ["publication:pending", "needs-maintainer-review", "needs-maintainer-permissions",
+				"infrastructure", "supervisor", "contributor", "persistent", "quality-review", "on hold",
+				"blocked", "parent-task", "meta", "consolidated", "status:done", "status:resolved"];
 			def eligible: .pull_request == null and .state == "open" and (.assignees | length) == 0
 				and any(.labels[]; .name == "auto-dispatch")
 				and any(.labels[]; .name == "status:available")
-				and all(.labels[]; .name != "publication:pending" and .name != "needs-maintainer-review"
-					and .name != "needs-maintainer-permissions" and .name != "infrastructure");
+				and all(.labels[]; .name as $label | (held_labels | index($label)) == null);
 			if (is_array | not) or (all(.[]; valid) | not) then error("invalid issue page")
 			elif any(.[]; eligible) then 1
 			elif length < 100 then 0

--- a/.agents/scripts/shared-gh-secondary-cooldown.sh
+++ b/.agents/scripts/shared-gh-secondary-cooldown.sh
@@ -658,7 +658,7 @@ _gh_secondary_cooldown_parse_response_metadata() {
 		case "$meta_key" in
 		[Rr][Ee][Tt][Rr][Yy]-[Aa][Ff][Tt][Ee][Rr]) retry_after="$meta_value" ;;
 		[Xx]-[Rr][Aa][Tt][Ee][Ll][Ii][Mm][Ii][Tt]-[Ll][Ii][Mm][Ii][Tt]) ratelimit_limit="$meta_value" ;;
-		[Xx]-[Rr][Aa][Tt][Ee][Ll][Ii][Mm][Ii][Tt]-[Rr][Ee][Mm][Aa][Ii][Nn][Ii][Ng]) ratelimit_remaining="$meta_value" ;;
+		[Xx]-[Rr][Aa][Tt][Ee][Ll][Ii][Mm][Ii][Tt]-[Rr][Ee][Mm][Aa][Ii][Nn][Ii][Nn][Gg]) ratelimit_remaining="$meta_value" ;;
 		[Xx]-[Rr][Aa][Tt][Ee][Ll][Ii][Mm][Ii][Tt]-[Rr][Ee][Ss][Ee][Tt]) ratelimit_reset="$meta_value" ;;
 		[Xx]-[Rr][Aa][Tt][Ee][Ll][Ii][Mm][Ii][Tt]-[Uu][Ss][Ee][Dd]) ratelimit_used="$meta_value" ;;
 		[Xx]-[Rr][Aa][Tt][Ee][Ll][Ii][Mm][Ii][Tt]-[Rr][Ee][Ss][Oo][Uu][Rr][Cc][Ee]) ratelimit_resource="$meta_value" ;;

--- a/.agents/scripts/tests/test-full-loop-remote-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-remote-evidence.sh
@@ -27,6 +27,19 @@ if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
 		draft) is_draft=true ;;
 		changes) review_decision="CHANGES_REQUESTED" ;;
 		closed) state="CLOSED" ;;
+		readiness-cooldown)
+			printf '%s\n' '[gh-cooldown] secondary-rate-limit active=true skip=read expires_at=1893456000' >&2
+			exit 75 ;;
+		readiness-ramp)
+			printf '%s\n' '[gh-cooldown] read-ramp active=true phase=cooldown-recovery budget_per_minute=60 action=defer' >&2
+			exit 75 ;;
+		readiness-local)
+			printf '%s\n' '[gh-transport] error_kind=github-api-read-deferred attempted=false deferred_by=local_admission retry_at=1893456000 reason="fixture wait"' >&2
+			exit 75 ;;
+		readiness-timeout) exit 124 ;;
+		readiness-api-error)
+			printf '%s\n' 'HTTP 503: service unavailable' >&2
+			exit 1 ;;
 		readiness-missing-cost)
 			printf '{"data":{"repository":{"pullRequest":{"state":"OPEN","isDraft":false,"reviewDecision":"APPROVED","headRefOid":"abc123","headRefName":"remote-branch"}}}}\n'
 			exit 0
@@ -254,5 +267,35 @@ else
 	printf 'FAIL read admission deferral lost its classification: rc=%s output=%s\n' "$deferred_rc" "$deferred_output"
 	exit 1
 fi
+
+for mode in readiness-cooldown readiness-ramp readiness-local readiness-timeout readiness-api-error; do
+	readiness_rc=0
+	readiness_output=$(run_gate "$mode" visible 2>&1) || readiness_rc=$?
+	[[ "$readiness_rc" -ne 0 ]] || {
+		printf 'FAIL readiness failure passed: %s\n' "$mode"
+		exit 1
+	}
+	case "$mode" in
+	readiness-cooldown)
+		[[ "$readiness_output" == *CHECK_STATUS=api-deferred* && "$readiness_output" == *'until epoch 1893456000'* ]]
+		;;
+	readiness-ramp)
+		[[ "$readiness_output" == *CHECK_STATUS=api-deferred* && "$readiness_output" == *'recovery/admission'* ]]
+		;;
+	readiness-local)
+		[[ "$readiness_output" == *CHECK_STATUS=api-deferred* && "$readiness_output" == *retry_at=1893456000* ]]
+		;;
+	readiness-timeout)
+		[[ "$readiness_output" == *CHECK_STATUS=indeterminate* && "$readiness_output" == *'timed out'* ]]
+		;;
+	readiness-api-error)
+		[[ "$readiness_output" == *CHECK_STATUS=indeterminate* && "$readiness_output" == *'exit 1'* ]]
+		;;
+	esac || {
+		printf 'FAIL readiness evidence lost: %s\n' "$readiness_output"
+		exit 1
+	}
+	printf 'PASS readiness preserves typed failure: %s\n' "$mode"
+done
 
 exit 0

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -576,6 +576,26 @@ test_transport_preserves_sanitized_caller_context() {
 	return 0
 }
 
+test_remaining_header_survives_diagnostics() {
+	local header="" response="" expected="27"
+	for header in X-RateLimit-Remaining x-ratelimit-remaining x-RaTeLiMiT-ReMaInInG missing; do
+		reset_case
+		if [[ "$header" == missing ]]; then
+			response=$'HTTP/2 403\r\n\r\n{"message":"secondary rate limit"}\n'
+			expected=""
+		else
+			response=$(printf 'HTTP/2 403\r\n%s: 27\r\n\r\n{"message":"secondary rate limit"}\n' "$header")
+		fi
+		_gh_secondary_cooldown_record_if_needed 1 "$response" GET /search/issues
+		jq -e --arg expected "$expected" '.diagnostic.headers.x_ratelimit_remaining == $expected and .diagnostic.body_classification == "secondary-rate-limit"' \
+			"$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null
+		jq -e --arg expected "$expected" '.headers.x_ratelimit_remaining == $expected and .body_message_class == "secondary-rate-limit"' \
+			"$AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE" >/dev/null
+	done
+	printf 'PASS remaining quota survives state/event diagnostics across header casing; missing remains unknown\n'
+	return 0
+}
+
 test_secondary_response_writes_cooldown
 test_header_response_writes_retry_after_cooldown
 test_generic_403_diagnostic_distinguishes_forbidden
@@ -600,3 +620,4 @@ test_primary_search_isolation
 test_search_expiry_and_secondary_precedence
 test_all_primary_resources_remain_isolated
 test_transport_preserves_sanitized_caller_context
+test_remaining_header_survives_diagnostics

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -25,12 +25,13 @@ fail() {
 	return 0
 }
 
+export HOME="${TMP}/home"
 export SCRIPT_DIR="${TMP}/scripts"
 export WRAPPER_LOGFILE="${TMP}/wrapper.log"
 export AIDEVOPS_GH_API_EVIDENCE_COVERAGE_START_FILE="${TMP}/coverage-start"
 export PULSE_SCOPE_REPOS="owner/repo"
 unset GH_API_REPORT
-mkdir -p "$SCRIPT_DIR"
+mkdir -p "$SCRIPT_DIR" "$HOME"
 : >"$WRAPPER_LOGFILE"
 
 GH_QUERY_FILE="${TMP}/query.txt"
@@ -42,7 +43,7 @@ export GH_CONTEXT_FILE
 export GH_CALL_COUNT_FILE
 export TIMEOUT_CALL_FILE
 export TIMEOUT_MODE="pass"
-export GH_OUTPUT="0"
+export GH_OUTPUT='[]'
 export IDLE_DECISION="skip"
 printf '0\n' >"$GH_CALL_COUNT_FILE"
 gh() {
@@ -130,25 +131,13 @@ else
 	pass "zero eligible issues does not bypass idle backoff"
 fi
 
-if grep -q -- '-label:needs-maintainer-review' "$GH_QUERY_FILE"; then
-	pass "idle-work query excludes NMR-held issues"
+if [[ "$(<"$GH_QUERY_FILE")" == 'api -X GET repos/owner/repo/issues -f state=open -f labels=auto-dispatch,status:available -f assignee=none -f per_page=100' ]]; then
+	pass "idle-work query uses one bounded repository REST page, not Search"
 else
-	fail "idle-work query excludes NMR-held issues" "query=$(<"$GH_QUERY_FILE")"
+	fail "idle-work query uses one bounded repository REST page, not Search" "query=$(<"$GH_QUERY_FILE")"
 fi
 
-if grep -q -- '-label:infrastructure' "$GH_QUERY_FILE"; then
-	pass "idle-work query excludes infrastructure advisory issues"
-else
-	fail "idle-work query excludes infrastructure advisory issues" "query=$(<"$GH_QUERY_FILE")"
-fi
-
-if grep -q -- '-label:publication:pending' "$GH_QUERY_FILE"; then
-	pass "idle-work query excludes unpublished planning issues"
-else
-	fail "idle-work query excludes unpublished planning issues" "query=$(<"$GH_QUERY_FILE")"
-fi
-
-if [[ "$(<"$GH_CONTEXT_FILE")" == 'GET|/search/issues|q=repo:owner/repo&per_page=1|idle_available_work|pulse-wrapper.sh|idle-backoff-availability' ]]; then
+if [[ "$(<"$GH_CONTEXT_FILE")" == 'GET|/repos/owner/repo/issues|state=open&labels=auto-dispatch,status:available&assignee=none&per_page=100|idle_available_work|pulse-wrapper.sh|idle-backoff-availability' ]]; then
 	pass "idle-work query carries sanitized cooldown attribution context"
 else
 	fail "idle-work query carries sanitized cooldown attribution context" "context=$(<"$GH_CONTEXT_FILE")"
@@ -224,7 +213,7 @@ else
 	fi
 fi
 
-export GH_OUTPUT="0"
+export GH_OUTPUT='[]'
 export IDLE_DECISION="proceed"
 printf '0\n' >"$GH_CALL_COUNT_FILE"
 if _pulse_check_idle_backoff_gate && [[ "$(<"$GH_CALL_COUNT_FILE")" -eq 0 ]]; then
@@ -272,13 +261,66 @@ else
 fi
 export TIMEOUT_MODE="pass"
 
-export GH_OUTPUT="1"
+ELIGIBLE_ISSUE='{"state":"open","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]}'
+export GH_OUTPUT="[$ELIGIBLE_ISSUE]"
 if _pulse_check_idle_backoff_gate; then
 	pass "visible work still bypasses active idle backoff"
 else
 	fail "visible work still bypasses active idle backoff"
 fi
-export GH_OUTPUT="0"
+for excluded_label in publication:pending needs-maintainer-review needs-maintainer-permissions infrastructure; do
+	GH_OUTPUT=$(printf '%s' "$ELIGIBLE_ISSUE" | jq -c --arg label "$excluded_label" '[.labels += [{name:$label}]]')
+	query_rc=0
+	_pulse_available_auto_dispatch_work_exists || query_rc=$?
+	if [[ "$query_rc" -eq 1 ]]; then pass "idle-work excludes $excluded_label"; else fail "idle-work excludes $excluded_label"; fi
+done
+for mutation in '.pull_request = {}' '.assignees = [{login:"fixture"}]' '.state = "closed"' '.labels = [{name:"auto-dispatch"}]'; do
+	GH_OUTPUT=$(printf '%s' "$ELIGIBLE_ISSUE" | jq -c "[${mutation}]")
+	query_rc=0
+	_pulse_available_auto_dispatch_work_exists || query_rc=$?
+	if [[ "$query_rc" -eq 1 ]]; then pass "idle-work rejects ineligible row: $mutation"; else fail "idle-work rejects ineligible row: $mutation"; fi
+done
+GH_OUTPUT=$(printf '%s' "$ELIGIBLE_ISSUE" | jq -c '[range(100) as $i | .pull_request = {}]')
+query_rc=0
+_pulse_available_auto_dispatch_work_exists || query_rc=$?
+if [[ "$query_rc" -eq 2 ]]; then pass "full excluded page is unknown, not empty"; else fail "full excluded page is unknown, not empty"; fi
+
+test_repeated_recovery_windows() (
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_HOME="$HOME"
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="$TMP/window-cooldown.json"
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE="$TMP/window-events.jsonl"
+	export AIDEVOPS_GH_READ_RAMP_STATE_FILE="$TMP/window-ramp.tsv"
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_SECS=300 AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS=300 AIDEVOPS_GH_READ_RAMP_BOOT_SECS=0
+	# shellcheck source=../shared-gh-secondary-cooldown.sh
+	source "${SOURCE_SCRIPT%/*}/shared-gh-secondary-cooldown.sh"
+	local fixture_now=1000 window=0 expiry="" response=""
+	_gh_secondary_cooldown_now() { printf '%s\n' "$fixture_now"; }
+	_gh_secondary_system_boot_ts() { return 1; }
+	GH_OUTPUT="[$ELIGIBLE_ISSUE]"
+	printf '0\n' >"$GH_CALL_COUNT_FILE"
+	for window in 1000 2000 3000; do
+		fixture_now="$window"
+		response=$'HTTP/2 403\r\nx-ratelimit-resource: search\r\nx-ratelimit-remaining: 27\r\n\r\n{"message":"secondary rate limit"}\n'
+		AIDEVOPS_GH_COOLDOWN_NO_PROBE=1 _gh_secondary_cooldown_record_if_needed 1 "$response" GET /search/issues || return 1
+		expiry=$(_gh_secondary_cooldown_expires_at)
+		fixture_now=$((window + 100))
+		if _pulse_check_idle_backoff_gate; then return 1; fi
+		fixture_now=$((window + 400))
+		if _pulse_check_idle_backoff_gate; then return 1; fi
+		[[ "$(<"$GH_CALL_COUNT_FILE")" -eq $((window / 1000 - 1)) ]] || return 1
+		fixture_now=$((window + 601))
+		_pulse_check_idle_backoff_gate || return 1
+		[[ "$(<"$GH_CALL_COUNT_FILE")" -eq $((window / 1000)) && "$(<"$GH_QUERY_FILE")" != *search/issues* ]] || return 1
+		[[ "$(_gh_secondary_cooldown_expires_at)" == "$expiry" ]] || return 1
+	done
+	return 0
+)
+if test_repeated_recovery_windows; then
+	pass "repeated cooldown/recovery windows resume useful REST discovery without Search or cooldown renewal"
+else
+	fail "repeated cooldown/recovery windows resume useful REST discovery without Search or cooldown renewal"
+fi
+export GH_OUTPUT='[]'
 
 : >"$EVIDENCE_FILE"
 : >"$EVIDENCE_TIMESTAMP_FILE"

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -268,7 +268,8 @@ if _pulse_check_idle_backoff_gate; then
 else
 	fail "visible work still bypasses active idle backoff"
 fi
-for excluded_label in publication:pending needs-maintainer-review needs-maintainer-permissions infrastructure; do
+for excluded_label in publication:pending needs-maintainer-review needs-maintainer-permissions infrastructure \
+	supervisor contributor persistent quality-review 'on hold' blocked parent-task meta consolidated status:done status:resolved; do
 	GH_OUTPUT=$(printf '%s' "$ELIGIBLE_ISSUE" | jq -c --arg label "$excluded_label" '[.labels += [{name:$label}]]')
 	query_rc=0
 	_pulse_available_auto_dispatch_work_exists || query_rc=$?
@@ -313,6 +314,11 @@ test_repeated_recovery_windows() (
 		[[ "$(<"$GH_CALL_COUNT_FILE")" -eq $((window / 1000)) && "$(<"$GH_QUERY_FILE")" != *search/issues* ]] || return 1
 		[[ "$(_gh_secondary_cooldown_expires_at)" == "$expiry" ]] || return 1
 	done
+	TIMEOUT_MODE=deferred
+	if _pulse_check_idle_backoff_gate; then return 1; fi
+	TIMEOUT_MODE=timeout
+	_pulse_check_idle_backoff_gate || return 1
+	[[ "$(<"$GH_CALL_COUNT_FILE")" -eq 3 && "$(_gh_secondary_cooldown_expires_at)" == "$expiry" ]] || return 1
 	return 0
 )
 if test_repeated_recovery_windows; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Replace optional Pulse availability Search with bounded repository-issue discovery and preserve typed PR-readiness deferrals and remaining-quota diagnostics (#31669).
+
 ## [3.32.349] - 2026-09-09
 
 ### Fixed


### PR DESCRIPTION
## Summary

For #31669. Remove the optional availability Search producer and false wake hints while preserving the safety boundaries needed for continuous development within finite GitHub and AI allowances.

- Use one bounded, server-filtered repository-issues REST page instead of Search. Preserve open/unassigned/positive-label filtering; exclude PRs and existing hard holds. A full excluded page remains unknown rather than becoming an empty queue.
- Match the dispatcher's hard management/status exclusions so permanent audit, parent, held, consolidated and completed tickets do not repeatedly reset idle backoff. A live observation found the old hint admitted the persistent audit ticket #24670 even though `pulse-dispatch-core.sh:1624` rejects it.
- Preserve typed cooldown, recovery-ramp, local-admission and timeout evidence across PR-readiness command substitution. Do not retry or weaken the merge gate.
- Correct `X-RateLimit-Remaining` metadata parsing across header casing; missing values remain unknown, and positive primary quota does not invalidate secondary throttling.

## Scope and decisions

Implementation owners: `.agents/scripts/pulse-wrapper-cycle-gates.sh`, `full-loop-helper-commit.sh`, and `shared-gh-secondary-cooldown.sh`. Existing regression suites, `.agents/reference/github-api-transport.md`, and `CHANGELOG.md` document and verify the changes.

This corrects the query and known false-positive supply signal instead of increasing global cooldowns, introducing a new cache, or adding scheduler state. Fresh dispatch/merge authorization, atomic admission, local-first idle ordering, the existing 300-second cooldown/recovery defaults, and typed unknown outcomes are unchanged. No migration or service restart is required. Rollback is a normal revert, preserving cooldown/admission state and guards.

## Verification

Passed:

```sh
.agents/scripts/linters-local.sh --changed --base-ref origin/main
bash .agents/scripts/tests/test-gh-secondary-cooldown.sh
bash .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
bash .agents/scripts/tests/test-full-loop-remote-evidence.sh
bash .agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh
```

- Cycle gates: **49 tests, 0 failures**, including three repeated cooldown/recovery windows, no Search/cooldown renewal, excluded/saturated pages, and subsequent `75`/`124` behavior.
- CodeRabbit/readiness integration: **15 tests, 0 failures**, preserving author/head/review gates and required response cost.
- Remote-evidence fixtures retain cooldown deadlines, local retry deadlines, recovery deferral, timeout and API-error distinctions; all existing positive and fail-closed cases pass.
- Changed-file quality passes ShellCheck, secrets, Markdown, whitespace, string-literal/complexity/Bash-3.2/portability ratchets and affected orchestration tests. Existing unrelated shfmt advisories were not expanded into this change.

## Runtime Testing

**Status: runtime-verified for the changed availability path.** Exercised the actual source function through normal authenticated wrapped `gh` (v2.100.0), without cooldown, credential, admission or scheduler overrides. The repository REST read succeeded; after applying management exclusions, it correctly returned `1` (no eligible implementation work) for the observed persistent audit ticket. A positive eligible-work case remains covered by isolated fixtures.

This is not a claim that the reporter's exact server throttle was independently reproduced or that fleet-wide recovery is proven. The fresh 15-minute local observation contained no successful worker outcome, and the known candidate was structurally non-dispatchable. **Keep #31669 open for the remaining bounded live-delivery confirmation**, including fresh interactive verification and an actual eligible worker outcome under normal scheduling. Do not manufacture work, pause schedulers, remove cooldown state or weaken policy to obtain that result.

## Review

Parent closeout found no introduced P0 blockers. Independent standard-tier advisory review of the changed source returned clean with explicit excerpt/live-environment limitations. A later advisory's alleged array-fixture defect was rejected: the tests feed the `ELIGIBLE_ISSUE` object, not the `GH_OUTPUT` array, and the exact fixtures pass.

Exact branch evidence: `aidevops.review-evidence/v1`, SHA-256 `5c027cee273cf13e9f2e1cb3332a57a1d17820615f2ea2704bb5e1d237f7cb57`, head `6704d0d4a674431e0b441784421d4d709c80ea03`; prompt-injection scan clean.

## Publication

The user explicitly authorized full-loop through patch release. Merge verification must use the committed worktree's `full-loop-helper.sh` because its readiness library changes here. Use the canonical release lane and exact-tag deployment; no separate version/tag/package publication.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.349 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 22m and 55,250 tokens on this with the user in an interactive session.