### PR TITLE
chore(planning): add object storage integration roadmap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1346,6 +1346,16 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18415 Triage refreshed Codacy findings into bounded remediation children #auto-dispatch #codacy #decomposition #quality blocked-by:t18414 ref:GH#31460 -> [todo/tasks/t18415-brief.md]
 
+- [ ] t18417 Add provider-neutral S3 object storage integrations for IDrive, Backblaze, and Wasabi #feat #parent-task #thinking ref:GH#31684 logged:2026-09-09 -> [todo/tasks/t18417-brief.md]
+
+- [ ] t18418 Build provider-neutral rclone-backed S3 object storage foundation #auto-dispatch #feat #standard ~3h ref:GH#31685 logged:2026-09-09 -> [todo/tasks/t18418-brief.md]
+
+- [ ] t18419 Add guarded IDrive e2 object storage integration #auto-dispatch #feat #standard ~2h blocked-by:t18418 ref:GH#31686 logged:2026-09-09 -> [todo/tasks/t18419-brief.md]
+
+- [ ] t18420 Add guarded Backblaze B2 object storage and official MCP integration #auto-dispatch #feat #standard ~4h blocked-by:t18418 ref:GH#31687 logged:2026-09-09 -> [todo/tasks/t18420-brief.md]
+
+- [ ] t18421 Add guarded Wasabi object storage integration with beta MCP boundary #auto-dispatch #feat #standard ~3h blocked-by:t18418 ref:GH#31688 logged:2026-09-09 -> [todo/tasks/t18421-brief.md]
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/todo/tasks/t18417-brief.md
+++ b/todo/tasks/t18417-brief.md
@@ -1,0 +1,125 @@
+<!-- aidevops:brief-schema=v2 -->
+
+# t18417: Add provider-neutral S3 object storage integrations for IDrive, Backblaze, and Wasabi
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `S3 object storage IDrive Backblaze Wasabi` → 0 hits — no relevant lessons
+- [x] Discovery pass: 6 recent commits / 0 related merged PRs / 0 open PRs touch the proposed integration surfaces; historical Backblaze references concern desktop backup exclusions, not B2 storage
+- [x] File refs verified: existing registry, agent mapping, activation tests, hosting-service parent, scripts parent, config parent, and domain index are present at HEAD; proposed provider files are new
+- [x] Tier: `tier:thinking` — this is a non-dispatched roadmap parent coordinating trust-boundary work
+- [x] Seeded draft PR decision recorded: skipped — implementation belongs in bounded child PRs
+
+## Origin
+
+- **Created:** 2026-09-09
+- **Session:** opencode:ses_f77f97e4affe54KJwSTn7JE3z9
+- **Created by:** ai-interactive
+- **Parent task:** none
+- **Blocked by:** none; this parent remains `parent-task` and is never dispatched
+- **Conversation context:** The user approved a thin rclone-backed IDrive integration instead of a new S3 CLI, then requested equivalent Backblaze B2 and Wasabi support with worker-ready auto-dispatch children.
+
+## What
+
+Coordinate a shared, provider-neutral S3-compatible object-storage capability and guarded provider integrations for IDrive e2, Backblaze B2, and Wasabi. Child tasks own implementation; this parent records decisions, dependencies, and completion.
+
+## Why
+
+Cloudron backup storage and other remote-storage workflows need deterministic readiness, inventory, backup-verification, restore, and protection audits. Reimplementing S3 signing, transfer, multipart, pagination, and retries would duplicate maintained clients. A shared helper prevents three provider-specific copies while optional MCPs remain isolated action layers.
+
+## Tier
+
+**Selected tier:** `tier:thinking`
+
+**Tier rationale:** Parent coordination spans provider trust, credentials, destructive operations, and MCP provenance; each resolved implementation boundary is delegated to a standard-tier child.
+
+## PR Conventions
+
+PRs against this parent use `For #31684`; child PRs use the normal closing keyword for their own leaf issue. Only the final child may close this parent after all children are complete.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** Separate child worktrees and PRs avoid cross-provider scope coupling.
+- **Status:** not-created
+- **Freshness evidence:** discovery and file verification completed against `19d1897997ee7910458cfb9e768138977ba700f1`
+- **Verification run:** planning and brief validation only
+- **Stale-assumption warning:** re-check provider MCP release/provenance and current registry patterns before each child implementation
+
+## Phases
+
+- Phase 1 - t18418 / [#31685](https://github.com/marcusquinn/aidevops/issues/31685): provider-neutral rclone-backed S3 foundation
+- Phase 2 - t18419 / [#31686](https://github.com/marcusquinn/aidevops/issues/31686): guarded IDrive e2 adapter and subagent
+- Phase 3 - t18420 / [#31687](https://github.com/marcusquinn/aidevops/issues/31687): guarded Backblaze B2 adapter, subagent, and official MCP
+- Phase 4 - t18421 / [#31688](https://github.com/marcusquinn/aidevops/issues/31688): guarded Wasabi adapter, subagent, and beta MCP boundary
+
+## How (Approach)
+
+### Progressive Context Plan
+
+- **Read first:** `.agents/aidevops/architecture.md` MCP lifecycle and extension sections; `.agents/tools/build-agent/build-agent.md` MCP and placement rules.
+- **Load only if:** `.agents/tools/build-mcp/build-mcp.md` when a child registers an MCP; `reference/high-stakes-operations.md` when defining destructive storage operations.
+- **Why:** retain one provider-neutral operational contract while keeping provider-specific authentication and MCP surfaces isolated.
+- **Stop when:** all four child issues are closed with merged PR evidence and provider docs point to the shared helper.
+
+### Files to Modify
+
+- `EDIT: TODO.md` — parent roadmap state only
+- `NEW: todo/tasks/t18417-brief.md` — parent coordination contract
+- Child briefs declare implementation files; this parent must not absorb child code.
+
+### Complete Write Surface
+
+- **Callers/readers:** `TODO.md`, issue #31684, and pulse/planning automation read this brief and child relationships.
+- **Writers/mutation paths:** planning publication writes only `TODO.md`, this brief, issue #31684, labels, and native sub-issue/dependency relationships.
+- **Tests/fixtures:** `verify-brief-helper.sh`, `git diff --check`, and changed-file lint validate planning artifacts; implementation tests belong to children.
+- **Schemas/config:** `todo/tasks/t18417-brief.md` schema-v2 metadata and `TODO.md` task markers are the only schemas changed by this parent.
+- **Generated/deployed mirrors:** GitHub issue `#31684` mirrors this canonical brief after issue sync; no runtime agent mirror changes here.
+- **Migrations/backfills:** `issue-sync-helper.sh` replaces the initial minimal issue body; no persisted runtime data exists.
+- **Cleanup/rollback paths:** `git revert` restores planning files and issue sync restores the prior body/relationships; child implementation is unaffected.
+
+### Implementation Steps
+
+1. Deliver t18418 first.
+2. Keep t18419, t18420, and t18421 blocked by t18418 until the native dependency is verified.
+3. Allow the three provider children to proceed independently after the foundation merges.
+4. Close the parent only after every child has merged and provider boundaries remain consistent.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** issue and relationship publication must use existing wrappers so concurrent pulse reconciliation does not create duplicate children.
+- **Migration/rollback:** no runtime migration; revert the planning commit and issue metadata together if the roadmap is withdrawn.
+- **Mixed-version/backward compatibility:** provider children must tolerate deployments where optional MCPs are absent while the shared helper remains available.
+- **Idempotency/retry:** issue sync and relationship reconciliation must update the existing #31684-#31688 records, never create replacements.
+- **Partial failure/recovery:** if publication stops mid-sync, keep `publication:pending`, inspect every issue, and resume reconciliation rather than dispatching partial briefs.
+
+### Verification Before Dispatch
+
+```bash
+.agents/scripts/verify-brief-helper.sh check-readiness todo/tasks/t18418-brief.md
+.agents/scripts/verify-brief-helper.sh check-readiness todo/tasks/t18419-brief.md
+.agents/scripts/verify-brief-helper.sh check-readiness todo/tasks/t18420-brief.md
+.agents/scripts/verify-brief-helper.sh check-readiness todo/tasks/t18421-brief.md
+```
+
+- **Surface mapping:** readiness checks prove every child brief contains bounded files, write surfaces, hazards, verification, and acceptance criteria; changed-file lint validates the parent planning files.
+- **Broad verification trigger:** Not required because this parent changes planning metadata only, not shared runtime contracts.
+
+### Files Scope
+
+- `TODO.md`
+- `todo/tasks/t18417-brief.md`
+
+## Acceptance Criteria
+
+- [ ] All four child issues retain their native sub-issue relationship to #31684 and provider children are blocked by #31685 until the foundation closes.
+- [ ] Each provider has a focused agent and shared-helper adapter without duplicated S3 protocol implementation.
+- [ ] Optional MCP failures never remove the deterministic rclone-backed path.
+- [ ] No child requires real credentials or a destructive live-storage operation for CI verification.
+
+## Context
+
+- IDrive documents standard region-specific S3 endpoints and recommends established S3 tooling.
+- `nktknshn/idrive-cli` is an unrelated iCloud Drive client and is not an implementation reference.
+- Backblaze's official Labs MCP is MIT, stdio-capable, capability-aware, and includes destructive gating.
+- Wasabi's official MCP is beta with more than 140 S3/IAM/account tools; source/package provenance was not exposed on the reviewed landing page.

--- a/todo/tasks/t18418-brief.md
+++ b/todo/tasks/t18418-brief.md
@@ -1,0 +1,134 @@
+<!-- aidevops:brief-schema=v2 -->
+
+# t18418: Build provider-neutral rclone-backed S3 object storage foundation
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `S3 object storage helper rclone` → 0 hits — no relevant lessons
+- [x] Discovery pass: 6 recent commits / 0 related merged PRs / 0 open PRs touch target surfaces; no existing object-storage helper exists
+- [x] File refs verified: `.agents/scripts/`, `.agents/scripts/tests/`, `configs/`, `.gitignore:4-11`, `.agents/aidevops/architecture.md:173-179`, and `.agents/reference/high-stakes-operations.md` are present at HEAD
+- [x] Tier: `tier:standard` — architecture and safety boundaries are decided; implementation adapts established helper patterns
+- [x] Seeded draft PR decision recorded: skipped — no implementation was requested in this planning session
+
+## Origin
+
+- **Created:** 2026-09-09
+- **Session:** opencode:ses_f77f97e4affe54KJwSTn7JE3z9
+- **Created by:** ai-interactive
+- **Parent task:** t18417 / #31684
+- **Blocked by:** none; first available leaf
+- **Conversation context:** Provide one deterministic operational layer for IDrive e2, Backblaze B2, and Wasabi without implementing S3 or depending on an MCP.
+
+## What
+
+Create a provider-neutral `object-storage-helper.sh` backed by an installed rclone binary, a safe account-alias config template, and fixture-driven tests. Expose bounded readiness, bucket listing, object listing/metadata, backup-freshness verification, protection audit, dry-run copy/download, and explicit guarded mutation interfaces that provider agents can reuse.
+
+## Why
+
+A full custom CLI would duplicate mature S3 signing, retry, pagination, multipart, checksum, and transfer logic. One helper creates stable JSON output and aidevops safety semantics while delegating protocol maintenance to rclone.
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** Existing shell/config/test conventions apply, but argument validation, output normalization, redaction, and safe mutation handling need normal implementation judgment.
+
+## PR Conventions
+
+Use the normal closing keyword for issue #31685. Reference parent #31684 without closing it.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** Issue-only dispatch is sufficient; no unverified code should anchor the worker.
+- **Status:** not-created
+- **Freshness evidence:** verified against `19d1897997ee7910458cfb9e768138977ba700f1`
+- **Verification run:** unrun — implementation not started
+- **Stale-assumption warning:** re-search for an object-storage helper or concurrent provider foundation before editing
+
+## How (Approach)
+
+### Progressive Context Plan
+
+- **Read first:** `.agents/aidevops/architecture.md:173-183` and `reference/high-stakes-operations.md` storage/deletion rules.
+- **Load only if:** `reference/shell-style-guide.md` and `reference/bash-compat.md` while implementing shell parsing and tests.
+- **Why:** preserve service-helper conventions, Bash 3.2 compatibility, and destructive-operation gates.
+- **Stop when:** the command contract, config schema, fixture tests, and changed-file lint are clear.
+
+### Worker Quick-Start
+
+```bash
+rg -n "confirm|dry-run|audit-log-helper|config.json.txt" .agents/scripts configs --glob '*.sh' --glob '*.json.txt'
+command -v rclone
+```
+
+### Files to Modify
+
+- `NEW: .agents/scripts/object-storage-helper.sh` — provider-neutral validated command surface using rclone
+- `NEW: configs/object-storage-config.json.txt` — placeholder-only account aliases, provider, endpoint, region, and bucket allowlists
+- `NEW: .agents/scripts/tests/test-object-storage-helper.sh` — fixture/mock tests with no live network or credentials
+- `EDIT only if required: .agents/scripts/setup/_deploy_agents.sh or the actual setup deployment manifest discovered by search` — ensure the new helper deploys through existing broad script-copy behavior; do not edit if scripts are already copied generically
+
+### Complete Write Surface
+
+- **Callers/readers:** `.agents/services/hosting/idrive-e2.md`, `.agents/services/hosting/backblaze-b2.md`, and `.agents/services/hosting/wasabi.md` will call the helper contract delivered here.
+- **Writers/mutation paths:** `.agents/scripts/object-storage-helper.sh` delegates only validated fixed operations to `rclone`; it never evaluates strings or accepts arbitrary flags.
+- **Tests/fixtures:** `.agents/scripts/tests/test-object-storage-helper.sh` mocks `rclone` and asserts argv, JSON, redaction, dependency/config failures, bounds, dry-run, and confirmations.
+- **Schemas/config:** `configs/object-storage-config.json.txt` defines placeholder-only aliases, provider, endpoint, region, remote reference, and bucket allowlists.
+- **Generated/deployed mirrors:** `.agents/scripts/setup/_deploy_agents.sh` or the discovered broad script-copy path deploys source `.agents/`; never edit `~/.aidevops/agents/` directly.
+- **Migrations/backfills:** no existing object-storage state exists; users opt in by creating ignored `configs/object-storage-config.json` and existing rclone remotes remain untouched.
+- **Cleanup/rollback paths:** remove the new helper/template/test with `git revert`; no live storage migration or automatic cleanup is performed.
+
+### Implementation Steps
+
+1. Define commands: `readiness`, `list-buckets`, `list-objects`, `object-info`, `verify-backups`, `audit-protection`, `copy`, and `download`; keep destructive deletion/policy mutation blocked unless a later provider adapter adds an exact guarded operation.
+2. Load accounts by explicit alias; fail when ambiguous or absent. Config contains no credentials and references secret-backed rclone remotes by generic alias.
+3. Emit structured JSON on stdout and diagnostics on stderr. Bound listings and reject path traversal, control characters, raw URLs, arbitrary flags, and unknown providers.
+4. Default transfer-changing commands to dry-run/preview. Require exact confirmation tokens under the high-stakes operation policy before irreversible provider adapters can call a mutation hook.
+5. Redact remote/account identities and secrets from logs; audit consequential operations without credential values.
+6. Add fixture tests and verify deployment behavior.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** concurrent read-only verification is allowed; mutation commands serialize per target and never share temporary output paths.
+- **Migration/rollback:** no state migration occurs and `git revert` removes the feature without touching user rclone configuration or remote objects.
+- **Mixed-version/backward compatibility:** detect the installed rclone capabilities and report unsupported operations instead of guessing flags across versions.
+- **Idempotency/retry:** read-only calls are replay-safe; write calls must not automatically retry after an ambiguous result and dry-run remains the default.
+- **Partial failure/recovery:** preserve rclone's failed/resumable transfer status and report failure until exit status plus post-operation evidence proves success.
+- Shell functions projected above 80 lines must be split before they exceed the repository's 100-line function gate.
+
+### Verification Before Dispatch
+
+```bash
+bash .agents/scripts/tests/test-object-storage-helper.sh
+shellcheck .agents/scripts/object-storage-helper.sh .agents/scripts/tests/test-object-storage-helper.sh
+.agents/scripts/linters-local.sh --changed
+```
+
+- **Surface mapping:** fixture tests cover helper/config/mutation behavior and all negative acceptance criteria; ShellCheck covers both shell files; changed-file lint covers the complete declared scope and deployment integration.
+- **Broad verification trigger:** Not required unless implementation changes shared setup deployment logic beyond adding the helper to an existing explicit manifest.
+
+### Recoverability Checkpoint
+
+- [ ] Focused functional verification passes: `bash .agents/scripts/tests/test-object-storage-helper.sh`
+- [ ] WIP commit created before broad gates: `wip: add object storage helper foundation`
+- [ ] Evidence-triggered broad verification then run: not required unless shared setup deployment logic changes
+
+### Files Scope
+
+- `.agents/scripts/object-storage-helper.sh`
+- `.agents/scripts/tests/test-object-storage-helper.sh`
+- `configs/object-storage-config.json.txt`
+- `.agents/scripts/setup/_deploy_agents.sh`
+
+## Acceptance Criteria
+
+- [ ] A fixture-backed `readiness` and `verify-backups` call returns stable JSON without exposing configured credentials or private account names.
+- [ ] Missing rclone, unknown aliases/providers, malformed endpoints, unbounded listings, and arbitrary pass-through flags fail closed before execution.
+- [ ] Write-capable paths produce a preview/dry-run by default and cannot perform an irreversible action without the exact confirmation contract.
+- [ ] Tests prove the helper never edits existing rclone config and invokes only allowlisted rclone commands/arguments.
+
+## Context
+
+- rclone is the selected maintained S3 transport; do not build AWS Signature V4, XML parsing, multipart, pagination, retries, or transfer code.
+- Cloudron continues to own actual backup creation and transfer. This helper verifies and administers remote storage; it does not impersonate Cloudron backup health.

--- a/todo/tasks/t18419-brief.md
+++ b/todo/tasks/t18419-brief.md
@@ -1,0 +1,133 @@
+<!-- aidevops:brief-schema=v2 -->
+
+# t18419: Add guarded IDrive e2 object storage integration
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `IDrive e2 S3 MCP subagent` → 0 hits — no relevant lessons
+- [x] Discovery pass: 6 recent commits / 0 related merged PRs / 0 open PRs touch target surfaces; no existing IDrive integration found
+- [x] File refs verified: hosting-services directory, Build+ subagent list, domain index, and t18418 target contract exist at HEAD; IDrive files are new
+- [x] Tier: `tier:standard` — use the decided shared helper and fail-closed MCP boundary
+- [x] Seeded draft PR decision recorded: skipped — blocked on t18418
+
+## Origin
+
+- **Created:** 2026-09-09
+- **Session:** opencode:ses_f77f97e4affe54KJwSTn7JE3z9
+- **Created by:** ai-interactive
+- **Parent task:** t18417 / #31684
+- **Blocked by:** native relationship to t18418 / #31685 plus `blocked-by:t18418`
+- **Conversation context:** IDrive e2 is already used for Cloudron backups and remote storage. The user selected a thin rclone-backed integration instead of a new S3 CLI.
+
+## What
+
+Add an `idrive-e2` subagent and provider profile over t18418 for endpoint validation, storage inventory, Cloudron backup presence/freshness checks, restore/download previews, versioning/encryption/Object Lock/retention/lifecycle audits, and guarded changes. Do not register the current IDrive MCP in this phase.
+
+## Why
+
+IDrive's S3-compatible API is adequately covered by maintained clients. The official MCP package reviewed at v0.1.3 is young, `UNLICENSED`, has no declared source repository, uses a separate loopback Streamable HTTP service, and therefore does not fit aidevops' current on-demand stdio lifecycle safely.
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** Provider boundaries are resolved; implementation adapts the shared helper and established service-agent patterns.
+
+## PR Conventions
+
+Use the normal closing keyword for issue #31686. Reference parent #31684 without closing it.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** t18418 must land first.
+- **Status:** blocked
+- **Freshness evidence:** reviewed IDrive API, endpoint, and MCP package evidence on 2026-09-09
+- **Verification run:** unrun — implementation blocked
+- **Stale-assumption warning:** re-check the current MCP package license, repository provenance, version, and transport before changing the no-registration decision
+
+## How (Approach)
+
+### Progressive Context Plan
+
+- **Read first:** t18418 brief and delivered helper contract; `.agents/services/hosting/cloudron.md` for backup ownership boundaries.
+- **Load only if:** `.agents/tools/build-mcp/build-mcp.md` only when newer evidence makes MCP registration eligible.
+- **Why:** keep Cloudron backup creation separate from remote-storage verification and avoid an unmanaged HTTP MCP.
+- **Stop when:** endpoint validation, account aliasing, provider commands, docs, and fixture tests are known.
+
+### Files to Modify
+
+- `NEW: .agents/services/hosting/idrive-e2.md` — focused provider subagent and safety policy
+- `EDIT: .agents/scripts/object-storage-helper.sh` — add only IDrive-specific endpoint/profile validation hooks not representable in config
+- `EDIT: configs/object-storage-config.json.txt` — placeholder IDrive example without credentials or private regions/buckets
+- `EDIT: .agents/scripts/tests/test-object-storage-helper.sh` — IDrive endpoint and backup-verification fixtures
+- `EDIT: .agents/build-plus.md:43-47` — add a short provider subagent pointer under deployment/hosting
+- `EDIT: .agents/reference/domain-index.md` — route IDrive/e2/S3/Cloudron backup-storage intent
+- `EDIT: README.md only if the existing integrations index requires a provider entry`
+
+### Complete Write Surface
+
+- **Callers/readers:** `.agents/build-plus.md` and `.agents/reference/domain-index.md` route IDrive/e2 intent to `.agents/services/hosting/idrive-e2.md`, which calls the shared helper.
+- **Writers/mutation paths:** `.agents/scripts/object-storage-helper.sh` selects the IDrive profile and delegates validated operations to rclone; the agent does not write storage directly.
+- **Tests/fixtures:** `.agents/scripts/tests/test-object-storage-helper.sh` covers endpoint normalization, region mismatch, backup verification, and mutation refusal with mocks.
+- **Schemas/config:** `configs/object-storage-config.json.txt` gains credential-free IDrive alias, endpoint, region, remote, and bucket placeholders.
+- **Generated/deployed mirrors:** `.agents/scripts/subagent-index-helper.sh` updates the canonical generated index when required; source deployment follows existing setup behavior.
+- **Migrations/backfills:** `configs/object-storage-config.json` remains opt-in and ignored; no persisted state migration exists and existing rclone remotes remain valid.
+- **Cleanup/rollback paths:** `git revert` removes provider routing/profile/docs/tests without changing other providers or live storage.
+
+### Implementation Steps
+
+1. Model supported endpoints from the reviewed region-specific `s3.<region>.idrivee2.com` service URL contract; reject arbitrary hosts and require configured region/endpoint agreement.
+2. Document Cloudron as the backup producer and the helper as readiness/inventory/restore/protection verifier.
+3. Default to read-only commands. Require bucket, key, version, proposed effect, and post-change read-back for lifecycle, retention, legal hold, Object Lock, policy, or deletion work.
+4. Treat presigned URLs as bearer capabilities and avoid returning them unless explicitly requested through a future guarded path.
+5. Record the MCP deferral and exact reconsideration criteria: official source/provenance, usable license, pinned release, transport/lifecycle compatibility, and focused activation tests.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** read-only audits may run concurrently; protection or lifecycle changes serialize by exact bucket/key/version target.
+- **Migration/rollback:** no account migration is performed; reverting code leaves existing IDrive and Cloudron credentials/configuration untouched.
+- **Mixed-version/backward compatibility:** endpoint lists may evolve, so explicit configured official endpoints remain usable while strict host and region validation is preserved.
+- **Idempotency/retry:** audits are replay-safe; Object Lock, retention, lifecycle, policy, and delete operations never auto-retry after ambiguous provider responses.
+- **Partial failure/recovery:** report only observed object metadata and freshness; a listing cannot be promoted to successful Cloudron restore evidence.
+- Object Lock at bucket creation and compliance retention can be irreversible; never infer or auto-apply them.
+
+### Verification Before Dispatch
+
+```bash
+bash .agents/scripts/tests/test-object-storage-helper.sh
+bunx markdownlint-cli2 ".agents/services/hosting/idrive-e2.md"
+.agents/scripts/subagent-index-helper.sh check
+.agents/scripts/linters-local.sh --changed
+```
+
+- **Surface mapping:** helper fixtures prove endpoint/config and guarded-operation criteria; markdown/index checks prove provider discovery; changed-file lint covers every declared source and generated index.
+- **Broad verification trigger:** Not required unless implementation changes shared MCP or setup infrastructure, which is outside this task's hard boundary.
+
+### Recoverability Checkpoint
+
+- [ ] Focused functional verification passes: `bash .agents/scripts/tests/test-object-storage-helper.sh`
+- [ ] WIP commit created before broad gates: `wip: add IDrive e2 storage integration`
+- [ ] Evidence-triggered broad verification then run: not required because MCP infrastructure is excluded
+
+### Files Scope
+
+- `.agents/services/hosting/idrive-e2.md`
+- `.agents/scripts/object-storage-helper.sh`
+- `.agents/scripts/tests/test-object-storage-helper.sh`
+- `configs/object-storage-config.json.txt`
+- `.agents/build-plus.md`
+- `.agents/reference/domain-index.md`
+- `README.md`
+
+## Acceptance Criteria
+
+- [ ] The IDrive agent can guide readiness, bounded inventory, backup freshness, and protection audits through the shared helper without requiring the MCP.
+- [ ] Invalid/non-IDrive endpoints, region mismatches, ambiguous account aliases, and missing rclone configuration fail before network access.
+- [ ] Destructive/protection-changing workflows require explicit target/version/effect confirmation and read-back; no write is the default.
+- [ ] The OpenCode MCP registry and tool map remain unchanged unless fresh provenance and lifecycle evidence satisfies every documented gate.
+
+## Context
+
+- Primary sources supplied by the user: `https://www.idrive.com/s3-storage-e2/s3-compatible-api`, `https://www.idrive.com/s3-storage-e2/e2-endpoint-urls`, and `https://www.idrive.com/s3-storage-e2/mcp-for-ai#selfhosted-mcp-works`.
+- The unrelated `nktknshn/idrive-cli` targets Apple iCloud Drive and must not be used as an IDrive e2 implementation reference.

--- a/todo/tasks/t18420-brief.md
+++ b/todo/tasks/t18420-brief.md
@@ -1,0 +1,146 @@
+<!-- aidevops:brief-schema=v2 -->
+
+# t18420: Add guarded Backblaze B2 object storage and official MCP integration
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `Backblaze B2 object storage MCP` → 0 hits — no relevant lessons
+- [x] Discovery pass: 6 recent commits / 0 related merged PRs / 0 open PRs touch target surfaces; historical Backblaze work concerns desktop backup exclusions
+- [x] File refs verified: registry, agent MCP mapping, activation profile builder, Blender/QuickFile registry tests, hosting-services directory, Build+ list, and domain index exist at HEAD
+- [x] Tier: `tier:standard` — official stdio MCP and existing bounded activation pattern provide a credible implementation path
+- [x] Seeded draft PR decision recorded: skipped — blocked on t18418
+
+## Origin
+
+- **Created:** 2026-09-09
+- **Session:** opencode:ses_f77f97e4affe54KJwSTn7JE3z9
+- **Created by:** ai-interactive
+- **Parent task:** t18417 / #31684
+- **Blocked by:** native relationship to t18418 / #31685 plus `blocked-by:t18418`
+- **Conversation context:** Add the same deterministic storage capability as IDrive, while taking advantage of Backblaze's stronger official MCP provenance and stdio lifecycle.
+
+## What
+
+Add a `backblaze-b2` subagent and shared-helper provider profile, plus a pinned on-demand integration for the official MIT `backblaze-labs/b2-mcp` stdio server. Keep credentials least-privilege, disable tools globally, preserve capability-aware registration, block destructive actions by default, and exclude partner/master-key operations from the aidevops baseline.
+
+## Why
+
+The shared helper covers deterministic backup/storage operations. Backblaze's official MCP adds B2-native control-plane features, analytics, key capability discovery, and guarded tools that generic S3 clients do not expose.
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** Trust and lifecycle decisions are specified; the worker applies established MCP registry, launcher, and service-agent patterns with normal compatibility validation.
+
+## PR Conventions
+
+Use the normal closing keyword for issue #31687. Reference parent #31684 without closing it.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** t18418 must land first and the package version/pin must be verified at implementation time.
+- **Status:** blocked
+- **Freshness evidence:** `backblaze-labs/b2-mcp` main branch and README reviewed 2026-09-09
+- **Verification run:** source metadata only; implementation unrun
+- **Stale-assumption warning:** verify the npm package version, engines, exports, integrity, and official repository release before pinning
+
+## How (Approach)
+
+### Progressive Context Plan
+
+- **Read first:** t18418 helper contract; `.agents/aidevops/architecture.md:148-170`; `.agents/plugins/opencode-aidevops/mcp-registry.mjs:175-223,465-474`; `.agents/plugins/opencode-aidevops/agent-mcp-tools.mjs:10-50`.
+- **Load only if:** `.agents/tools/build-mcp/build-mcp.md` for MCP security and package verification; QuickFile/Blender tests for exact activation assertions.
+- **Why:** combine deterministic storage operations with a least-privilege, disabled, explicit MCP activation profile.
+- **Stop when:** package pin, secret launcher, tool pattern, provider profile, and tests are exact.
+
+### Files to Modify
+
+- `NEW: .agents/services/hosting/backblaze-b2.md` — provider subagent covering helper and MCP usage
+- `EDIT: .agents/scripts/object-storage-helper.sh` and its test — Backblaze endpoint/profile and backup-verification behavior
+- `EDIT: configs/object-storage-config.json.txt` — placeholder Backblaze profile
+- `NEW: .agents/scripts/backblaze-b2-mcp-launcher.sh` — pinned stdio launcher injecting only approved B2 application-key secrets
+- `EDIT: .agents/plugins/opencode-aidevops/mcp-registry.mjs:194-456` — disabled local MCP with activation agent/source/model tier
+- `EDIT: .agents/plugins/opencode-aidevops/agent-mcp-tools.mjs:17-50` — restrict MCP tools to `backblaze-b2`
+- `NEW: .agents/plugins/opencode-aidevops/tests/test-backblaze-b2-mcp-registry.mjs` — registry, isolation, pin, and activation tests modeled on Blender/QuickFile
+- `EDIT: .agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs:35-75` — update explicit profile count/assertions if required
+- `EDIT: .agents/build-plus.md:43-47`, `.agents/reference/domain-index.md`, and generated subagent index through the canonical helper
+- `EDIT: README.md only if required by the integrations index`
+
+### Complete Write Surface
+
+- **Callers/readers:** `.agents/build-plus.md` and `.agents/reference/domain-index.md` route B2 intent to `.agents/services/hosting/backblaze-b2.md`; OpenCode reads the registry/tool-map entries.
+- **Writers/mutation paths:** `.agents/scripts/object-storage-helper.sh` delegates storage work to rclone, while `.agents/scripts/backblaze-b2-mcp-launcher.sh` starts the pinned stdio MCP with approved application-key secrets.
+- **Tests/fixtures:** object-storage fixtures cover provider behavior; `test-backblaze-b2-mcp-registry.mjs` and `test-mcp-activation.mjs` cover pinning, denial, activation, isolation, and disconnect.
+- **Schemas/config:** `configs/object-storage-config.json.txt` gains a credential-free B2 profile; `mcp-registry.mjs` and `agent-mcp-tools.mjs` gain one disabled, scoped server definition.
+- **Generated/deployed mirrors:** `.agents/scripts/subagent-index-helper.sh` updates the canonical generated index; setup deploys source agents/scripts and preserves user custom MCP configuration.
+- **Migrations/backfills:** `mcp-registry.mjs` updates an existing framework-generated Backblaze entry only if positively identified; otherwise no migration or user-config rewrite occurs.
+- **Cleanup/rollback paths:** `git revert` removes MCP registration/profile/launcher independently while shared-helper B2 support can remain operational.
+
+### Implementation Steps
+
+1. Verify current package metadata and source correspondence; pin an exact reviewed version rather than `latest`.
+2. Add the provider profile to the shared helper with explicit B2 endpoint/region handling.
+3. Create a least-privilege launcher sourcing only `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY`; do not request or pass `B2_MASTER_KEY_ID` or `B2_MASTER_KEY`.
+4. Set destructive policy to block by default, durable-secret sink off, inline secrets off, local-file access off unless a later explicit workflow requires a bounded root.
+5. Register disabled globally with an explicit activation agent and scoped tool pattern; connect only within `backblaze-b2`, then disconnect.
+6. Document capability-aware tool visibility and prefer presigned byte paths for large transfers; use the helper/rclone for deterministic backup verification.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** registry activation is session-bounded and disconnects after use; concurrent storage reads are safe while destructive operations serialize by exact target.
+- **Migration/rollback:** do not rewrite custom MCP configs; registry rollback removes only the positively identified framework entry and launcher.
+- **Mixed-version/backward compatibility:** detect supported Node and exact package exports before launch; helper-backed B2 operations remain available when the MCP cannot run.
+- **Idempotency/retry:** connection and read-only queries may retry after clean failure; destructive/key-management operations never retry after ambiguous completion.
+- **Partial failure/recovery:** disconnect on startup/tool failure, preserve diagnostic output without secrets, and verify remote state before considering any mutation successful.
+- Tool prefixes include B2-native and S3 tools; verify actual OpenCode namespacing instead of guessing the glob.
+- Key-management and partner/group tools remain outside the baseline because they create durable credentials or require master keys.
+
+### Verification Before Dispatch
+
+```bash
+bash .agents/scripts/tests/test-object-storage-helper.sh
+shellcheck .agents/scripts/backblaze-b2-mcp-launcher.sh
+node --test .agents/plugins/opencode-aidevops/tests/test-backblaze-b2-mcp-registry.mjs
+node --test .agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs
+bunx markdownlint-cli2 ".agents/services/hosting/backblaze-b2.md"
+.agents/scripts/subagent-index-helper.sh check
+.agents/scripts/linters-local.sh --changed
+```
+
+- **Surface mapping:** object-storage fixtures prove provider behavior; launcher ShellCheck proves shell safety; registry/activation tests prove pinning, global denial, scoped activation, config preservation, and disconnect; changed-file lint covers all declared integration files.
+- **Broad verification trigger:** Not required unless the implementation changes shared registry schema or setup behavior beyond one additive MCP entry.
+
+### Recoverability Checkpoint
+
+- [ ] Focused functional verification passes: `node --test .agents/plugins/opencode-aidevops/tests/test-backblaze-b2-mcp-registry.mjs`
+- [ ] WIP commit created before broad gates: `wip: add Backblaze B2 storage and MCP integration`
+- [ ] Evidence-triggered broad verification then run: not required unless shared registry schema changes
+
+### Files Scope
+
+- `.agents/services/hosting/backblaze-b2.md`
+- `.agents/scripts/object-storage-helper.sh`
+- `.agents/scripts/tests/test-object-storage-helper.sh`
+- `configs/object-storage-config.json.txt`
+- `.agents/scripts/backblaze-b2-mcp-launcher.sh`
+- `.agents/plugins/opencode-aidevops/mcp-registry.mjs`
+- `.agents/plugins/opencode-aidevops/agent-mcp-tools.mjs`
+- `.agents/plugins/opencode-aidevops/tests/test-backblaze-b2-mcp-registry.mjs`
+- `.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs`
+- `.agents/build-plus.md`
+- `.agents/reference/domain-index.md`
+- `README.md`
+
+## Acceptance Criteria
+
+- [ ] Backblaze helper operations work without MCP and distinguish B2 cloud storage from the unrelated Backblaze desktop backup client.
+- [ ] The MCP is pinned, disabled globally, available only to `backblaze-b2`, and starts through a launcher that does not expose or request master keys.
+- [ ] Missing/invalid credentials, unsupported Node, unavailable package, destructive calls, durable-secret output, and unauthorized local-file access fail closed.
+- [ ] Focused tests prove registry allowlisting, global denial, bounded agent registration, custom-config preservation, and disconnect behavior.
+
+## Context
+
+- Primary source supplied by the user: `https://github.com/backblaze-labs/b2-mcp`.
+- Reviewed repository facts: official Backblaze Labs incubation, MIT license, 40 capability-aware tools, stdio default, explicit destructive policy, and maintained tests/CI.

--- a/todo/tasks/t18421-brief.md
+++ b/todo/tasks/t18421-brief.md
@@ -1,0 +1,136 @@
+<!-- aidevops:brief-schema=v2 -->
+
+# t18421: Add guarded Wasabi object storage integration with beta MCP boundary
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `Wasabi object storage MCP` → 0 hits — no relevant lessons
+- [x] Discovery pass: 6 recent commits / 0 related merged PRs / 0 open PRs touch target surfaces; no existing Wasabi integration found
+- [x] File refs verified: hosting-services directory, Build+ list, domain index, shared MCP registry patterns, and t18418 target contract exist at HEAD; Wasabi files are new
+- [x] Tier: `tier:standard` — deterministic adapter is decided and MCP eligibility has an explicit fail-closed gate
+- [x] Seeded draft PR decision recorded: skipped — blocked on t18418
+
+## Origin
+
+- **Created:** 2026-09-09
+- **Session:** opencode:ses_f77f97e4affe54KJwSTn7JE3z9
+- **Created by:** ai-interactive
+- **Parent task:** t18417 / #31684
+- **Blocked by:** native relationship to t18418 / #31685 plus `blocked-by:t18418`
+- **Conversation context:** Add deterministic Wasabi support equivalent to IDrive while acknowledging that the reviewed official MCP is a broad beta surface.
+
+## What
+
+Add a `wasabi` subagent and provider profile over t18418 for endpoint/account aliases, backup verification, restore/download previews, lifecycle/Object Lock/replication/IAM audits, and guarded operations. Evaluate the official beta MCP at implementation time and register it only if an official source/package, usable license, exact version pin, transport contract, and safe credential/lifecycle design are verifiable; otherwise document the deferral while shipping the complete helper path.
+
+## Why
+
+Wasabi is S3-compatible, so deterministic storage work should reuse rclone. Its MCP advertises more than 140 tools across S3, IAM, sub-accounts, and governance, which is valuable but materially broader than the initial backup-verification requirement and requires stronger provenance and tool-boundary evidence.
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** The adapter boundary and fail-closed MCP decision rule are resolved; the worker need not invent policy even if current MCP evidence remains insufficient.
+
+## PR Conventions
+
+Use the normal closing keyword for issue #31688. Reference parent #31684 without closing it unless this is the verified final child and all siblings are complete.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** t18418 must land first and the MCP source/package was not available from the reviewed landing page.
+- **Status:** blocked
+- **Freshness evidence:** official Wasabi MCP landing page reviewed 2026-09-09
+- **Verification run:** source landing-page review only; implementation unrun
+- **Stale-assumption warning:** beta capabilities and packaging may change; re-fetch official evidence before implementation
+
+## How (Approach)
+
+### Progressive Context Plan
+
+- **Read first:** t18418 helper contract and the Wasabi source linked in this brief.
+- **Load only if:** build-MCP, registry, activation, and MCP security docs after an official package/repository is positively identified.
+- **Why:** ship a useful provider integration even when MCP provenance or lifecycle remains insufficient.
+- **Stop when:** adapter tests pass and either a safely pinned MCP integration is proven or the agent clearly reports the evidence-based deferral.
+
+### Files to Modify
+
+- `NEW: .agents/services/hosting/wasabi.md` — provider subagent and MCP beta boundary
+- `EDIT: .agents/scripts/object-storage-helper.sh` and its tests — Wasabi endpoint/profile and backup-verification behavior
+- `EDIT: configs/object-storage-config.json.txt` — placeholder Wasabi profile
+- `EDIT: .agents/build-plus.md:43-47` and `.agents/reference/domain-index.md` — provider routing
+- `EDIT: README.md only if required by the integrations index`
+- `CONDITIONAL: .agents/plugins/opencode-aidevops/mcp-registry.mjs`, `agent-mcp-tools.mjs`, a least-privilege launcher, and focused registry test — only when every MCP eligibility gate is proven from official sources
+
+### Complete Write Surface
+
+- **Callers/readers:** `.agents/build-plus.md` and `.agents/reference/domain-index.md` route Wasabi intent to `.agents/services/hosting/wasabi.md`; the agent calls the shared helper.
+- **Writers/mutation paths:** `.agents/scripts/object-storage-helper.sh` delegates validated storage operations to rclone; conditional MCP writes require a separately proven scoped registry/launcher path.
+- **Tests/fixtures:** object-storage fixtures cover Wasabi endpoints and operations; conditional MCP registration adds a focused registry test plus `test-mcp-activation.mjs` assertions.
+- **Schemas/config:** `configs/object-storage-config.json.txt` gains a credential-free Wasabi profile; MCP registry/tool-map schemas change only if every eligibility gate passes.
+- **Generated/deployed mirrors:** `.agents/scripts/subagent-index-helper.sh` updates the canonical generated index; source setup deployment preserves user config.
+- **Migrations/backfills:** `mcp-registry.mjs` changes only when a prior framework-generated MCP entry can be positively identified; no provider-state migration or custom-config rewrite occurs.
+- **Cleanup/rollback paths:** `git revert` removes provider docs/profile/tests; any eligible MCP registry/profile/launcher can be removed independently while helper support remains.
+
+### Implementation Steps
+
+1. Add explicit Wasabi S3 endpoint and region validation based on current official service URL documentation; do not accept arbitrary hosts.
+2. Implement the same provider-neutral readiness, inventory, backup-freshness, restore preview, and protection-audit contract as other providers.
+3. Distinguish S3 object operations from IAM/account-control operations. Default all IAM, policy, lifecycle, replication, retention, Object Lock, sub-account, and deletion changes to refusal until exact preview and confirmation are present.
+4. Reassess MCP eligibility from official source/package evidence. If any gate is missing, do not register it and explain the deterministic helper fallback in the agent.
+5. If eligible, expose only the minimum tool families needed initially, keep it disabled globally, use OAuth/least-privilege IAM, and add explicit activation/isolation tests.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** read-only helper audits may run concurrently; lifecycle, replication, IAM, retention, Object Lock, account, and delete changes serialize by exact target.
+- **Migration/rollback:** no account migration occurs; rollback removes framework integration only and never changes live Wasabi policy or objects.
+- **Mixed-version/backward compatibility:** the beta MCP may change schemas/transports, so helper-backed behavior remains canonical and MCP failure cannot remove it.
+- **Idempotency/retry:** read-only audits are replay-safe; irreversible/costly mutations stop after ambiguous outcomes and require state verification before retry.
+- **Partial failure/recovery:** preserve provider response/operation identifiers without secrets, disconnect failed MCP sessions, and read back exact remote state before success.
+- A 140-tool surface does not justify broad IAM/account governance; existing IAM policy is necessary but not sufficient for safe agent intent.
+
+### Verification Before Dispatch
+
+```bash
+bash .agents/scripts/tests/test-object-storage-helper.sh
+bunx markdownlint-cli2 ".agents/services/hosting/wasabi.md"
+.agents/scripts/subagent-index-helper.sh check
+.agents/scripts/linters-local.sh --changed
+# If MCP registration is eligible, also run its focused registry test and test-mcp-activation.mjs.
+```
+
+- **Surface mapping:** helper fixtures prove endpoint/config and guarded-operation behavior; markdown/index checks prove routing; conditional MCP tests must prove provenance pin, global denial, focused activation, config preservation, and disconnect before registration is accepted.
+- **Broad verification trigger:** Not required for helper-only delivery; reassess if eligible MCP work alters shared registry schema or setup infrastructure.
+
+### Recoverability Checkpoint
+
+- [ ] Focused functional verification passes: `bash .agents/scripts/tests/test-object-storage-helper.sh`
+- [ ] WIP commit created before broad gates: `wip: add Wasabi storage integration`
+- [ ] Evidence-triggered broad verification then run: not required for helper-only delivery; conditional MCP uses focused registry tests
+
+### Files Scope
+
+- `.agents/services/hosting/wasabi.md`
+- `.agents/scripts/object-storage-helper.sh`
+- `.agents/scripts/tests/test-object-storage-helper.sh`
+- `configs/object-storage-config.json.txt`
+- `.agents/build-plus.md`
+- `.agents/reference/domain-index.md`
+- `README.md`
+- `.agents/plugins/opencode-aidevops/mcp-registry.mjs`
+- `.agents/plugins/opencode-aidevops/agent-mcp-tools.mjs`
+- `.agents/plugins/opencode-aidevops/tests/test-mcp-activation.mjs`
+
+## Acceptance Criteria
+
+- [ ] Wasabi readiness, bounded inventory, backup freshness, restore preview, and protection audits work through the shared helper without MCP availability.
+- [ ] Invalid endpoints, ambiguous aliases, arbitrary flags, missing rclone, and mutation attempts without exact approval fail closed.
+- [ ] IAM/account governance and destructive storage tools are not exposed by default.
+- [ ] MCP registration occurs only with cited official provenance, license, pin, transport, and security evidence plus global-denial/agent-isolation tests; otherwise the shipped agent clearly documents the safe deferral.
+
+## Context
+
+- Primary source supplied by the user: `https://wasabi.com/cloud-object-storage/mcp-for-ai`.
+- Reviewed facts: official beta; hosted and self-hosted options; OAuth; more than 140 S3, IAM, and account-governance tools; existing IAM policies carry through; object bytes are claimed to bypass the MCP server.


### PR DESCRIPTION
## Planning publication

- Publishes TODO.md and todo/ planning-file changes through a PR because main does not accept direct planning pushes.
- Source branch at helper invocation: feature/auto-20260909-223539.
- Commit message: plan: add object storage integration roadmap.

## Task and issue manifest

<!-- aidevops:planning-publication:v1 id=e6b6c67829357120db2d753699e4bedea3ae9d8e -->
<!-- aidevops:planning-task:v1 task=t18417 issue=31684 -->
<!-- aidevops:planning-task:v1 task=t18418 issue=31685 -->
<!-- aidevops:planning-task:v1 task=t18419 issue=31686 -->
<!-- aidevops:planning-task:v1 task=t18420 issue=31687 -->
<!-- aidevops:planning-task:v1 task=t18421 issue=31688 -->
- For #31684
- For #31685
- For #31686
- For #31687
- For #31688

## Security and architecture guardrails

- This PR does not update .task-counter.
- Task IDs still come from claim-task-id.sh CAS allocation on a branch that permits atomic counter pushes.
- Do not replace counter allocation with a PR-backed counter update; PR review is not an atomic ID lock.

## Merge note

- Merge this planning-only PR before expecting pulse or issue-sync to see the TODO/todo changes.
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 46m and 82,654 tokens on this with the user in an interactive session.