### PR TITLE
GH#31677: resume preserved release tags before protected PR creation

### DIFF
--- a/.agents/reference/release-lane-coordination.md
+++ b/.agents/reference/release-lane-coordination.md
@@ -106,6 +106,18 @@ release branch, GitHub release, npm version, and Homebrew version are all proven
 absent. The publisher rotates the operation token through the lane compare-and-swap,
 retains durable `preparing_recovery` evidence, and restarts from a fresh copy of
 the pinned commit; lookup uncertainty or any existing artifact refuses recovery.
+
+An already-signed local candidate interrupted before its protected-main PR is a
+different checkpoint: status reports pending without creating the PR. Authorized
+same-source reconciliation verifies its local source provenance, exact persisted
+manifest and snapshot, dead local executor/no surviving release process, write
+permission, and absent publication channels. It rotates the lane token with CAS,
+records the unchanged tag object/commit in `preserved_tag_recovery`, and resumes
+the existing protected-main queue without another bump. Every queue mutation
+rechecks the token and tag identity; live/unknown owners, competing sources,
+legacy contracts, source drift, and uncertain remote state remain blocked.
+Interruption after this claim can resume the same fenced tag; no tag is rewritten.
+
 Same-source reservation reclaim still removes automatic eligibility, but now
 records a `same-source-reclaim/v1` marker when it removes a modern fenced
 contract. For lanes reclaimed before that marker existed, recovery must verify

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -255,7 +255,7 @@ _full_loop_release_guard_existing() {
 		_full_loop_release_validate_existing_tag_authorization "$repo" "$source_pr" "$expected_sources" || return 1
 		printf 'Existing signed release tag found for PR #%s; reconciling without another version bump\n' "$source_pr"
 		_full_loop_release_timing_finish release-existing-guard "$guard_started" existing-tag
-		_full_loop_release_existing_command reconcile "$source_pr"
+		_full_loop_release_existing_with_lane reconcile "$source_pr"
 		return $?
 		;;
 	1)

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -21,6 +21,7 @@ _FULL_LOOP_RELEASE_CONCLUSION_SKIPPED="skipped"
 _FULL_LOOP_RELEASE_CONCLUSION_SUCCESS="success"
 _FULL_LOOP_RELEASE_JSON_STRING_TYPE="string"
 _FULL_LOOP_RELEASE_MODE_RECONCILE="reconcile"
+_FULL_LOOP_RELEASE_PHASE_REMOTE="remote-publication"
 _FULL_LOOP_RELEASE_STEP_QUEUE_POSTFLIGHT="Queue exact-tag postflight"
 _FULL_LOOP_RELEASE_PROVENANCE_PREDICATE="https://slsa.dev/provenance/v1"
 _FULL_LOOP_RELEASE_TRUE="true"
@@ -121,7 +122,7 @@ _full_loop_release_verify_candidate_tag_provenance() {
 			>/dev/null || protected_state_rc=$?
 		[[ "$protected_state_rc" -eq 0 ]] || return 1
 		case "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" in
-		pr-pending | tag-ready) return 0 ;;
+		pr-pending | tag-ready | "$_VERSION_MANAGER_RELEASE_PR_MISSING") return 0 ;;
 		remote-tag-present)
 			_full_loop_release_verify_tag_provenance "$repo" "$tag_name"
 			return $?
@@ -130,6 +131,103 @@ _full_loop_release_verify_candidate_tag_provenance() {
 		;;
 	esac
 	return 1
+}
+
+#aidevops:trust-boundary
+# A signed candidate is not publication authority. Claim only its exact modern
+# snapshot lane, after proving the old local executor and descendants are gone.
+_full_loop_release_claim_preserved_tag() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local expected_sources="" source_json="" snapshot="" release_parent=""
+	local lane_head="" release_path="" observation="" permission="" state_json="" token=""
+	local owner_pid=""
+	release_lane_read "$repo" || return 1
+	lane_head="$_AIDEVOPS_RELEASE_LANE_HEAD"
+	_version_manager_local_tag_identity "$tag_name" || return 1
+	jq -e --argjson pr "$source_pr" --arg tag "$tag_name" \
+		--arg phase "$_FULL_LOOP_RELEASE_PHASE_REMOTE" \
+		--arg object "$_VERSION_MANAGER_LOCAL_TAG_OBJECT" \
+		--arg commit "$_VERSION_MANAGER_LOCAL_TAG_COMMIT" '
+		.active == true and .source_pr == $pr and .terminal_receipt == null
+		and .reservation_contract == "fenced-prepublication/v1"
+		and .snapshot_manifest_bound == true
+		and (.aggregate_recovery // null) == null and (.aggregate_successor // null) == null
+		and (.reserved_authorization_refresh // null) == null
+		and (.prepublication_recovery // null) == null
+		and ((.phase == "preparing" and .tag == null)
+			or (.phase == $phase and .tag == $tag
+				and .preserved_tag_recovery.tag_object == $object
+				and .preserved_tag_recovery.release_commit == $commit))
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 75
+	expected_sources=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	[[ "$expected_sources" == "$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON")" ]] || return 1
+	source_json=$(_full_loop_release_source_json_from_tag "$tag_name") || return 1
+	_full_loop_recovery_source_matches_authorization "$expected_sources" "$source_json" || return 1
+	snapshot=$(jq -er '.snapshot_sha' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	release_parent=$(git -C "$REPO_ROOT" rev-parse "${_VERSION_MANAGER_LOCAL_TAG_COMMIT}^") || return 1
+	[[ "$snapshot" == "$release_parent" ]] || return 1
+	observation=$(_release_lane_executor_observe "$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	[[ "$(jq -r '.state' <<<"$observation")" == "dead" ]] || return 75
+	owner_pid=$(jq -er '.executor.pid | select(type == "number" and . > 0 and floor == .)' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	release_path="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}/aidevops-release-${source_pr}-${owner_pid}"
+	if [[ "$(jq -r '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON")" == "$_FULL_LOOP_RELEASE_PHASE_REMOTE" ]]; then
+		release_path="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}/aidevops-release-reconcile-${tag_name#v}-${owner_pid}"
+	fi
+	_full_loop_recovery_process_uses_path "$release_path" || return 75
+	permission=$(gh api "repos/${repo}" \
+		--jq '.permissions.push == true or .permissions.maintain == true or .permissions.admin == true') || return 1
+	[[ "$permission" == "true" ]] || return 75
+	_full_loop_recovery_verify_channels_absent "$repo" "$tag_name" || return 1
+	token=$(uuidgen) || return 1
+	state_json=$(jq -c --arg token "$token" --arg tag "$tag_name" \
+		--arg phase "$_FULL_LOOP_RELEASE_PHASE_REMOTE" \
+		--arg object "$_VERSION_MANAGER_LOCAL_TAG_OBJECT" --arg commit "$_VERSION_MANAGER_LOCAL_TAG_COMMIT" \
+		--arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" \
+		--arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" --argjson executor "$(_release_lane_executor_capture)" '
+		.executor as $previous_executor | .phase=$phase | .tag=$tag
+		| .operation_token=$token | .owner=$owner | .executor=$executor | .updated_at=$now
+		| .preserved_tag_recovery={tag_object:$object,release_commit:$commit,
+			previous_executor:$previous_executor,claimed_at:$now}
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$lane_head" || return $?
+	_AIDEVOPS_RELEASE_LANE_TOKEN="$token"
+	return 0
+}
+
+_full_loop_release_queue_preserved_tag() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local tag_object="" release_commit="" lane_token=""
+	_full_loop_release_verify_protected_source_provenance "$repo" "$tag_name" || return 1
+	_full_loop_release_claim_preserved_tag "$repo" "$source_pr" "$tag_name" || return $?
+	tag_object="$_VERSION_MANAGER_LOCAL_TAG_OBJECT"
+	release_commit="$_VERSION_MANAGER_LOCAL_TAG_COMMIT"
+	lane_token="$_AIDEVOPS_RELEASE_LANE_TOKEN"
+	(
+		REPO_ROOT="$_FULL_LOOP_RELEASE_PATH"
+		AIDEVOPS_VERSION_MANAGER_REPO_SLUG="$repo"
+		#aidevops:trust-boundary
+		# Existing protected-main mutation boundaries recheck this rotated token
+		# and the immutable local tag, in addition to any aggregate fence.
+		_version_manager_verify_preserved_lane_fence() {
+			release_lane_read "$repo" || return 1
+			jq -e --argjson pr "$source_pr" --arg token "$lane_token" --arg tag "$tag_name" \
+				--arg phase "$_FULL_LOOP_RELEASE_PHASE_REMOTE" '
+				.active == true and .source_pr == $pr and .phase == $phase
+				and .operation_token == $token and .tag == $tag and .terminal_receipt == null
+			' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+			_version_manager_local_tag_identity "$tag_name" || return 1
+			[[ "$_VERSION_MANAGER_LOCAL_TAG_OBJECT" == "$tag_object" &&
+				"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" == "$release_commit" ]]
+			return $?
+		}
+		_version_manager_queue_protected_main_release "${tag_name#v}"
+	) || return 1
+	return 8
 }
 
 _full_loop_release_raw_candidate_tags_for_pr() {
@@ -1192,6 +1290,24 @@ _full_loop_release_finalize_stale_supersession() {
 	return $?
 }
 
+_full_loop_release_reconcile_protected_state() {
+	local repo="$1"
+	local requested_pr="$2"
+	local tag_name="$3"
+	local mode="$4"
+	_version_manager_reconcile_protected_release_tag "$repo" "$tag_name" "$mode" || return 1
+	case "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" in
+	"$_VERSION_MANAGER_RELEASE_PR_MISSING")
+		[[ "$mode" == "$_FULL_LOOP_RELEASE_MODE_RECONCILE" ]] || return 8
+		_full_loop_release_queue_preserved_tag "$repo" "$requested_pr" "$tag_name"
+		return $?
+		;;
+	pr-pending | tag-ready | tag-pushed) return 8 ;;
+	remote-tag-present) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
 _full_loop_release_existing_command() {
 	local mode="$1"
 	local requested_pr="$2"
@@ -1199,7 +1315,6 @@ _full_loop_release_existing_command() {
 	local tag_name=""
 	local latest_tag=""
 	local inspect_rc=0
-	local protected_tag_state_rc=0
 	local receipt_path=""
 	local receipt_status=""
 	local source_json=""
@@ -1251,15 +1366,7 @@ _full_loop_release_existing_command() {
 		printf 'release:superseded source_tag=%s successor_tag=%s\n' "$tag_name" "$latest_tag"
 		return 0
 	fi
-	_version_manager_reconcile_protected_release_tag "$repo" "$tag_name" "$mode" || protected_tag_state_rc=$?
-	[[ "$protected_tag_state_rc" -eq 0 ]] || return 1
-	case "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" in
-	pr-pending | tag-ready | tag-pushed)
-		return 8
-		;;
-	remote-tag-present) ;;
-	*) return 1 ;;
-	esac
+	_full_loop_release_reconcile_protected_state "$repo" "$requested_pr" "$tag_name" "$mode" || return $?
 	_full_loop_release_inspect_remote "$repo" "$tag_name" || inspect_rc=$?
 	if [[ "$inspect_rc" -eq 0 ]]; then
 		if [[ "$mode" == "$_FULL_LOOP_RELEASE_MODE_RECONCILE" ]]; then

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -1605,13 +1605,18 @@ export protected_state_log protected_source_log protected_push_log protected_rem
 		local repo="$1"
 		local tag_name="$2"
 		printf '%s %s\n' "$repo" "$tag_name" >>"$protected_source_log"
-		return 0
+		[[ "${invalid_local_source:-false}" == "false" ]]
+		return $?
 	}
 	_version_manager_reconcile_protected_release_tag() {
 		local repo="$1"
 		local tag_name="$2"
 		local mode="$3"
 		printf '%s %s %s\n' "$repo" "$tag_name" "$mode" >>"$protected_state_log"
+		if [[ "${missing_protected_pr:-false}" == "true" ]]; then
+			_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="$_VERSION_MANAGER_RELEASE_PR_MISSING"
+			return 0
+		fi
 		if [[ "$mode" == "reconcile" ]]; then
 			printf '%s %s\n' "$repo" "$tag_name" >"$protected_push_log"
 			_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-pushed"
@@ -1624,6 +1629,30 @@ export protected_state_log protected_source_log protected_push_log protected_rem
 		printf 'v1.2.3\n'
 		return 0
 	}
+	_full_loop_release_queue_preserved_tag() {
+		[[ "$1" == "test/repo" && "$2" == "90" && "$3" == "v1.2.3" ]] || return 1
+		printf 'queued\n' >"${TEST_ROOT}/preserved-queue.log"
+		return 8
+	}
+	missing_protected_pr=true
+	status_rc=0
+	AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command status 90 \
+		>/dev/null 2>&1 || status_rc=$?
+	[[ "$status_rc" -eq 8 && ! -e "${TEST_ROOT}/preserved-queue.log" ]] || exit 1
+	reconcile_rc=0
+	AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
+		>/dev/null 2>&1 || reconcile_rc=$?
+	[[ "$reconcile_rc" -eq 8 && -e "${TEST_ROOT}/preserved-queue.log" ]] || exit 1
+	rm -f "${TEST_ROOT}/preserved-queue.log"
+	invalid_local_source=true
+	reconcile_rc=0
+	AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
+		>/dev/null 2>&1 || reconcile_rc=$?
+	[[ "$reconcile_rc" -eq 1 && ! -e "${TEST_ROOT}/preserved-queue.log" ]] || exit 1
+	printf 'PASS missing-PR discovery reaches only authorized reconcile and still verifies provenance\n'
+	missing_protected_pr=false
+	invalid_local_source=false
+	rm -f "$protected_state_log" "$protected_source_log"
 	status_rc=0
 	AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command status 90 \
 		>/dev/null 2>&1 || status_rc=$?

--- a/.agents/scripts/tests/test-release-dead-preparing-recovery.sh
+++ b/.agents/scripts/tests/test-release-dead-preparing-recovery.sh
@@ -216,3 +216,113 @@ for refusal in authorization channels process permission branch executor registr
 	[[ "$RECOVERY_CALLS" -eq 0 && "$RECONSTRUCT_CALLS" -eq 0 ]] || exit 1
 done
 printf 'PASS missing preparation refuses uncertain ownership, publication, registration, and paths\n'
+
+(
+	# shellcheck source=../full-loop-release-reconcile.sh
+	source "$SCRIPT_DIR/full-loop-release-reconcile.sh"
+	# shellcheck source=../release-authorization-manifest-helper.sh
+	source "$SCRIPT_DIR/release-authorization-manifest-helper.sh"
+	_full_loop_release_source_json_from_tag() {
+		printf '{"source_pr":101,"source_merge":"1111111111111111111111111111111111111111","aggregated_sources":[]}\n'
+		return 0
+	}
+	_version_manager_local_tag_identity() {
+		[[ "$1" == "v1.2.4" ]] || return 1
+		_VERSION_MANAGER_LOCAL_TAG_OBJECT=4444444444444444444444444444444444444444
+		_VERSION_MANAGER_LOCAL_TAG_COMMIT=5555555555555555555555555555555555555555
+		return 0
+	}
+	git() {
+		[[ "$*" == *'rev-parse 5555555555555555555555555555555555555555^' ]] || return 1
+		printf '%s\n' "$SNAPSHOT"
+		return 0
+	}
+	_full_loop_release_verify_protected_source_provenance() {
+		_FULL_LOOP_RELEASE_PATH="${TEST_ROOT}/tag-checkout"
+		[[ "$VALID_SOURCE" == "true" ]]
+		return $?
+	}
+	_release_lane_executor_capture() {
+		printf '{"host_id":"local","pid":43,"started_at":"new"}\n'
+		return 0
+	}
+	_release_lane_write() {
+		[[ "$1" == "test/repo" && "$3" == aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ]] || return 1
+		[[ "$CAS_FAIL" == "false" ]] || return 75
+		STATE="$2"
+		RECOVERY_CALLS=$((RECOVERY_CALLS + 1))
+		return 0
+	}
+	_version_manager_queue_protected_main_release() {
+		[[ "$1" == "1.2.4" && "$REPO_ROOT" == "${TEST_ROOT}/tag-checkout" ]] || return 1
+		[[ "$AIDEVOPS_VERSION_MANAGER_REPO_SLUG" == "test/repo" ]] || return 1
+		if [[ "$FENCE_RACE" == "true" ]]; then
+			STATE=$(jq '.operation_token = "competing-fixture"' <<<"$STATE") || return 1
+		fi
+		_version_manager_require_aggregate_fence || return 1
+		printf 'queued\n' >>"${TEST_ROOT}/preserved-queue.log"
+		return 0
+	}
+	reset_preserved_fixture() {
+		# Do not follow the dangling path deliberately left by the preceding fixture.
+		STATE="$BASE_STATE"
+		AUTHORIZATION="$EXPECTED"
+		CHANNELS_ABSENT=true
+		SURVIVING_PROCESS=false
+		PERMISSION=true
+		LANE_ABSENT=false
+		EXECUTOR_STATE=dead
+		RECOVERY_CALLS=0
+		VALID_SOURCE=true
+		CAS_FAIL=false
+		FENCE_RACE=false
+		rm -f "${TEST_ROOT}/preserved-queue.log"
+		return 0
+	}
+	reset_preserved_fixture
+	queue_rc=0
+	_full_loop_release_queue_preserved_tag test/repo 101 v1.2.4 >/dev/null || queue_rc=$?
+	[[ "$queue_rc" -eq 8 && "$RECOVERY_CALLS" -eq 1 && -e "${TEST_ROOT}/preserved-queue.log" ]]
+	jq -e '.phase == "remote-publication" and .tag == "v1.2.4"
+		and .operation_token != "token-old"
+		and .preserved_tag_recovery.tag_object == "4444444444444444444444444444444444444444"
+		and .preserved_tag_recovery.release_commit == "5555555555555555555555555555555555555555"
+		and .expected_sources == "101@1111111111111111111111111111111111111111"' <<<"$STATE" >/dev/null
+	# An interruption after the claim but before PR creation retains the same tag.
+	queue_rc=0
+	_full_loop_release_queue_preserved_tag test/repo 101 v1.2.4 >/dev/null || queue_rc=$?
+	[[ "$queue_rc" -eq 8 && "$RECOVERY_CALLS" -eq 2 ]]
+	printf 'PASS preserved signed candidate resumes after either preparation interruption without a bump\n'
+	for refusal in provenance authorization manifest channels process permission alive unknown competing phase snapshot contract cas; do
+		reset_preserved_fixture
+		case "$refusal" in
+		provenance) VALID_SOURCE=false ;;
+		authorization) AUTHORIZATION='101@9999999999999999999999999999999999999999' ;;
+		manifest)
+			STATE=$(jq '.expected_sources="101@9999999999999999999999999999999999999999"' <<<"$STATE")
+			AUTHORIZATION='101@9999999999999999999999999999999999999999'
+			;;
+		channels) CHANNELS_ABSENT=false ;;
+		process) SURVIVING_PROCESS=true ;;
+		permission) PERMISSION=false ;;
+		alive | unknown) EXECUTOR_STATE="$refusal" ;;
+		competing) STATE=$(jq '.source_pr=102' <<<"$STATE") ;;
+		phase) STATE=$(jq '.phase="reserved"' <<<"$STATE") ;;
+		snapshot) STATE=$(jq '.snapshot_sha="9999999999999999999999999999999999999999"' <<<"$STATE") ;;
+		contract) STATE=$(jq 'del(.reservation_contract)' <<<"$STATE") ;;
+		cas) CAS_FAIL=true ;;
+		esac
+		queue_rc=0
+		_full_loop_release_queue_preserved_tag test/repo 101 v1.2.4 >/dev/null 2>&1 || queue_rc=$?
+		[[ "$queue_rc" -ne 8 && "$queue_rc" -ne 0 && "$RECOVERY_CALLS" -eq 0 && ! -e "${TEST_ROOT}/preserved-queue.log" ]] || {
+			printf 'FAIL unsafe preserved-tag %s state queued publication\n' "$refusal" >&2
+			exit 1
+		}
+	done
+	reset_preserved_fixture
+	FENCE_RACE=true
+	queue_rc=0
+	_full_loop_release_queue_preserved_tag test/repo 101 v1.2.4 >/dev/null 2>&1 || queue_rc=$?
+	[[ "$queue_rc" -eq 1 && "$RECOVERY_CALLS" -eq 1 && ! -e "${TEST_ROOT}/preserved-queue.log" ]]
+	printf 'PASS preserved-tag recovery fails closed before CAS and at the publication fence\n'
+)

--- a/.agents/scripts/tests/test-version-manager-protected-main-fallback.sh
+++ b/.agents/scripts/tests/test-version-manager-protected-main-fallback.sh
@@ -187,6 +187,24 @@ unset AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN
 unset -f _version_manager_verify_aggregate_lane_fence
 printf 'PASS stale aggregate lane is checked immediately before direct publication push\n'
 
+for unqueued_mode in status reconcile; do
+	_version_manager_reconcile_protected_release_tag test/repo v1.2.3 "$unqueued_mode" >/dev/null
+	[[ "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" == "$_VERSION_MANAGER_RELEASE_PR_MISSING" ]]
+	[[ ! -e "$PR_CREATED_FILE" && ! -e "$DIRECT_PUSH_COUNT" ]]
+done
+[[ -z "$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3)" ]]
+printf 'PASS missing protected PR is typed read-only state, not invalid local provenance\n'
+
+_version_manager_verify_preserved_lane_fence() { return 1; }
+if _version_manager_queue_protected_main_release 1.2.3 >/dev/null 2>&1; then
+	printf 'FAIL stale preserved-tag lane queued publication\n'
+	exit 1
+fi
+[[ ! -e "$PR_CREATED_FILE" && ! -e "$DIRECT_PUSH_COUNT" ]]
+[[ -z "$("$REAL_GIT" ls-remote --heads "$REMOTE" refs/heads/chore/release-v1.2.3-provenance)" ]]
+unset -f _version_manager_verify_preserved_lane_fence
+printf 'PASS preserved-tag fence refuses branch and PR mutation\n'
+
 push_rc=0
 push_output=$(push_changes 1.2.3 2>&1) || push_rc=$?
 if [[ "$push_rc" -ne 8 ]]; then
@@ -215,6 +233,13 @@ printf 'PASS recovery branch preserves the original release commit and tag objec
 grep -q '^pr create .*--head chore/release-v1.2.3-provenance .*--base main ' "$FAKE_GH_LOG"
 grep -q "^pr merge 77 --repo test/repo --auto --merge --match-head-commit ${RECOVERY_HEAD}$" "$FAKE_GH_LOG"
 printf 'PASS recovery queues merge topology against the exact PR head\n'
+
+create_calls_before=$(grep -c '^pr create ' "$FAKE_GH_LOG")
+_version_manager_queue_protected_main_release 1.2.3 >/dev/null
+create_calls_after=$(grep -c '^pr create ' "$FAKE_GH_LOG")
+[[ "$create_calls_after" -eq "$create_calls_before" ]]
+[[ "$("$REAL_GIT" -C "$REPO" rev-parse refs/tags/v1.2.3)" == "$TAG_OBJECT" ]]
+printf 'PASS resumed queue reuses the exact protected PR and immutable tag\n'
 
 merge_calls_before=$(grep -c '^pr merge ' "$FAKE_GH_LOG")
 AIDEVOPS_RELEASE_LANE_OPERATION_TOKEN=stale-token

--- a/.agents/scripts/version-manager-protected-main.sh
+++ b/.agents/scripts/version-manager-protected-main.sh
@@ -33,6 +33,7 @@ _VERSION_MANAGER_PROTECTED_SUPERSESSION_JSON=""
 _VERSION_MANAGER_TAG_STATE_ABSENT="absent"
 _VERSION_MANAGER_TAG_STATE_MATCHING="matching"
 _VERSION_MANAGER_RELEASE_RESULT_QUEUED="queued"
+_VERSION_MANAGER_RELEASE_PR_MISSING="pr-missing"
 _VERSION_MANAGER_MODE_RECONCILE="reconcile"
 _VERSION_MANAGER_PR_STATE_OPEN="open"
 _VERSION_MANAGER_PR_STATE_CLOSED="closed"
@@ -40,6 +41,9 @@ _VERSION_MANAGER_TIMESTAMP_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:
 
 #aidevops:trust-boundary
 _version_manager_require_aggregate_fence() {
+	if declare -F _version_manager_verify_preserved_lane_fence >/dev/null 2>&1; then
+		_version_manager_verify_preserved_lane_fence || return 1
+	fi
 	if declare -F _version_manager_verify_aggregate_lane_fence >/dev/null 2>&1; then
 		_version_manager_verify_aggregate_lane_fence
 		return $?
@@ -664,8 +668,9 @@ _version_manager_reconcile_protected_release_tag() {
 	branch_name=$(_version_manager_protected_release_branch_name "$version") || return 1
 	_version_manager_find_protected_release_pr "$repo" "$branch_name" || return 1
 	if [[ -z "$_VERSION_MANAGER_PROTECTED_PR_NUMBER" ]]; then
-		print_error "No protected release PR exists for preserved ${tag_name}"
-		return 1
+		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="$_VERSION_MANAGER_RELEASE_PR_MISSING"
+		printf 'Protected release PR is not yet queued for preserved %s\n' "$tag_name"
+		return 0
 	fi
 	pr_head=$(jq -r '.head.sha // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
 	_version_manager_verify_protected_pr_head "$pr_head" || return 1


### PR DESCRIPTION
## Summary

Resolves #31677. Release-blocking follow-up discovered while publishing #31673 for #31669.

- Recognize a provenance-valid local tag with no protected-main PR as pending, not a provenance failure. Keep status read-only.
- Resume the existing protected-main queue only after exact snapshot/manifest checks, dead local executor and no surviving release process, fresh write permission, absent publication channels, and a compare-and-swap claim with a rotated token.
- Bind every resumed mutation to the lane token and unchanged tag object/commit. Same-source patch retries now enter the lane-aware reconciliation wrapper. No new bump, tag rewrite, or relaxed publication gates.

## Implementation context

- `.agents/scripts/full-loop-release-reconcile.sh`: typed discovery, guarded preserved-tag claim/queue, and protected-state reconciliation.
- `.agents/scripts/full-loop-release-helper.sh`: reuse the lane-aware wrapper for an existing signed tag.
- `.agents/scripts/version-manager-protected-main.sh`: reuse existing exact-head protected-main queue and its mutation boundaries.
- Existing release reconciliation, dead-preparation and protected-main fallback tests; `.agents/reference/release-lane-coordination.md` documents the separate signed-candidate checkpoint.

## Runtime Testing

`runtime-verified` for read-only discovery: the normal helper's `status 31673` verified the existing signed `v3.32.350`, reported its unqueued protected PR, and returned pending (`8`) rather than failure (`1`). It did not queue a PR or publish the tag. Production mutation is intentionally deferred until this repair is reviewed and merged; package/deployment completion is not claimed.

Passed:

- `bash .agents/scripts/tests/test-full-loop-release-reconcile.sh`
- `bash .agents/scripts/tests/test-release-dead-preparing-recovery.sh`
- `bash .agents/scripts/tests/test-version-manager-protected-main-fallback.sh`
- `bash .agents/scripts/tests/test-full-loop-release-helper.sh`
- `bash .agents/scripts/tests/test-release-lane-liveness.sh`
- `bash .agents/scripts/tests/test-release-lane.sh`
- `.agents/scripts/linters-local.sh --changed --base-ref origin/main`

Fixtures cover interruption before/after the claim, real Git queue idempotence and immutable tag identity, invalid source, manifest/snapshot drift, live/unknown/competing owners, channel/process/permission uncertainty, CAS loss, and mutation-time fencing.

## Review evidence

Exact branch head: `c1dd29baa6833fa196ddc26e7412681420c603a1`.
`aidevops.review-evidence/v1` digest: `e1efd66ec008b3e2402075177e5b2da19624f791bbe6315aea12c9435fb61c82`; prompt-injection scan clean.
Parent closeout and independent exact-bundle P0 review found no concrete blocker. No package publication or sustained worker recovery is inferred from these checks.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.349 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 2h 4m and 806,990 tokens on this with the user in an interactive session.