### PR TITLE
GH#31744: fix: respect issue-sync publication branch

### DIFF
--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -351,7 +351,10 @@ issue_sync_prepare_base_snapshot() {
 	issue_sync_git -C "$repo_path" fetch -q origin "$default_branch" || return 1
 	ISSUE_SYNC_BASE_SHA=$(issue_sync_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
 	source_head=$(issue_sync_git -C "$repo_path" rev-parse "HEAD^{commit}") || return 1
-	ISSUE_SYNC_SOURCE_BASE_SHA=$(issue_sync_git -C "$repo_path" merge-base "$source_head" "$ISSUE_SYNC_BASE_SHA") || return 1
+	if ! ISSUE_SYNC_SOURCE_BASE_SHA=$(issue_sync_git -C "$repo_path" merge-base "$source_head" "$ISSUE_SYNC_BASE_SHA"); then
+		echo "::error::Cannot find a common ancestor between the source checkout and publication branch '${default_branch}'; refusing TODO.md publication. Verify branch selection and trusted checkout history." >&2
+		return 1
+	fi
 	cp -p "$source_file" "$merged_file" || return 1
 	issue_sync_read_todo_blob "$repo_path" "$ISSUE_SYNC_SOURCE_BASE_SHA" "$source_ancestor" || return 1
 	issue_sync_read_todo_blob "$repo_path" "$ISSUE_SYNC_BASE_SHA" "$latest_todo" || return 1

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -350,6 +350,7 @@ run_issue_sync_helper() {
 	local fallback_token="${10:-}"
 	local reject_pr_token="${11:-}"
 	local trusted_git="${12:-}"
+	local target_branch="${13:-main}"
 	local ci_home="${output_file}.home"
 	local runner_temp="${output_file}.runner"
 	mkdir -p "$ci_home" "$runner_temp"
@@ -371,7 +372,7 @@ run_issue_sync_helper() {
 			GH_STUB_REJECT_PR_TOKEN="$reject_pr_token" \
 			GIT_GUARD_LOG="${output_file}.git-guard" \
 			AIDEVOPS_PLANNING_GIT_BIN="$trusted_git" \
-			bash "$HELPER" publish-todo main "$attempts" \
+			bash "$HELPER" publish-todo "$target_branch" "$attempts" \
 			"chore: sync fixture issue refs to TODO.md [skip ci]" >"$output_file" 2>&1
 	)
 	return $?
@@ -939,6 +940,63 @@ test_noop_publishes_nothing() {
 	return 0
 }
 
+test_shallow_publication_target() {
+	local target_branch="$1"
+	local origin_dir="$TMP/target-${target_branch}-origin.git"
+	local seed_dir="$TMP/target-${target_branch}-seed"
+	local work_dir="$TMP/target-${target_branch}-work"
+	local fake_bin="$TMP/target-${target_branch}-bin"
+	local gh_log="$TMP/target-${target_branch}-gh.log"
+	local output_file="$TMP/target-${target_branch}-output.log"
+	local main_before=""
+	local develop_before=""
+	local candidate_before=""
+	local rc=0
+
+	create_origin "$origin_dir" "$seed_dir"
+	git -C "$seed_dir" checkout -b develop >/dev/null 2>&1
+	printf '\nDevelopment branch context.\n' >>"$seed_dir/TODO.md"
+	git -C "$seed_dir" add TODO.md
+	git -C "$seed_dir" commit -m "advance develop" >/dev/null
+	git -C "$seed_dir" push origin develop >/dev/null 2>&1
+	git clone --depth 1 --branch develop "file://${origin_dir}" "$work_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	write_fake_gh "$fake_bin"
+	: >"$gh_log"
+	printf '\n- [ ] t9004 development-only projection ref:GH#9004\n' >>"$work_dir/TODO.md"
+	main_before=$(git --git-dir="$origin_dir" rev-parse main)
+	develop_before=$(git --git-dir="$origin_dir" rev-parse develop)
+	candidate_before=$(git -C "$work_dir" hash-object TODO.md)
+
+	run_issue_sync_helper "$work_dir" "$fake_bin" "$gh_log" "$TMP/target-${target_branch}-pr.marker" \
+		"$TMP/target-${target_branch}-head" "$TMP/target-${target_branch}-title" "$output_file" 1 \
+		"fixture-token" "" "" "" "$target_branch" || rc=$?
+	if [[ "$target_branch" == "develop" ]]; then
+		if [[ "$rc" -eq 0 ]] && git --git-dir="$origin_dir" show develop:TODO.md | grep -q 't9004 development-only projection'; then
+			pass "shallow develop checkout publishes to develop"
+		else
+			fail "shallow develop checkout publishes to develop"
+		fi
+	else
+		if [[ "$rc" -ne 0 ]] && grep -q 'Cannot find a common ancestor.*refusing TODO.md publication' "$output_file" &&
+			[[ "$(git --git-dir="$origin_dir" rev-parse develop)" == "$develop_before" ]]; then
+			pass "shallow branch mismatch fails closed with an actionable diagnostic"
+		else
+			fail "shallow branch mismatch fails closed with an actionable diagnostic"
+		fi
+	fi
+	if [[ "$(git --git-dir="$origin_dir" rev-parse main)" == "$main_before" &&
+	"$(git -C "$work_dir" rev-parse HEAD)" == "$develop_before" &&
+	"$(git -C "$work_dir" hash-object TODO.md)" == "$candidate_before" && ! -s "$gh_log" ]]; then
+		pass "${target_branch} target preserves main, caller state, and avoids GitHub writes"
+	else
+		fail "${target_branch} target preserves main, caller state, and avoids GitHub writes"
+	fi
+	return 0
+}
+
+test_shallow_publication_target develop
+test_shallow_publication_target main
 test_successful_push
 test_rebase_conflict_neutralizes_cleanly
 test_protected_branch_uses_one_rebased_pr

--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -255,7 +255,7 @@ PLANS_BODY=$(printf '%s\n' "${JOB_BODY}" | awk '
 ')
 # shellcheck disable=SC2016 # Assert the literal workflow variable reference.
 if printf '%s\n' "${JOB_BODY}" | grep -qE 'AIDEVOPS_PLANNING_GIT_BIN=.*RUNNER_GIT' &&
-	printf '%s\n' "${PROOF_BODY}" | grep -qE 'issue-sync-git-push-helper\.sh"?[[:space:]]+publish-todo[[:space:]]+main' &&
+	printf '%s\n' "${PROOF_BODY}" | grep -qE 'issue-sync-git-push-helper\.sh"?[[:space:]]+publish-todo[[:space:]]+"\$ISSUE_SYNC_TARGET_BRANCH"' &&
 	! printf '%s\n' "${PROOF_BODY}" | grep -qE 'planning_publish[[:space:]]' &&
 	! printf '%s\n' "${PROOF_BODY}" | grep -qE '^[[:space:]]+git[[:space:]]+(config|add|commit|pull|push)' &&
 	printf '%s\n' "${PLANS_BODY}" | grep -qE 'planning_publish[[:space:]]' &&
@@ -270,8 +270,9 @@ fi
 # Test 7: every legacy issue-sync TODO writer routes through the same helper.
 # The deterministic helper owns GH006 detection and PR deduplication.
 # ============================================================
-PUBLISH_CALL_COUNT=$(grep -cE 'issue-sync-git-push-helper\.sh"?[[:space:]]+publish-todo[[:space:]]+main' "$WORKFLOW_FILE" || true)
-LEGACY_PUSH_COUNT=$(grep -cE 'issue-sync-git-push-helper\.sh[[:space:]]+push-todo[[:space:]]+main' "$WORKFLOW_FILE" || true)
+# shellcheck disable=SC2016 # Match the literal workflow variable, not the test environment.
+PUBLISH_CALL_COUNT=$(grep -cE 'issue-sync-git-push-helper\.sh"?[[:space:]]+publish-todo[[:space:]]+"\$ISSUE_SYNC_TARGET_BRANCH"' "$WORKFLOW_FILE" || true)
+LEGACY_PUSH_COUNT=$(grep -cE 'issue-sync-git-push-helper\.sh[[:space:]]+push-todo[[:space:]]+' "$WORKFLOW_FILE" || true)
 if [[ "$PUBLISH_CALL_COUNT" -eq 4 && "$LEGACY_PUSH_COUNT" -eq 0 ]]; then
 	check 1 "all four TODO publication paths share the idempotent PR-safe helper" ""
 else
@@ -301,6 +302,25 @@ if [[ "$PR_TOKEN_FALLBACK_COUNT" -eq 4 ]]; then
 else
 	check 0 "all four TODO publication paths expose the bounded PR token fallback" \
 		"fallback exports=${PR_TOKEN_FALLBACK_COUNT}"
+fi
+
+# ============================================================
+# Publication must follow the trusted caller branch, independently of the
+# framework checkout ref. PR base takes precedence over synthetic merge refs;
+# tag/non-branch events fall back to the consumer's default branch.
+# ============================================================
+TARGET_BRANCH_EXPRESSION="ISSUE_SYNC_TARGET_BRANCH: \${{ github.event.pull_request.base.ref || (github.ref_type == 'branch' && github.ref_name) || github.event.repository.default_branch }}"
+if grep -Fq "$TARGET_BRANCH_EXPRESSION" "$WORKFLOW_FILE" &&
+	grep -Fq "origin \"\$ISSUE_SYNC_TARGET_BRANCH\" todo/PLANS.md" "$WORKFLOW_FILE" &&
+	! grep -qE 'publish-todo main|origin main todo/PLANS.md|merged to main\.' "$WORKFLOW_FILE"; then
+	check 1 "TODO, PLANS and completion messages use the caller publication branch" ""
+else
+	check 0 "TODO, PLANS and completion messages use the caller publication branch" "hard-coded main or unsafe branch precedence remains"
+fi
+if grep -Fq "ref: \${{ inputs.aidevops_ref || 'main' }}" "$WORKFLOW_FILE"; then
+	check 1 "framework checkout retains its independent upstream ref" ""
+else
+	check 0 "framework checkout retains its independent upstream ref" "consumer branch must not replace aidevops_ref"
 fi
 
 # ============================================================

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -55,6 +55,12 @@ on:
         required: false
         description: 'Optional fine-grained PAT with Contents:read/write; add Pull requests:read/write when it must backstop disabled Actions PR creation'
 
+# Match the trusted caller checkout: never use a PR head or synthetic merge ref.
+# Issue events fall back to the consumer's default branch; framework refs remain
+# independently pinned by aidevops_ref.
+env:
+  ISSUE_SYNC_TARGET_BRANCH: ${{ github.event.pull_request.base.ref || (github.ref_type == 'branch' && github.ref_name) || github.event.repository.default_branch }}
+
 jobs:
   forge-event:
     name: Record ordered forge event
@@ -357,7 +363,7 @@ jobs:
           if git diff --quiet TODO.md 2>/dev/null; then
             echo "No TODO.md changes to publish"
           else
-            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh publish-todo main 3 \
+            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh publish-todo "$ISSUE_SYNC_TARGET_BRANCH" 3 \
               "chore: sync GitHub issue refs to TODO.md [skip ci]"
           fi
 
@@ -466,7 +472,7 @@ jobs:
           if git diff --quiet TODO.md 2>/dev/null; then
             echo "No TODO.md changes to publish"
           else
-            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh publish-todo main 3 \
+            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh publish-todo "$ISSUE_SYNC_TARGET_BRANCH" 3 \
               "chore: sync ref:GH#${ISSUE_NUMBER} to TODO.md [skip ci]"
           fi
 
@@ -751,14 +757,14 @@ jobs:
           if git diff --quiet TODO.md 2>/dev/null; then
             echo "No TODO.md changes to publish"
           else
-            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh publish-todo main 3 \
+            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh publish-todo "$ISSUE_SYNC_TARGET_BRANCH" 3 \
               "chore: manual issue sync ($SYNC_COMMAND) [skip ci]"
           fi
 
   # =========================================================================
   # t1339: Sync issue hygiene on PR merge
   # =========================================================================
-  # When a PR merges to main, this job:
+  # When a PR merges to its target branch, this job:
   #   1. Extracts task ID from PR title (tNNN: ... pattern)
   #   2. Finds linked issues (from PR body Closes/Fixes/Resolves #NNN, or by task ID)
   #   3. Posts a closing comment with PR link
@@ -1070,9 +1076,9 @@ jobs:
 
               # Choose comment text based on rejection state
               if [[ "$IS_REJECTED" == "true" ]]; then
-                COMMENT_BODY="Referenced by [PR #${PR_NUMBER}](${PR_URL}).${TASK_REF} merged to main."
+                COMMENT_BODY="Referenced by [PR #${PR_NUMBER}](${PR_URL}).${TASK_REF} merged to ${ISSUE_SYNC_TARGET_BRANCH}."
               else
-                COMMENT_BODY="Completed via [PR #${PR_NUMBER}](${PR_URL}).${TASK_REF} merged to main."
+                COMMENT_BODY="Completed via [PR #${PR_NUMBER}](${PR_URL}).${TASK_REF} merged to ${ISSUE_SYNC_TARGET_BRANCH}."
               fi
 
               # Check if issue is locked before attempting to comment (locked issues reject comments with exit 1)
@@ -1399,7 +1405,7 @@ jobs:
           fi
 
           SCRIPT_DIR="$GITHUB_WORKSPACE/__aidevops/.agents/scripts"
-          if ! bash "$SCRIPT_DIR/issue-sync-git-push-helper.sh" publish-todo main 3 \
+          if ! bash "$SCRIPT_DIR/issue-sync-git-push-helper.sh" publish-todo "$ISSUE_SYNC_TARGET_BRANCH" 3 \
             "chore: mark $UPDATED_TASK_IDS complete ($PROOF) [skip ci]"; then
             echo "::error::TODO.md publication failed through both direct and protected-branch PR paths"
             exit 1
@@ -1532,7 +1538,7 @@ jobs:
             if ! planning_publish \
               "$GITHUB_WORKSPACE" \
               "chore: sync PLANS.md status for $TASK_IDS (PR #${PR_NUMBER}) [skip ci]" \
-              origin main todo/PLANS.md; then
+              origin "$ISSUE_SYNC_TARGET_BRANCH" todo/PLANS.md; then
               echo "::error::Failed to publish PLANS.md status with a fenced planning update"
               exit 1
             fi


### PR DESCRIPTION
## Summary

Resolves #31744.

- Route all four TODO publishers and the PLANS publisher to the trusted PR base, otherwise the triggering branch, otherwise the consumer default branch. Correct the completion messages to name that branch.
- Keep the framework checkout independently pinned by `aidevops_ref`; never select a PR head or synthetic merge ref.
- Explain missing common ancestry and refuse publication rather than returning silently or broadening fetch/write authority.
- Preserve protected-branch handling, deterministic PR fallback, Git guards and capability-scoped planning publication.

## Files and regression coverage

- `.github/workflows/issue-sync-reusable.yml`: shared branch selection, quoted publisher arguments and accurate completion comments.
- `.agents/scripts/issue-sync-git-push-helper.sh`: actionable diagnostic in `issue_sync_prepare_base_snapshot`.
- `.agents/scripts/tests/test-issue-sync-git-push-helper.sh`: temporary bare-origin/fake-GitHub fixtures for shallow `develop` publication and fail-closed mismatched `main`; assert untouched mock `main`, preserved caller HEAD/candidate and no GitHub writes.
- `.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh`: branch-routing assertions alongside existing trusted checkout/protection invariants.

## Verification

Rerun after rebasing onto the current upstream base:

- `bash .agents/scripts/tests/test-issue-sync-git-push-helper.sh` — 18 checks passed.
- `bash .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh` — 18 checks passed.
- `.agents/scripts/linters-local.sh --changed` — passed, including ShellCheck, Secretlint, portability and complexity ratchets. One existing shfmt formatting difference remains advisory in untouched test code.
- Pre-commit workflow YAML validation and shell checks — passed. `actionlint` was unavailable locally; YAML parsing is not an actionlint certification.
- Pre-push checks — passed.

No live workflow replay, branch-protection relaxation, secret change or production release was performed. Runtime regression tests use only local disposable fixtures.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.353 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra
