### PR TITLE
GH#31771: release held product reservation slack

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -380,7 +380,7 @@ _dispatch_candidate_failure_reason() {
 _dispatch_candidate_benign_block_reason() {
 	local reason="$1"
 	case "$reason" in
-		blocked_by_unresolved | consolidated | dedup_active_claim | dirty_worktree_recovery | footprint_overlap | interactive_review_hold | issue_closed | no_auto_dispatch | parent_task | pr_target_not_dispatchable | renovate_dependency_dashboard | terminal_blocker_circuit)
+		blocked_by_unresolved | consolidated | dedup_active_claim | dirty_worktree_recovery | footprint_overlap | interactive_review_hold | issue_closed | no_auto_dispatch | parent_task | policy_gate | pr_target_not_dispatchable | renovate_dependency_dashboard | terminal_blocker_circuit)
 			return 0
 			;;
 	esac

--- a/.agents/scripts/tests/test-pulse-dispatch-idle-debt-borrowing.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-idle-debt-borrowing.sh
@@ -48,6 +48,60 @@ assert_order "retains excess debt for idle-capacity borrowing" 1 "4,5,6,1,2,3"
 QUALITY_DEBT_CAP_PCT=100
 assert_order "honours an explicit full debt share" 2 "1,2,4,5,6,3"
 
+assert_product_reservation_outcome() {
+	local mode="$1" expected_result="$2" expected_attempts="$3" expected_launches="$4" expected_log="$5"
+	local candidate_file="" outcomes_file="" attempts_file="" launches_file="" result=""
+	candidate_file=$(mktemp)
+	outcomes_file=$(mktemp)
+	attempts_file=$(mktemp)
+	launches_file=$(mktemp)
+	jq -nc '
+		{number:101,repo_slug:"example/product",repo_priority:"product",labels:[]},
+		{number:201,repo_slug:"example/tooling",repo_priority:"tooling",labels:[]},
+		{number:202,repo_slug:"example/tooling",repo_priority:"tooling",labels:[]}
+	' >"$candidate_file"
+
+	_dispatch_process_candidate() {
+		local candidate_json="$1" issue_number="" repo_slug=""
+		issue_number=$(jq -r '.number' <<<"$candidate_json")
+		repo_slug=$(jq -r '.repo_slug' <<<"$candidate_json")
+		printf '%s\n' "$issue_number" >>"$attempts_file"
+		if [[ "$issue_number" == 101 ]]; then
+			if [[ "$mode" == policy-held ]]; then
+				printf '[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=policy_gate signal=HOLD_FOR_REVIEW_BLOCKED issue=#%s repo=%s\n' \
+					"$issue_number" "$repo_slug" >>"$LOGFILE"
+				_dispatch_record_nonzero_dispatch_result "$issue_number" "$repo_slug" 3
+			else
+				_DISPATCH_CANDIDATE_ELIGIBILITY="unknown"
+			fi
+			return 1
+		fi
+		printf '%s\n' "$issue_number" >>"$launches_file"
+		_DISPATCH_CANDIDATE_ELIGIBILITY="eligible"
+		return 0
+	}
+	_dispatch_graphql_budget_allows_next() { return 0; }
+	_dispatch_rest_core_progress_allows_next() { return 0; }
+	unset STOP_FLAG || true
+
+	result=$(_dispatch_priority_loop "$candidate_file" 2 test-user 1 "$outcomes_file" 2 true)
+	if [[ "$result" == "$expected_result" && "$(paste -sd, "$attempts_file")" == "$expected_attempts" &&
+	"$(paste -sd, "$launches_file")" == "$expected_launches" ]] && grep -q "$expected_log" "$LOGFILE"; then
+		printf 'PASS: %s product reservation outcome is safe\n' "$mode"
+	else
+		printf 'FAIL: %s product reservation outcome (result=%s attempts=%s launches=%s)\n' \
+			"$mode" "$result" "$(paste -sd, "$attempts_file")" "$(paste -sd, "$launches_file")" >&2
+		failures=$((failures + 1))
+	fi
+	rm -f "$candidate_file" "$outcomes_file" "$attempts_file" "$launches_file"
+	return 0
+}
+
+assert_product_reservation_outcome policy-held "2 3" "101,201,202" "201,202" \
+	'PRIORITY_RESERVATION requested=2 product_launched=0 held=0 discovery_complete=true launched=2'
+assert_product_reservation_outcome unknown "0 1" "101" "" \
+	'PRIORITY_RESERVATION requested=2 product_launched=0 held=2 discovery_complete=true launched=0'
+
 if [[ "$failures" -ne 0 ]]; then
 	exit 1
 fi


### PR DESCRIPTION
## Summary

Classify verified product policy holds as ineligible for the current launch round so reserved slots become borrowable without bypassing the hold; retain reservations for unknown outcomes.



## Files Changed

.agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/tests/test-pulse-dispatch-idle-debt-borrowing.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime-verified with the focused held/unknown two-slot reservation fixture, 35 worker-detection integration tests, 23 current-state guardrail tests, changed-file ShellCheck, and changed-file linters.

Resolves #31771


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.357 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 14m and 156,605 tokens on this as a headless worker.
