### PR TITLE
GH#31674: add opt-in Pulse launchd integration check

### DIFF
--- a/.agents/scripts/tests/README-pulse-launchd-integration.md
+++ b/.agents/scripts/tests/README-pulse-launchd-integration.md
@@ -1,0 +1,42 @@
+# Pulse launchd integration check
+
+`test-pulse-launchd-integration.sh` is an explicit real-launchd validation for
+macOS. It does not run in ordinary test discovery: no arguments prints `SKIP`
+
+## Run
+
+```bash
+bash .agents/scripts/tests/test-pulse-launchd-integration.sh
+bash .agents/scripts/tests/test-pulse-launchd-integration.sh --help
+bash .agents/scripts/tests/test-pulse-launchd-integration-guards.sh
+```
+
+On an authorized macOS host with the current user's accessible GUI launchd
+
+```bash
+bash .agents/scripts/tests/test-pulse-launchd-integration.sh --run
+```
+
+The fixture refuses non-macOS hosts, missing `launchctl`, and inaccessible GUI
+
+## Bounded side effects and cleanup
+
+The runner creates a private `mktemp` root and a fresh
+`com.aidevops.test.pulse.*` label. It only disables, enables, bootouts, and
+checks that exact label in the current user's `gui/UID` domain. It sources the
+checkout's production installer and lifecycle functions, but uses an inert,
+self-expiring wrapper (75 seconds maximum) and a fixture HOME. It never uses
+sudo, the production Pulse label/wrapper, network access, credentials, or a
+system launchd domain.
+
+The test proves disabled-state repair, registration, managed-start PID evidence,
+cleanup and verifies that the owned job, disabled state, and wrapper process
+are gone. Cleanup failure changes the result to failure and preserves a private
+`RECOVERY.txt` in the fixture root with the exact owned identity. Do not use
+global `launchctl` resets or broad `pkill` commands. SIGKILL prevents trap
+execution; the wrapper's hard lifetime is the containment fallback. A retry
+always creates a new label and must not adopt a previous fixture.
+
+The guard suite is deterministic and safe on Linux; it verifies the opt-in,
+production-source, ownership, inherited-override, and cleanup contracts. Run
+the real fixture only where the launchd prerequisite is genuinely available.

--- a/.agents/scripts/tests/test-pulse-launchd-integration-guards.sh
+++ b/.agents/scripts/tests/test-pulse-launchd-integration-guards.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$SCRIPT_DIR/test-pulse-launchd-integration.sh"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$1"
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$1"
+}
+
+test_skip_requires_no_macos_service() {
+	local output
+	output=$(bash "$RUNNER") || return 1
+	[[ "$output" == *'SKIP: real launchd integration requires explicit --run'* ]]
+}
+
+test_help_and_unknown_options() {
+	bash "$RUNNER" --help | grep -Fq 'Usage:' || return 1
+	if bash "$RUNNER" --unexpected >/dev/null 2>&1; then return 1; fi
+}
+
+test_source_is_production_backed_and_owned() {
+	grep -Fq 'setup/modules/schedulers-pulse.sh' "$RUNNER" || return 1
+	grep -Fq 'scripts/pulse-lifecycle-helper.sh' "$RUNNER" || return 1
+	grep -Fq '_install_pulse_launchd' "$RUNNER" || return 1
+	grep -Fq '_pulse_start_managed' "$RUNNER" || return 1
+	grep -Fq 'com.aidevops.test.pulse.' "$RUNNER" || return 1
+	! grep -Fq 'com.aidevops.aidevops-supervisor-pulse' "$RUNNER"
+}
+
+test_cleanup_and_override_guards() {
+	grep -Fq 'trap cleanup EXIT INT TERM' "$RUNNER" || return 1
+	grep -Fq 'launchctl bootout' "$RUNNER" || return 1
+	grep -Fq 'launchctl enable' "$RUNNER" || return 1
+	grep -Fq 'write_recovery_record' "$RUNNER" || return 1
+	grep -Fq 'unset AIDEVOPS_AGENTS_DIR' "$RUNNER" || return 1
+	grep -Fq 'pgrep -f' "$RUNNER"
+}
+
+for test_name in test_skip_requires_no_macos_service test_help_and_unknown_options test_source_is_production_backed_and_owned test_cleanup_and_override_guards; do
+	if "$test_name"; then pass "$test_name"; else fail "$test_name"; fi
+done
+printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-pulse-launchd-integration.sh
+++ b/.agents/scripts/tests/test-pulse-launchd-integration.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+#
+# Explicitly opt-in real-launchd verification.  This never targets the
+# production Pulse label, wrapper, HOME, or runtime bundle.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+RUN=false
+FIXTURE_ROOT=""
+FIXTURE_LABEL=""
+FIXTURE_DOMAIN=""
+FIXTURE_WRAPPER=""
+FIXTURE_PID=""
+CLEANUP_FAILED=false
+
+usage() {
+	printf '%s\n' 'Usage: bash .agents/scripts/tests/test-pulse-launchd-integration.sh [--run]'
+	printf '%s\n' 'Without --run this check SKIPs without calling launchctl.'
+	return 0
+}
+
+fail() {
+	printf 'FAIL: %s\n' "$*" >&2
+	return 1
+}
+
+fixture_disabled() {
+	if launchctl print-disabled "$FIXTURE_DOMAIN" 2>/dev/null | tr -d '[:space:]' | grep -Fq "\"${FIXTURE_LABEL}\"=>true"; then
+		return 0
+	fi
+	return 1
+}
+
+fixture_present() {
+	if launchctl print "${FIXTURE_DOMAIN}/${FIXTURE_LABEL}" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+write_recovery_record() {
+	[[ -n "$FIXTURE_ROOT" && -d "$FIXTURE_ROOT" ]] || return 0
+	printf 'label=%s\ndomain=%s\n' "$FIXTURE_LABEL" "$FIXTURE_DOMAIN" >"$FIXTURE_ROOT/RECOVERY.txt"
+	chmod 600 "$FIXTURE_ROOT/RECOVERY.txt"
+	return 0
+}
+
+cleanup() {
+	local original_status=$?
+	local cleanup_status=0
+	trap - EXIT INT TERM
+	if [[ -n "$FIXTURE_LABEL" && -n "$FIXTURE_DOMAIN" ]]; then
+		launchctl bootout "${FIXTURE_DOMAIN}/${FIXTURE_LABEL}" >/dev/null 2>&1 || true
+		launchctl disable "${FIXTURE_DOMAIN}/${FIXTURE_LABEL}" >/dev/null 2>&1 || true
+		launchctl enable "${FIXTURE_DOMAIN}/${FIXTURE_LABEL}" >/dev/null 2>&1 || cleanup_status=1
+		fixture_present && cleanup_status=1
+		fixture_disabled && cleanup_status=1
+	fi
+	if [[ "$FIXTURE_PID" =~ ^[0-9]+$ ]] && kill -0 "$FIXTURE_PID" 2>/dev/null; then
+		kill -TERM "$FIXTURE_PID" 2>/dev/null || cleanup_status=1
+	fi
+	if [[ -n "$FIXTURE_ROOT" ]] && pgrep -f "${FIXTURE_ROOT}/pulse-wrapper.sh" >/dev/null 2>&1; then
+		cleanup_status=1
+	fi
+	if [[ "$cleanup_status" -ne 0 ]]; then
+		CLEANUP_FAILED=true
+		write_recovery_record
+		printf 'FAIL: fixture cleanup was not proven; recovery record retained at fixture root\n' >&2
+	else
+		[[ -z "$FIXTURE_ROOT" || ! -d "$FIXTURE_ROOT" ]] || rm -rf "$FIXTURE_ROOT"
+	fi
+	if [[ "$original_status" -ne 0 || "$cleanup_status" -ne 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+while [[ "$#" -gt 0 ]]; do
+	case "$1" in
+	--run) RUN=true ;;
+	--help | -h)
+		usage
+		exit 0
+		;;
+	*)
+		usage >&2
+		exit 2
+		;;
+	esac
+	shift
+done
+
+if [[ "$RUN" != true ]]; then
+	printf 'SKIP: real launchd integration requires explicit --run\n'
+	exit 0
+fi
+
+[[ "$(uname -s)" == Darwin ]] || fail 'requires macOS with an accessible GUI launchd domain' || exit 1
+command -v launchctl >/dev/null 2>&1 || fail 'launchctl is unavailable' || exit 1
+FIXTURE_DOMAIN="gui/$(id -u)"
+launchctl print-disabled "$FIXTURE_DOMAIN" >/dev/null 2>&1 || fail "cannot access ${FIXTURE_DOMAIN}" || exit 1
+
+# Do not allow a caller's production settings to redirect this fixture.
+unset AIDEVOPS_AGENTS_DIR AIDEVOPS_ACTIVE_AGENTS_LINK AIDEVOPS_RUNTIME_BUNDLES_DIR
+unset AIDEVOPS_PULSE_PROCESS_PATTERN AIDEVOPS_PULSE_MERGE_PROCESS_PATTERN
+unset AIDEVOPS_PULSE_LAUNCHD_LABEL AIDEVOPS_SKIP_PULSE_RESTART
+FIXTURE_ROOT=$(mktemp -d -t aidevops-pulse-launchd-integration)
+chmod 700 "$FIXTURE_ROOT"
+export HOME="$FIXTURE_ROOT"
+mkdir -p "$HOME/Library/LaunchAgents" "$HOME/.aidevops/agents/scripts" "$HOME/.aidevops/logs"
+FIXTURE_LABEL="com.aidevops.test.pulse.$$.${RANDOM}${RANDOM}"
+FIXTURE_WRAPPER="$FIXTURE_ROOT/pulse-wrapper.sh"
+FIXTURE_PATTERN="${FIXTURE_ROOT//./\\.}/pulse-wrapper\\.sh( |$)"
+export AIDEVOPS_AGENTS_DIR="$HOME/.aidevops/agents"
+export AIDEVOPS_ACTIVE_AGENTS_LINK="$AIDEVOPS_AGENTS_DIR"
+export AIDEVOPS_PULSE_PROCESS_PATTERN="$FIXTURE_PATTERN"
+export AIDEVOPS_PULSE_LAUNCHD_LABEL="$FIXTURE_LABEL"
+export AIDEVOPS_PULSE_OS_NAME=Darwin
+export AIDEVOPS_PULSE_RESTART_WAIT=0
+export AIDEVOPS_PULSE_SIGTERM_WAIT=1
+
+trap cleanup EXIT INT TERM
+if fixture_present; then
+	fail "fixture label collision: ${FIXTURE_LABEL}"
+	exit 1
+fi
+if fixture_disabled; then
+	fail "fixture disabled-state collision: ${FIXTURE_LABEL}"
+	exit 1
+fi
+cat >"$FIXTURE_WRAPPER" <<'WRAPPER'
+#!/usr/bin/env bash
+set -eu
+deadline=$((SECONDS + 75))
+while [[ "$SECONDS" -lt "$deadline" ]]; do sleep 1; done
+WRAPPER
+chmod 700 "$FIXTURE_WRAPPER"
+
+# Source the checkout's production functions; do not copy their bodies here.
+# shellcheck source=../setup/_scheduler_runtime.sh
+source "$REPO_ROOT/.agents/scripts/setup/_scheduler_runtime.sh"
+# shellcheck source=../setup/modules/schedulers-pulse.sh
+source "$REPO_ROOT/.agents/scripts/setup/modules/schedulers-pulse.sh"
+# shellcheck source=../pulse-lifecycle-helper.sh
+source "$REPO_ROOT/.agents/scripts/pulse-lifecycle-helper.sh"
+
+launchctl disable "${FIXTURE_DOMAIN}/${FIXTURE_LABEL}"
+_pulse_launchd_supervisor_disabled || fail 'production disabled-state parser did not detect fixture override'
+_install_pulse_launchd "$FIXTURE_LABEL" "$FIXTURE_WRAPPER" "$(command -v bash)" false
+if _pulse_launchd_supervisor_disabled; then fail 'production installer did not clear fixture disabled override'; fi
+fixture_present || fail 'fixture was not registered by production installer'
+_pulse_start_managed
+FIXTURE_PID=$(_pulse_pids | awk 'NR == 1 { print; exit }')
+[[ "$FIXTURE_PID" =~ ^[0-9]+$ ]] || fail 'production managed-start did not prove a new fixture runtime PID'
+
+# Reinstalling an unchanged, loaded job must retain registration/runtime.
+_install_pulse_launchd "$FIXTURE_LABEL" "$FIXTURE_WRAPPER" "$(command -v bash)" true
+fixture_present || fail 'unchanged fixture registration disappeared after reinstall'
+kill -0 "$FIXTURE_PID" 2>/dev/null || fail 'unchanged fixture runtime was unnecessarily replaced'
+printf 'PASS: real launchd fixture repaired, started, retained, and will be cleaned up\n'


### PR DESCRIPTION
## Summary

Added an explicit --run macOS fixture, deterministic ownership guards, and recovery documentation.



## Files Changed

.agents/scripts/tests/README-pulse-launchd-integration.md, .agents/scripts/tests/test-pulse-launchd-integration-guards.sh, .agents/scripts/tests/test-pulse-launchd-integration.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — shellcheck; opt-in skip/help and guard tests; existing Pulse launchd setup and lifecycle tests; changed-file linters

Resolves #31674


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.349 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 6m and 85,595 tokens on this as a headless worker.