### PR TITLE
GH#31767: recover signed release with existing provenance PR

### DIFF
--- a/.agents/reference/release-lane-coordination.md
+++ b/.agents/reference/release-lane-coordination.md
@@ -118,6 +118,16 @@ rechecks the token and tag identity; live/unknown owners, competing sources,
 legacy contracts, source drift, and uncertain remote state remain blocked.
 Interruption after this claim can resume the same fenced tag; no tag is rewritten.
 
+The protected-main PR may itself already be durable while the lane still says
+`preparing`. For an explicitly authorized same-source reconcile, recovery first
+verifies that existing PR without mutation: its metadata and head must bind the
+unchanged signed tag, and a merged PR must preserve both release and PR-head
+ancestry on `main`. Only then may the same dead-executor, source-manifest,
+snapshot, absent-channel, permission, and remote-CAS checks rotate the lane into
+`remote-publication`. An open exact PR remains queued; a merged exact PR resumes
+the existing tag publication. Unknown or conflicting PR, ancestry, channel,
+executor, or CAS evidence leaves the preparing lane unchanged.
+
 Same-source reservation reclaim still removes automatic eligibility, but now
 records a `same-source-reclaim/v1` marker when it removes a modern fenced
 contract. For lanes reclaimed before that marker existed, recovery must verify

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -1025,6 +1025,19 @@ _full_loop_release_reset_tag_worktree() {
 	return 0
 }
 
+_full_loop_release_validate_explicit_reconciliation_intent() {
+	local repo="$1"
+	local requested_pr="$2"
+	local source_json="$3"
+	local persisted_sources="" persisted_json="" observed_json="" observed_sources=""
+	persisted_sources=$(_full_loop_read_release_authorization "$repo" "$requested_pr") || return 1
+	persisted_json=$(release_authorization_manifest_json "$persisted_sources") || return 1
+	observed_json=$(release_authorization_observed_sources_json "$persisted_json" "$source_json") || return 1
+	observed_sources=$(jq -r 'sort_by(.pr) | map([.pr, .merge] | join("@")) | join(",")' \
+		<<<"$observed_json") || return 1
+	release_authorization_compare "$persisted_sources" "$observed_sources"
+}
+
 _full_loop_release_validate_published_reconciliation_intent() {
 	local repo="$1"
 	local requested_pr="$2"
@@ -1308,6 +1321,33 @@ _full_loop_release_reconcile_protected_state() {
 	esac
 }
 
+#aidevops:trust-boundary
+# A protected PR is durable provenance, but it is not lane ownership. Verify the
+# exact PR read-only before rotating a dead preparing lane through the existing
+# preserved-tag CAS boundary.
+_full_loop_release_recover_existing_protected_pr_lane() {
+	local repo="$1"
+	local requested_pr="$2"
+	local tag_name="$3"
+	local mode="$4"
+	[[ "$mode" == "$_FULL_LOOP_RELEASE_MODE_RECONCILE" ]] || return 0
+	release_lane_read "$repo" || return 1
+	if ! jq -e --argjson source_pr "$requested_pr" '
+		.active == true and .source_pr == $source_pr and .phase == "preparing" and .tag == null
+		and .terminal_receipt == null and .reservation_contract == "fenced-prepublication/v1"
+		and .snapshot_manifest_bound == true
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null; then
+		return 0
+	fi
+	_full_loop_release_verify_protected_source_provenance "$repo" "$tag_name" || return 1
+	_version_manager_reconcile_protected_release_tag "$repo" "$tag_name" status || return 1
+	case "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" in
+	pr-pending | tag-ready) ;;
+	*) return 1 ;;
+	esac
+	_full_loop_release_claim_preserved_tag "$repo" "$requested_pr" "$tag_name"
+}
+
 _full_loop_release_existing_command() {
 	local mode="$1"
 	local requested_pr="$2"
@@ -1341,6 +1381,14 @@ _full_loop_release_existing_command() {
 			return 1
 		}
 		source_json=$(_full_loop_release_source_json_from_tag "$tag_name") || return 1
+		_full_loop_release_validate_explicit_reconciliation_intent \
+			"$repo" "$requested_pr" "$source_json" || {
+			printf 'Cannot reconcile release:not-requested without matching explicit publication intent for PR #%s\n' \
+				"$requested_pr" >&2
+			return 1
+		}
+		_full_loop_release_recover_existing_protected_pr_lane \
+			"$repo" "$requested_pr" "$tag_name" "$mode" || return $?
 		_full_loop_release_validate_published_reconciliation_intent \
 			"$repo" "$requested_pr" "$tag_name" "$source_json" || {
 			printf 'Cannot reconcile release:not-requested without matching explicit publication intent for PR #%s\n' \

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -852,7 +852,7 @@ _full_loop_read_release_authorization() {
 	local repo="$1"
 	local requested_pr="$2"
 	[[ "$repo" == "test/repo" && "$requested_pr" == "90" ]] || return 1
-	printf '%s\n' '90@1111111111111111111111111111111111111111'
+	printf '%s\n' "${authorization_expected_sources:-90@1111111111111111111111111111111111111111}"
 	return 0
 }
 lane_expected_sources='90@1111111111111111111111111111111111111111'
@@ -1718,7 +1718,30 @@ _version_manager_reconcile_protected_release_tag() {
 	local tag_name="$2"
 	local mode="$3"
 	[[ -n "$repo" && -n "$tag_name" && ("$mode" == "status" || "$mode" == "reconcile") ]] || return 1
-	_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="remote-tag-present"
+	case "${PROTECTED_FIXTURE_MODE:-remote}" in
+	open) _VERSION_MANAGER_PROTECTED_RELEASE_RESULT="pr-pending" ;;
+	merged)
+		if [[ "$mode" == "status" ]]; then
+			_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-ready"
+		else
+			_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-pushed"
+		fi
+		;;
+	mismatch) return 1 ;;
+	remote) _VERSION_MANAGER_PROTECTED_RELEASE_RESULT="remote-tag-present" ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+_full_loop_release_verify_protected_source_provenance() {
+	[[ "$1" == "test/repo" && "$2" == "v1.2.3" ]]
+	return $?
+}
+_full_loop_release_claim_preserved_tag() {
+	[[ "$1" == "test/repo" && "$2" == "90" && "$3" == "v1.2.3" ]] || return 1
+	[[ "${CLAIM_FIXTURE_RC:-0}" -eq 0 ]] || return "$CLAIM_FIXTURE_RC"
+	printf 'claimed\n' >>"${TEST_ROOT}/existing-pr-claim.log"
+	lane_patch_json='{"phase":"remote-publication","tag":"v1.2.3","reservation_contract":"fenced-prepublication/v1","snapshot_manifest_bound":true}'
 	return 0
 }
 _full_loop_release_finalize_stale_supersession() {
@@ -1742,6 +1765,72 @@ _full_loop_update_superseded_cleanup_receipt() {
 	printf '%s %s\n' "$repo" "$pr_number" >"${TEST_ROOT}/cleanup-update.log"
 	return 0
 }
+
+printf 'not-requested\n' >"${TEST_ROOT}/receipts/test_repo-90.status"
+lane_patch_json='{"phase":"preparing","tag":null,"reservation_contract":"fenced-prepublication/v1","snapshot_manifest_bound":true}'
+PROTECTED_FIXTURE_MODE=open
+export PROTECTED_FIXTURE_MODE
+authorization_expected_sources='91@2222222222222222222222222222222222222222'
+protected_intent_rc=0
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
+	>/dev/null 2>&1 || protected_intent_rc=$?
+if [[ "$protected_intent_rc" -ne 1 || -e "${TEST_ROOT}/existing-pr-claim.log" ]] ||
+	[[ "$(jq -r '.phase' <<<"$lane_patch_json")" != "preparing" ]]; then
+	printf 'FAIL mismatched explicit intent mutated the dead preparing lane\n'
+	exit 1
+fi
+printf 'PASS explicit intent is verified before the dead preparing lane is claimed\n'
+authorization_expected_sources=''
+protected_open_rc=0
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
+	>/dev/null 2>"${TEST_ROOT}/protected-open.err" || protected_open_rc=$?
+if [[ "$protected_open_rc" -ne 8 ]] ||
+	[[ "$(grep -c '^claimed$' "${TEST_ROOT}/existing-pr-claim.log")" -ne 1 ]] ||
+	[[ "$(jq -r '.phase' <<<"$lane_patch_json")" != "remote-publication" ]]; then
+	printf 'FAIL exact open protected PR did not claim and resume the dead preparing lane (rc=%s claim=%s lane=%s)\n' \
+		"$protected_open_rc" "$(test -f "${TEST_ROOT}/existing-pr-claim.log" && grep -c '^claimed$' "${TEST_ROOT}/existing-pr-claim.log" || true)" \
+		"$lane_patch_json stderr=$(<"${TEST_ROOT}/protected-open.err")"
+	exit 1
+fi
+printf 'PASS exact open protected PR claims the lane and remains queued\n'
+
+rm -f "${TEST_ROOT}/existing-pr-claim.log" "${TEST_ROOT}/finalize.log"
+lane_patch_json='{"phase":"preparing","tag":null,"reservation_contract":"fenced-prepublication/v1","snapshot_manifest_bound":true}'
+PROTECTED_FIXTURE_MODE=merged
+protected_merged_rc=0
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
+	>/dev/null 2>&1 || protected_merged_rc=$?
+if [[ "$protected_merged_rc" -ne 8 ]] ||
+	! grep -qx claimed "${TEST_ROOT}/existing-pr-claim.log"; then
+	printf 'FAIL exact merged protected PR did not resume its preserved tag\n'
+	exit 1
+fi
+PROTECTED_FIXTURE_MODE=remote
+INSPECT_RC=0
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 >/dev/null
+if ! grep -qx 'test/repo 90 v1.2.3' "${TEST_ROOT}/finalize.log"; then
+	printf 'FAIL merged protected PR recovery did not reach terminal reconciliation\n'
+	exit 1
+fi
+printf 'PASS exact merged protected PR resumes and reaches terminal reconciliation\n'
+
+rm -f "${TEST_ROOT}/existing-pr-claim.log" "${TEST_ROOT}/finalize.log"
+lane_patch_json='{"phase":"preparing","tag":null,"reservation_contract":"fenced-prepublication/v1","snapshot_manifest_bound":true}'
+PROTECTED_FIXTURE_MODE=mismatch
+protected_mismatch_rc=0
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
+	>/dev/null 2>&1 || protected_mismatch_rc=$?
+if [[ "$protected_mismatch_rc" -ne 1 || -e "${TEST_ROOT}/existing-pr-claim.log" ]] ||
+	[[ "$(jq -r '.phase' <<<"$lane_patch_json")" != "preparing" ]]; then
+	printf 'FAIL mismatched protected PR mutated the dead preparing lane\n'
+	exit 1
+fi
+printf 'PASS protected PR mismatch leaves the dead preparing lane unchanged\n'
+
+rm -f "${TEST_ROOT}/receipts/test_repo-90.status"
+lane_patch_json='{}'
+PROTECTED_FIXTURE_MODE=remote
+INSPECT_RC=3
 
 reconcile_rc=0
 AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \


### PR DESCRIPTION
## Summary

Recover exact signed releases from dead preparing lanes after their protected-main provenance PR already exists, validating explicit intent and PR identity before the lane CAS.



## Files Changed

.agents/reference/release-lane-coordination.md, .agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Release reconciliation, dead-preparing, lane, and protected-main suites pass; ShellCheck and changed-file lint pass; independent high-risk review is clean.

Resolves #31767


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.357 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 15m and 135,563 tokens on this as a headless worker.
