### PR TITLE
GH#31773: keep verified Dependabot external at early merge gate

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -489,7 +489,17 @@ _pm_gate_author_trust() {
 	fi
 	if [[ "$trusted" -eq 0 && "$author_collab_rc" -ne 0 ]]; then
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha"; then
-			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is trusted Dependabot with allowlisted dependency update, proceeding (GH#24473)" >>"$LOGFILE"
+			# #aidevops:trust-boundary — verified provenance and dependency
+			# allowlisting establish authenticity, not collaborator authority.
+			# Dependabot remains external and may proceed only with independent,
+			# current-head maintainer approval. Do not route a policy-only hold to
+			# repair intake: there is no code or dependency defect to repair.
+			if _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$expected_head_sha"; then
+				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — verified Dependabot author ${pr_author} remains external but has current-head maintainer crypto-approval, proceeding" >>"$LOGFILE"
+			else
+				echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — verified Dependabot author ${pr_author} remains external and lacks current-head maintainer crypto-approval; preserving policy hold without repair intake" >>"$LOGFILE"
+				return 1
+			fi
 		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$expected_head_sha"; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator but has maintainer crypto-approval, proceeding (t3063)" >>"$LOGFILE"
 		else

--- a/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
+++ b/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
@@ -224,6 +224,7 @@ define_helpers_under_test() {
 		/^_extract_linked_issue\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 	gates_src=$(awk '
+		/^_pmg_gh_read\(\) \{/,/^}$/ { print }
 		/^_pulse_is_trusted_issue_sync_pr\(\) \{/,/^}$/ { print }
 		/^_pulse_merge_classify_final_authority\(\) \{/,/^}$/ { print }
 		/^_pulse_merge_admin_pr_json_graphql\(\) \{/,/^}$/ { print }

--- a/.agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh
+++ b/.agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh
@@ -15,7 +15,10 @@ TESTS_RUN=0
 TESTS_FAILED=0
 FIXTURE_TRUSTED=0
 FIXTURE_LABELS=""
+FIXTURE_DEPENDABOT_TRUSTED=0
+FIXTURE_CRYPTO_APPROVED=0
 WORKER_BRIEFED_CALLS="${TEST_ROOT}/worker-briefed-calls.log"
+DEPENDABOT_ROUTE_CALLS="${TEST_ROOT}/dependabot-route-calls.log"
 PULSE_UNKNOWN_STATE="UNKNOWN"
 PULSE_REVIEW_EVIDENCE_SCHEMA="aidevops.review-gate-evidence/v1"
 export LOGFILE AGENTS_DIR
@@ -63,9 +66,12 @@ _is_collaborator_author() {
 	_PULSE_AUTHOR_PERMISSION_VALUE="none"
 	return 1
 }
-_is_trusted_dependabot_update_pr() { return 1; }
-_pulse_route_dependabot_pr_to_worker_issue() { return 1; }
-_has_maintainer_crypto_approval() { return 1; }
+_is_trusted_dependabot_update_pr() { [[ "$FIXTURE_DEPENDABOT_TRUSTED" -eq 1 ]]; }
+_pulse_route_dependabot_pr_to_worker_issue() {
+	printf '%s %s %s %s %s\n' "$1" "$2" "$3" "$4" "$5" >>"$DEPENDABOT_ROUTE_CALLS"
+	return 1
+}
+_has_maintainer_crypto_approval() { [[ "$FIXTURE_CRYPTO_APPROVED" -eq 1 ]]; }
 check_permission_failure_pr() { return 0; }
 check_pr_modifies_workflows() { return 1; }
 check_gh_workflow_scope() { return 0; }
@@ -98,8 +104,9 @@ eval "$gate_src"
 
 run_gate() {
 	local expected_head="${1:-head-current}"
+	local author="${2:-app/github-actions}"
 	local rc=0
-	_check_pr_merge_gates 950 owner/repo app/github-actions APPROVED "" \
+	_check_pr_merge_gates 950 owner/repo "$author" APPROVED "" \
 		"$FIXTURE_LABELS" "$expected_head" merge || rc=$?
 	printf '%s\n' "$rc"
 }
@@ -139,6 +146,41 @@ if [[ "$result" -eq 1 ]] && grep -q '^950 owner/repo stale-head$' "$TRUST_CALLS"
 else
 	print_result "stale-head Issue Sync trust evidence fails closed" 1 \
 		"rc=${result} calls=$(cat "$TRUST_CALLS")"
+fi
+
+FIXTURE_DEPENDABOT_TRUSTED=1
+FIXTURE_CRYPTO_APPROVED=0
+: >"$DEPENDABOT_ROUTE_CALLS"
+: >"$LOGFILE"
+result=$(run_gate head-current 'dependabot[bot]')
+if [[ "$result" -eq 1 ]] && [[ ! -s "$DEPENDABOT_ROUTE_CALLS" ]] &&
+	grep -qF "remains external and lacks current-head maintainer crypto-approval" "$LOGFILE"; then
+	print_result "verified Dependabot without independent authority stops without repair intake" 0
+else
+	print_result "verified Dependabot without independent authority stops without repair intake" 1 \
+		"rc=${result} route=$(cat "$DEPENDABOT_ROUTE_CALLS") log=$(cat "$LOGFILE")"
+fi
+
+FIXTURE_CRYPTO_APPROVED=1
+: >"$LOGFILE"
+result=$(run_gate head-current 'dependabot[bot]')
+if [[ "$result" -eq 0 ]] && grep -qF "remains external but has current-head maintainer crypto-approval" "$LOGFILE"; then
+	print_result "verified Dependabot with exact-head authority may continue through remaining gates" 0
+else
+	print_result "verified Dependabot with exact-head authority may continue through remaining gates" 1 \
+		"rc=${result} log=$(cat "$LOGFILE")"
+fi
+
+FIXTURE_DEPENDABOT_TRUSTED=0
+FIXTURE_CRYPTO_APPROVED=0
+: >"$DEPENDABOT_ROUTE_CALLS"
+: >"$LOGFILE"
+result=$(run_gate head-current 'dependabot[bot]')
+if [[ "$result" -eq 1 ]] && grep -qF "950 owner/repo dependabot[bot] head-current policy-ineligible" "$DEPENDABOT_ROUTE_CALLS"; then
+	print_result "unverified Dependabot remains eligible for defect repair intake" 0
+else
+	print_result "unverified Dependabot remains eligible for defect repair intake" 1 \
+		"rc=${result} route=$(cat "$DEPENDABOT_ROUTE_CALLS") log=$(cat "$LOGFILE")"
 fi
 
 printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Keep authenticated Dependabot updates external at Pulse's early author gate, requiring exact-head maintainer crypto approval and avoiding policy-only repair intake.



## Files Changed

.agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh, .agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: 6 early-authority, 22 final-safety, 36 Dependabot compatibility, and 42 CI-repair routing cases passed; ShellCheck, changed-file lint, and git diff --check passed. Independent security review found no actionable issues.

Resolves #31773


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.357 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 12m and 125,910 tokens on this as a headless worker.
