### PR TITLE
GH#31722: fix Pulse session worker detection

### DIFF
--- a/.agents/scripts/pulse-session-helper.sh
+++ b/.agents/scripts/pulse-session-helper.sh
@@ -31,6 +31,8 @@ unset _aidevops_path_prefix
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/config-helper.sh" 2>/dev/null || true
+# shellcheck source=./worker-lifecycle-common.sh
+source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
 
 # Configuration
 readonly SESSION_FLAG="${HOME}/.aidevops/logs/pulse-session.flag"
@@ -91,9 +93,7 @@ is_session_active() {
 # Returns: count via stdout
 #######################################
 count_workers() {
-	local count
-	count=$(ps axwwo command | grep '[/]full-loop' | grep -c '\.opencode') || count=0
-	echo "$count"
+	count_active_workers
 	return 0
 }
 
@@ -427,13 +427,13 @@ _stop_force_kill_workers() {
 	print_warning "Force mode: sending SIGTERM to all workers..."
 	local killed=0
 	while IFS= read -r line; do
-		local pid
-		pid=$(echo "$line" | awk '{print $1}')
+		local pid _worker_details
+		read -r pid _worker_details <<<"$line"
 		if [[ -n "$pid" ]]; then
 			kill "$pid" 2>/dev/null || true
 			killed=$((killed + 1))
 		fi
-	done < <(ps axwwo pid,command | grep '[/]full-loop' | grep '\.opencode')
+	done < <(list_active_worker_processes)
 
 	if [[ "$killed" -gt 0 ]]; then
 		print_info "Sent SIGTERM to ${killed} worker(s)"
@@ -444,7 +444,7 @@ _stop_force_kill_workers() {
 		if [[ "$remaining" -gt 0 ]]; then
 			print_warning "${remaining} worker(s) still running after SIGTERM"
 			echo "  They will finish their current operation and exit."
-			echo "  Force kill with: kill -9 \$(ps axwwo pid,command | grep '[/]full-loop' | grep '\\.opencode' | awk '{print \$1}')"
+			echo "  Inspect with: worker-activity-helper.sh live-workers"
 		else
 			print_success "All workers stopped"
 		fi
@@ -691,7 +691,7 @@ _status_print_worker_details() {
 		echo -e "${BOLD}Active Workers${NC}"
 		echo "──────────────"
 		echo ""
-		ps axwwo pid,etime,command | grep '[/]full-loop' | grep '\.opencode' | while IFS= read -r line; do
+		list_active_worker_processes | while IFS= read -r line; do
 			local w_pid w_etime w_cmd
 			read -r w_pid w_etime w_cmd <<<"$line"
 

--- a/.agents/scripts/pulse-session-helper.sh
+++ b/.agents/scripts/pulse-session-helper.sh
@@ -427,7 +427,7 @@ _stop_force_kill_workers() {
 	print_warning "Force mode: sending SIGTERM to all workers..."
 	local killed=0
 	while IFS= read -r line; do
-		local pid _worker_details
+		local pid="" _worker_details=""
 		read -r pid _worker_details <<<"$line"
 		if [[ -n "$pid" ]]; then
 			kill "$pid" 2>/dev/null || true

--- a/.agents/scripts/tests/test-pulse-session-last-run.sh
+++ b/.agents/scripts/tests/test-pulse-session-last-run.sh
@@ -20,7 +20,10 @@ trap _cleanup EXIT
 # Load functions without invoking the CLI. The helper derives all readonly
 # paths from the isolated HOME above.
 # shellcheck source=/dev/null
-source <(sed '/^main "\$@"$/d' "$_TEST_TARGET")
+source <(sed \
+	-e '/^main "\$@"$/d' \
+	-e "s|^SCRIPT_DIR=.*|SCRIPT_DIR=\"${_TEST_REPO_ROOT}/.agents/scripts\"|" \
+	"$_TEST_TARGET")
 
 _TESTS_RUN=0
 _TESTS_FAILED=0
@@ -110,11 +113,75 @@ _test_status_summary_uses_marker() {
 	return 0
 }
 
+_test_status_uses_canonical_worker_detector() {
+	local worker_count=""
+	local output=""
+	worker_count=$(
+		list_active_worker_processes() {
+			printf '%s\n' '650 00:18 bash /Users/test/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key issue-14944 --dir /tmp/aidevops --title "Issue #14944" --prompt-file /tmp/pulse-14944.prompt'
+			return 0
+		}
+		count_workers
+	)
+	_assert_equal "1" "$worker_count" \
+		"worker count delegates to the canonical detector"
+	output=$(
+		list_active_worker_processes() {
+			printf '%s\n' '650 00:18 bash /Users/test/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key issue-14944 --dir /tmp/aidevops --title "Issue #14944" --prompt-file /tmp/pulse-14944.prompt'
+			return 0
+		}
+		_status_print_worker_details 1
+	)
+	if [[ "$output" == *"PID 650 (00:18): Issue #14944"* ]]; then
+		_assert_equal "present" "present" \
+			"status displays a detached headless worker from the canonical detector"
+	else
+		_assert_equal "present" "missing" \
+			"status displays a detached headless worker from the canonical detector"
+	fi
+	return 0
+}
+
+_test_force_stop_targets_canonical_worker_pid() {
+	local killed_pid_file="${_TEST_TMP_DIR}/killed-pid"
+	local output=""
+	output=$(
+		list_active_worker_processes() {
+			printf '%s\n' '651 00:19 bash /Users/test/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key issue-14945 --dir /tmp/aidevops'
+			return 0
+		}
+		count_workers() {
+			printf '%s\n' "0"
+			return 0
+		}
+		kill() {
+			printf '%s\n' "$1" >"$killed_pid_file"
+			return 0
+		}
+		sleep() {
+			return 0
+		}
+		_stop_force_kill_workers 1
+	)
+	_assert_equal "651" "$(<"$killed_pid_file")" \
+		"force stop targets the logical PID from the canonical detector"
+	if [[ "$output" == *"Sent SIGTERM to 1 worker(s)"* && "$output" == *"All workers stopped"* ]]; then
+		_assert_equal "present" "present" \
+			"force stop reports canonical worker termination"
+	else
+		_assert_equal "present" "missing" \
+			"force stop reports canonical worker termination"
+	fi
+	return 0
+}
+
 main() {
 	_test_marker_precedes_optional_cycle_log
 	_test_log_fallbacks
 	_test_portable_date_fallback
 	_test_status_summary_uses_marker
+	_test_status_uses_canonical_worker_detector
+	_test_force_stop_targets_canonical_worker_pid
 	printf '1..%d\n' "$_TESTS_RUN"
 	if [[ "$_TESTS_FAILED" -ne 0 ]]; then
 		return 1


### PR DESCRIPTION
## Summary

Route Pulse status, graceful stop, worker details, and force-stop targeting through the canonical logical-worker detector.



## Files Changed

.agents/scripts/pulse-session-helper.sh, .agents/scripts/tests/test-pulse-session-last-run.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified with a controlled headless-runtime launcher: Pulse status and pulse-check both reported one active worker; 10 Pulse-session tests and 35 canonical detector tests passed; changed-file lint, bash -n, and ShellCheck passed.

Resolves #31722


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.351 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 20m and 144,286 tokens on this with the user in an interactive session.