### PR TITLE
docs: specify worker lease-attempt efficiency metrics

### DIFF
--- a/todo/tasks/t18424-brief.md
+++ b/todo/tasks/t18424-brief.md
@@ -78,6 +78,9 @@ Created 2026-09-10 through interactive planning. Parent: t18422. Blocked by t184
 4. Contribution outcomes distinguish accepted unchanged, accepted with repair, rejected, reused and unknown. Capture observed repair linkage and intervention counts, never invent human minutes or semantic success from tool exit/host finish. Preserve original observations and append corrections/supersession rather than rewriting history.
 5. Extend `runtime-events.mjs emit` with explicit session attribution as needed (its current CLI lacks a session flag), validate bounded fields, and return a receipt that can be checked with `query`. Preserve fail-open legacy writes; strict validation/readback for this new evidence must reveal when recording was unavailable, not silently claim recorded success.
 6. Add one optional terminal recording instruction in the owning reference: record only when the parent has acceptance evidence, once per contribution/objective, not every turn. Support headless lineage already supplied through event correlation/run IDs without modifying launch mechanics. Protect outcome/attachment events in retention and preserve private evidence outside Git.
+7. **Worker lease attempts:** bind each distinct successfully acquired worker lease to the issue/solve episode, execution attempt and contributing sessions. Read existing evidence from `.agents/scripts/dispatch-ledger-helper.sh:376` (registration includes issue, attempt and lease identity; repeated registration is idempotent at line 494) and `.agents/scripts/dispatch-lease-claims.jq` (trusted claim/phase/release parsing). These are reference/read surfaces, not added dispatch write scope. Use opaque attempt/claim identities; never persist or publish raw lease tokens or account/device identifiers.
+8. Count a fresh won lease once, including a lease whose worker fails before launch. Renewals, heartbeats, ready/terminal transitions, replayed registrations and request/tool retries under the same lease do not increment it. Losing claim races are separate acquisition failures, not worker lease attempts. A new lease after expiry/handoff counts even if it resumes the same session/worktree. Distinguish allocated leases from launched workers and record termination/retry reason and observed model/effort per lease; never attribute all earlier attempts to the final successful model.
+9. Retain complete issue-attempt history through the verified solve event, including failed/expired/prelaunch and still-open episodes. A current-active-lease list or age-filtered claim view cannot establish lifetime attempts. Missing history is partial/unknown, not zero. Reopened issues start a separate solve episode while lifetime counts remain distinguishable; productive/no-progress classifications require evidence and otherwise remain unknown.
 
 ### Hazards and Compatibility
 
@@ -100,6 +103,8 @@ bash .agents/scripts/tests/test-observability-runtime-events.sh
 
 Add focused fixtures for a root+child+repair chain, two objectives in one session, shared/unallocated work, duplicate/out-of-order/corrected observations, bare host-success, forged verification source, redaction and interrupted recording. Exercise `emit`→`query` on a disposable database. These commands are requirements, not claims of completed implementation testing.
 
+Lease fixtures: one acquired lease with three renewals and duplicate terminal observations counts as one; a fresh won replacement counts as two. Losing claims add zero leases, while a won prelaunch failure counts as one lease and zero launched workers. Cover cross-runner replay, mixed models, missing history, unsolved issues and a reopened solve episode.
+
 - **Surface mapping:** Event/CLI tests prove payload validation and readback; routing join proves contribution identity; retention proves durable lifecycle evidence; changed-file lint covers all modified modules/references.
 
 ### Progressive Context Plan
@@ -111,6 +116,7 @@ Read the CLI/envelope/allowlist first, then the host outcome callback. Load rete
 - [ ] An objective can be joined to uniquely bounded contributing requests, children and repair attempts using explicit evidence.
 - [ ] Host completion and parent assertions cannot manufacture automated verification; missing/conflicting attribution is reported unknown/unallocated.
 - [ ] Event replay and retention preserve one logical contribution without duplicate cost or loss of evidence; old consumers and permission/dispatch behaviour are unchanged.
+- [ ] Verified solved issues expose distinct worker lease attempts with completeness evidence; renewals and replay never inflate attempts, and unsuccessful/unfinished episodes remain observable.
 
 ## Recovery and Seeded Draft PR
 

--- a/todo/tasks/t18425-brief.md
+++ b/todo/tasks/t18425-brief.md
@@ -73,6 +73,9 @@ Created 2026-09-10, interactive auto-dispatch brief. Parent: t18422. Blocked by 
 4. Include parent/child/repair token and estimated-cost components, observed interventions, active inference time versus wall/CI/tool wait where available, and p50/p95 only with sample counts. Do not sum overlapping durations into wall time. Distinguish normal tool turns, route changes and actual retries; default fields are not evidence of absent transport retries.
 5. Keep recorded pricing versions unchanged; reprice only as a labelled comparable estimate with exact model-match coverage and known rate/service-context limitations. Unknown prices, long-context uplifts and shared-account quota attribution stay unavailable, not fabricated dollars or percentages.
 6. Add coverage fields for objective mapping, verification, effort evidence, population, lineage and price provenance. Reuse them in feedback without changing automatic routing or downgrading task tiers. Keep public output to aggregates and opaque fingerprints.
+7. **Lease attempts to solve:** report the number of distinct won worker leases through verified resolution per issue/solve episode, using t18424's identity/completeness contract. Include median/p95/max, a 1/2/3/4+ distribution and the one-lease share among fully observed solved issues, always with the denominator and independent issue count. Show overall completion rate plus attempts-to-date for unsolved/censored issues alongside these solved-only statistics to avoid survivorship bias.
+8. Separate allocated leases, actually launched workers, prelaunch failures, expiry/handoff and evidence-backed no-progress/repair. Renewals, duplicate observations, losing claim races and within-lease model/tool retries must not inflate the lease count. Keep partial historical counts labelled lower-bound/unknown, separate reopened solve episodes from lifetime totals, and preserve per-attempt model/effort attribution for mixed-route issues.
+9. Pair lease counts with total issue cost/time including unsuccessful attempts. When showing a cohort ratio of total leases divided by verified solved issues, include failed-issue leases in the numerator, label that cohort ratio separately from per-solved-issue counts, and return null for a zero or unknown verified denominator. Lease counts indicate recovery overhead, not task difficulty or model causality on their own.
 
 ### Hazards and Compatibility
 
@@ -93,6 +96,8 @@ node .agents/plugins/opencode-aidevops/tests/test-routing-feedback.mjs
 
 Use disposable fixtures for 2 successful objectives plus 1 failure, descendant/repair joins, multi-objective sessions, shared work, unknown effort/price, no verified outcomes and incomplete windows. Assert hand-calculated totals and denominator, no double counting, original DB bytes unchanged, and no inference/provider calls. The live read-only command is a smoke check, not evidence of a model winner.
 
+Lease arithmetic fixture: solved issue A has one lease plus three renewals; solved B has three distinct leases; unsolved C has two leases. Report solved distribution `{1:1, 3:1}`, median two, one-lease share 1/2, C attempts-to-date two, and the separately labelled cohort ratio six leases / two verified solves = three. Unknown/incomplete history cannot silently enter the complete-history denominator.
+
 - **Surface mapping:** Python fixtures prove attribution/arithmetic/read-only privacy; JS feedback tests prove consistent acceptance semantics; the existing CLI smoke checks production compatibility; changed-file lint covers the edited surface.
 
 ### Progressive Context Plan
@@ -108,6 +113,7 @@ Keep any shell entry-point change to argument forwarding; put new aggregation in
 - [ ] Fixture totals include failed attempts and all observed parent/child/repair work exactly once, with an independently checkable verified denominator.
 - [ ] Unknown/mixed/partial evidence prevents a spurious cheapest-route claim; legacy databases still return useful request-level output.
 - [ ] Production smoke output contains no raw private identifiers and leaves historical records/costs untouched.
+- [ ] Lease-attempt statistics match the explicit fixture arithmetic, preserve unsolved-issue visibility and do not count renewals as fresh attempts or confuse solved-only statistics with cohort-wide expenditure.
 
 ## Recovery and Seeded Draft PR
 


### PR DESCRIPTION
## Planning publication

- Publishes TODO.md and todo/ planning-file changes through a PR because main does not accept direct planning pushes.
- Source branch at helper invocation: feature/auto-20260910-012744.
- Commit message: docs: specify worker lease-attempt efficiency metrics.

## Task and issue manifest

<!-- aidevops:planning-publication:v1 id=c90cad18ec66a2e7c3baf6b59f677854b3ce9b71 -->
<!-- aidevops:planning-task:v1 task=t18424 issue=31699 -->
<!-- aidevops:planning-task:v1 task=t18425 issue=31701 -->
- For #31699
- For #31701

## Security and architecture guardrails

- This PR does not update .task-counter.
- Task IDs still come from claim-task-id.sh CAS allocation on a branch that permits atomic counter pushes.
- Do not replace counter allocation with a PR-backed counter update; PR review is not an atomic ID lock.

## Merge note

- Merge this planning-only PR before expecting pulse or issue-sync to see the TODO/todo changes.
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.350 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 7m and 36,193 tokens on this with the user in an interactive session.