### PR TITLE
GH#31758: Verify workflow-generated Cloudron release receipts

### DIFF
--- a/.agents/scripts/cloudron-release-evidence.py
+++ b/.agents/scripts/cloudron-release-evidence.py
@@ -10,6 +10,7 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -40,13 +41,20 @@ def decode_json(value):
 
 
 def gh(*args):
-    result = subprocess.run(["gh", *args], capture_output=True, timeout=60, check=False)
+    executable = shutil.which("gh")
+    require(executable is not None, "GitHub CLI is unavailable")
+    result = subprocess.run(  # nosec B603 -- fixed gh CLI, validated argv, never a shell
+        [executable, *args], capture_output=True, timeout=60, check=False,
+    )
     require(result.returncode == 0, "GitHub API or attestation verification failed")
     return decode_json(result.stdout)
 
 
 class CatalogEvidence:
-    def __init__(self, repo, tag, source, commit, workflow, event):
+    def __init__(self, settings):
+        repo, tag, source, commit, workflow, event = (
+            settings[key] for key in ("repo", "tag", "source", "commit", "workflow", "event")
+        )
         require(re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo)
                 and all(part not in (".", "..") for part in repo.split("/")), "invalid repository")
         require(re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", tag), "invalid release tag")
@@ -112,12 +120,12 @@ class CatalogEvidence:
         runs = self.api("actions/workflows/" + self.workflow
                         + "/runs?event=" + self.event + "&status=success&per_page=100")["workflow_runs"]
         accepted = set()
+        expected = {"status": "completed", "conclusion": "success", "event": self.event,
+                    "head_sha": self.source, "head_branch": "main", "path": self.workflow_path}
         for run in runs:
-            if (run.get("status") == "completed" and run.get("conclusion") == "success"
-                    and run.get("event") == self.event and run.get("head_sha") == self.source
-                    and run.get("head_branch") == "main" and run.get("path") == self.workflow_path
-                    and run.get("repository", {}).get("full_name") == self.repo
-                    and run.get("head_repository", {}).get("full_name") == self.repo):
+            same_repository = all(run.get(key, {}).get("full_name") == self.repo
+                                  for key in ("repository", "head_repository"))
+            if all(run.get(key) == value for key, value in expected.items()) and same_repository:
                 run_id, attempt = run["id"], run["run_attempt"]
                 require(type(run_id) is int and run_id > 0 and type(attempt) is int and attempt > 0,
                         "invalid workflow invocation identity")
@@ -148,11 +156,14 @@ class CatalogEvidence:
                 "buildSignerDigest": self.source,
                 "buildTrigger": self.event,
             }
-            if (all(cert.get(key) == value for key, value in expected.items())
-                    and invocation in invocations
-                    and statement.get("predicateType") == "https://slsa.dev/provenance/v1"
-                    and statement.get("subject") == [{"name": name, "digest": {"sha256": digest}}]
-                    and statement["predicate"]["runDetails"]["metadata"]["invocationId"] == invocation):
+            bindings = (
+                all(cert.get(key) == value for key, value in expected.items()),
+                invocation in invocations,
+                statement.get("predicateType") == "https://slsa.dev/provenance/v1",
+                statement.get("subject") == [{"name": name, "digest": {"sha256": digest}}],
+                statement["predicate"]["runDetails"]["metadata"]["invocationId"] == invocation,
+            )
+            if all(bindings):
                 accepted.add(invocation)
         require(accepted, "attestation does not bind the artifact to the expected source/workflow/run")
         return accepted
@@ -180,8 +191,8 @@ def main():
         parser.add_argument("--" + option, required=True)
     args = parser.parse_args()
     try:
-        CatalogEvidence(**vars(args)).verify()
-    except (EvidenceError, KeyError, TypeError, ValueError, OSError, subprocess.TimeoutExpired) as error:
+        CatalogEvidence(vars(args)).verify()
+    except (EvidenceError, KeyError, TypeError, ValueError, AttributeError, OSError, subprocess.TimeoutExpired) as error:
         message = str(error) if isinstance(error, EvidenceError) else "malformed or unavailable evidence"
         print("Generated catalog verification failed: " + message, file=sys.stderr)
         return 1

--- a/.agents/scripts/cloudron-release-evidence.py
+++ b/.agents/scripts/cloudron-release-evidence.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Read-only, fail-closed proof for a direct generated Cloudron catalog commit."""
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+CATALOG = "CloudronVersions.json"
+SOURCE_REF = "refs/heads/main"
+
+
+class EvidenceError(Exception):
+    """An incomplete or inconsistent publication proof."""
+
+
+def require(condition, message):
+    if not condition:
+        raise EvidenceError(message)
+
+
+def unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        require(key not in result, "duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def decode_json(value):
+    return json.loads(value, object_pairs_hook=unique_object)
+
+
+def gh(*args):
+    result = subprocess.run(["gh", *args], capture_output=True, timeout=60, check=False)
+    require(result.returncode == 0, "GitHub API or attestation verification failed")
+    return decode_json(result.stdout)
+
+
+class CatalogEvidence:
+    def __init__(self, repo, tag, source, commit, workflow, event):
+        require(re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo)
+                and all(part not in (".", "..") for part in repo.split("/")), "invalid repository")
+        require(re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", tag), "invalid release tag")
+        require(all(re.fullmatch(r"[0-9a-f]{40}", sha) for sha in (source, commit)), "invalid commit")
+        require(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml", workflow), "exact workflow filename required")
+        require(event in ("push", "workflow_dispatch"), "generated catalogs require push/dispatch evidence")
+        self.repo, self.tag, self.source, self.commit = repo, tag, source, commit
+        self.workflow, self.event = workflow, event
+        self.version = tag[1:]
+        self.repository_url = "https://github.com/" + repo
+        self.workflow_path = ".github/workflows/" + workflow
+        self.signer = self.repository_url + "/" + self.workflow_path + "@" + SOURCE_REF
+
+    def api(self, suffix):
+        return gh("api", "repos/" + self.repo + "/" + suffix)
+
+    def content(self, path, commit):
+        item = self.api("contents/" + path + "?ref=" + commit)
+        require(item["type"] == "file" and item["path"] == path and item["encoding"] == "base64",
+                "expected an ordinary source file")
+        require(0 < item["size"] <= 1024 * 1024, "source file outside bounded size")
+        data = base64.b64decode("".join(item["content"].split()), validate=True)
+        require(len(data) == item["size"], "source file size mismatch")
+        return data
+
+    def generated_commit(self):
+        commit = self.api("commits/" + self.commit)
+        require(commit["sha"] == self.commit and len(commit["parents"]) == 1
+                and commit["parents"][0]["sha"] == self.source, "tag must be a direct child of the merged source")
+        files = commit["files"]
+        require(len(files) == 1 and files[0]["filename"] == CATALOG
+                and files[0]["status"] == "modified" and "previous_filename" not in files[0],
+                "generated commit must modify only the existing catalog")
+
+    def catalog(self):
+        before = decode_json(self.content(CATALOG, self.source))
+        data = self.content(CATALOG, self.commit)
+        after = decode_json(data)
+        entry = after["versions"][self.version]
+        require(self.version not in before["versions"], "release version already exists in source catalog")
+        remaining = dict(after, versions=dict(after["versions"]))
+        del remaining["versions"][self.version]
+        require(remaining == before and after["stable"] is True, "catalog must append exactly one stable entry")
+        require(entry["publishState"] == "published", "catalog entry is not published")
+        manifest = entry["manifest"]
+        source_manifest = decode_json(self.content("CloudronManifest.json", self.source))
+        require(source_manifest["version"] == self.version and source_manifest["changelog"] == "file://CHANGELOG",
+                "source manifest version/changelog contract mismatch")
+        image = manifest["dockerImage"]
+        require(re.fullmatch(re.escape("ghcr.io/" + self.repo.lower() + "@sha256:") + r"[0-9a-f]{64}", image),
+                "image must be a digest in this repository's GHCR namespace")
+        comparable = dict(manifest)
+        del comparable["dockerImage"]
+        comparable["changelog"] = source_manifest["changelog"]
+        require(comparable == source_manifest, "generated manifest changes source settings")
+        changelog = self.content("CHANGELOG", self.source).decode("utf-8")
+        section = re.search(r"(?m)^\[" + re.escape(self.version) + r"\]\s*\n(.*?)(?=^\[|\Z)", changelog, re.S)
+        require(section is not None and manifest["changelog"].strip() == section[1].strip(),
+                "published changelog differs from the source release section")
+        return data, image
+
+    def invocations(self):
+        runs = self.api("actions/workflows/" + self.workflow
+                        + "/runs?event=" + self.event + "&status=success&per_page=100")["workflow_runs"]
+        accepted = set()
+        for run in runs:
+            if (run.get("status") == "completed" and run.get("conclusion") == "success"
+                    and run.get("event") == self.event and run.get("head_sha") == self.source
+                    and run.get("head_branch") == "main" and run.get("path") == self.workflow_path
+                    and run.get("repository", {}).get("full_name") == self.repo
+                    and run.get("head_repository", {}).get("full_name") == self.repo):
+                run_id, attempt = run["id"], run["run_attempt"]
+                require(type(run_id) is int and run_id > 0 and type(attempt) is int and attempt > 0,
+                        "invalid workflow invocation identity")
+                accepted.add(self.repository_url + "/actions/runs/" + str(run_id) + "/attempts/" + str(attempt))
+        require(accepted, "no successful exact-source repository-owned workflow")
+        return accepted
+
+    def verified_invocations(self, artifact, name, digest, invocations):
+        # aidevops:trust-boundary — consume only gh's cryptographically verified
+        # results, never the unverified bundle alongside them or a plain checksum.
+        results = gh("attestation", "verify", artifact, "--repo", self.repo,
+                     "--signer-workflow", self.repo + "/" + self.workflow_path,
+                     "--source-ref", SOURCE_REF, "--format", "json")
+        accepted = set()
+        for result in results:
+            verified = result["verificationResult"]
+            cert = verified["signature"]["certificate"]
+            statement = verified["statement"]
+            invocation = cert.get("runInvocationURI")
+            expected = {
+                "issuer": "https://token.actions.githubusercontent.com",
+                "sourceRepositoryURI": self.repository_url,
+                "sourceRepositoryDigest": self.source,
+                "sourceRepositoryRef": SOURCE_REF,
+                "buildConfigURI": self.signer,
+                "buildConfigDigest": self.source,
+                "buildSignerURI": self.signer,
+                "buildSignerDigest": self.source,
+                "buildTrigger": self.event,
+            }
+            if (all(cert.get(key) == value for key, value in expected.items())
+                    and invocation in invocations
+                    and statement.get("predicateType") == "https://slsa.dev/provenance/v1"
+                    and statement.get("subject") == [{"name": name, "digest": {"sha256": digest}}]
+                    and statement["predicate"]["runDetails"]["metadata"]["invocationId"] == invocation):
+                accepted.add(invocation)
+        require(accepted, "attestation does not bind the artifact to the expected source/workflow/run")
+        return accepted
+
+    def verify(self):
+        self.generated_commit()
+        release = self.api("releases/tags/" + self.tag)
+        require(release["tag_name"] == self.tag and release["draft"] is False
+                and release["prerelease"] is False, "expected a published stable release")
+        data, image = self.catalog()
+        invocations = self.invocations()
+        temporary_root = os.environ.get("AIDEVOPS_TEMP_DIR", str(Path.home() / ".aidevops/.agent-workspace/tmp"))
+        with tempfile.TemporaryDirectory(prefix="catalog-evidence-", dir=temporary_root) as directory:
+            catalog = Path(directory) / CATALOG
+            catalog.write_bytes(data)
+            file_runs = self.verified_invocations(str(catalog), CATALOG, hashlib.sha256(data).hexdigest(), invocations)
+            image_runs = self.verified_invocations("oci://" + image, image.split("@")[0], image.split(":")[-1], invocations)
+            require(file_runs & image_runs, "catalog and image were not attested by the same successful invocation")
+        return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    for option in ("repo", "tag", "source", "commit", "workflow", "event"):
+        parser.add_argument("--" + option, required=True)
+    args = parser.parse_args()
+    try:
+        CatalogEvidence(**vars(args)).verify()
+    except (EvidenceError, KeyError, TypeError, ValueError, OSError, subprocess.TimeoutExpired) as error:
+        message = str(error) if isinstance(error, EvidenceError) else "malformed or unavailable evidence"
+        print("Generated catalog verification failed: " + message, file=sys.stderr)
+        return 1
+    print("Verified direct catalog-only commit and exact-source image/catalog provenance")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -2125,6 +2125,7 @@ _full_loop_verify_published_release() {
 	local merge_commit="$3"
 	local workflow_file="${4:-}"
 	local workflow_event="${5:-$_FULL_LOOP_WORKFLOW_EVENT_RELEASE}"
+	local generated_catalog="${6:-false}"
 	local tag_commit=""
 	local release_json=""
 	local workflow_runs_json=""
@@ -2145,7 +2146,13 @@ _full_loop_verify_published_release() {
 		workflow_runs_endpoint="repos/${repo}/actions/runs?event=release&status=success&per_page=100"
 	fi
 	tag_commit=$(_full_loop_resolve_remote_release_tag_commit "$repo" "$tag_name") || return 1
-	[[ "$tag_commit" == "$merge_commit" ]] || return 1
+	if [[ "$tag_commit" != "$merge_commit" ]]; then
+		# aidevops:trust-boundary — never substitute a generic ancestry check.
+		[[ "$generated_catalog" == "true" && -n "$workflow_file" ]] || return 1
+		python3 "${SCRIPT_DIR}/cloudron-release-evidence.py" --repo "$repo" --tag "$tag_name" \
+			--source "$merge_commit" --commit "$tag_commit" --workflow "$workflow_file" --event "$workflow_event" || return 1
+		[[ "$tag_commit" == "$(_full_loop_resolve_remote_release_tag_commit "$repo" "$tag_name")" ]] || return 1
+	fi
 	release_json=$(gh api "repos/${repo}/releases/tags/${tag_name}" 2>/dev/null) || return 1
 	jq -e --arg tag_name "$tag_name" '.tag_name == $tag_name and .draft == false' <<<"$release_json" >/dev/null || return 1
 	workflow_runs_json=$(gh api "$workflow_runs_endpoint" 2>/dev/null) || return 1
@@ -2217,6 +2224,7 @@ _full_loop_parse_published_release_options() {
 	_FULL_LOOP_PARSED_REPO_ARG=""
 	_FULL_LOOP_PARSED_WORKFLOW_FILE=""
 	_FULL_LOOP_PARSED_WORKFLOW_EVENT="$_FULL_LOOP_WORKFLOW_EVENT_RELEASE"
+	_FULL_LOOP_PARSED_GENERATED_CATALOG="false"
 	if [[ "$arg_index" -lt "$arg_count" ]]; then
 		option="${args[$arg_index]}"
 	fi
@@ -2227,6 +2235,10 @@ _full_loop_parse_published_release_options() {
 	while [[ "$arg_index" -lt "$arg_count" ]]; do
 		option="${args[$arg_index]}"
 		case "$option" in
+		--generated-cloudron-catalog)
+			_FULL_LOOP_PARSED_GENERATED_CATALOG="true"
+			arg_index=$((arg_index + 1))
+			;;
 		--workflow | --event)
 			[[ $((arg_index + 1)) -lt "$arg_count" ]] || {
 				print_error "${option} requires a value"
@@ -2289,7 +2301,7 @@ cmd_record_published_release() {
 		return 1
 	}
 	_full_loop_verify_published_release "$repo" "$tag_name" "$merge_commit" \
-		"$workflow_file" "$workflow_event" || {
+		"$workflow_file" "$workflow_event" "$_FULL_LOOP_PARSED_GENERATED_CATALOG" || {
 		print_error "Cannot record release:published: release, tag, and successful release workflow evidence do not match PR #${pr_number}"
 		return 1
 	}

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -347,9 +347,11 @@ Commands:
                                   --auto is dropped (GH#19310).
   record-no-release <PR> [REPO]  Verify merged evidence and record release:not-requested.
   record-published-release <PR> <TAG> [REPO] [--workflow FILE] [--event EVENT]
-                                  Verify a GitHub release and record release:published.
-                                  Defaults to release-event evidence; repository-owned
-                                  push/dispatch workflows require an exact workflow identity.
+                                   Verify a GitHub release and record release:published.
+                                   Defaults to release-event evidence; repository-owned
+                                   push/dispatch workflows require an exact workflow identity.
+                                   --generated-cloudron-catalog verifies a direct catalog-only
+                                   commit with exact-source image and catalog attestations.
   adopt-merged-receipt <PR> [REPO]
                                  Adopt an externally merged exact-head worktree into cleanup.
   finalize-receipt <PR> [REPO]   Finalize a direct-merge cleanup receipt without local state.

--- a/.agents/scripts/profile-contribution-chart.py
+++ b/.agents/scripts/profile-contribution-chart.py
@@ -186,6 +186,22 @@ def safe_paths(repo, readme):
         raise ValueError("Profile README is not a regular file")
 
 
+def _valid_month_totals(points, through, expected_total):
+    """Validate ordered cached months and their aggregate without rendering them."""
+    cumulative, previous = 0, ""
+    for point in points:
+        month = point["month"]
+        if not re.fullmatch(r"[0-9]{4}-(0[1-9]|1[0-2])", month) or not previous < month <= through.strftime("%Y-%m"):
+            return False
+        if type(point["total"]) is not int or point["total"] < 0:
+            return False
+        cumulative += point["total"]
+        if type(point["cumulative"]) is not int or point["cumulative"] != cumulative:
+            return False
+        previous = month
+    return type(expected_total) is int and expected_total == cumulative
+
+
 def valid_history(data, login, today):
     """Do not trust repository-cached strings as SVG markup or freshness proof."""
     try:
@@ -197,18 +213,7 @@ def valid_history(data, login, today):
             return False
         if not isinstance(data["months"], list) or len(data["months"]) > 400:
             return False
-        cumulative, previous = 0, ""
-        for point in data["months"]:
-            month = point["month"]
-            if not re.fullmatch(r"[0-9]{4}-(0[1-9]|1[0-2])", month) or not previous < month <= through.strftime("%Y-%m"):
-                return False
-            if type(point["total"]) is not int or point["total"] < 0:
-                return False
-            cumulative += point["total"]
-            if type(point["cumulative"]) is not int or point["cumulative"] != cumulative:
-                return False
-            previous = month
-        return type(data["total"]) is int and data["total"] == cumulative
+        return _valid_month_totals(data["months"], through, data["total"])
     except (KeyError, TypeError, ValueError):
         return False
 

--- a/.agents/scripts/tests/test-cloudron-release-evidence.py
+++ b/.agents/scripts/tests/test-cloudron-release-evidence.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+"""Offline trust-negative coverage using the existing unittest/mock tooling."""
+
+import base64
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location("catalog_evidence", Path(__file__).resolve().parents[1] / "cloudron-release-evidence.py")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class EvidenceTests(unittest.TestCase):
+    def setUp(self):
+        self.repo = "testorg/package"
+        self.source, self.commit = "1" * 40, "2" * 40
+        self.proof = MODULE.CatalogEvidence(self.repo, "v2.0.12", self.source, self.commit, "publish.yml", "push")
+        self.before = {"stable": True, "versions": {"2.0.11": {"retained": True}}}
+        self.manifest = {"version": "2.0.12", "upstreamVersion": "0.77.1", "changelog": "file://CHANGELOG"}
+        self.image = "ghcr.io/" + self.repo + "@sha256:" + "3" * 64
+        self.after = copy.deepcopy(self.before)
+        self.after["versions"]["2.0.12"] = {
+            "publishState": "published",
+            "manifest": dict(self.manifest, dockerImage=self.image, changelog="* Fix startup.\n"),
+        }
+        self.commit_data = {"sha": self.commit, "parents": [{"sha": self.source}],
+                            "files": [{"filename": MODULE.CATALOG, "status": "modified"}]}
+        self.release = {"tag_name": "v2.0.12", "draft": False, "prerelease": False}
+        self.run = {"id": 123, "run_attempt": 1, "event": "push", "status": "completed", "conclusion": "success",
+                    "head_sha": self.source, "head_branch": "main", "path": ".github/workflows/publish.yml",
+                    "repository": {"full_name": self.repo}, "head_repository": {"full_name": self.repo}}
+        self.attest_mutation = lambda result, image: None
+        self.extra_runs = []
+
+    def api_content(self, path, value):
+        data = value.encode() if isinstance(value, str) else json.dumps(value).encode()
+        return {"type": "file", "path": path, "encoding": "base64", "size": len(data),
+                "content": base64.b64encode(data).decode()}
+
+    def fake_gh(self, *args):
+        if args[0] == "api":
+            endpoint = args[1].removeprefix("repos/" + self.repo + "/")
+            mapping = {
+                "commits/" + self.commit: self.commit_data,
+                "releases/tags/v2.0.12": self.release,
+                "contents/CloudronVersions.json?ref=" + self.source: self.api_content(MODULE.CATALOG, self.before),
+                "contents/CloudronVersions.json?ref=" + self.commit: self.api_content(MODULE.CATALOG, self.after),
+                "contents/CloudronManifest.json?ref=" + self.source: self.api_content("CloudronManifest.json", self.manifest),
+                "contents/CHANGELOG?ref=" + self.source: self.api_content("CHANGELOG", "[2.0.12]\n* Fix startup.\n\n[2.0.11]\n* Earlier.\n"),
+                "actions/workflows/publish.yml/runs?event=push&status=success&per_page=100": {"workflow_runs": [self.run, *self.extra_runs]},
+            }
+            return copy.deepcopy(mapping[endpoint])
+        self.assertEqual(args[:2], ("attestation", "verify"))
+        self.assertEqual(args[3:], ("--repo", self.repo, "--signer-workflow", self.repo + "/.github/workflows/publish.yml",
+                                    "--source-ref", "refs/heads/main", "--format", "json"))
+        image = args[2].startswith("oci://")
+        name = self.image.split("@")[0] if image else MODULE.CATALOG
+        digest = "3" * 64 if image else hashlib.sha256(Path(args[2]).read_bytes()).hexdigest()
+        invocation = self.proof.repository_url + "/actions/runs/123/attempts/1"
+        cert = dict(issuer="https://token.actions.githubusercontent.com",
+                    sourceRepositoryURI=self.proof.repository_url, sourceRepositoryDigest=self.source,
+                    sourceRepositoryRef=MODULE.SOURCE_REF, buildConfigURI=self.proof.signer,
+                    buildConfigDigest=self.source, buildSignerURI=self.proof.signer,
+                    buildSignerDigest=self.source, buildTrigger="push", runInvocationURI=invocation)
+        verified = {"signature": {"certificate": cert}, "statement": {
+            "predicateType": "https://slsa.dev/provenance/v1", "subject": [{"name": name, "digest": {"sha256": digest}}],
+            "predicate": {"runDetails": {"metadata": {"invocationId": invocation}}}}}
+        self.attest_mutation(verified, image)
+        return [{"verificationResult": verified}]
+
+    def verify(self):
+        with tempfile.TemporaryDirectory() as directory, patch.dict(os.environ, AIDEVOPS_TEMP_DIR=directory), \
+                patch.object(MODULE, "gh", side_effect=self.fake_gh):
+            return self.proof.verify()
+
+    def test_valid_catalog_and_replay(self):
+        self.assertTrue(self.verify())
+        self.assertTrue(self.verify())
+
+    def test_generated_commit_boundaries(self):
+        cases = [
+            {"sha": "4" * 40}, {"parents": [{"sha": "4" * 40}]},
+            {"parents": [{"sha": self.source}, {"sha": "4" * 40}]},
+            {"files": [{"filename": "README.md", "status": "modified"}]},
+            {"files": self.commit_data["files"] + [{"filename": "start.sh", "status": "modified"}]},
+            {"files": [{"filename": MODULE.CATALOG, "status": "renamed", "previous_filename": "other.json"}]},
+        ]
+        original = copy.deepcopy(self.commit_data)
+        for change in cases:
+            with self.subTest(change=change):
+                self.commit_data = dict(original, **change)
+                with self.assertRaises(MODULE.EvidenceError):
+                    self.verify()
+
+    def test_catalog_cannot_change_history_or_manifest(self):
+        mutations = [
+            lambda c: c.update(stable=False),
+            lambda c: c["versions"]["2.0.11"].update(retained=False),
+            lambda c: c["versions"].update({"2.0.13": {}}),
+            lambda c: c["versions"]["2.0.12"].update(publishState="testing"),
+            lambda c: c["versions"]["2.0.12"]["manifest"].update(upstreamVersion="other"),
+            lambda c: c["versions"]["2.0.12"]["manifest"].update(changelog="unreviewed content"),
+            lambda c: c["versions"]["2.0.12"]["manifest"].update(dockerImage="evil.invalid/image@sha256:" + "3" * 64),
+        ]
+        original = copy.deepcopy(self.after)
+        for mutation in mutations:
+            self.after = copy.deepcopy(original)
+            mutation(self.after)
+            with self.subTest(catalog=self.after), self.assertRaises(MODULE.EvidenceError):
+                self.verify()
+
+    def test_release_and_workflow_negatives(self):
+        original = copy.deepcopy(self.run)
+        for field, value in (("conclusion", "failure"), ("status", "in_progress"), ("event", "workflow_dispatch"),
+                             ("head_sha", "4" * 40), ("head_branch", "other"), ("path", ".github/workflows/evil.yml"),
+                             ("head_repository", {"full_name": "fork/package"}), ("repository", {"full_name": "other/repo"})):
+            self.run = dict(original, **{field: value})
+            with self.subTest(field=field), self.assertRaises(MODULE.EvidenceError):
+                self.verify()
+        self.run = original
+        self.release["draft"] = True
+        with self.assertRaises(MODULE.EvidenceError):
+            self.verify()
+
+    def test_attestation_certificate_negatives(self):
+        for field in ("issuer", "sourceRepositoryURI", "sourceRepositoryDigest", "sourceRepositoryRef",
+                      "buildConfigURI", "buildConfigDigest", "buildSignerURI", "buildSignerDigest",
+                      "buildTrigger", "runInvocationURI"):
+            self.attest_mutation = lambda result, image: result["signature"]["certificate"].update({field: "wrong"})
+            with self.subTest(field=field), self.assertRaises(MODULE.EvidenceError):
+                self.verify()
+
+    def test_attestation_subject_and_invocation_negatives(self):
+        mutations = [
+            lambda v, image: v["statement"].update(subject=[]),
+            lambda v, image: v["statement"]["subject"][0].update(name="other"),
+            lambda v, image: v["statement"]["subject"][0].update(digest={"sha256": "4" * 64}),
+            lambda v, image: v["statement"].update(predicateType="unverified"),
+            lambda v, image: v["statement"]["predicate"]["runDetails"]["metadata"].update(invocationId="wrong"),
+        ]
+        for mutate in mutations:
+            self.attest_mutation = mutate
+            with self.subTest(mutation=mutate), self.assertRaises(MODULE.EvidenceError):
+                self.verify()
+
+    def test_different_successful_runs_do_not_combine(self):
+        self.extra_runs = [dict(self.run, id=124)]
+        def different_run(result, image):
+            if image:
+                invocation = self.proof.repository_url + "/actions/runs/124/attempts/1"
+                result["signature"]["certificate"]["runInvocationURI"] = invocation
+                result["statement"]["predicate"]["runDetails"]["metadata"]["invocationId"] = invocation
+        self.attest_mutation = different_run
+        with self.assertRaises(MODULE.EvidenceError):
+            self.verify()
+
+    def test_duplicate_json_and_api_failure(self):
+        with self.assertRaises(MODULE.EvidenceError):
+            MODULE.decode_json('{"stable":true,"stable":false}')
+        with patch.object(MODULE, "gh", side_effect=MODULE.EvidenceError("API unavailable")), \
+                self.assertRaises(MODULE.EvidenceError):
+            self.proof.verify()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/tests/test-cloudron-release-evidence.py
+++ b/.agents/scripts/tests/test-cloudron-release-evidence.py
@@ -23,7 +23,8 @@ class EvidenceTests(unittest.TestCase):
     def setUp(self):
         self.repo = "testorg/package"
         self.source, self.commit = "1" * 40, "2" * 40
-        self.proof = MODULE.CatalogEvidence(self.repo, "v2.0.12", self.source, self.commit, "publish.yml", "push")
+        self.proof = MODULE.CatalogEvidence(dict(repo=self.repo, tag="v2.0.12", source=self.source,
+                                                commit=self.commit, workflow="publish.yml", event="push"))
         self.before = {"stable": True, "versions": {"2.0.11": {"retained": True}}}
         self.manifest = {"version": "2.0.12", "upstreamVersion": "0.77.1", "changelog": "file://CHANGELOG"}
         self.image = "ghcr.io/" + self.repo + "@sha256:" + "3" * 64

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -254,6 +254,23 @@ grep -qx 'published' "${receipt_dir}/marcusquinn_aidevops-61.status"
 jq -e '.release_status == "published"' "$push_published_receipt" >/dev/null
 printf 'PASS exact repository-owned push workflow records published evidence\n'
 
+# The opt-in does not change the exact-commit path or existing receipt bytes.
+cp "$push_published_receipt" "${ROOT}/generated-opt-in-before.json"
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$published_record_runner" 61 v3.0.0 marcusquinn/aidevops \
+		--workflow release.yml --event push --generated-cloudron-catalog >/dev/null
+cmp -s "$push_published_receipt" "${ROOT}/generated-opt-in-before.json"
+if COMPLETION_RELEASE_MODE=wrong-tag-commit AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
+	AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$published_record_runner" 61 v3.0.0 marcusquinn/aidevops \
+		--workflow release.yml --event push --generated-cloudron-catalog >/dev/null 2>&1; then
+	printf 'FAIL generated catalog opt-in accepted an unproven descendant\n'
+	exit 1
+fi
+cmp -s "$push_published_receipt" "${ROOT}/generated-opt-in-before.json"
+printf 'PASS generated catalog opt-in preserves exact-commit replay and rejects missing proof without mutation\n'
+
 for invalid_push_mode in push-failed-workflow push-wrong-event push-wrong-sha; do
 	invalid_push_worktree="${ROOT}/invalid-${invalid_push_mode}"
 	mkdir -p "$invalid_push_worktree"

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -271,6 +271,26 @@ receipt's executor finalization fields. After an explicit repository rename, use
 new identity and migrates cleanup plus release receipts while preserving owner,
 lease, worktree, branch, creation time, and irreversible cleanup state.
 
+**Generated Cloudron catalogs:** a repository-owned push/dispatch workflow may
+build at a merged release PR, then create a direct child commit containing only
+the generated `CloudronVersions.json` and tag that child. After independently
+verifying publication, record this explicitly:
+
+```bash
+full-loop-helper.sh record-published-release PR vX.Y.Z OWNER/REPO \
+  --workflow cloudron-catalog-publish.yml --event push --generated-cloudron-catalog
+```
+
+The default still requires tag/merge equality. The opt-in requires a direct
+catalog-only child, exactly one appended published entry, unchanged historical
+entries and source manifest settings, and verified image/catalog attestations
+from the same successful invocation of the exact workflow at the merged source.
+It supports the repository's own GHCR namespace and `refs/heads/main`, not
+arbitrary descendants, registries, reusable-workflow signers, or branch layouts.
+Missing or mismatched proof leaves receipts unchanged. Python 3 and a `gh`
+version exposing verified attestation JSON are required. This command verifies
+an existing release; it never creates or republishes artifacts.
+
 If a maintainer or merge queue merges the PR before the merge wrapper records its
 cleanup receipt, first establish terminal release evidence, then run
 `full-loop-helper.sh adopt-merged-receipt <PR> [REPO]` from the still-registered


### PR DESCRIPTION
## Summary

Add explicit --generated-cloudron-catalog receipt verification without weakening the default tag/merge equality path. Prove a direct catalog-only child, one appended published entry, exact source manifest/changelog, and matching cryptographically verified image/catalog provenance from one successful repository-owned run. Keep parsing and proof in a small Python helper rather than expanding the existing shell file.



## Files Changed

.agents/scripts/cloudron-release-evidence.py, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/tests/test-cloudron-release-evidence.py, .agents/scripts/tests/test-full-loop-completion-evidence.sh, .agents/workflows/full-loop.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: Read-only verification against the published Cloudron 2.0.12 release succeeded with gh2.100.0. The committed helper then ran the normal record-published-release and finalize-receipt commands successfully for the original release PR103, resolving the observed failure without republishing. Eight offline unittest methods cover positive/replay and trust-negative subcases. Existing full-loop completion-evidence suite passes, including byte-preserving rejection and exact-commit opt-in replay. ShellCheck, changed-file linters and mapped orchestration tests pass. Independent implementation security review by openai/gpt-5.6-terra found no blockers; unsupported malformed structures still fail closed.

Resolves #31758


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.355 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-6-astra spent 2h 11m and 510,268 tokens on this with the user in an interactive session.