### PR TITLE
GH#31761: refactor: separate cached contribution monthly validation

### DIFF
--- a/.agents/scripts/profile-contribution-chart.py
+++ b/.agents/scripts/profile-contribution-chart.py
@@ -186,6 +186,22 @@ def safe_paths(repo, readme):
         raise ValueError("Profile README is not a regular file")
 
 
+def _valid_month_totals(points, through, expected_total):
+    """Validate ordered cached months and their aggregate without rendering them."""
+    cumulative, previous = 0, ""
+    for point in points:
+        month = point["month"]
+        if not re.fullmatch(r"[0-9]{4}-(0[1-9]|1[0-2])", month) or not previous < month <= through.strftime("%Y-%m"):
+            return False
+        if type(point["total"]) is not int or point["total"] < 0:
+            return False
+        cumulative += point["total"]
+        if type(point["cumulative"]) is not int or point["cumulative"] != cumulative:
+            return False
+        previous = month
+    return type(expected_total) is int and expected_total == cumulative
+
+
 def valid_history(data, login, today):
     """Do not trust repository-cached strings as SVG markup or freshness proof."""
     try:
@@ -197,18 +213,7 @@ def valid_history(data, login, today):
             return False
         if not isinstance(data["months"], list) or len(data["months"]) > 400:
             return False
-        cumulative, previous = 0, ""
-        for point in data["months"]:
-            month = point["month"]
-            if not re.fullmatch(r"[0-9]{4}-(0[1-9]|1[0-2])", month) or not previous < month <= through.strftime("%Y-%m"):
-                return False
-            if type(point["total"]) is not int or point["total"] < 0:
-                return False
-            cumulative += point["total"]
-            if type(point["cumulative"]) is not int or point["cumulative"] != cumulative:
-                return False
-            previous = month
-        return type(data["total"]) is int and data["total"] == cumulative
+        return _valid_month_totals(data["months"], through, data["total"])
     except (KeyError, TypeError, ValueError):
         return False
 


### PR DESCRIPTION
## Summary

Implementation for issue #31761.



## Files Changed

.agents/scripts/profile-contribution-chart.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #31761


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.355 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-6-astra spent 2h 38m and 835,415 tokens on this with the user in an interactive session.