### PR TITLE
chore(planning): correct object storage task label mappings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1346,15 +1346,15 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18415 Triage refreshed Codacy findings into bounded remediation children #auto-dispatch #codacy #decomposition #quality blocked-by:t18414 ref:GH#31460 -> [todo/tasks/t18415-brief.md]
 
-- [ ] t18417 Add provider-neutral S3 object storage integrations for IDrive, Backblaze, and Wasabi #feat #parent-task #thinking ref:GH#31684 logged:2026-09-09 -> [todo/tasks/t18417-brief.md]
+- [ ] t18417 Add provider-neutral S3 object storage integrations for IDrive, Backblaze, and Wasabi #feat #parent-task #tier:thinking #interactive ref:GH#31684 logged:2026-09-09 -> [todo/tasks/t18417-brief.md]
 
-- [ ] t18418 Build provider-neutral rclone-backed S3 object storage foundation #auto-dispatch #feat #standard ~3h ref:GH#31685 logged:2026-09-09 -> [todo/tasks/t18418-brief.md]
+- [ ] t18418 Build provider-neutral rclone-backed S3 object storage foundation #auto-dispatch #feat #tier:standard #interactive ~3h ref:GH#31685 logged:2026-09-09 -> [todo/tasks/t18418-brief.md]
 
-- [ ] t18419 Add guarded IDrive e2 object storage integration #auto-dispatch #feat #standard ~2h blocked-by:t18418 ref:GH#31686 logged:2026-09-09 -> [todo/tasks/t18419-brief.md]
+- [ ] t18419 Add guarded IDrive e2 object storage integration #auto-dispatch #feat #tier:standard #interactive ~2h blocked-by:t18418 ref:GH#31686 logged:2026-09-09 -> [todo/tasks/t18419-brief.md]
 
-- [ ] t18420 Add guarded Backblaze B2 object storage and official MCP integration #auto-dispatch #feat #standard ~4h blocked-by:t18418 ref:GH#31687 logged:2026-09-09 -> [todo/tasks/t18420-brief.md]
+- [ ] t18420 Add guarded Backblaze B2 object storage and official MCP integration #auto-dispatch #feat #tier:standard #interactive ~4h blocked-by:t18418 ref:GH#31687 logged:2026-09-09 -> [todo/tasks/t18420-brief.md]
 
-- [ ] t18421 Add guarded Wasabi object storage integration with beta MCP boundary #auto-dispatch #feat #standard ~3h blocked-by:t18418 ref:GH#31688 logged:2026-09-09 -> [todo/tasks/t18421-brief.md]
+- [ ] t18421 Add guarded Wasabi object storage integration with beta MCP boundary #auto-dispatch #feat #tier:standard #interactive ~3h blocked-by:t18418 ref:GH#31688 logged:2026-09-09 -> [todo/tasks/t18421-brief.md]
 
 ## In Progress
 


### PR DESCRIPTION
## Planning publication

- Publishes TODO.md and todo/ planning-file changes through a PR because main does not accept direct planning pushes.
- Source branch at helper invocation: feature/auto-20260909-223539.
- Commit message: plan: correct object storage task label mappings.

## Task and issue manifest

<!-- aidevops:planning-publication:v1 id=52918729a8dd4783b5e54e9bb4a5fd904b1c4efe -->
<!-- aidevops:planning-task:v1 task=t18417 issue=31684 -->
<!-- aidevops:planning-task:v1 task=t18418 issue=31685 -->
<!-- aidevops:planning-task:v1 task=t18419 issue=31686 -->
<!-- aidevops:planning-task:v1 task=t18420 issue=31687 -->
<!-- aidevops:planning-task:v1 task=t18421 issue=31688 -->
- For #31684
- For #31685
- For #31686
- For #31687
- For #31688

## Security and architecture guardrails

- This PR does not update .task-counter.
- Task IDs still come from claim-task-id.sh CAS allocation on a branch that permits atomic counter pushes.
- Do not replace counter allocation with a PR-backed counter update; PR review is not an atomic ID lock.

## Merge note

- Merge this planning-only PR before expecting pulse or issue-sync to see the TODO/todo changes.
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 13m and 47,503 tokens on this with the user in an interactive session.