### PR TITLE
GH#31700: add bounded model-effort pilot

### DIFF
--- a/.agents/configs/model-effort-pilot.json
+++ b/.agents/configs/model-effort-pilot.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "aidevops-model-effort-pilot/v1",
+  "purpose": "Narrow isolated replay pilot; not production-routing evidence.",
+  "source": {
+    "repository": "marcusquinn/aidevops",
+    "base_sha": "3226532e2659b69f644a9aba99feda4a02845a79",
+    "rebuild": "Reconstruct private corpus inputs from this public commit on the approved runner; do not commit prompts, checks, patches, catalogs, or run artifacts."
+  },
+  "cases": [
+    {
+      "case_id": "pilot-simple",
+      "tier": "simple",
+      "profile": "aidevops",
+      "visibility": "private",
+      "prompt_fidelity": "reconstructed",
+      "check_recipe": "One deterministic fail-to-pass and one pass-to-pass check, retained locally."
+    },
+    {
+      "case_id": "pilot-standard",
+      "tier": "standard",
+      "profile": "aidevops",
+      "visibility": "private",
+      "prompt_fidelity": "reconstructed",
+      "check_recipe": "One deterministic fail-to-pass and one pass-to-pass check, retained locally."
+    },
+    {
+      "case_id": "pilot-thinking",
+      "tier": "thinking",
+      "profile": "aidevops",
+      "visibility": "private",
+      "prompt_fidelity": "reconstructed",
+      "check_recipe": "One deterministic fail-to-pass and one pass-to-pass check, retained locally."
+    }
+  ],
+  "budget": {
+    "schema_version": "aidevops-model-replay-budget/v1",
+    "max_cell_launches": 24,
+    "per_cell_timeout_seconds": 180,
+    "program_wall_seconds": 5400,
+    "concurrency": 1,
+    "reservation": "Four canaries, twelve primary cells, then retained capacity for explicit confirmation; retries never renew this ceiling."
+  },
+  "candidate_arms": {
+    "provider": "openai",
+    "required": ["gpt-5.6-sol:medium", "gpt-6-astra:low", "gpt-6-astra:medium", "gpt-6-astra:observed-highest"],
+    "rule": "Each same-model effort arm needs a separate candidate manifest because replay rejects duplicate model identities. Names remain requests until the runtime records the concrete model and effective effort."
+  }
+}

--- a/.agents/reference/model-effort-pilot.md
+++ b/.agents/reference/model-effort-pilot.md
@@ -1,0 +1,45 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2026 Marcus Quinn -->
+
+# Portable bounded model-effort pilot
+
+This is a three-case, isolated historical-replay pilot. It produces harness evidence,
+not aidevops end-to-end efficiency or an automatic routing change. Reconstructed
+prompts and any non-fresh case remain quarantined in the result.
+
+## Public handoff
+
+`configs/model-effort-pilot.json` supplies the public base commit, case metadata,
+candidate requests, and the aggregate budget. On an approved runner, create the
+private corpus, catalog, candidate manifests, hidden checks, and gold patches under
+`$PILOT_ROOT`; none are committed. Use `init --profiles aidevops --quick-size 3
+--full-size 3`, add the three cases, then qualify them three times.
+
+The runner must label reconstructed prompts and unavailable variants. Do not replace
+an unavailable requested arm with another model or effort.
+
+## Sealed execution recipe
+
+Use separate candidate manifests for each same-model effort arm. Before a provider
+call, create and seal each plan with the committed budget contract:
+
+```bash
+HELPER="$HOME/.aidevops/agents/scripts/brief-tier-test-helper.sh"
+"$HELPER" qualify --corpus "$PILOT_ROOT/corpus" --catalog "$PILOT_ROOT/catalog.json" --repetitions 3
+"$HELPER" plan --corpus "$PILOT_ROOT/corpus" --candidates "$PILOT_ROOT/candidates/ARM.json" --experiment "$PILOT_ROOT/experiments/ARM" --experiment-id "ARM" --suite quick --stage canary --mode autonomous --execution-posture enforced --budget "$PILOT_ROOT/budget.json"
+"$HELPER" seal --experiment "$PILOT_ROOT/experiments/ARM" --input "$PILOT_ROOT/predictions/ARM.json"
+"$HELPER" run --experiment "$PILOT_ROOT/experiments/ARM" --corpus "$PILOT_ROOT/corpus" --catalog "$PILOT_ROOT/catalog.json" --dry-run
+```
+
+For a real run, extract the `budget` object into a local JSON file with schema
+`aidevops-model-replay-budget/v1`; the public pilot file also contains metadata and
+is intentionally not accepted as a bare budget contract. A sealed plan copies the
+contract. It reserves a cell before launch, persists the reservation, and rejects a
+resume with an uncompleted launch until reconciled. These limits bound launches,
+wall time, per-cell timeout, and concurrency; they do not cap provider cost or quota.
+
+Real execution is restricted to approved OpenAI ChatGPT OAuth. It must retain the
+existing enforced egress sandbox and observed concrete model/effort evidence; do not
+use API-key billing, fixture runtimes, trusted-local posture, or alternate providers.
+The runner records the outcome and exact prerequisite failure. The t18425 report may
+join only sealed receipts and public hashes, not raw artifacts.

--- a/.agents/scripts/model-replay-benchmark.mjs
+++ b/.agents/scripts/model-replay-benchmark.mjs
@@ -33,6 +33,7 @@ function commandPlan(options) {
     mode: options.mode || "autonomous",
     executionPosture: options.execution_posture || "enforced",
     allowContaminated: Boolean(options.allow_contaminated),
+    budgetPath: options.budget ? resolve(options.budget) : "",
   });
 }
 

--- a/.agents/scripts/model-replay-budget.mjs
+++ b/.agents/scripts/model-replay-budget.mjs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { sha256, stableJson, writeJson } from "./model-replay-core.mjs";
+
+export const BUDGET_SCHEMA = "aidevops-model-replay-budget/v1";
+
+function positiveInteger(value, label) {
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${label} must be a positive integer`);
+  return value;
+}
+
+export function validateBudgetContract(contract) {
+  if (!contract || contract.schema_version !== BUDGET_SCHEMA) {
+    throw new Error("Model replay budget schema is unsupported");
+  }
+  const required = [
+    [contract.max_cell_launches, "Budget max_cell_launches"],
+    [contract.per_cell_timeout_seconds, "Budget per_cell_timeout_seconds"],
+    [contract.program_wall_seconds, "Budget program_wall_seconds"],
+    [contract.concurrency, "Budget concurrency"],
+  ];
+  required.forEach(([value, label]) => positiveInteger(value, label));
+  if (contract.concurrency !== 1) throw new Error("Model replay budget concurrency must be one");
+  return structuredClone(contract);
+}
+
+export function loadBudgetContract(path) {
+  if (!existsSync(path)) throw new Error("Model replay budget file is missing");
+  return validateBudgetContract(JSON.parse(readFileSync(path, "utf8")));
+}
+
+function receiptPath(experimentDir) {
+  return join(experimentDir, "budget-receipt.json");
+}
+
+function receiptDigest(receipt) {
+  const payload = { ...receipt };
+  delete payload.receipt_sha256;
+  return sha256(stableJson(payload));
+}
+
+export function loadBudgetReceipt(experimentDir, plan) {
+  if (!plan.budget) return null;
+  const path = receiptPath(experimentDir);
+  if (!existsSync(path)) {
+    const receipt = {
+      schema_version: BUDGET_SCHEMA,
+      plan_sha256: plan.plan_sha256,
+      budget: validateBudgetContract(plan.budget),
+      started_at: new Date().toISOString(),
+      launched_cell_ids: [],
+      completed_cell_ids: [],
+    };
+    receipt.receipt_sha256 = receiptDigest(receipt);
+    writeJson(path, receipt);
+    return receipt;
+  }
+  const receipt = JSON.parse(readFileSync(path, "utf8"));
+  if (receipt.receipt_sha256 !== receiptDigest(receipt)
+    || receipt.plan_sha256 !== plan.plan_sha256
+    || stableJson(receipt.budget) !== stableJson(validateBudgetContract(plan.budget))
+    || !Array.isArray(receipt.launched_cell_ids)
+    || !Array.isArray(receipt.completed_cell_ids)
+    || receipt.completed_cell_ids.some((cellID) => !receipt.launched_cell_ids.includes(cellID))) {
+    throw new Error("Model replay budget receipt integrity check failed");
+  }
+  return receipt;
+}
+
+function persistReceipt(experimentDir, receipt) {
+  receipt.receipt_sha256 = receiptDigest(receipt);
+  writeJson(receiptPath(experimentDir), receipt);
+}
+
+export function reserveCellLaunch(experimentDir, plan, receipt, cell) {
+  if (!receipt || receipt.launched_cell_ids.includes(cell.cell_id)) return;
+  if (receipt.launched_cell_ids.length >= receipt.budget.max_cell_launches) {
+    throw new Error("Model replay aggregate launch budget is exhausted");
+  }
+  if (cell.timeout_seconds > receipt.budget.per_cell_timeout_seconds) {
+    throw new Error("Model replay cell timeout exceeds the sealed budget");
+  }
+  if ((Date.now() - Date.parse(receipt.started_at)) / 1000 > receipt.budget.program_wall_seconds) {
+    throw new Error("Model replay programme wall-time budget is exhausted");
+  }
+  receipt.launched_cell_ids.push(cell.cell_id);
+  persistReceipt(experimentDir, receipt);
+}
+
+export function completeCellLaunch(experimentDir, receipt, cell) {
+  if (!receipt || receipt.completed_cell_ids.includes(cell.cell_id)) return;
+  receipt.completed_cell_ids.push(cell.cell_id);
+  persistReceipt(experimentDir, receipt);
+}
+
+export function assertNoAmbiguousLaunches(receipt, results) {
+  if (!receipt) return;
+  const completed = new Set(results.map((result) => result.cell_id));
+  const ambiguous = receipt.launched_cell_ids.find((cellID) => !completed.has(cellID));
+  if (ambiguous) throw new Error(`Model replay launch is ambiguous and requires reconciliation: ${ambiguous}`);
+}

--- a/.agents/scripts/model-replay-cli-options.mjs
+++ b/.agents/scripts/model-replay-cli-options.mjs
@@ -24,7 +24,7 @@ const COMMAND_OPTIONS = {
   ],
   plan: [
     "corpus", "candidates", "experiment", "experiment_id", "suite", "stage", "mode",
-    "execution_posture", "allow_contaminated",
+    "execution_posture", "allow_contaminated", "budget",
   ],
   seal: ["experiment", "input"],
   run: ["experiment", "corpus", "catalog", "dry_run"],
@@ -47,7 +47,7 @@ Usage:
   brief-tier-test-helper.sh plan --corpus DIR --candidates FILE --experiment DIR \\
     --experiment-id ID [--suite quick|full] [--stage canary|primary|sweep|confirm] \\
     [--mode autonomous|prescriptive] [--execution-posture enforced|trusted-local] \\
-    [--allow-contaminated]
+    [--allow-contaminated] [--budget FILE]
   brief-tier-test-helper.sh seal --experiment DIR --input FILE
   brief-tier-test-helper.sh run --experiment DIR --corpus DIR --catalog FILE [--dry-run]
   brief-tier-test-helper.sh report --experiment DIR

--- a/.agents/scripts/model-replay-plan.mjs
+++ b/.agents/scripts/model-replay-plan.mjs
@@ -3,6 +3,7 @@
 
 import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { loadBudgetContract, validateBudgetContract } from "./model-replay-budget.mjs";
 import { contaminationFor, loadCandidates } from "./model-replay-candidates.mjs";
 import {
   EXECUTION_POSTURES,
@@ -56,6 +57,7 @@ export function loadVerifiedPlan(experimentDir) {
     throw new Error("Experiment plan integrity check failed");
   }
   modelReplayExecutionPosture(plan);
+  if (plan.budget !== null && plan.budget !== undefined) validateBudgetContract(plan.budget);
   return plan;
 }
 
@@ -195,6 +197,7 @@ export function createPlan({
   mode = "autonomous",
   executionPosture = "enforced",
   allowContaminated = false,
+  budgetPath = "",
 }) {
   experimentDir = resolveExperimentDirectory(experimentDir, true);
   validatePlanOptions({ experimentID, suite, stage, mode, executionPosture });
@@ -203,6 +206,7 @@ export function createPlan({
   }
   const corpus = loadCorpus(corpusDir);
   const candidateConfig = loadCandidates(candidatePath);
+  const budget = budgetPath ? loadBudgetContract(budgetPath) : null;
   const entries = selectSuiteEntries(corpus, suite, stage);
   const cases = entries.map((entry) => plannedCase(corpusDir, entry, mode));
   const planned = buildCells({
@@ -226,6 +230,7 @@ export function createPlan({
     framework: frameworkIdentity(candidateConfig),
     candidate_config_sha256: sha256(stableJson(candidateConfig)),
     allowed_providers: candidateConfig.allowed_providers,
+    budget,
     cases,
     cells: planned.cells,
     integrity: {

--- a/.agents/scripts/model-replay-runner.mjs
+++ b/.agents/scripts/model-replay-runner.mjs
@@ -4,6 +4,12 @@
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { executeCell } from "./model-replay-cell.mjs";
+import {
+  assertNoAmbiguousLaunches,
+  completeCellLaunch,
+  loadBudgetReceipt,
+  reserveCellLaunch,
+} from "./model-replay-budget.mjs";
 import { modelReplayExecutionPosture } from "./model-replay-contracts.mjs";
 import {
   appendJsonLine,
@@ -78,9 +84,10 @@ function createDryRunRecord({ experimentDir, plan, sealed, pending }) {
   };
 }
 
-function executePendingCells({ cells, plan, sealed, corpusDir, catalog, experimentDir, candidates }) {
+function executePendingCells({ cells, plan, sealed, corpusDir, catalog, experimentDir, candidates, receipt }) {
   const results = [];
   for (const cell of cells) {
+    reserveCellLaunch(experimentDir, plan, receipt, cell);
     const result = executeCell({
       cell,
       plan,
@@ -91,6 +98,7 @@ function executePendingCells({ cells, plan, sealed, corpusDir, catalog, experime
       candidates,
     });
     appendJsonLine(join(experimentDir, "results.jsonl"), result);
+    completeCellLaunch(experimentDir, receipt, cell);
     results.push(result);
   }
   return results;
@@ -119,6 +127,8 @@ export function runExperiment({ experimentDir, corpusDir, catalogPath, dryRun = 
       writeJson(join(experimentDir, "dry-run.json"), record);
       return record;
     }
+    const receipt = loadBudgetReceipt(experimentDir, plan);
+    assertNoAmbiguousLaunches(receipt, existingResults);
     const lockedResults = validatedResultRecords(experimentDir, plan, sealed);
     const executableCells = pendingCells(plan, lockedResults);
     if (executableCells.length > 0 && modelReplayExecutionPosture(plan) === "enforced") {
@@ -132,6 +142,7 @@ export function runExperiment({ experimentDir, corpusDir, catalogPath, dryRun = 
       catalog,
       experimentDir,
       candidates,
+      receipt,
     });
     return {
       experiment_id: plan.experiment_id,

--- a/.agents/scripts/tests/test-model-replay-benchmark.mjs
+++ b/.agents/scripts/tests/test-model-replay-benchmark.mjs
@@ -295,6 +295,26 @@ try {
   );
   assert.equal(plan.cells.length, 1);
   assert.equal(plan.execution_posture, "enforced");
+  const budgetPath = join(sandbox, "budget.json");
+  writeJson(budgetPath, {
+    schema_version: "aidevops-model-replay-budget/v1",
+    max_cell_launches: 1,
+    per_cell_timeout_seconds: 60,
+    program_wall_seconds: 3600,
+    concurrency: 1,
+  });
+  const budgetExperiment = join(sandbox, "experiment-budget");
+  const budgetPlan = invokeRequired(
+    environment,
+    "plan", "--corpus", corpus, "--candidates", candidates,
+    "--experiment", budgetExperiment, "--experiment-id", "fixture-budget",
+    "--suite", "quick", "--stage", "primary", "--mode", "autonomous",
+    "--budget", budgetPath,
+  );
+  assert.equal(budgetPlan.budget.max_cell_launches, 1);
+  const budgetPredictions = join(sandbox, "predictions-budget.json");
+  writeJson(budgetPredictions, completedPredictions(budgetExperiment));
+  invokeRequired(environment, "seal", "--experiment", budgetExperiment, "--input", budgetPredictions);
   const predictionInput = join(sandbox, "predictions-autonomous.json");
   writeJson(predictionInput, completedPredictions(experiment));
   invokeRequired(environment, "seal", "--experiment", experiment, "--input", predictionInput);
@@ -321,6 +341,12 @@ try {
   assert.equal(dryRun.provider_calls_made, 0);
   assert.equal(dryRun.execution_posture, "enforced");
   assert.equal(existsSync(runtimeMarker), false);
+  const budgetDryRun = invokeRequired(
+    environment,
+    "run", "--experiment", budgetExperiment, "--corpus", corpus, "--catalog", catalog, "--dry-run",
+  );
+  assert.equal(budgetDryRun.provider_calls_made, 0);
+  assert.equal(existsSync(join(budgetExperiment, "budget-receipt.json")), false);
   assert.equal(existsSync(join(experiment, "report.json")), true);
   invokeRequired(environment, "report", "--experiment", experiment);
   const firstReport = readFileSync(join(experiment, "report.json"), "utf8");
@@ -545,6 +571,51 @@ try {
   assert.equal(existsSync(runtimeState), false);
   assert.equal(existsSync(sharedOauthPool), false);
   assert.deepEqual(readdirSync(sensitiveTemp), []);
+  const budgetRun = invokeRequired(
+    environment,
+    "run", "--experiment", budgetExperiment, "--corpus", corpus, "--catalog", catalog,
+  );
+  assert.equal(budgetRun.results.length, 1);
+  const budgetReceipt = JSON.parse(readFileSync(join(budgetExperiment, "budget-receipt.json"), "utf8"));
+  assert.deepEqual(budgetReceipt.launched_cell_ids, [budgetPlan.cells[0].cell_id]);
+  assert.deepEqual(budgetReceipt.completed_cell_ids, [budgetPlan.cells[0].cell_id]);
+  const exhaustedCandidates = join(sandbox, "candidates-exhausted.json");
+  const exhaustedCandidateConfig = JSON.parse(readFileSync(candidates, "utf8"));
+  exhaustedCandidateConfig.candidates.push({
+    ...exhaustedCandidateConfig.candidates[0],
+    model: "openai/replay-fixture-second",
+  });
+  writeJson(exhaustedCandidates, exhaustedCandidateConfig);
+  const exhaustedExperiment = join(sandbox, "experiment-budget-exhausted");
+  const exhaustedPlan = invokeRequired(
+    environment,
+    "plan", "--corpus", corpus, "--candidates", exhaustedCandidates,
+    "--experiment", exhaustedExperiment, "--experiment-id", "fixture-budget-exhausted",
+    "--suite", "quick", "--stage", "primary", "--mode", "autonomous",
+    "--budget", budgetPath,
+  );
+  const exhaustedPredictions = join(sandbox, "predictions-budget-exhausted.json");
+  writeJson(exhaustedPredictions, completedPredictions(exhaustedExperiment));
+  invokeRequired(
+    environment,
+    "seal", "--experiment", exhaustedExperiment, "--input", exhaustedPredictions,
+  );
+  expectFailure(
+    environment,
+    /aggregate launch budget is exhausted/u,
+    "run", "--experiment", exhaustedExperiment, "--corpus", corpus, "--catalog", catalog,
+  );
+  const exhaustedReceipt = JSON.parse(readFileSync(
+    join(exhaustedExperiment, "budget-receipt.json"),
+    "utf8",
+  ));
+  assert.deepEqual(exhaustedReceipt.launched_cell_ids, [exhaustedPlan.cells[0].cell_id]);
+  assert.deepEqual(exhaustedReceipt.completed_cell_ids, [exhaustedPlan.cells[0].cell_id]);
+  expectFailure(
+    environment,
+    /aggregate launch budget is exhausted/u,
+    "run", "--experiment", exhaustedExperiment, "--corpus", corpus, "--catalog", catalog,
+  );
   const patch = readFileSync(join(experiment, "artifacts", `${plan.cells[0].cell_id}.patch`), "utf8");
   assert.equal(patch.includes("created.txt"), true);
   assert.equal(patch.includes("PATCH_END_MARKER"), true);

--- a/.agents/workflows/optimize-tiers.md
+++ b/.agents/workflows/optimize-tiers.md
@@ -160,6 +160,14 @@ The dry run holds the experiment lock, validates the corpus, catalog, exact base
 trees, plan, candidate, prediction, and runtime seals, makes zero provider calls,
 and writes a reproducible report.
 
+### Bounded pilot
+
+`configs/model-effort-pilot.json` defines a portable three-case pilot and its public
+source metadata. Pass a local file containing its `budget` object to `plan --budget`.
+The sealed receipt reserves launches before execution and does not refund an
+interrupted launch on resume. See `reference/model-effort-pilot.md` for the approved
+runner recipe and limitations.
+
 ### 4. Execute and interpret
 
 ```bash


### PR DESCRIPTION
Resolves #31700

## Summary

- Add portable public metadata and a sealed pilot protocol.
- Add fail-closed aggregate replay launch receipts and budget validation.
- Extend fake-runtime coverage for dry runs, persistence, and exhaustion.

## Testing

- `.agents/scripts/linters-local.sh --changed`
- `bash .agents/scripts/brief-tier-test-helper.sh --help`
- Node syntax checks for changed modules
- `node .agents/scripts/tests/test-model-replay-benchmark.mjs` *(blocked before target assertions: no enforcing Linux verifier sandbox is available)*

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.352 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 8m and 130,197 tokens on this as a headless worker.
