### PR TITLE
GH#31746: isolate label-only Qlty checks

### DIFF
--- a/.agents/scripts/tests/test-workflow-cascade-lint.sh
+++ b/.agents/scripts/tests/test-workflow-cascade-lint.sh
@@ -400,6 +400,12 @@ test_real_qlty_regression_mitigated() {
 	if [[ $rc -ne 0 ]]; then
 		failed=1
 	fi
+	if ! grep -Fq "github.event.action == 'labeled' && github.event.label.name != 'ratchet-bump'" "$qlty_file"; then
+		failed=1
+	fi
+	if ! grep -Fq "'Qlty Regression Gate (label ignored)' || 'Qlty Regression Gate'" "$qlty_file"; then
+		failed=1
+	fi
 	print_result "real: qlty-regression.yml NOT flagged (cancel disabled)" "$failed" "exit=$rc output=$output"
 	return 0
 }

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -18,16 +18,17 @@ env:
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
-    # t2220/t3403: suppress concurrency-cancellation cascade on docs-only PRs.
+    # t2220/t3403/GH#31746: suppress required-check cascades on label events.
     # `gh pr create --label "a,b,c,d"` fires one `labeled` event per label
     # after the initial `opened`; each event can trigger a new run. When this
     # workflow used `cancel-in-progress: true`, label runs cancelled the
     # in-flight required check before job-level guards could skip them. Docs-only
     # PRs observed 15+ cancelled runs per workflow, which `gh pr checks`
     # then surfaces as `fail` (it displays `cancelled` conclusions as
-    # `fail` in its TSV output). Keep the workflow trigger unconditional so the
-    # stable required-check summary below is always published; `detect-scope`
-    # avoids the expensive Qlty scan for docs-only and unrelated label events.
+    # `fail` in its TSV output). Keep the workflow trigger unconditional so a
+    # `ratchet-bump` label can refresh the gate. Unrelated label events use a
+    # distinct non-required summary name below, preventing duplicate required
+    # contexts while `detect-scope` avoids the expensive Qlty scan.
 
 permissions:
   pull-requests: write
@@ -203,7 +204,7 @@ jobs:
           exit 1
 
   required-check:
-    name: Qlty Regression Gate
+    name: "${{ github.event.action == 'labeled' && github.event.label.name != 'ratchet-bump' && 'Qlty Regression Gate (label ignored)' || 'Qlty Regression Gate' }}"
     runs-on: ubuntu-latest
     needs: [detect-scope, qlty-diff]
     if: always()


### PR DESCRIPTION
## Summary

Implementation for issue #31746.



## Files Changed

.agents/scripts/tests/test-workflow-cascade-lint.sh, .github/workflows/qlty-regression.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — no additional evidence supplied

Resolves #31746


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.353 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 4h 29m and 804,621 tokens on this with the user in an interactive session.