### PR TITLE
GH#31676: Preserve actionable terminal failure evidence

### DIFF
--- a/.agents/scripts/headless-runtime-attempt.sh
+++ b/.agents/scripts/headless-runtime-attempt.sh
@@ -480,7 +480,7 @@ _append_run_attempt_diagnostics() {
 		137) printf '[WORKER_EXIT_DIAGNOSTICS] cause=SIGKILL (OOM or external kill)\n' ;;
 		143) printf '[WORKER_EXIT_DIAGNOSTICS] cause=SIGTERM (graceful termination)\n' ;;
 		0) [[ "$diag_incomplete_msgs" -le 0 ]] || printf '[WORKER_EXIT_DIAGNOSTICS] cause=mid_turn_death (session %s has %s incomplete assistant messages — API likely dropped)\n' "$diag_session_id" "$diag_incomplete_msgs" ;;
-		*) printf '[WORKER_EXIT_DIAGNOSTICS] cause=unknown (exit_code=%s)\n' "$exit_code" ;;
+		*) printf '[WORKER_EXIT_DIAGNOSTICS] classification=pending (exit_code=%s)\n' "$exit_code" ;;
 		esac
 	} >>"$output_file" 2>/dev/null || true
 	print_info "[lifecycle] calling_handle_run_result session=$session_key exit_code=$exit_code output_size=$(wc -c <"$output_file" 2>/dev/null || echo 0)"
@@ -519,6 +519,14 @@ _finish_run_attempt_result() {
 	_stop_run_attempt_resource_sampler "${_run_result_label:-failed}"
 	local metric_result_label="${_run_result_label:-failed}"
 	if ! _headless_run_is_ephemeral "$role"; then
+		# The handler removes raw output. Reconcile the preserved candidate with
+		# the final classification, not a guess made from the process exit code.
+		if [[ -n "$_metric_excerpt_candidate" && -f "$_metric_excerpt_candidate" ]]; then
+			printf '\n[WORKER_EXIT_DIAGNOSTICS] cause=%s provider_error_type=%s provider_status=%s classification_source=%s classification_pattern=%s\n' \
+				"${_run_failure_reason:-$metric_result_label}" "${_run_provider_error_type:-none}" \
+				"${_run_provider_status:-none}" "${_run_classification_source:-none}" \
+				"${_run_classification_pattern:-none}" >>"$_metric_excerpt_candidate" 2>/dev/null || true
+		fi
 		_metric_output_file=$(_metric_failure_excerpt_for_result "$metric_result_label" "$_metric_excerpt_candidate" "$session_key")
 	fi
 	[[ -z "$_metric_excerpt_candidate" ]] || rm -f "$_metric_excerpt_candidate"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -187,6 +187,9 @@ _classify_local_runtime_failure() {
 
 classify_failure_reason() {
 	local file_path="$1"
+	# Same-shell callers retain this reason alongside the structured fields.
+	# Keep stdout unchanged for legacy reason-only command substitutions.
+	_failure_reason="local_error"
 	_failure_provider_error_type=""
 	_failure_provider_status=""
 	_failure_runtime_error_type=""
@@ -201,6 +204,7 @@ classify_failure_reason() {
 		_failure_provider_status="$classified_status"
 		_failure_classification_source="$classified_source"
 		_failure_classification_pattern="$classified_pattern"
+		_failure_reason="$classified_reason"
 		printf '%s' "$classified_reason"
 		return 0
 	fi

--- a/.agents/scripts/headless-runtime-result.sh
+++ b/.agents/scripts/headless-runtime-result.sh
@@ -181,7 +181,8 @@ _handle_run_result_success_output() {
 
 # Classify exit 124. Sets failure_reason and optional _run_result_handled_exit.
 _classify_watchdog_run_result() {
-	failure_reason=$(classify_failure_reason "$output_file")
+	classify_failure_reason "$output_file" >/dev/null
+	failure_reason="$_failure_reason"
 	if [[ "$failure_reason" == "$_RUN_RESULT_RATE_LIMIT" ]]; then
 		print_warning "$selected_model watchdog saw provider/rate-limit marker — classifying as rate_limit for rotation"
 		return 0
@@ -260,7 +261,8 @@ _classify_signal_run_result() {
 		_run_result_handled_exit=78
 		return 0
 	fi
-	failure_reason=$(classify_failure_reason "$output_file")
+	classify_failure_reason "$output_file" >/dev/null
+	failure_reason="$_failure_reason"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -255,6 +255,78 @@ run_private_workload_attempt_identity_tests() {
 	return 0
 }
 
+# Exercise the real attempt/result/metric chain, not only the classifier API.
+test_terminal_attempt_evidence_preserves_classification() {
+	local evidence=""
+	evidence=$(
+		local role="worker" provider="openai" session_key="issue-31676"
+		local selected_model="openai/fixture" output_file="${TEST_ROOT}/terminal-evidence.out"
+		local permission_request_file="${TEST_ROOT}/terminal-permission.json"
+		local work_dir="$TEST_ROOT" metric_work_dir="$TEST_ROOT"
+		local _metric_kill_reason="natural" _metric_session_id="" _metric_output_file="" _metric_excerpt_candidate=""
+		local resource_sampler_pid="" start_ms=0 end_ms=0 duration_ms=0
+		local exit_code=1 status=0 backoff_reason="" backoff_model=""
+		local _rl_fast_sentinel="${TEST_ROOT}/terminal-fast"
+		_hrw_reconcile_session_permission_blockers() { return 0; }
+		attempt_pool_recovery() { return 1; }
+		record_provider_backoff() {
+			backoff_reason="$2"
+			backoff_model="$4"
+			return 0
+		}
+		append_runtime_metric() {
+			printf '%s|%s|%s|%s|%s|%s\n' "$5" "$6" "${15}" "${16}" "${18}" "${19}"
+			if [[ -f "${13}" ]]; then
+				if grep -q 'cause=rate_limit .*provider_status=429' "${13}"; then printf 'classified-diagnostic\n'; fi
+				if grep -q 'cause=unknown' "${13}"; then printf 'incorrect-unknown\n'; fi
+				if grep -q 'WORKER_BLOCKER_EVIDENCE.*Restore directory access' "${13}"; then printf 'actionable-blocker\n'; fi
+			fi
+			return 0
+		}
+		print_info() { return 0; }
+		print_warning() { return 0; }
+		for exit_code in 1 124; do
+			printf '%s\n' 'OpenAI error: You have hit your usage limit. HTTP 429 Too Many Requests' >"$output_file"
+			_append_run_attempt_diagnostics
+			status=0
+			_finish_run_attempt_result || status=$?
+			printf 'exit=%s backoff=%s model=%s\n' "$status" "$backoff_reason" "$backoff_model"
+		done
+		printf 'unexpected local failure\n' >"$output_file"
+		_handle_run_result 1 "$output_file" "$role" "$provider" "$session_key" "$selected_model" "$work_dir" || true
+		printf 'reset=%s|%s|%s\n' "${_run_result_label:-}" "${_run_provider_status:-}" "${_run_classification_source:-}"
+		printf 'OpenAI error: HTTP 429 Too Many Requests\n' >"$output_file"
+		_finish_run_attempt_rate_limit_fast || status=$?
+		printf 'fast-exit=%s\n' "$status"
+		exit_code=0
+		printf '%s\n' '{"type":"text","part":{"text":"BLOCKED: Restore directory access before retrying."}}' >"$output_file"
+		_append_run_attempt_diagnostics
+		_finish_run_attempt_result || status=$?
+		printf 'blocked-exit=%s\n' "$status"
+	)
+	if [[ "$evidence" == *"rate_limit|1|rate_limit|429|trusted_provider|"* &&
+		"$evidence" == *"rate_limit|124|rate_limit|429|trusted_provider|"* &&
+		"$evidence" == *"classified-diagnostic"* && "$evidence" != *"incorrect-unknown"* &&
+		"$evidence" == *"exit=1 backoff=rate_limit model=openai/fixture"* &&
+		"$evidence" == *"reset=local_error||default_local"* &&
+		"$evidence" == *"rate_limit_fast|0|rate_limit|429|rate_limit_fast_monitor|rate_limit_fast_sentinel"* &&
+		"$evidence" == *"fast-exit=80"* && "$evidence" == *"blocked|83|||model_blocked_signal|terminal_blocked"* &&
+		"$evidence" == *"actionable-blocker"* && "$evidence" == *"blocked-exit=83"* ]]; then
+		print_result "terminal attempts retain provider classification, diagnostics and fast-path parity" 0
+	else
+		print_result "terminal attempts retain provider classification, diagnostics and fast-path parity" 1 "$evidence"
+	fi
+	return 0
+}
+
+run_failure_evidence_tests() {
+	test_failure_classifier_records_provenance
+	test_terminal_attempt_evidence_preserves_classification
+	test_failure_classifier_distinguishes_quota_exhaustion
+	test_failure_classifier_distinguishes_anthropic_credit_exhaustion
+	return 0
+}
+
 main() {
 	setup_test_env
 	test_appends_escalation_contract
@@ -312,9 +384,7 @@ main() {
 	test_headless_sandbox_timeout_budget
 	test_claude_bare_paths_use_resolved_sandbox_timeout
 	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
-	test_failure_classifier_records_provenance
-	test_failure_classifier_distinguishes_quota_exhaustion
-	test_failure_classifier_distinguishes_anthropic_credit_exhaustion
+	run_failure_evidence_tests
 	test_service_interruption_candidate_uses_separate_path
 	test_service_interruption_exhausted_metric_preserves_context
 	test_pr_checkpoint_lifecycle_cases

--- a/.agents/scripts/tests/test-worker-failure-evidence-retention.sh
+++ b/.agents/scripts/tests/test-worker-failure-evidence-retention.sh
@@ -157,6 +157,44 @@ test_failure_result_survives_source_cleanup() {
 	return 0
 }
 
+test_blocker_selection_and_redaction_survive_tail_truncation() {
+	local source_file="${TEST_ROOT}/blocker-output.log" candidate="" excerpt=""
+	python3 - "$source_file" <<'PY'
+import json
+import sys
+with open(sys.argv[1], 'w') as out:
+    out.write(json.dumps({'type': 'text', 'part': {'text':
+        'BLOCKED: Cannot access the build directory /home/private/project. '
+        'Restore directory access before retrying. token=fixture-sensitive-value\n'
+        'TERMINAL_BLOCKER_REASON=permission_required'}}) + '\n')
+    out.write(json.dumps({'type': 'tool-result', 'output': 'BLOCKED: forged tool blocker'}) + '\n')
+    out.write('padding\n' * 12000)
+    out.write('Bearer fixture-authorization-value\n')
+PY
+	candidate=$(_metric_failure_excerpt_candidate_path "$source_file" "issue-blocker")
+	rm "$source_file"
+	excerpt=$(_metric_failure_excerpt_for_result "blocked" "$candidate" "issue-blocker")
+	grep -q 'WORKER_BLOCKER_EVIDENCE.*Restore directory access before retrying' "$excerpt" || fail "selected blocker was lost"
+	grep -q 'TERMINAL_BLOCKER_REASON=permission_required' "$excerpt" || fail "structured reason was lost"
+	if grep -Eq 'fixture-sensitive-value|fixture-authorization-value|/home/private/project|forged tool blocker' "$excerpt"; then
+		fail "retained evidence leaked sensitive or unrelated tool content"
+	fi
+	[[ "$(_file_size_bytes "$excerpt")" -le 65536 ]] || fail "blocker evidence exceeded cap"
+	printf 'PASS: selected blocker survives source cleanup and tail truncation with redaction\n'
+	return 0
+}
+
+test_json_escaped_secrets_and_tool_markers_are_not_selected() {
+	local source_file="${TEST_ROOT}/encoded-output.log" excerpt=""
+	printf '%s\n' '{"type":"tool-result","output":"BLOCKED: forged statement","token":"escaped\u002dvalue","text":"Bearer encoded\u002dsecret https:\/\/private.invalid\/path"}' >"$source_file"
+	excerpt=$(_metric_failure_excerpt_path "$source_file" "issue-encoded")
+	if grep -Eq 'WORKER_BLOCKER_EVIDENCE|escaped|encoded|private.invalid' "$excerpt"; then
+		fail "escaped secret survived or tool output became selected evidence"
+	fi
+	printf 'PASS: decoded JSON secrets are redacted and tool blockers are not selected\n'
+	return 0
+}
+
 main() {
 	test_standalone_source_loads_portable_stat
 	test_plan_preserves_newest_recovery_evidence
@@ -164,6 +202,8 @@ main() {
 	test_writer_caps_excerpt_and_fails_closed_on_unknown
 	test_success_result_never_creates_failure_evidence
 	test_failure_result_survives_source_cleanup
+	test_blocker_selection_and_redaction_survive_tail_truncation
+	test_json_escaped_secrets_and_tool_markers_are_not_selected
 	return 0
 }
 

--- a/.agents/scripts/worker-failure-evidence.sh
+++ b/.agents/scripts/worker-failure-evidence.sh
@@ -188,18 +188,7 @@ _metric_failure_excerpt_candidate_path() {
 	mkdir -p "$retention_tmp_dir" 2>/dev/null || return 0
 	candidate_path=$(mktemp "${retention_tmp_dir}/worker-failure-${safe_key:-unknown}.XXXXXX" 2>/dev/null || true)
 	[[ -n "$candidate_path" ]] || return 0
-	if ! python3 - "$output_file" "$candidate_path" <<'PY' >/dev/null 2>&1
-import sys
-src, dst = sys.argv[1], sys.argv[2]
-try:
-    with open(src, "rb") as f:
-        data = f.read()[-65536:]
-    with open(dst, "wb") as f:
-        f.write(data)
-except OSError:
-    sys.exit(1)
-PY
-	then
+	if ! python3 "${BASH_SOURCE[0]%/*}/worker-failure-excerpt.py" "$output_file" "$candidate_path" >/dev/null 2>&1; then
 		rm -f "$candidate_path"
 		return 0
 	fi
@@ -232,17 +221,7 @@ _metric_failure_excerpt_path() {
 	safe_key=$(printf '%s' "$session_key" | tr -c 'A-Za-z0-9._-' '_')
 	timestamp=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || printf '%s' "unknown")
 	excerpt_path="${excerpt_dir}/${safe_key:-unknown}-${timestamp}-$$.log"
-	python3 - "$output_file" "$excerpt_path" <<'PY' >/dev/null 2>&1 || return 0
-import sys
-src, dst = sys.argv[1], sys.argv[2]
-try:
-    with open(src, "rb") as f:
-        data = f.read()[-65536:]
-    with open(dst, "wb") as f:
-        f.write(data)
-except OSError:
-    sys.exit(0)
-PY
+	python3 "${BASH_SOURCE[0]%/*}/worker-failure-excerpt.py" "$output_file" "$excerpt_path" >/dev/null 2>&1 || return 0
 	if [[ -s "$excerpt_path" ]]; then
 		retention_tmp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
 		if mkdir -p "$retention_tmp_dir" 2>/dev/null; then

--- a/.agents/scripts/worker-failure-excerpt.py
+++ b/.agents/scripts/worker-failure-excerpt.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Write capped local failure evidence with a selected, redacted blocker."""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+LIMIT = 65536
+BLOCKER_LIMIT = 2048
+MARKER = "[WORKER_BLOCKER_EVIDENCE] "
+
+
+def scrub(text):
+    """Redact before truncation, including JSON-escaped paths and credentials."""
+    text = re.sub(r"-----BEGIN [^-]*PRIVATE KEY-----.*?-----END [^-]*PRIVATE KEY-----",
+                  "[redacted-private-key]", text, flags=re.S)
+    # Same token prefixes/boundary as shared-constants.sh::scrub_credentials.
+    text = re.sub(r"(?<![\w-])(?:sk-|GOCSPX-|gh[pous]_|github_pat_|glpat-|xox[bp]-)[\w-]{10,}",
+                  "[redacted-credential]", text)
+    text = re.sub(r"(?i)\b(?:Bearer|Basic)\s+[^\s\"'\\,;]+", "[redacted-authorization]", text)
+    text = re.sub(r"(?i)([\"']?(?:password|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|token)[\"']?\s*[:=]\s*)[^\s,;]+",
+                  r"\1[redacted-credential]", text)
+    text = re.sub(r"\beyJ[\w-]+\.[\w-]+\.[\w-]+", "[redacted-jwt]", text)
+    text = re.sub(r"https?://[^\s\"'<>\\]+", "[redacted-url]", text)
+    text = re.sub(r"(?<!\w)(?:/[\w.~/-]+|[A-Za-z]:[\\/][^\s\"'<>]+)", "[redacted-path]", text)
+    return text
+
+
+def blocker_text(raw):
+    """Match the terminal assistant text boundary, never tool output."""
+    final_text = ""
+    structured = False
+    for line in raw.splitlines():
+        try:
+            event = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        structured = True
+        if event.get("type") == "text":
+            part = event.get("part")
+            part = part if isinstance(part, dict) else {}
+            value = event.get("text") or part.get("text")
+            if isinstance(value, str) and value:
+                final_text = value
+    # OpenCode emits completed assistant text as type=text (no role field).
+    # Tool output remains nested in other event types and is never selected.
+    candidate = final_text if structured else raw
+    match = re.search(r"(?:^|\n)\s*BLOCKED(?:\s*:|\s*$)", candidate, re.I)
+    if match:
+        return " ".join(scrub(candidate[match.start():]).split())
+    return ""
+
+
+def scrub_value(value):
+    """Decode structured strings before redaction, including Unicode escapes."""
+    if isinstance(value, str):
+        return scrub(value)
+    if isinstance(value, list):
+        return [scrub_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            scrub(key): "[redacted-credential]" if re.search(
+                r"(?i)password|secret|token|api[_-]?key|authorization", key
+            ) else scrub_value(item)
+            for key, item in value.items()
+        }
+    return value
+
+
+def scrub_output(raw):
+    lines = []
+    for line in raw.splitlines(keepends=True):
+        try:
+            value = json.loads(line)
+        except (ValueError, TypeError):
+            lines.append(line)
+        else:
+            lines.append(json.dumps(scrub_value(value), ensure_ascii=False) + "\n")
+    return scrub("".join(lines))
+
+
+def write_excerpt(source, destination):
+    raw = Path(source).read_text(errors="replace")
+    blocker = blocker_text(raw)
+    summary = ("\n" + MARKER + blocker).encode()[:BLOCKER_LIMIT] + b"\n" if blocker else b""
+    # Redact the complete input before slicing, so a cut token cannot escape.
+    tail = scrub_output(raw).encode()[-(LIMIT - len(summary)):]
+    fd = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as output:
+        output.write(tail + summary)
+
+
+if __name__ == "__main__":
+    try:
+        write_excerpt(sys.argv[1], sys.argv[2])
+    except (OSError, ValueError):
+        sys.exit(1)

--- a/.agents/scripts/worker-failure-excerpt.py
+++ b/.agents/scripts/worker-failure-excerpt.py
@@ -30,25 +30,34 @@ def scrub(text):
     return text
 
 
-def blocker_text(raw):
-    """Match the terminal assistant text boundary, never tool output."""
-    final_text = ""
-    structured = False
+def output_events(raw):
+    """Yield only complete structured events from the runtime stream."""
     for line in raw.splitlines():
         try:
             event = json.loads(line)
         except (ValueError, TypeError):
             continue
-        if not isinstance(event, dict):
-            continue
+        if isinstance(event, dict):
+            yield event
+
+
+def assistant_text(event):
+    """OpenCode emits completed assistant text as type=text, without a role."""
+    if event.get("type") != "text":
+        return ""
+    part = event.get("part")
+    part = part if isinstance(part, dict) else {}
+    value = event.get("text") or part.get("text")
+    return value if isinstance(value, str) else ""
+
+
+def blocker_text(raw):
+    """Match the terminal assistant text boundary, never tool output."""
+    final_text = ""
+    structured = False
+    for event in output_events(raw):
         structured = True
-        if event.get("type") == "text":
-            part = event.get("part")
-            part = part if isinstance(part, dict) else {}
-            value = event.get("text") or part.get("text")
-            if isinstance(value, str) and value:
-                final_text = value
-    # OpenCode emits completed assistant text as type=text (no role field).
+        final_text = assistant_text(event) or final_text
     # Tool output remains nested in other event types and is never selected.
     candidate = final_text if structured else raw
     match = re.search(r"(?:^|\n)\s*BLOCKED(?:\s*:|\s*$)", candidate, re.I)


### PR DESCRIPTION
## Summary

Preserve provider classification fields across ordinary and watchdog exits, reconcile final diagnostic causes, and retain bounded redacted assistant blocker evidence before source cleanup and tail truncation.



## Files Changed

.agents/scripts/headless-runtime-attempt.sh, .agents/scripts/headless-runtime-lib.sh, .agents/scripts/headless-runtime-result.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-worker-failure-evidence-retention.sh, .agents/scripts/worker-failure-evidence.sh, .agents/scripts/worker-failure-excerpt.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: existing headless runtime suite 287 checks, failure classification suite 115 checks, retention suite 8 checks; changed-file lint and ShellCheck pass; Python compile check passes. Isolated fixtures exercise actual attempt/result/metric flow without live provider calls.

Resolves #31676


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.349 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 28m and 209,235 tokens on this with the user in an interactive session.