### PR TITLE
GH#31742: restore live readiness and merge recovery

### DIFF
--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -8,7 +8,9 @@
 const CODEX_RESPONSES_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
 const OPENAI_IMAGES_GENERATE_ENDPOINT = "https://api.openai.com/v1/images/generations";
 const OPENAI_IMAGES_EDIT_ENDPOINT = "https://api.openai.com/v1/images/edits";
-const SUBSCRIPTION_ROUTER_MODEL = "gpt-5.5";
+import { readFileSync } from "node:fs";
+
+const MODEL_ROUTING_TABLE = new URL("../../configs/model-routing-table.json", import.meta.url);
 const MAX_SSE_BUFFER_CHARS = 96 * 1024 * 1024;
 const MAX_SSE_TOTAL_BYTES = 128 * 1024 * 1024;
 const MAX_API_RESPONSE_BYTES = 96 * 1024 * 1024;
@@ -35,11 +37,20 @@ function imageToolArgs(args) {
   };
 }
 
-function oauthRequestBody(args, images) {
+function subscriptionRouterModels() {
+  const routing = JSON.parse(readFileSync(MODEL_ROUTING_TABLE, "utf8"));
+  const models = ["thinking", "standard", "simple"]
+    .flatMap((tier) => routing.tiers?.[tier]?.models || [])
+    .filter((model) => model.startsWith("openai/"))
+    .map((model) => model.slice("openai/".length));
+  return [...new Set(models)].slice(0, 2);
+}
+
+function oauthRequestBody(args, images, model) {
   const content = [{ type: "input_text", text: args.prompt }];
   for (const image of images) content.push({ type: "input_image", image_url: image.dataUrl });
   return {
-    model: SUBSCRIPTION_ROUTER_MODEL,
+    model,
     instructions: "Generate the requested image by invoking the image_generation tool exactly once.",
     input: [{ role: "user", content }],
     tools: [imageToolArgs(args)],
@@ -146,15 +157,22 @@ export async function parseImageSse(stream) {
 }
 
 export async function requestOAuthImage(auth, args, images, fetchImpl) {
+  const models = subscriptionRouterModels();
+  if (models.length === 0) throw new Error("No OpenAI subscription router model is configured.");
   return withImageRequestTimeout(async (signal) => {
-    const response = await fetchImpl(CODEX_RESPONSES_ENDPOINT, {
-      method: "POST",
-      headers: oauthHeaders(auth),
-      body: JSON.stringify(oauthRequestBody(args, images)),
-      signal,
-    });
-    if (!response.ok) return { response, base64: "", error: await imageRequestError(response, "oauth") };
-    return { response, base64: await parseImageSse(response.body) };
+    let result;
+    for (const model of models) {
+      const response = await fetchImpl(CODEX_RESPONSES_ENDPOINT, {
+        method: "POST",
+        headers: oauthHeaders(auth),
+        body: JSON.stringify(oauthRequestBody(args, images, model)),
+        signal,
+      });
+      if (response.ok) return { response, base64: await parseImageSse(response.body) };
+      result = { response, base64: "", error: await imageRequestError(response, "oauth") };
+      if (result.error.code !== "model_not_found") return result;
+    }
+    return result;
   });
 }
 
@@ -250,5 +268,8 @@ export async function imageRequestError(response, mode) {
     message = "provider returned a non-JSON error";
   }
   const detail = [code, message].filter(Boolean).map(redactProviderDetail).join(": ");
-  return new Error(`OpenAI ${mode} image request failed (${response.status})${detail ? `: ${detail}` : "."}`);
+  const error = new Error(`OpenAI ${mode} image request failed (${response.status})${detail ? `: ${detail}` : "."}`);
+  error.code = code;
+  error.status = response.status;
+  return error;
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
@@ -47,6 +47,7 @@ describe("GPT image provider requests", () => {
     const body = JSON.parse(captured.init.body);
     assert.equal(captured.url, "https://chatgpt.com/backend-api/codex/responses");
     assert.equal(captured.init.headers.Authorization, "Bearer oauth-test-token");
+    assert.equal(body.model, "gpt-5.6-sol");
     assert.equal(body.tools[0].type, "image_generation");
     assert.equal(body.tools[0].output_format, "webp");
     assert.equal(body.tools[0].size, "1024x1024");
@@ -70,6 +71,43 @@ describe("GPT image provider requests", () => {
       },
     );
     assert.equal(Object.hasOwn(captured.tools[0], "size"), false);
+  });
+
+  test("retries OAuth image generation once with the next routed model", async () => {
+    const models = [];
+    const event = `data: ${JSON.stringify({
+      type: "response.output_item.done",
+      item: { type: "image_generation_call", result: IMAGE_RESULT },
+    })}\n\n`;
+    const result = await requestOAuthImage(
+      { accessToken: "[redacted-credential]" },
+      { prompt: "draw a test", quality: "auto", size: "auto", format: "png" },
+      [],
+      async (_url, init) => {
+        models.push(JSON.parse(init.body).model);
+        if (models.length === 1) {
+          return Response.json({ error: { code: "model_not_found", message: "unavailable" } }, { status: 404 });
+        }
+        return new Response(event, { status: 200 });
+      },
+    );
+    assert.deepEqual(models, ["gpt-5.6-sol", "gpt-5.6-terra"]);
+    assert.equal(result.base64, IMAGE_RESULT);
+  });
+
+  test("does not retry non-model OAuth errors", async () => {
+    let calls = 0;
+    const result = await requestOAuthImage(
+      { accessToken: "[redacted-credential]" },
+      { prompt: "draw a test", quality: "auto", size: "auto", format: "png" },
+      [],
+      async () => {
+        calls += 1;
+        return Response.json({ error: { code: "permission_denied", message: "denied" } }, { status: 403 });
+      },
+    );
+    assert.equal(calls, 1);
+    assert.equal(result.error.code, "permission_denied");
   });
 
   test("uses the explicit GPT Image 2 generations endpoint for API auth", async () => {

--- a/.agents/reference/agent-routing.md
+++ b/.agents/reference/agent-routing.md
@@ -7,7 +7,7 @@
 
 Dispatch issue-backed workers with `dispatch-single-issue-helper.sh dispatch NUMBER OWNER/REPO`. It performs deduplication and ownership ceremony, creates the worktree, and forwards the verified runner identity to `headless-runtime-helper.sh`. Use `headless-runtime-helper.sh run` directly only for non-issue headless jobs. Never use bare runtime CLIs: they skip lifecycle reinforcement and can stop after PR creation (GH#5096).
 
-Capability cataloguing is not evidence of live usability. Before routing execution that depends on an external tool or service, run `scripts/capability-readiness-helper.py route <capability> --runtime <opencode|claude-code>`. Mandatory dimensions that are false **or unknown** force the declared fallback; the structured response reports the reason and coverage impact. The canonical contract is `configs/capability-registry.json`; generated inventory: `reference/capability-registry.md`.
+Capability cataloguing is not evidence of live usability. Before routing execution that depends on an external tool or service, run `scripts/capability-readiness-helper.py route <capability> --runtime <opencode|claude-code>`. GitHub operations also require `--target OWNER/REPO --operation read|write|admin` so live reachability and repository permission evidence are bound to the intended action. Mandatory dimensions that are false **or unknown** force the declared fallback; the structured response reports the reason, coverage impact, and evidence scope. The canonical contract is `configs/capability-registry.json`; generated inventory: `reference/capability-registry.md`.
 
 Conceptual comparison using supplied information needs no service probe. Select
 domain knowledge without claiming installed, authenticated or authorized access.

--- a/.agents/scripts/capability-readiness-helper.py
+++ b/.agents/scripts/capability-readiness-helper.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 from typing import Any
 
-from capability_readiness_probes import assess
+from capability_readiness_probes import AssessmentContext, assess
 from capability_registry_validation import validate
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -117,7 +117,8 @@ def main() -> int:
             print(json.dumps({"error": "invalid_target", "detail": str(error)}))
             return 2
     capabilities = [selected] if selected else registry["capabilities"]
-    results = [assess(item, registry["dimensions"], runtime, fixture, AGENTS_DIR, live_evidence if item["name"] == "github-operations" else None) for item in capabilities]
+    context = AssessmentContext(AGENTS_DIR, fixture, live_evidence)
+    results = [assess(item, registry["dimensions"], runtime, context) for item in capabilities]
     payload, status = route_output(results[0], evidence_scope) if args.command == "route" else ({"schema_version": registry["schema_version"], "runtime": runtime, "capabilities": results}, 0)
     print(json.dumps(payload, indent=2))
     return status

--- a/.agents/scripts/capability-readiness-helper.py
+++ b/.agents/scripts/capability-readiness-helper.py
@@ -7,6 +7,8 @@ import argparse
 import json
 import os
 from pathlib import Path
+import re
+import subprocess
 import sys
 from typing import Any
 
@@ -16,6 +18,7 @@ from capability_registry_validation import validate
 SCRIPT_DIR = Path(__file__).resolve().parent
 AGENTS_DIR = SCRIPT_DIR.parent
 DEFAULT_REGISTRY = AGENTS_DIR / "configs" / "capability-registry.json"
+GITHUB_TARGET_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -26,6 +29,34 @@ def load_json(path: Path) -> dict[str, Any]:
 def capability_for(registry: dict[str, Any], requested: str) -> dict[str, Any] | None:
     key = requested.casefold()
     return next((item for item in registry["capabilities"] if key in {name.casefold() for name in [item["name"], *item.get("aliases", [])]}), None)
+
+
+def github_live_evidence(target: str, operation: str) -> tuple[dict[str, str], dict[str, str]]:
+    if not GITHUB_TARGET_PATTERN.fullmatch(target):
+        raise ValueError("GitHub target must be OWNER/REPO")
+    try:
+        result = subprocess.run(  # nosec B603
+            ["gh", "api", f"repos/{target}"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {"reachable": "false", "authorized": "unknown"}, {"target": target, "operation": operation}
+    if result.returncode != 0:
+        return {"reachable": "false", "authorized": "unknown"}, {"target": target, "operation": operation}
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"reachable": "false", "authorized": "unknown"}, {"target": target, "operation": operation}
+    permissions = payload.get("permissions") or {}
+    allowed = operation == "read"
+    if operation == "write":
+        allowed = bool(permissions.get("push") or permissions.get("maintain") or permissions.get("admin"))
+    elif operation == "admin":
+        allowed = bool(permissions.get("admin"))
+    return {"reachable": "true", "authorized": "true" if allowed else "false"}, {"target": target, "operation": operation}
 
 
 def generate(registry: dict[str, Any], output: Path) -> None:
@@ -47,15 +78,17 @@ def parse_args() -> argparse.Namespace:
         child = sub.add_parser(command)
         child.add_argument("capability", nargs="?" if command == "query" else None)
         child.add_argument("--runtime", choices=["opencode", "claude-code"])
+        child.add_argument("--target")
+        child.add_argument("--operation", choices=["read", "write", "admin"], default="read")
     sub.add_parser("check")
     generator = sub.add_parser("generate")
     generator.add_argument("--output", type=Path, default=AGENTS_DIR / "reference" / "capability-registry.md")
     return parser.parse_args()
 
 
-def route_output(result: dict[str, Any]) -> tuple[dict[str, Any], int]:
+def route_output(result: dict[str, Any], evidence_scope: dict[str, str] | None = None) -> tuple[dict[str, Any], int]:
     ready = result["route_ready"]
-    payload = {"decision": "route" if ready else "fallback", "capability": result["name"], "owner": result["owner"] if ready else None, "fallback": None if ready else result["fallback"], "reason": None if ready else "mandatory readiness is false or unknown", "coverage_impact": result["missing_required"], "readiness": result["readiness"]}
+    payload = {"decision": "route" if ready else "fallback", "capability": result["name"], "owner": result["owner"] if ready else None, "fallback": None if ready else result["fallback"], "reason": None if ready else "mandatory readiness is false or unknown", "coverage_impact": result["missing_required"], "readiness": result["readiness"], "evidence_scope": evidence_scope}
     return payload, 0 if ready else 3
 
 
@@ -75,9 +108,17 @@ def main() -> int:
         return 2
     runtime = args.runtime or os.environ.get("AIDEVOPS_RUNTIME", "unknown").casefold()
     fixture = load_json(args.fixture) if args.fixture else None
+    live_evidence = None
+    evidence_scope = None
+    if selected and selected["name"] == "github-operations" and args.target:
+        try:
+            live_evidence, evidence_scope = github_live_evidence(args.target, args.operation)
+        except ValueError as error:
+            print(json.dumps({"error": "invalid_target", "detail": str(error)}))
+            return 2
     capabilities = [selected] if selected else registry["capabilities"]
-    results = [assess(item, registry["dimensions"], runtime, fixture, AGENTS_DIR) for item in capabilities]
-    payload, status = route_output(results[0]) if args.command == "route" else ({"schema_version": registry["schema_version"], "runtime": runtime, "capabilities": results}, 0)
+    results = [assess(item, registry["dimensions"], runtime, fixture, AGENTS_DIR, live_evidence if item["name"] == "github-operations" else None) for item in capabilities]
+    payload, status = route_output(results[0], evidence_scope) if args.command == "route" else ({"schema_version": registry["schema_version"], "runtime": runtime, "capabilities": results}, 0)
     print(json.dumps(payload, indent=2))
     return status
 

--- a/.agents/scripts/capability_readiness_probes.py
+++ b/.agents/scripts/capability_readiness_probes.py
@@ -80,11 +80,22 @@ def probe_value(spec: dict[str, Any], agents_dir: Path) -> str:
     return handler(spec, agents_dir) if handler else "unknown"
 
 
-def assess(capability: dict[str, Any], dimensions: list[str], runtime: str, fixture: dict[str, Any] | None, agents_dir: Path) -> dict[str, Any]:
+def assess(
+    capability: dict[str, Any],
+    dimensions: list[str],
+    runtime: str,
+    fixture: dict[str, Any] | None,
+    agents_dir: Path,
+    live_evidence: dict[str, str] | None = None,
+) -> dict[str, Any]:
     readiness = dict.fromkeys(dimensions, "unknown")
     readiness["catalogued"] = "true"
     readiness["runtime_compatible"] = "true" if runtime in capability["runtimes"] else ("unknown" if runtime == "unknown" else "false")
-    readiness.update({dimension: probe_value(spec, agents_dir) for dimension, spec in capability.get("probes", {}).items()})
+    evidence = live_evidence or {}
+    readiness.update({
+        dimension: evidence.get(dimension, "unknown") if "live" in spec else probe_value(spec, agents_dir)
+        for dimension, spec in capability.get("probes", {}).items()
+    })
     overrides = (fixture or {}).get("capabilities", {}).get(capability["name"], {})
     readiness.update({dimension: value for dimension, value in overrides.items() if dimension in readiness and value in STATES})
     missing = [dimension for dimension in capability["required"] if readiness[dimension] != "true"]

--- a/.agents/scripts/capability_readiness_probes.py
+++ b/.agents/scripts/capability_readiness_probes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import os
 from pathlib import Path
 import re
@@ -10,6 +11,13 @@ import subprocess
 from typing import Any, Callable
 
 STATES = {"true", "false", "unknown", "not_applicable"}
+
+
+@dataclass(frozen=True)
+class AssessmentContext:
+    agents_dir: Path
+    fixture: dict[str, Any] | None
+    live_evidence: dict[str, str] | None
 
 
 def _command(spec: dict[str, Any], _: Path) -> str:
@@ -84,19 +92,17 @@ def assess(
     capability: dict[str, Any],
     dimensions: list[str],
     runtime: str,
-    fixture: dict[str, Any] | None,
-    agents_dir: Path,
-    live_evidence: dict[str, str] | None = None,
+    context: AssessmentContext,
 ) -> dict[str, Any]:
     readiness = dict.fromkeys(dimensions, "unknown")
     readiness["catalogued"] = "true"
     readiness["runtime_compatible"] = "true" if runtime in capability["runtimes"] else ("unknown" if runtime == "unknown" else "false")
-    evidence = live_evidence or {}
+    evidence = context.live_evidence or {}
     readiness.update({
-        dimension: evidence.get(dimension, "unknown") if "live" in spec else probe_value(spec, agents_dir)
+        dimension: evidence.get(dimension, "unknown") if "live" in spec else probe_value(spec, context.agents_dir)
         for dimension, spec in capability.get("probes", {}).items()
     })
-    overrides = (fixture or {}).get("capabilities", {}).get(capability["name"], {})
+    overrides = (context.fixture or {}).get("capabilities", {}).get(capability["name"], {})
     readiness.update({dimension: value for dimension, value in overrides.items() if dimension in readiness and value in STATES})
     missing = [dimension for dimension in capability["required"] if readiness[dimension] != "true"]
     return {**capability, "readiness": readiness, "route_ready": not missing, "missing_required": missing, "runtime": runtime}

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -51,6 +51,21 @@ _pmrc_gh_read() {
 	return "$rc"
 }
 
+_pmrc_required_contexts_timeout_seconds() {
+	local timeout_seconds="${AIDEVOPS_PULSE_REQUIRED_CONTEXTS_TIMEOUT_SECONDS:-30}"
+	local deadline="${_PMP_MERGE_PASS_DEADLINE_EPOCH:-0}"
+	local now_epoch="" remaining_seconds=""
+	[[ "$timeout_seconds" =~ ^[0-9]+$ && "$timeout_seconds" -ge 1 && "$timeout_seconds" -le 120 ]] || timeout_seconds=30
+	if [[ "$deadline" =~ ^[0-9]+$ && "$deadline" -gt 0 ]]; then
+		now_epoch=$(date +%s) || return 1
+		remaining_seconds=$((deadline - now_epoch))
+		[[ "$remaining_seconds" -ge 1 ]] || return 1
+		[[ "$remaining_seconds" -lt "$timeout_seconds" ]] && timeout_seconds="$remaining_seconds"
+	fi
+	printf '%s' "$timeout_seconds"
+	return 0
+}
+
 _pmrc_cache_key() {
 	local raw_key="$1"
 	local safe_key=""
@@ -354,7 +369,7 @@ _required_contexts_for_default_branch() {
 	local repo_slug="$1"
 	local cache_dir="${AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR:-}"
 	local cache_key="" cache_body_file="" cache_rc_file="" cache_rc=""
-	local contexts="" rc=0
+	local contexts="" rc=0 timeout_seconds=""
 
 	if [[ -n "$cache_dir" && -d "$cache_dir" ]]; then
 		cache_key=$(_pmrc_cache_key "$repo_slug")
@@ -375,13 +390,14 @@ _required_contexts_for_default_branch() {
 		fi
 	fi
 
+	timeout_seconds=$(_pmrc_required_contexts_timeout_seconds) || return 1
 	if [[ -n "$cache_body_file" ]]; then
-		contexts=$(_required_contexts_for_default_branch_uncached "$repo_slug" 2>"${cache_body_file}.error") || rc=$?
+		contexts=$(AIDEVOPS_GH_READ_TIMEOUT="$timeout_seconds" _required_contexts_for_default_branch_uncached "$repo_slug" 2>"${cache_body_file}.error") || rc=$?
 		[[ "$rc" -eq 0 ]] || _pmrc_emit_local_deferral "$(<"${cache_body_file}.error")"
 	else
-		contexts=$(_required_contexts_for_default_branch_uncached "$repo_slug") || rc=$?
+		contexts=$(AIDEVOPS_GH_READ_TIMEOUT="$timeout_seconds" _required_contexts_for_default_branch_uncached "$repo_slug") || rc=$?
 	fi
-	if [[ -n "$cache_body_file" && -n "$cache_rc_file" ]]; then
+	if [[ "$rc" -eq 0 && -n "$cache_body_file" && -n "$cache_rc_file" ]]; then
 		printf '%s\n' "$rc" >"$cache_rc_file"
 		if [[ -n "$contexts" ]]; then
 			printf '%s\n' "$contexts" >"$cache_body_file"

--- a/.agents/scripts/tests/test-capability-readiness.py
+++ b/.agents/scripts/tests/test-capability-readiness.py
@@ -77,6 +77,58 @@ class CapabilityReadinessTests(unittest.TestCase):
         self.assertEqual("fallback", output["decision"])
         self.assertIn("authenticated", output["coverage_impact"])
 
+    def test_github_live_evidence_is_target_and_operation_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fake_gh = Path(directory) / "gh"
+            fake_gh.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$1\" = auth ]; then exit 0; fi\n"
+                "if [ \"$1\" = api ] && [ \"$2\" = repos/owner/repo ]; then\n"
+                "  printf \"%s\\n\" '{\"permissions\":{\"push\":true,\"admin\":false}}'\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 1\n"
+            )
+            fake_gh.chmod(0o755)
+            environment = dict(os.environ)
+            environment["PATH"] = f"{directory}{os.pathsep}{environment['PATH']}"
+            result = subprocess.run(  # nosec B603
+                [sys.executable, str(HELPER), "route", "github", "--runtime", "opencode", "--target", "owner/repo", "--operation", "write"],
+                text=True,
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+        self.assertEqual(0, result.returncode, result.stderr or result.stdout)
+        output = json.loads(result.stdout)
+        self.assertEqual("route", output["decision"])
+        self.assertEqual({"target": "owner/repo", "operation": "write"}, output["evidence_scope"])
+        self.assertEqual("true", output["readiness"]["reachable"])
+        self.assertEqual("true", output["readiness"]["authorized"])
+
+    def test_github_live_evidence_denies_unproven_admin(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fake_gh = Path(directory) / "gh"
+            fake_gh.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$1\" = auth ]; then exit 0; fi\n"
+                "printf \"%s\\n\" '{\"permissions\":{\"push\":true,\"admin\":false}}'\n"
+            )
+            fake_gh.chmod(0o755)
+            environment = dict(os.environ)
+            environment["PATH"] = f"{directory}{os.pathsep}{environment['PATH']}"
+            result = subprocess.run(  # nosec B603
+                [sys.executable, str(HELPER), "route", "github", "--runtime", "opencode", "--target", "owner/repo", "--operation", "admin"],
+                text=True,
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+        self.assertEqual(3, result.returncode, result.stderr or result.stdout)
+        output = json.loads(result.stdout)
+        self.assertEqual("true", output["readiness"]["reachable"])
+        self.assertEqual("false", output["readiness"]["authorized"])
+
     def test_unreachable_service_falls_back(self) -> None:
         output = self.run_helper("route", "seo-data", "--runtime", "opencode", expected=3)
         self.assertIn("reachable", output["coverage_impact"])

--- a/.agents/tests/test-pulse-merge-cycle-cache.sh
+++ b/.agents/tests/test-pulse-merge-cycle-cache.sh
@@ -151,9 +151,53 @@ test_required_context_lookup_uses_cycle_cache() {
 	return 0
 }
 
+test_required_context_lookup_uses_scoped_timeout() {
+	local name="required context lookup uses the scoped merge timeout"
+	local observed_file="${TMPDIR:-/tmp}/aidevops-context-timeout.$$"
+	_required_contexts_for_default_branch_uncached() {
+		printf '%s\n' "${AIDEVOPS_GH_READ_TIMEOUT:-unset}" >"$observed_file"
+		return 0
+	}
+	AIDEVOPS_PULSE_REQUIRED_CONTEXTS_TIMEOUT_SECONDS=30 _required_contexts_for_default_branch "owner/repo" || true
+	if [[ "$(<"$observed_file")" != "30" ]]; then
+		_fail "$name" "expected scoped timeout 30"
+	else
+		_pass "$name"
+	fi
+	rm -f -- "$observed_file"
+	return 0
+}
+
+test_required_context_lookup_does_not_cache_failures() {
+	local name="required context lookup retries after an uncached failure"
+	local cache_dir="" calls_file="${TMPDIR:-/tmp}/aidevops-context-failure-calls.$$"
+	cache_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-context-failure-cache.XXXXXX") || return 1
+	printf '0\n' >"$calls_file"
+	_required_contexts_for_default_branch_uncached() {
+		_increment_counter_file "$calls_file"
+		return 1
+	}
+	AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR="$cache_dir"
+	_required_contexts_for_default_branch "owner/repo" >/dev/null 2>&1 || true
+	_required_contexts_for_default_branch "owner/repo" >/dev/null 2>&1 || true
+	unset AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR
+	if [[ "$(<"$calls_file")" != "2" ]]; then
+		_fail "$name" "expected two uncached attempts"
+	elif [[ -f "$cache_dir/owner_repo.rc" ]]; then
+		_fail "$name" "failure unexpectedly populated the cache"
+	else
+		_pass "$name"
+	fi
+	rm -rf -- "$cache_dir"
+	rm -f -- "$calls_file"
+	return 0
+}
+
 main() {
 	test_author_permission_lookup_uses_cycle_cache
 	test_required_context_lookup_uses_cycle_cache
+	test_required_context_lookup_uses_scoped_timeout
+	test_required_context_lookup_does_not_cache_failures
 
 	printf '\nSummary: %d passed, %d failed\n' "$TESTS_PASSED" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Bind GitHub readiness to the intended repository operation, route OAuth image requests through configured OpenAI models, and make merge-context timeouts retry-safe.



## Files Changed

.agents/plugins/opencode-aidevops/gpt-image-request.mjs, .agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs, .agents/reference/agent-routing.md, .agents/scripts/capability-readiness-helper.py, .agents/scripts/capability_readiness_probes.py, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/tests/test-capability-readiness.py, .agents/tests/test-pulse-merge-cycle-cache.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime GitHub readiness succeeded for marcusquinn/aidevops; focused Python, Node, and Bash tests passed; plugin suite passed; ShellCheck, changed-file lint, and diff checks passed.

Resolves #31742
Resolves #31748
Resolves #31749
Resolves #31750


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.354 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 9m and 7,577 tokens on this with the user in an interactive session.
