### PR TITLE
GH#31697: retry deferred feedback routes

### DIFF
--- a/.agents/scripts/pulse-merge-dirty-queue.py
+++ b/.agents/scripts/pulse-merge-dirty-queue.py
@@ -18,6 +18,7 @@ from gh_transport_budget import private_directory, process_birth
 
 
 MAX_HINTS = 4096
+MAX_DEFERRED_HINTS = 4096
 RETENTION_SECONDS = 604800
 
 
@@ -57,7 +58,11 @@ class Queue:
             repo TEXT NOT NULL, pr INTEGER NOT NULL, generation TEXT NOT NULL,
             updated REAL NOT NULL, wake_until REAL NOT NULL DEFAULT 0,
             nonce TEXT NOT NULL DEFAULT '', pid INTEGER NOT NULL DEFAULT 0,
-            birth TEXT NOT NULL DEFAULT '', PRIMARY KEY(repo,pr))""")
+            birth TEXT NOT NULL DEFAULT '', durable INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY(repo,pr))""")
+        columns = {row[1] for row in self.db.execute("PRAGMA table_info(work)")}
+        if "durable" not in columns:
+            self.db.execute("ALTER TABLE work ADD COLUMN durable INTEGER NOT NULL DEFAULT 0")
 
     def row(self, repo: str, pr: int):
         row = self.db.execute("SELECT * FROM work WHERE repo=? AND pr=?", (repo, pr)).fetchone()
@@ -66,30 +71,33 @@ class Queue:
             return self.db.execute("SELECT * FROM work WHERE repo=? AND pr=?", (repo, pr)).fetchone()
         return row
 
-    def capacity(self, now: float) -> None:
+    def capacity(self, now: float, durable: bool = False) -> None:
         # Expiry removes hints, not GitHub work. Polling remains authoritative.
         self.db.execute("DELETE FROM work WHERE nonce='' AND updated<?", (now - RETENTION_SECONDS,))
-        if self.db.execute("SELECT count(*) FROM work").fetchone()[0] >= MAX_HINTS:
+        limit = MAX_DEFERRED_HINTS if durable else MAX_HINTS
+        if self.db.execute("SELECT count(*) FROM work WHERE durable=?", (int(durable),)).fetchone()[0] >= limit:
             # Preserve active leases, but let a newer exact target replace the
-            # oldest idle hint. Broad polling remains the recovery path for the
-            # evicted target and the queue stays strictly bounded.
+            # oldest idle hint within the same tier. Deferred-route capacity is
+            # independent, so ordinary event churn cannot evict durable retries.
             oldest = self.db.execute(
-                "SELECT repo,pr FROM work WHERE nonce='' ORDER BY updated ASC LIMIT 1"
+                "SELECT repo,pr FROM work WHERE durable=? AND nonce='' ORDER BY updated ASC LIMIT 1",
+                (int(durable),),
             ).fetchone()
             if not oldest:
                 raise ValueError("queue capacity reached; polling recovery required")
             self.db.execute("DELETE FROM work WHERE repo=? AND pr=?", (oldest["repo"], oldest["pr"]))
 
-    def enqueue(self, repo: str, pr: int, now: float) -> str:
+    def enqueue(self, repo: str, pr: int, now: float, durable: bool = False) -> str:
         repo = repo.lower()
         row = self.row(repo, pr)
         if not row:
-            self.capacity(now)
-            self.db.execute("INSERT INTO work(repo,pr,generation,updated) VALUES(?,?,?,?)",
-                            (repo, pr, "", now))
+            self.capacity(now, durable)
+            self.db.execute("INSERT INTO work(repo,pr,generation,updated,durable) VALUES(?,?,?,?,?)",
+                            (repo, pr, "", now, int(durable)))
         wake = not row or (not row["nonce"] and row["wake_until"] <= now)
-        self.db.execute("UPDATE work SET generation=?,updated=?,wake_until=? WHERE repo=? AND pr=?",
-                        (uuid.uuid4().hex, now, now + 30 if wake else (row["wake_until"] if row else 0), repo, pr))
+        self.db.execute("UPDATE work SET generation=?,updated=?,wake_until=?,durable=max(durable,?) WHERE repo=? AND pr=?",
+                        (uuid.uuid4().hex, now, now + 30 if wake else (row["wake_until"] if row else 0),
+                         int(durable), repo, pr))
         return "wake" if wake else "coalesced"
 
     def claim(self, repo: str, pr: int, pid: int, now: float) -> dict | None:
@@ -143,6 +151,8 @@ def main(args: list[str]) -> int:
         output = None
         if command == "enqueue" and len(args) == 3:
             output = queue.enqueue(*target(args[1], args[2]), now)
+        elif command == "defer" and len(args) == 3:
+            output = queue.enqueue(*target(args[1], args[2]), now, durable=True)
         elif command == "claim" and len(args) == 4:
             receipt = queue.claim(*target(args[1], args[2]), int(args[3]), now)
             if receipt is None:

--- a/.agents/scripts/pulse-merge-dirty-queue.py
+++ b/.agents/scripts/pulse-merge-dirty-queue.py
@@ -70,7 +70,15 @@ class Queue:
         # Expiry removes hints, not GitHub work. Polling remains authoritative.
         self.db.execute("DELETE FROM work WHERE nonce='' AND updated<?", (now - RETENTION_SECONDS,))
         if self.db.execute("SELECT count(*) FROM work").fetchone()[0] >= MAX_HINTS:
-            raise ValueError("queue capacity reached; polling recovery required")
+            # Preserve active leases, but let a newer exact target replace the
+            # oldest idle hint. Broad polling remains the recovery path for the
+            # evicted target and the queue stays strictly bounded.
+            oldest = self.db.execute(
+                "SELECT repo,pr FROM work WHERE nonce='' ORDER BY updated ASC LIMIT 1"
+            ).fetchone()
+            if not oldest:
+                raise ValueError("queue capacity reached; polling recovery required")
+            self.db.execute("DELETE FROM work WHERE repo=? AND pr=?", (oldest["repo"], oldest["pr"]))
 
     def enqueue(self, repo: str, pr: int, now: float) -> str:
         repo = repo.lower()

--- a/.agents/scripts/pulse-merge-dirty-queue.py
+++ b/.agents/scripts/pulse-merge-dirty-queue.py
@@ -131,7 +131,7 @@ class Queue:
             self.db.execute("UPDATE work SET nonce='',pid=0,birth='' WHERE repo=? AND pr=?", (repo, pr))
 
     def priority(self, repo: str, now: float) -> str:
-        rows = self.db.execute("SELECT pr FROM work WHERE repo=? AND generation!='' AND updated>=? ORDER BY updated DESC LIMIT ?",
+        rows = self.db.execute("SELECT pr FROM work WHERE repo=? AND generation!='' AND updated>=? ORDER BY durable DESC,updated DESC LIMIT ?",
                                (repo.lower(), now - RETENTION_SECONDS, MAX_HINTS)).fetchall()
         return "|" + "|".join(str(row[0]) for row in rows) + "|" if rows else ""
 

--- a/.agents/scripts/pulse-merge-dirty-queue.sh
+++ b/.agents/scripts/pulse-merge-dirty-queue.sh
@@ -31,6 +31,17 @@ _pulse_merge_queue_enqueue() {
 	return $?
 }
 
+_pulse_merge_queue_defer() {
+	local repo="$1" pr="$2"
+	if [[ "${AIDEVOPS_PULSE_MERGE_DIRTY_QUEUE_ENABLED:-0}" != 1 || "${DRY_RUN:-0}" == 1 ]]; then
+		printf 'legacy\n'
+		return 0
+	fi
+	_pulse_merge_queue_enabled || return 1
+	python3 "$_PULSE_MERGE_DIRTY_HELPER" defer "$repo" "$pr"
+	return $?
+}
+
 # Outputs are caller-local dynamic-scope variables. Context is deliberately not
 # exported, and a borrowed claim must match the current Bash process and target.
 _pulse_merge_queue_begin() {

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -62,6 +62,7 @@ _PULSE_MERGE_PROCESS_LOADED=1
 _PMP_ORIGIN_INTERACTIVE_PATTERN=",origin:interactive,"
 _PMP_ORIGIN_WORKER_PATTERN=",origin:worker,"
 _PMP_ORIGIN_TAKEOVER_PATTERN=",origin:worker-takeover,"
+_PMP_CHECK_FAILURE="FAILURE"
 
 #######################################
 # Return the persistent state path for one interactive PR's semantic
@@ -241,9 +242,9 @@ _pmp_classify_pr_backlog_state() {
 	local _RS=$'\x1e'
 	local number="" mergeable="" review_decision="" is_draft="" labels="" failed_count="" pending_count=""
 	IFS="$_RS" read -r number mergeable review_decision is_draft labels failed_count pending_count < <(
-		printf '%s' "$pr_obj" | jq -r '
+		printf '%s' "$pr_obj" | jq -r --arg failure "$_PMP_CHECK_FAILURE" '
 			def up(v): (v // "" | ascii_upcase);
-			def failed: [.statusCheckRollup[]? | select(up(.conclusion) == "FAILURE" or up(.state) == "FAILURE")] | length;
+			def failed: [.statusCheckRollup[]? | select(up(.conclusion) == $failure or up(.state) == $failure)] | length;
 			def pending: [.statusCheckRollup[]? | select(up(.status) == "QUEUED" or up(.status) == "IN_PROGRESS" or up(.state) == "PENDING" or up(.state) == "EXPECTED" or ((up(.conclusion) == "") and (up(.state) != "SUCCESS") and (up(.status) != "COMPLETED")))] | length;
 			"\(.number // "")\u001e\(.mergeable // "UNKNOWN")\u001e\(if ((has("reviewDecision") | not) or .reviewDecision == null or (.reviewDecision | tostring | length) == 0) then "UNKNOWN" else .reviewDecision end)\u001e\(.isDraft // false)\u001e\([.labels[].name] | join(","))\u001e\(failed)\u001e\(pending)"' 2>/dev/null
 	)
@@ -288,10 +289,10 @@ _pmp_enrich_prs_with_rest_check_status() {
 	local status_json=""
 	status_json=$(gh_pr_check_status_rest_batch "$repo_slug" "$pr_json" 2>/dev/null) || status_json="[]"
 	[[ -n "$status_json" && "$status_json" != "null" ]] || status_json="[]"
-	jq -n --argjson prs "$pr_json" --argjson statuses "$status_json" '
+	jq -n --arg failure "$_PMP_CHECK_FAILURE" --argjson prs "$pr_json" --argjson statuses "$status_json" '
 		def rollup($s):
 			if $s == "PASS" then [{status:"COMPLETED", conclusion:"SUCCESS", state:"SUCCESS"}]
-			elif $s == "FAIL" then [{status:"COMPLETED", conclusion:"FAILURE", state:"FAILURE"}]
+			elif $s == "FAIL" then [{status:"COMPLETED", conclusion:$failure, state:$failure}]
 			elif $s == "PENDING" then [{status:"IN_PROGRESS", conclusion:null, state:"PENDING"}]
 			else [] end;
 		$prs | map(. as $pr | ($statuses | map(select(.number == $pr.number)) | last | .status // "none") as $s | $pr + {statusCheckRollup: rollup($s)})' \
@@ -1304,7 +1305,9 @@ _route_pr_preserve_deferred_retry() {
 	local queue_action="unavailable"
 
 	[[ "$route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ]] || return "$route_rc"
-	if declare -F _pulse_merge_queue_enqueue >/dev/null 2>&1; then
+	if declare -F _pulse_merge_queue_defer >/dev/null 2>&1; then
+		queue_action=$(_pulse_merge_queue_defer "$repo_slug" "$pr_number" 2>>"$LOGFILE") || queue_action="unavailable"
+	elif declare -F _pulse_merge_queue_enqueue >/dev/null 2>&1; then
 		queue_action=$(_pulse_merge_queue_enqueue "$repo_slug" "$pr_number" 2>>"$LOGFILE") || queue_action="unavailable"
 	fi
 	echo "[pulse-wrapper] _route_pr_to_fix_worker: preserved deferred ${kind} route for PR #${pr_number} and issue #${linked_issue} in ${repo_slug} (retry_hint=${queue_action})" >>"$LOGFILE"

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1344,6 +1344,9 @@ _route_pr_guard_and_dispatch_with_retry() {
 	if [[ "$route_rc" -eq 0 ]]; then
 		_dispatch_pr_repair_by_kind "$kind" "$pr_number" "$repo_slug" "$linked_issue" "$pr_title" "$checks_json" || route_rc=$?
 	fi
+	if [[ "$route_rc" -eq 0 ]] && declare -F _pulse_merge_queue_finish >/dev/null 2>&1; then
+		_pulse_merge_queue_finish 2
+	fi
 	_route_pr_preserve_deferred_retry "$route_rc" "$pr_number" "$repo_slug" "$linked_issue" "$kind"
 	return $?
 }

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -349,19 +349,20 @@ _pmp_sort_prs_by_backlog_priority() {
 	fi
 	local i=0
 	while [[ "$i" -lt "$pr_count" ]]; do
-		local pr_obj="" category="" priority="" dirty_priority=1 pr_number=""
+		local pr_obj="" category="" priority="" retry_priority=1 dirty_priority=1 pr_number=""
 		pr_obj=$(printf '%s' "$pr_json" | jq -c ".[$i]" 2>/dev/null)
 		category=$(_pmp_classify_pr_backlog_state "$pr_obj" "$repo_slug")
 		priority=$(_pmp_backlog_priority "$category")
+		printf '%s' "$pr_obj" | jq -e '._pulseDeferredRetry == true' >/dev/null 2>&1 && retry_priority=0
 		if [[ -n "$dirty_keys" ]]; then
 			pr_number=$(printf '%s' "$pr_obj" | jq -r '.number // empty')
 			[[ "$pr_number" =~ ^[1-9][0-9]*$ && "$dirty_keys" == *"|${pr_number}|"* ]] && dirty_priority=0
 		fi
-		printf '%03d\t%d\t%06d\t%s\n' "$priority" "$dirty_priority" "$i" "$pr_obj" >>"$_tmp_lines"
+		printf '%d\t%03d\t%d\t%06d\t%s\n' "$retry_priority" "$priority" "$dirty_priority" "$i" "$pr_obj" >>"$_tmp_lines"
 		i=$((i + 1))
 	done
 
-	LC_ALL=C sort "$_tmp_lines" | cut -f4- | jq -s '.'
+	LC_ALL=C sort "$_tmp_lines" | cut -f5- | jq -s '.'
 	rm -f "$_tmp_lines"
 	return 0
 }
@@ -557,6 +558,73 @@ _pmp_fetch_ready_pr_list() {
 }
 
 #######################################
+# Add due queue targets that fell outside the bounded broad PR list. Each
+# target is fetched authoritatively and remains subject to the normal per-PR
+# enrichment and action gates. Queue output and fetched objects are validated;
+# failures leave the durable hint for a later pass.
+#
+# Args: $1=repo slug, $2=broad PR JSON
+# Output: JSON array with due exact targets prepended and deduplicated
+#######################################
+_pmp_include_queued_pr_targets() {
+	local repo_slug="$1"
+	local pr_json="$2"
+	local dirty_keys=""
+	local remaining=""
+	local pr_number=""
+	local target_json=""
+	local fetched=0
+	local target_limit="${AIDEVOPS_PULSE_MERGE_DIRTY_TARGET_LIMIT:-5}"
+	local target_timeout="${AIDEVOPS_PULSE_MERGE_DIRTY_TARGET_TIMEOUT_SECONDS:-10}"
+
+	[[ "$target_limit" =~ ^[0-9]+$ && "$target_limit" -ge 1 && "$target_limit" -le 20 ]] || target_limit=5
+	[[ "$target_timeout" =~ ^[0-9]+$ && "$target_timeout" -ge 1 && "$target_timeout" -le 30 ]] || target_timeout=10
+	if ! declare -F _pulse_merge_queue_priority_keys >/dev/null 2>&1; then
+		printf '%s' "$pr_json"
+		return 0
+	fi
+	dirty_keys=$(_pulse_merge_queue_priority_keys "$repo_slug") || dirty_keys=""
+	remaining="$dirty_keys"
+	while [[ "$remaining" =~ ^\|([1-9][0-9]*)\|(.*)$ && "$fetched" -lt "$target_limit" ]]; do
+		pr_number="${BASH_REMATCH[1]}"
+		remaining="|${BASH_REMATCH[2]}"
+		if printf '%s' "$pr_json" | jq -e --argjson pr "$pr_number" 'any(.number == $pr)' >/dev/null 2>&1; then
+			pr_json=$(printf '%s' "$pr_json" | jq -c --argjson pr "$pr_number" \
+				'map(if .number == $pr then . + {_pulseDeferredRetry:true} else . end)') || return 1
+			continue
+		fi
+		fetched=$((fetched + 1))
+		target_json=$(AIDEVOPS_GH_READ_TIMEOUT="$target_timeout" AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 AIDEVOPS_GH_REST_FIRST_READS=1 \
+			gh_pr_view "$pr_number" --repo "$repo_slug" --json "$(_pulse_merge_ready_pr_json_fields)" 2>/dev/null) || target_json=""
+		if ! printf '%s' "$target_json" | jq -e --argjson pr "$pr_number" \
+			'type == "object" and .number == $pr and ((.state // "") | ascii_upcase) == "OPEN"' >/dev/null 2>&1; then
+			echo "[pulse-wrapper] Merge pass: due exact retry target PR #${pr_number} in ${repo_slug} was unavailable or no longer open; retaining hint for bounded recovery" >>"$LOGFILE"
+			continue
+		fi
+		pr_json=$(jq -cn --argjson target "$target_json" --argjson current "$pr_json" \
+			'[($target + {_pulseDeferredRetry:true})] + [$current[] | select(.number != $target.number)]') || return 1
+	done
+	printf '%s' "$pr_json"
+	return 0
+}
+
+_pmp_include_queued_pr_targets_or_fallback() {
+	local repo_slug="$1"
+	local pr_json="$2"
+	local error_file="${3:-}"
+	local expanded_pr_json=""
+
+	[[ -z "$error_file" ]] || rm -f "$error_file"
+	expanded_pr_json=$(_pmp_include_queued_pr_targets "$repo_slug" "$pr_json") || {
+		echo "[pulse-wrapper] Merge pass: exact retry target expansion failed for ${repo_slug}; retaining authoritative bounded broad-list fallback" >>"$LOGFILE"
+		printf '%s' "$pr_json"
+		return 1
+	}
+	printf '%s' "$expanded_pr_json"
+	return 0
+}
+
+#######################################
 # Record elapsed PR-list time and whether the observed list was authoritative.
 #######################################
 _pmp_record_pr_list_timing() {
@@ -617,7 +685,7 @@ _merge_ready_prs_for_repo() {
 		pr_json="[]"
 		pr_list_complete=0
 	fi
-	rm -f "$pr_merge_err"
+	pr_json=$(_pmp_include_queued_pr_targets_or_fallback "$repo_slug" "$pr_json" "$pr_merge_err") || pr_list_complete=0
 	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || { pr_count=0; pr_list_complete=0; }
 	[[ "$pr_count" =~ ^[0-9]+$ ]] || { pr_count=0; pr_list_complete=0; }
 	_pmp_record_pr_list_timing "$_timing_prefix" "$_list_start" "$pr_list_complete"
@@ -1227,6 +1295,59 @@ _route_pr_feedback_terminal_guard() {
 	return $?
 }
 
+_route_pr_preserve_deferred_retry() {
+	local route_rc="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local linked_issue="$4"
+	local kind="$5"
+	local queue_action="unavailable"
+
+	[[ "$route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ]] || return "$route_rc"
+	if declare -F _pulse_merge_queue_enqueue >/dev/null 2>&1; then
+		queue_action=$(_pulse_merge_queue_enqueue "$repo_slug" "$pr_number" 2>>"$LOGFILE") || queue_action="unavailable"
+	fi
+	echo "[pulse-wrapper] _route_pr_to_fix_worker: preserved deferred ${kind} route for PR #${pr_number} and issue #${linked_issue} in ${repo_slug} (retry_hint=${queue_action})" >>"$LOGFILE"
+	return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+}
+
+_route_pr_issue_labels_with_retry() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local kind="$4"
+	local issue_labels=""
+	local route_rc=0
+
+	issue_labels=$(_route_pr_issue_labels_for_dispatch "$pr_number" "$repo_slug" "$linked_issue") || route_rc=$?
+	if [[ "$route_rc" -ne 0 ]]; then
+		_route_pr_preserve_deferred_retry "$route_rc" "$pr_number" "$repo_slug" "$linked_issue" "$kind"
+		return $?
+	fi
+	printf '%s' "$issue_labels"
+	return 0
+}
+
+_route_pr_guard_and_dispatch_with_retry() {
+	local has_routed_label="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local linked_issue="$4"
+	local kind="$5"
+	local routed_label="$6"
+	local pr_title="$7"
+	local checks_json="$8"
+	local route_rc=0
+
+	_route_pr_feedback_terminal_guard "$has_routed_label" "$pr_number" "$repo_slug" \
+		"$linked_issue" "$kind" "$routed_label" || route_rc=$?
+	if [[ "$route_rc" -eq 0 ]]; then
+		_dispatch_pr_repair_by_kind "$kind" "$pr_number" "$repo_slug" "$linked_issue" "$pr_title" "$checks_json" || route_rc=$?
+	fi
+	_route_pr_preserve_deferred_retry "$route_rc" "$pr_number" "$repo_slug" "$linked_issue" "$kind"
+	return $?
+}
+
 #######################################
 # Route a PR to the appropriate fix worker based on origin label and kind.
 #
@@ -1268,7 +1389,6 @@ _route_pr_to_fix_worker() {
 	local label_list=""
 	local takeover_pattern="$_PMP_ORIGIN_TAKEOVER_PATTERN"
 	local has_routed_label=0
-	local issue_labels_rc=0
 
 	_route_pr_has_linked_issue "$pr_number" "$repo_slug" "$linked_issue" "$kind" || return 1
 
@@ -1306,8 +1426,7 @@ _route_pr_to_fix_worker() {
 	fi
 
 	# A linked issue on explicit maintainer hold is never rewritten or reopened.
-	issue_labels=$(_route_pr_issue_labels_for_dispatch "$pr_number" "$repo_slug" "$linked_issue") || issue_labels_rc=$?
-	[[ "$issue_labels_rc" -eq 0 ]] || return "$issue_labels_rc"
+	issue_labels=$(_route_pr_issue_labels_with_retry "$pr_number" "$repo_slug" "$linked_issue" "$kind") || return $?
 
 	if _route_pr_issue_supplies_worker_origin "$label_list" "$issue_labels"; then
 		issue_has_worker_origin=1
@@ -1321,11 +1440,13 @@ _route_pr_to_fix_worker() {
 			local origin_reconcile_rc=0
 			_route_issue_origin_is_trusted "$pr_number" "$repo_slug" "$linked_issue" \
 				|| origin_reconcile_rc=$?
-			[[ "$origin_reconcile_rc" -eq 0 ]] || return "$origin_reconcile_rc"
+			if [[ "$origin_reconcile_rc" -ne 0 ]]; then
+				_route_pr_preserve_deferred_retry "$origin_reconcile_rc" "$pr_number" "$repo_slug" "$linked_issue" "$kind"
+				return $?
+			fi
 		fi
-		_route_pr_feedback_terminal_guard "$has_routed_label" "$pr_number" "$repo_slug" \
-			"$linked_issue" "$kind" "$routed_label" || return $?
-		_dispatch_pr_repair_by_kind "$kind" "$pr_number" "$repo_slug" "$linked_issue" "$pr_title" "$checks_json"
+		_route_pr_guard_and_dispatch_with_retry "$has_routed_label" "$pr_number" "$repo_slug" \
+			"$linked_issue" "$kind" "$routed_label" "$pr_title" "$checks_json"
 		return $?
 	fi
 
@@ -1342,9 +1463,8 @@ _route_pr_to_fix_worker() {
 			echo "[pulse-wrapper] _route_pr_to_fix_worker: origin:worker-takeover not confirmed for PR #${pr_number} in ${repo_slug} — refusing destructive routing" >>"$LOGFILE"
 			return 1
 		fi
-		_route_pr_feedback_terminal_guard "$has_routed_label" "$pr_number" "$repo_slug" \
-			"$linked_issue" "$kind" "$routed_label" || return $?
-		_dispatch_pr_repair_by_kind "$kind" "$pr_number" "$repo_slug" "$linked_issue" "$pr_title" "$checks_json"
+		_route_pr_guard_and_dispatch_with_retry "$has_routed_label" "$pr_number" "$repo_slug" \
+			"$linked_issue" "$kind" "$routed_label" "$pr_title" "$checks_json"
 		return $?
 	fi
 

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1490,7 +1490,11 @@ _pmp_stage_handle_conflict() {
 		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 		return 2
 	fi
-	if [[ "$conflict_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" || "$conflict_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
+	if [[ "$conflict_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ]]; then
+		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+		return 4
+	fi
+	if [[ "$conflict_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
 		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-dirty-queue.py
+++ b/.agents/scripts/tests/test-pulse-merge-dirty-queue.py
@@ -80,6 +80,14 @@ class QueueTests(unittest.TestCase):
             self.queue.enqueue("owner/repo", 43, 1000 + module.RETENTION_SECONDS * 2)
         self.assertIsNotNone(self.queue.row("owner/repo", 42))
 
+    def test_capacity_admits_new_target_by_evicting_oldest_idle_hint(self):
+        self.queue.enqueue("owner/repo", 41, 1000)
+        self.queue.enqueue("owner/repo", 42, 1001)
+        with patch.object(module, "MAX_HINTS", 2):
+            self.assertEqual(self.queue.enqueue("owner/repo", 43, 1002), "wake")
+        self.assertIsNone(self.queue.row("owner/repo", 41))
+        self.assertEqual(self.queue.priority("owner/repo", 1003), "|43|42|")
+
     def test_unhandled_hints_remain_available_to_polling(self):
         self.queue.enqueue("owner/repo", 42, 1000)
         receipt = self.queue.claim("owner/repo", 42, os.getpid(), 1001)

--- a/.agents/scripts/tests/test-pulse-merge-dirty-queue.py
+++ b/.agents/scripts/tests/test-pulse-merge-dirty-queue.py
@@ -88,6 +88,15 @@ class QueueTests(unittest.TestCase):
         self.assertIsNone(self.queue.row("owner/repo", 41))
         self.assertEqual(self.queue.priority("owner/repo", 1003), "|43|42|")
 
+    def test_ordinary_capacity_cannot_evict_deferred_retry(self):
+        self.queue.enqueue("owner/repo", 41, 1000, durable=True)
+        self.queue.enqueue("owner/repo", 42, 1001)
+        with patch.object(module, "MAX_HINTS", 1):
+            self.assertEqual(self.queue.enqueue("other/repo", 43, 1002), "wake")
+        self.assertIsNotNone(self.queue.row("owner/repo", 41))
+        self.assertIsNone(self.queue.row("owner/repo", 42))
+        self.assertEqual(self.queue.priority("other/repo", 1003), "|43|")
+
     def test_unhandled_hints_remain_available_to_polling(self):
         self.queue.enqueue("owner/repo", 42, 1000)
         receipt = self.queue.claim("owner/repo", 42, os.getpid(), 1001)

--- a/.agents/scripts/tests/test-pulse-merge-dirty-queue.py
+++ b/.agents/scripts/tests/test-pulse-merge-dirty-queue.py
@@ -97,6 +97,13 @@ class QueueTests(unittest.TestCase):
         self.assertIsNone(self.queue.row("owner/repo", 42))
         self.assertEqual(self.queue.priority("other/repo", 1003), "|43|")
 
+    def test_priority_budget_selects_durable_retries_before_ordinary_hints(self):
+        self.queue.enqueue("owner/repo", 41, 1000, durable=True)
+        self.queue.enqueue("owner/repo", 42, 1001)
+        self.queue.enqueue("owner/repo", 43, 1002)
+        with patch.object(module, "MAX_HINTS", 2):
+            self.assertEqual(self.queue.priority("owner/repo", 1003), "|41|43|")
+
     def test_unhandled_hints_remain_available_to_polling(self):
         self.queue.enqueue("owner/repo", 42, 1000)
         receipt = self.queue.claim("owner/repo", 42, os.getpid(), 1001)

--- a/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
@@ -66,6 +66,11 @@ gh() {
 	return 1
 }
 
+_pulse_merge_ready_pr_json_fields() {
+	printf '%s' 'number,state,author,title,isDraft,labels,updatedAt,headRefOid,headRefName,baseRefName,createdAt'
+	return 0
+}
+
 printf '%s=== GH#22303: PR backlog priority tests ===%s\n' "$TEST_BLUE" "$TEST_NC"
 
 merge_ready_pr='{"number":1,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}'
@@ -139,6 +144,20 @@ sorted_numbers=$(_pmp_sort_prs_by_backlog_priority "[$human_pr,$dirty_pr,$checks
 assert_eq "2b: dirty hints break ties without overriding readiness priorities" \
 	"6,1,3,2,4,5" "$sorted_numbers"
 unset -f _pulse_merge_queue_priority_keys
+
+_pulse_merge_queue_priority_keys() { printf '|99|'; return 0; }
+gh_pr_view() {
+	local pr_number="$1"
+	[[ "$pr_number" == 99 ]] || return 1
+	printf '%s\n' '{"number":99,"state":"OPEN","mergeable":"CONFLICTING","reviewDecision":"APPROVED","isDraft":false,"labels":[],"statusCheckRollup":[]}'
+	return 0
+}
+queued_json=$(_pmp_include_queued_pr_targets owner/repo "[$merge_ready_pr]")
+assert_eq "2c: due exact retry target outside the broad list is prepended" \
+	"99,1" "$(printf '%s' "$queued_json" | jq -r '[.[].number] | join(",")')"
+assert_eq "2d: due exact retry target is processed before ordinary backlog priorities" \
+	"99,1" "$(_pmp_sort_prs_by_backlog_priority "$queued_json" owner/repo | jq -r '[.[].number] | join(",")')"
+unset -f _pulse_merge_queue_priority_keys gh_pr_view
 
 : >"$LOGFILE"
 _pmp_log_pr_backlog_counts "owner/repo" "$unsorted_json"

--- a/.agents/scripts/tests/test-pulse-merge-pr-context.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-context.sh
@@ -55,6 +55,9 @@ define_functions_under_test() {
 		/^_route_pr_has_linked_issue\(\) \{/,/^}$/ { print }
 		/^_route_pr_issue_labels_for_dispatch\(\) \{/,/^}$/ { print }
 		/^_route_pr_feedback_terminal_guard\(\) \{/,/^}$/ { print }
+		/^_route_pr_preserve_deferred_retry\(\) \{/,/^}$/ { print }
+		/^_route_pr_issue_labels_with_retry\(\) \{/,/^}$/ { print }
+		/^_route_pr_guard_and_dispatch_with_retry\(\) \{/,/^}$/ { print }
 		/^_route_pr_to_fix_worker\(\) \{/,/^}$/ { print }
 	' "$PROCESS_SCRIPT")
 	if [[ -z "$fn_src" ]]; then
@@ -76,6 +79,7 @@ install_stubs() {
 	SET_ORIGIN_RC=0
 	RECONCILED_PR_LABELS="origin:worker"
 	ROUTE_GUARD_RC=0
+	DISPATCH_RC=0
 	COMPARE_FAIL=0
 	COMPARE_BEHIND=1
 	TERMINAL_CHECK_RC=0
@@ -119,9 +123,10 @@ install_stubs() {
 		fi
 		return 0
 	}
-	_dispatch_ci_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-ci %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
-	_dispatch_pr_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-review %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
-	_dispatch_conflict_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-conflict %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
+	_dispatch_ci_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-ci %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return "$DISPATCH_RC"; }
+	_dispatch_pr_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-review %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return "$DISPATCH_RC"; }
+	_dispatch_conflict_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-conflict %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return "$DISPATCH_RC"; }
+	_pulse_merge_queue_enqueue() { local repo_slug="$1"; local pr_number="$2"; printf 'retry-hint %s %s\n' "$repo_slug" "$pr_number" >>"$GH_CALL_LOG"; printf 'coalesced\n'; return 0; }
 	_check_required_checks_has_terminal_failure() { local repo_slug="$1"; local pr_number="$2"; local expected_head_sha="${3:-}"; printf 'terminal-check %s %s %s\n' "$repo_slug" "$pr_number" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$TERMINAL_CHECK_RC"; }
 	_check_required_checks_have_pending_or_in_progress() { local repo_slug="$1"; local pr_number="$2"; local expected_head_sha="${3:-}"; printf 'pending-check %s %s %s\n' "$repo_slug" "$pr_number" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$PENDING_CHECK_RC"; }
 	_pulse_merge_admin_safety_check() { local pr_number="$1"; local repo_slug="$2"; local expected_head_sha="${3:-}"; printf 'admin-safety %s %s %s\n' "$pr_number" "$repo_slug" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$ADMIN_SAFETY_RC"; }
@@ -431,7 +436,8 @@ test_linked_issue_metadata_failure_is_retryable() {
 	local route_rc=0
 	_route_pr_to_fix_worker "9014" "owner/repo" "456" "conflict" \
 		"origin:worker" || route_rc=$?
-	if [[ "$route_rc" -ne 75 ]] || grep -Eq 'route-guard|dispatch-' "$GH_CALL_LOG"; then
+	if [[ "$route_rc" -ne 75 ]] || grep -Eq 'route-guard|dispatch-' "$GH_CALL_LOG" \
+		|| ! grep -qF 'retry-hint owner/repo 9014' "$GH_CALL_LOG"; then
 		fail "linked issue metadata failure is retryable" \
 			"rc=${route_rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
 		return 0
@@ -479,12 +485,31 @@ test_trusted_worker_terminal_guard_outcome_propagates() {
 	_route_pr_to_fix_worker "9013" "owner/repo" "456" "ci" \
 		"origin:worker,ci-feedback-routed" || route_rc=$?
 	if [[ "$route_rc" -ne 75 ]] || ! grep -qF 'route-guard 9013 owner/repo 456 ci' "$GH_CALL_LOG" \
+		|| ! grep -qF 'retry-hint owner/repo 9013' "$GH_CALL_LOG" \
 		|| grep -qF 'dispatch-ci' "$GH_CALL_LOG"; then
 		fail "trusted worker terminal guard outcome propagates" \
 			"rc=${route_rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
 		return 0
 	fi
 	pass "trusted worker partial-route outcome propagates without dispatch"
+	return 0
+}
+
+test_deferred_finalizer_dispatch_persists_retry_hint() {
+	install_stubs
+	DISPATCH_RC=75
+	: >"$GH_CALL_LOG"
+	local route_rc=0
+	_route_pr_to_fix_worker "9016" "owner/repo" "456" "conflict" \
+		"origin:worker" || route_rc=$?
+	if [[ "$route_rc" -ne 75 ]] \
+		|| ! grep -qF 'dispatch-conflict 9016 owner/repo 456' "$GH_CALL_LOG" \
+		|| ! grep -qF 'retry-hint owner/repo 9016' "$GH_CALL_LOG"; then
+		fail "deferred finalizer dispatch persists retry hint" \
+			"rc=${route_rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "deferred finalizer dispatch persists retry hint"
 	return 0
 }
 
@@ -515,6 +540,7 @@ main() {
 	test_fresh_interactive_route_does_not_enter_terminal_guard
 	test_review_terminal_label_rechecks_current_evidence
 	test_trusted_worker_terminal_guard_outcome_propagates
+	test_deferred_finalizer_dispatch_persists_retry_hint
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?

--- a/.agents/scripts/tests/test-pulse-merge-pr-context.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-context.sh
@@ -127,6 +127,7 @@ install_stubs() {
 	_dispatch_pr_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-review %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return "$DISPATCH_RC"; }
 	_dispatch_conflict_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-conflict %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return "$DISPATCH_RC"; }
 	_pulse_merge_queue_enqueue() { local repo_slug="$1"; local pr_number="$2"; printf 'retry-hint %s %s\n' "$repo_slug" "$pr_number" >>"$GH_CALL_LOG"; printf 'coalesced\n'; return 0; }
+	_pulse_merge_queue_finish() { local result="$1"; printf 'retry-finish %s\n' "$result" >>"$GH_CALL_LOG"; return 0; }
 	_check_required_checks_has_terminal_failure() { local repo_slug="$1"; local pr_number="$2"; local expected_head_sha="${3:-}"; printf 'terminal-check %s %s %s\n' "$repo_slug" "$pr_number" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$TERMINAL_CHECK_RC"; }
 	_check_required_checks_have_pending_or_in_progress() { local repo_slug="$1"; local pr_number="$2"; local expected_head_sha="${3:-}"; printf 'pending-check %s %s %s\n' "$repo_slug" "$pr_number" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$PENDING_CHECK_RC"; }
 	_pulse_merge_admin_safety_check() { local pr_number="$1"; local repo_slug="$2"; local expected_head_sha="${3:-}"; printf 'admin-safety %s %s %s\n' "$pr_number" "$repo_slug" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$ADMIN_SAFETY_RC"; }
@@ -513,6 +514,21 @@ test_deferred_finalizer_dispatch_persists_retry_hint() {
 	return 0
 }
 
+test_successful_finalizer_dispatch_retires_retry_hint() {
+	install_stubs
+	: >"$GH_CALL_LOG"
+	_route_pr_to_fix_worker "9017" "owner/repo" "456" "review" "origin:worker" || true
+	if ! grep -qF 'dispatch-review 9017 owner/repo 456' "$GH_CALL_LOG" \
+		|| ! grep -qF 'retry-finish 2' "$GH_CALL_LOG" \
+		|| grep -qF 'retry-hint owner/repo 9017' "$GH_CALL_LOG"; then
+		fail "successful finalizer dispatch retires retry hint" \
+			"calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "successful finalizer dispatch retires retry hint"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -541,6 +557,7 @@ main() {
 	test_review_terminal_label_rechecks_current_evidence
 	test_trusted_worker_terminal_guard_outcome_propagates
 	test_deferred_finalizer_dispatch_persists_retry_hint
+	test_successful_finalizer_dispatch_retires_retry_hint
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?

--- a/.agents/scripts/tests/test-pulse-merge-pr-context.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-context.sh
@@ -127,6 +127,7 @@ install_stubs() {
 	_dispatch_pr_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-review %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return "$DISPATCH_RC"; }
 	_dispatch_conflict_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-conflict %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return "$DISPATCH_RC"; }
 	_pulse_merge_queue_enqueue() { local repo_slug="$1"; local pr_number="$2"; printf 'retry-hint %s %s\n' "$repo_slug" "$pr_number" >>"$GH_CALL_LOG"; printf 'coalesced\n'; return 0; }
+	_pulse_merge_queue_defer() { local repo_slug="$1"; local pr_number="$2"; printf 'retry-hint %s %s\n' "$repo_slug" "$pr_number" >>"$GH_CALL_LOG"; printf 'coalesced\n'; return 0; }
 	_pulse_merge_queue_finish() { local result="$1"; printf 'retry-finish %s\n' "$result" >>"$GH_CALL_LOG"; return 0; }
 	_check_required_checks_has_terminal_failure() { local repo_slug="$1"; local pr_number="$2"; local expected_head_sha="${3:-}"; printf 'terminal-check %s %s %s\n' "$repo_slug" "$pr_number" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$TERMINAL_CHECK_RC"; }
 	_check_required_checks_have_pending_or_in_progress() { local repo_slug="$1"; local pr_number="$2"; local expected_head_sha="${3:-}"; printf 'pending-check %s %s %s\n' "$repo_slug" "$pr_number" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$PENDING_CHECK_RC"; }


### PR DESCRIPTION
## Summary

Persist typed feedback-route deferrals as durable exact PR retry hints, process them ahead of bounded broad-list fallback, reserve durable queue capacity, and retire hints after successful dispatch.



## Files Changed

.agents/scripts/pulse-merge-dirty-queue.py, .agents/scripts/pulse-merge-dirty-queue.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-dirty-queue.py, .agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh, .agents/scripts/tests/test-pulse-merge-pr-context.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Runtime path covered by deferred-route persistence, exact-target expansion, queue lifecycle and saturation tests; CI repair routing tests pass; shellcheck and linters-local.sh --changed pass.

Resolves #31697


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 17m and 163,205 tokens on this with the user in an interactive session.