### PR TITLE
GH#31692: fix(recovery): report unavailable evidence stage

### DIFF
--- a/.agents/reference/storage-lifecycle-worktree-recovery.md
+++ b/.agents/reference/storage-lifecycle-worktree-recovery.md
@@ -103,7 +103,12 @@ eligible only when GitHub independently proves the archived HEAD is the merge
 base of the repository's current default-branch tip. A changed producer/context,
 unavailable API, non-ancestor commit, dirty archive, or live local reference
 still preserves the bucket. Other detached producers remain protected until
-they define an equally specific evidence contract.
+they define an equally specific evidence contract. Classification recognises
+the exact producer identity before external publication proof is available, so
+an early evidence failure reports its owning stage (for example,
+`process-evidence-unavailable`) instead of misreporting a supported producer as
+an unsupported detached branch. Identity recognition grants no deletion
+authority: provenance and publication proof remain mandatory for candidacy.
 
 Automatic maintenance may reclaim those same approved cache roots from an
 otherwise protected mixed archive without deleting the archive. This narrower

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -481,6 +481,31 @@ test_detached_claim_does_not_invent_active_owner() {
 	return 0
 }
 
+assert_profile_unavailable_process_reason() {
+	local identity="$1"
+	local evidence_path="${TEST_DIR}/profile-evidence.json"
+	local evidence=""
+	local result=""
+
+	(
+		_worktree_recovery_plan_git_state() { printf 'clear\n'; }
+		_worktree_recovery_plan_worktree_reference_state() { printf 'clear\n'; }
+		_worktree_recovery_plan_registry_state() { printf 'clear\n'; }
+		_worktree_recovery_plan_claim_state() { printf 'not-applicable\n'; }
+		_worktree_recovery_plan_process_state() { printf 'unavailable\n'; }
+		_worktree_recovery_plan_external_evidence_json() { return 99; }
+		_worktree_recovery_plan_evidence_json "$identity" >"$evidence_path"
+	) || return 1
+	evidence=$(<"$evidence_path") || return 1
+	result=$(_worktree_recovery_plan_classification_json "$identity" "$evidence" true) || return 1
+	[[ "$(printf '%s\n' "$result" | jq -r '.disposition + ":" + .reasons[0]')" == 'unknown:process-evidence-unavailable' ]] || return 1
+	result=$(_worktree_recovery_plan_classification_json \
+		"$(printf '%s\n' "$identity" | jq -c '.producer_context = "legacy"')" \
+		"$evidence" true) || return 1
+	[[ "$(printf '%s\n' "$result" | jq -r '.disposition + ":" + .reasons[0]')" == 'protected:detached-or-unresolved-branch' ]]
+	return $?
+}
+
 test_profile_publication_detached_evidence_is_exact_and_fail_closed() {
 	local identity='' evidence='' result='' disposition='' reason='' mode=''
 	local evidence_path="${TEST_DIR}/profile-evidence.json"
@@ -539,7 +564,7 @@ test_profile_publication_detached_evidence_is_exact_and_fail_closed() {
 		case "$mode" in
 		published) [[ "$disposition:$reason" == 'candidate:producer-published-detached-evidence-clear' ]] || rc=1 ;;
 		unpublished) [[ "$disposition:$reason" == 'protected:exact-commit-not-published' ]] || rc=1 ;;
-		unavailable) [[ "$disposition:$reason" == 'unknown:required-evidence-unavailable' ]] || rc=1 ;;
+		unavailable) [[ "$disposition:$reason" == 'unknown:commit-evidence-unavailable' ]] || rc=1 ;;
 		esac
 	done
 	evidence='{"commit":"published","open_pr":"clear","task":"not-applicable","issue_number":null,"repo":"example/profile","provenance":"profile-publication"}'
@@ -566,8 +591,9 @@ test_profile_publication_detached_evidence_is_exact_and_fail_closed() {
 	evidence=$(<"$evidence_path") || rc=1
 	[[ "$(printf '%s\n' "$evidence" | jq -r '.claim')" == 'not-applicable' ]] || rc=1
 	[[ "$(printf '%s\n' "$evidence" | jq -r '.external.commit')" == 'published' ]] || rc=1
+	assert_profile_unavailable_process_reason "$identity" || rc=1
 	print_result "profile_publication_detached_evidence_is_exact_and_fail_closed" "$rc" \
-		"Expected producer-bound publication proof while malformed, live, unavailable, or unpublished archives remain preserved"
+		"Expected identity-aware unavailable reasons while malformed, live, unavailable, or unpublished archives remain preserved"
 	return 0
 }
 

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -931,14 +931,27 @@ _worktree_recovery_plan_classification_json() {
 		--arg profile_provenance "$WORKTREE_RECOVERY_PROFILE_PROVENANCE" \
 		--arg published "$WORKTREE_RECOVERY_PLAN_COMMIT_PUBLISHED" \
 		--arg not_applicable "$WORKTREE_RECOVERY_PLAN_STATE_NOT_APPLICABLE" \
+		--arg unrecognised "unrecognised-evidence-state" \
 		--argjson identity "$identity_json" --argjson evidence "$evidence_json" \
 		--argjson stable "$stable" '
-		def profile_publication:
+		def profile_identity:
 			$identity.format == "aidevops-worktree-recovery-v2" and
 			$identity.branch == "detached" and
 			$identity.producer == $profile_producer and
-			$identity.producer_context == $profile_context and
+			$identity.producer_context == $profile_context;
+		def profile_publication:
+			profile_identity and
 			($evidence.external.provenance // "") == $profile_provenance;
+		def unavailable_reason:
+			if $evidence.git == $unavailable then "git-evidence-unavailable"
+			elif $evidence.worktree == $unavailable then "worktree-evidence-unavailable"
+			elif $evidence.registry == $unavailable then "registry-evidence-unavailable"
+			elif $evidence.claim == $unavailable then "claim-evidence-unavailable"
+			elif $evidence.process == $unavailable then "process-evidence-unavailable"
+			elif $evidence.external.commit == $unavailable then "commit-evidence-unavailable"
+			elif $evidence.external.open_pr == $unavailable then "pull-request-evidence-unavailable"
+			elif $evidence.external.task == $unavailable then "task-evidence-unavailable"
+			else "required-evidence-unavailable" end;
 		if $stable != true then {disposition:$unknown,reasons:["identity-or-size-changed"]}
 		elif $evidence.git == $dirty then {disposition:$protected,reasons:["archive-worktree-dirty"]}
 		elif $evidence.worktree == $active then {disposition:$protected,reasons:["active-git-worktree-reference"]}
@@ -947,15 +960,17 @@ _worktree_recovery_plan_classification_json() {
 		elif $evidence.process == $active then {disposition:$protected,reasons:["active-process-reference"]}
 		elif $evidence.external.open_pr == $active then {disposition:$protected,reasons:["open-pull-request"]}
 		elif $identity.source_removal_outcome != "removed" then {disposition:$protected,reasons:["source-removal-not-complete"]}
-		elif ($identity.branch | startswith("refs/heads/") | not) and (profile_publication | not)
+		elif ($identity.branch | startswith("refs/heads/") | not) and (profile_identity | not)
 		then {disposition:$protected,reasons:["detached-or-unresolved-branch"]}
 		elif ([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.claim,$evidence.process,
 			$evidence.external.commit,$evidence.external.open_pr,$evidence.external.task ] | index($unavailable)) != null
-		then {disposition:$unknown,reasons:["required-evidence-unavailable"]}
+		then {disposition:$unknown,reasons:[unavailable_reason]}
+		elif profile_identity and (profile_publication | not)
+		then {disposition:$unknown,reasons:[$unrecognised]}
 		elif profile_publication and $evidence.external.commit != $published
 		then {disposition:$protected,reasons:["exact-commit-not-published"]}
 		elif profile_publication and $evidence.external.task != $not_applicable
-		then {disposition:$unknown,reasons:["unrecognised-evidence-state"]}
+		then {disposition:$unknown,reasons:[$unrecognised]}
 		elif profile_publication and
 			([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.process ] | all(. == $clear)) and
 			$evidence.claim == $not_applicable
@@ -964,7 +979,7 @@ _worktree_recovery_plan_classification_json() {
 		elif $evidence.external.task != "closed" then {disposition:$protected,reasons:["linked-task-not-closed"]}
 		elif ([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.claim,$evidence.process ] | all(. == $clear))
 		then {disposition:$candidate,reasons:["all-required-evidence-clear"]}
-		else {disposition:$unknown,reasons:["unrecognised-evidence-state"]}
+		else {disposition:$unknown,reasons:[$unrecognised]}
 		end'
 	return $?
 }

--- a/.agents/scripts/worktree-recovery-maintenance-helper.sh
+++ b/.agents/scripts/worktree-recovery-maintenance-helper.sh
@@ -274,7 +274,11 @@ _worktree_recovery_maintenance_order_inventory() {
 
 _worktree_recovery_maintenance_zero_reason_counts_json() {
 	jq -cn '{unknown_archive:0,sizing_unavailable:0,sizing_timeout:0,classification_unavailable:0,
-		identity_or_size_changed:0,required_evidence_unavailable:0,
+		identity_or_size_changed:0,required_evidence_unavailable:0,git_evidence_unavailable:0,
+		worktree_evidence_unavailable:0,registry_evidence_unavailable:0,
+		claim_evidence_unavailable:0,process_evidence_unavailable:0,
+		commit_evidence_unavailable:0,pull_request_evidence_unavailable:0,
+		task_evidence_unavailable:0,
 		unrecognised_evidence_state:0,age_unavailable:0,archive_worktree_dirty:0,
 		active_git_worktree_reference:0,active_registry_owner:0,active_session_claim:0,
 		active_process_reference:0,open_pull_request:0,source_removal_not_complete:0,
@@ -297,6 +301,14 @@ _worktree_recovery_maintenance_record_reason() {
 	classification-unavailable) safe_reason="classification_unavailable" ;;
 	identity-or-size-changed) safe_reason="identity_or_size_changed" ;;
 	required-evidence-unavailable) safe_reason="required_evidence_unavailable" ;;
+	git-evidence-unavailable) safe_reason="git_evidence_unavailable" ;;
+	worktree-evidence-unavailable) safe_reason="worktree_evidence_unavailable" ;;
+	registry-evidence-unavailable) safe_reason="registry_evidence_unavailable" ;;
+	claim-evidence-unavailable) safe_reason="claim_evidence_unavailable" ;;
+	process-evidence-unavailable) safe_reason="process_evidence_unavailable" ;;
+	commit-evidence-unavailable) safe_reason="commit_evidence_unavailable" ;;
+	pull-request-evidence-unavailable) safe_reason="pull_request_evidence_unavailable" ;;
+	task-evidence-unavailable) safe_reason="task_evidence_unavailable" ;;
 	unrecognised-evidence-state) safe_reason="unrecognised_evidence_state" ;;
 	age-unavailable) safe_reason="age_unavailable" ;;
 	archive-worktree-dirty) safe_reason="archive_worktree_dirty" ;;


### PR DESCRIPTION
## Summary

- separate supported profile producer identity from completed publication proof
- report the exact unavailable evidence stage without changing deletion eligibility
- retain unsupported detached identities as protected and expose fixed-cardinality maintenance counters

## Safety

Identity recognition grants no deletion authority. Profile provenance, published-commit proof, clear live-reference evidence, and final identity/size revalidation remain mandatory before candidacy.

## Verification

- `bash .agents/scripts/tests/test-worktree-recovery-lifecycle.sh` — 52 passed
- `bash .agents/scripts/tests/test-worktree-removal-audit.sh` — 51 passed
- `bash -n` and ShellCheck for changed shell files
- `.agents/scripts/linters-local.sh --changed`
- independent deletion-safety design review: clean, no P0–P3 findings

Resolves #31692
Ref #31690

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 1h 36m and 579,279 tokens on this with the user in an interactive session.