### PR TITLE
GH#31772: report REST admission uncertainty and policy holds

### DIFF
--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 UNKNOWN_STATUS="unknown"
 CURRENT_STATUS="current"
+REST_UNKNOWN_JSON='{"state":"unknown"}'
 
 _usage() {
 	cat <<'EOF'
@@ -359,6 +360,17 @@ _current_graphql_budget_status() {
 	return 0
 }
 
+_current_rest_admission_status() {
+	if [[ -n "${AIDEVOPS_REST_ADMISSION_STATUS_OVERRIDE:-}" ]]; then
+		printf '%s\n' "$AIDEVOPS_REST_ADMISSION_STATUS_OVERRIDE"
+	elif [[ -f "${SCRIPT_DIR}/gh_transport_budget.py" ]]; then
+		python3 "${SCRIPT_DIR}/gh_transport_budget.py" status 2>/dev/null || printf '%s\n' "$REST_UNKNOWN_JSON"
+	else
+		printf '%s\n' "$REST_UNKNOWN_JSON"
+	fi
+	return 0
+}
+
 main() {
 	local window="15m"
 	local repo_path="${AIDEVOPS_REPO_PATH:-$HOME/Git/aidevops}"
@@ -425,7 +437,7 @@ main() {
 	projection_output=$(
 		AIDEVOPS_ACTIVE_WORKER_PROCESSES="$active_worker_processes" \
 			AIDEVOPS_WORKER_WORKTREE_COUNT="$worker_worktree_count" \
-			AIDEVOPS_GRAPHQL_BUDGET_STATUS="$graphql_budget_status" \
+			AIDEVOPS_GRAPHQL_BUDGET_STATUS="$graphql_budget_status" AIDEVOPS_REST_ADMISSION_STATUS="$(_current_rest_admission_status)" \
 			AIDEVOPS_OBJECTIVE_STATE_FILE="$objective_state_file" \
 			AIDEVOPS_RUNTIME_STATE_OUTPUT="$runtime_state_file" \
 			python3 "${SCRIPT_DIR}/pulse-current-state.py" \

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -461,17 +461,28 @@ def rest_admission_status_from_env():
     return projection
 
 
+def is_rest_deferral_counter(name):
+    aggregate_names = {
+        'pulse_rest_core_budget_stage_deferred',
+        'pulse_rest_core_unit_blocked',
+        'pulse_rest_core_progress_blocked',
+    }
+    detail_prefixes = (
+        'pulse_rest_core_budget_stage_deferred_',
+        'pulse_rest_core_unit_blocked_',
+        'pulse_rest_core_progress_blocked_',
+    )
+    if name in aggregate_names:
+        return True
+    return name.startswith(detail_prefixes)
+
+
 def build_rest_admission(counter_hits, counter_latest, transport_status):
     deferred_stages = matching_counter_counts(counter_hits, 'pulse_rest_core_budget_stage_deferred_')
     blocked_modes = matching_counter_counts(counter_hits, 'pulse_rest_core_progress_blocked_')
     counter_names = [
         name for name in counter_hits
-        if name == 'pulse_rest_core_budget_stage_deferred'
-        or name.startswith('pulse_rest_core_budget_stage_deferred_')
-        or name == 'pulse_rest_core_unit_blocked'
-        or name.startswith('pulse_rest_core_unit_blocked_')
-        or name == 'pulse_rest_core_progress_blocked'
-        or name.startswith('pulse_rest_core_progress_blocked_')
+        if is_rest_deferral_counter(name)
     ]
     stage_count = counter_hits.get('pulse_rest_core_budget_stage_deferred', 0)
     unit_count = counter_hits.get('pulse_rest_core_unit_blocked', 0)
@@ -566,7 +577,7 @@ def blocker_category(reason):
 
 
 def build_zero_worker_underutilization(active_workers, worker_terminal_events, cycle_state,
-                                       pre_launch_blockers, gauge_values, rest_admission):
+                                       pre_launch_blockers, gauge_values):
     threshold_raw = os.environ.get('AIDEVOPS_ZERO_WORKER_MIN_CYCLES', '3')
     threshold = int(threshold_raw) if threshold_raw.isdigit() and int(threshold_raw) > 0 else 3
     available = gauge_values.get('pulse_dispatch_guardrail_available_slots')
@@ -889,8 +900,7 @@ objective_reconciliation = build_objective_reconciliation(
     os.environ.get('AIDEVOPS_OBJECTIVE_STATE_FILE', '')
 )
 zero_worker_underutilization = build_zero_worker_underutilization(
-    active_worker_processes, len(worker_metrics), cycle_state, pre_launch_blockers, gauge_values,
-    rest_admission,
+    active_worker_processes, len(worker_metrics), cycle_state, pre_launch_blockers, gauge_values
 )
 permission_evidence = build_permission_evidence(
     os.environ.get('AIDEVOPS_WORKER_BLOCKER_LOG_FILE', os.path.join(log_dir, 'worker-progress-blockers.jsonl'))

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -427,6 +427,92 @@ def graphql_deferred_stages(counter_hits):
     }
 
 
+def matching_counter_counts(counter_hits, prefix):
+    return {
+        key[len(prefix):]: count
+        for key, count in sorted(counter_hits.items())
+        if key.startswith(prefix)
+    }
+
+
+def latest_counter_time(counter_latest, names):
+    observed = [counter_latest.get(name, 0) for name in names]
+    latest = max(observed, default=0)
+    if not latest:
+        return None
+    return datetime.datetime.fromtimestamp(latest, datetime.timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def rest_admission_status_from_env():
+    try:
+        status = json.loads(os.environ.get('AIDEVOPS_REST_ADMISSION_STATUS', '{}'))
+    except (json.JSONDecodeError, TypeError):
+        status = {}
+    if not isinstance(status, dict):
+        status = {}
+    allowed = {
+        'state', 'source', 'scope_mode', 'bound_credentials', 'ambiguity',
+        'remaining', 'limit', 'reserved', 'floor', 'blocked_until', 'reset',
+        'observation_age_seconds',
+    }
+    projection = {key: value for key, value in status.items() if key in allowed}
+    if projection.get('state') not in {'available', 'cooldown', 'exhausted', 'unknown'}:
+        projection = {'state': 'unknown'}
+    return projection
+
+
+def build_rest_admission(counter_hits, counter_latest, transport_status):
+    deferred_stages = matching_counter_counts(counter_hits, 'pulse_rest_core_budget_stage_deferred_')
+    blocked_modes = matching_counter_counts(counter_hits, 'pulse_rest_core_progress_blocked_')
+    counter_names = [
+        name for name in counter_hits
+        if name == 'pulse_rest_core_budget_stage_deferred'
+        or name.startswith('pulse_rest_core_budget_stage_deferred_')
+        or name == 'pulse_rest_core_unit_blocked'
+        or name.startswith('pulse_rest_core_unit_blocked_')
+        or name == 'pulse_rest_core_progress_blocked'
+        or name.startswith('pulse_rest_core_progress_blocked_')
+    ]
+    stage_count = counter_hits.get('pulse_rest_core_budget_stage_deferred', 0)
+    unit_count = counter_hits.get('pulse_rest_core_unit_blocked', 0)
+    progress_count = counter_hits.get('pulse_rest_core_progress_blocked', 0)
+    deferral_count = stage_count + unit_count + progress_count
+    transport_observed = transport_status.get('state') != 'unknown'
+    availability = 'observed' if deferral_count or transport_observed else 'unknown'
+    evidence_state = 'read_incomplete' if deferral_count else 'unknown'
+    return {
+        'availability': availability,
+        'evidence_state': evidence_state,
+        'deferred_by': 'local_admission' if deferral_count else None,
+        'request_attempted': False if deferral_count else None,
+        'deferral_count': deferral_count,
+        'stage_deferral_count': stage_count,
+        'unit_block_count': unit_count,
+        'progress_block_count': progress_count,
+        'deferred_stages': deferred_stages,
+        'blocked_modes': blocked_modes,
+        'last_observed_at': latest_counter_time(counter_latest, counter_names),
+        'source': 'pulse-stats',
+        'transport': transport_status,
+        'window_seconds': window_s,
+        'remote_rejection_observed': False,
+        'authentication_failure_inferred': False,
+    }
+
+
+def build_policy_holds(counter_hits, counter_latest):
+    counter_name = 'dispatch_candidate_failed_reason_policy_gate'
+    count = counter_hits.get(counter_name, 0)
+    return {
+        'availability': 'observed' if count else 'not_observed',
+        'active_in_window': count > 0,
+        'count': count,
+        'last_observed_at': latest_counter_time(counter_latest, [counter_name]),
+        'source': 'pulse-stats',
+        'window_seconds': window_s,
+    }
+
+
 def graphql_related_gauges(gauge_values):
     return {
         key: value
@@ -480,7 +566,7 @@ def blocker_category(reason):
 
 
 def build_zero_worker_underutilization(active_workers, worker_terminal_events, cycle_state,
-                                       pre_launch_blockers, gauge_values):
+                                       pre_launch_blockers, gauge_values, rest_admission):
     threshold_raw = os.environ.get('AIDEVOPS_ZERO_WORKER_MIN_CYCLES', '3')
     threshold = int(threshold_raw) if threshold_raw.isdigit() and int(threshold_raw) > 0 else 3
     available = gauge_values.get('pulse_dispatch_guardrail_available_slots')
@@ -497,6 +583,9 @@ def build_zero_worker_underutilization(active_workers, worker_terminal_events, c
     prolonged = no_progress >= threshold
     free_capacity = available is not None and available > 0
     zero_delivery = active_workers == 0 and worker_terminal_events == 0
+    github_read_complete = None
+    if categories['github_read_incomplete'] > 0 or rest_admission['evidence_state'] == 'read_incomplete':
+        github_read_complete = False
     return {
         'actionable': bool(free_capacity and zero_delivery and prolonged),
         'available_slots': available,
@@ -504,7 +593,10 @@ def build_zero_worker_underutilization(active_workers, worker_terminal_events, c
         'consecutive_no_progress_cycles': no_progress,
         'minimum_cycles': threshold,
         'classifications': categories,
-        'github_read_complete': categories['github_read_incomplete'] == 0,
+        'github_read_complete': github_read_complete,
+        'github_read_status': (
+            'incomplete' if github_read_complete is False else 'unknown'
+        ),
     }
 
 
@@ -573,6 +665,7 @@ for line in recent_lines(os.path.join(log_dir, 'headless-runtime-metrics.jsonl')
         metrics.append(item)
 
 counter_hits = {}
+counter_latest = {}
 gauge_values = {}
 stats_path = os.path.join(log_dir, 'pulse-stats.json')
 if os.path.exists(stats_path):
@@ -584,11 +677,13 @@ if os.path.exists(stats_path):
                 hits = [v for v in values if isinstance(v, (int, float)) and v >= since]
                 if hits:
                     counter_hits[key] = len(hits)
+                    counter_latest[key] = max(hits)
         for key, item in (stats.get('gauges') or {}).items():
             if isinstance(item, dict) and float(item.get('ts', 0)) >= since:
                 gauge_values[key] = item.get('value')
     except (OSError, json.JSONDecodeError):
         counter_hits = {}
+        counter_latest = {}
         gauge_values = {}
 
 wrapper_log_lines = recent_lines(os.path.join(log_dir, 'pulse-wrapper.log'), 400)
@@ -663,6 +758,10 @@ pr_opened_count, pr_opened_examples = line_count(['pr opened', 'opened pr', 'pul
 pr_merged_count, pr_merged_examples = line_count(['pr merged', 'merged pr', 'squash merged'], wrapper_activity)
 issue_closed_count, issue_closed_examples = line_count(['issue closed', 'closed issue', 'status:done'], wrapper_activity)
 graphql_budget = build_graphql_budget(counter_hits, gauge_values)
+rest_admission = build_rest_admission(
+    counter_hits, counter_latest, rest_admission_status_from_env()
+)
+policy_holds = build_policy_holds(counter_hits, counter_latest)
 dispatch_pacing = {
     'inter_launch_staggered_count': counter_hits.get('dispatch_inter_launch_staggered', 0),
     'last_inter_launch_delay_seconds': gauge_values.get('dispatch_inter_launch_delay_seconds'),
@@ -790,7 +889,8 @@ objective_reconciliation = build_objective_reconciliation(
     os.environ.get('AIDEVOPS_OBJECTIVE_STATE_FILE', '')
 )
 zero_worker_underutilization = build_zero_worker_underutilization(
-    active_worker_processes, len(worker_metrics), cycle_state, pre_launch_blockers, gauge_values
+    active_worker_processes, len(worker_metrics), cycle_state, pre_launch_blockers, gauge_values,
+    rest_admission,
 )
 permission_evidence = build_permission_evidence(
     os.environ.get('AIDEVOPS_WORKER_BLOCKER_LOG_FILE', os.path.join(log_dir, 'worker-progress-blockers.jsonl'))
@@ -830,6 +930,8 @@ result = {
         'load_blocked_count': load_blocked_count,
     },
     'graphql_budget': graphql_budget,
+    'rest_admission': rest_admission,
+    'policy_holds': policy_holds,
     'dispatch_pacing': dispatch_pacing,
     'current_state_guardrails': current_state_guardrails,
     'pre_launch_blockers': pre_launch_blockers,
@@ -875,6 +977,8 @@ runtime_state = {
     'dispatch_pacing': dispatch_pacing,
     'dispatch_stage_counts': dict(stage_counts),
     'graphql_budget': graphql_budget,
+    'rest_admission': rest_admission,
+    'policy_holds': policy_holds,
     'prefetch_cache': prefetch_cache,
     'cycle_state': cycle_state,
     'pre_launch_blockers': pre_launch_blockers,
@@ -912,6 +1016,8 @@ else:
     print(f'- Worker outcomes: {json.dumps(result["worker_outcomes"], sort_keys=True)}')
     print(f'- Resource context: {json.dumps(result["resource_context"], sort_keys=True)}')
     print(f'- GraphQL budget: {json.dumps(result["graphql_budget"], sort_keys=True)}')
+    print(f'- REST admission: {json.dumps(rest_admission, sort_keys=True)}')
+    print(f'- Policy holds: {json.dumps(policy_holds, sort_keys=True)}')
     print(f'- Dispatch pacing: {json.dumps(result["dispatch_pacing"], sort_keys=True)}')
     print(f'- Current-state guardrails: {json.dumps(result["current_state_guardrails"], sort_keys=True)}')
     print(f'- Top pre-launch blockers: {json.dumps(result["top_pre_launch_blockers"], sort_keys=True)}')

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -51,6 +51,12 @@ json.dump({
         'dispatch_candidate_failed_reason_cost_budget_exceeded': [now, now],
         'dispatch_candidate_failed_reason_dedup_active_claim': [now],
         'dispatch_candidate_failed_reason_graphql_circuit_breaker': [now],
+        'dispatch_candidate_failed_reason_policy_gate': [now],
+        'pulse_rest_core_progress_blocked': [now],
+        'pulse_rest_core_progress_blocked_unknown': [now],
+        'pulse_rest_core_unit_blocked': [now],
+        'pulse_rest_core_unit_blocked_progress': [now],
+        'pulse_rest_core_progress_blocked_emergency': [now - 3600],
     },
     'gauges': {
         'graphql_remaining': {'value': 1234, 'ts': now},
@@ -148,6 +154,7 @@ export AIDEVOPS_GH_REQUEST_STATE_AUTH_SCOPE="pulse-current-state-test"
 export AIDEVOPS_GH_API_POOL="default"
 export AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR="$TMP_DIR/review-thread-state"
 export AIDEVOPS_OBJECTIVE_STATE_FILE="$TMP_DIR/objective-reconciliation.json"
+export AIDEVOPS_REST_ADMISSION_STATUS_OVERRIDE='{"state":"available","source":"local_response_headers","remaining":462,"limit":5000,"reserved":0,"floor":0,"blocked_until":0,"reset":1893456000,"observation_age_seconds":3,"scope_mode":"configured","bound_credentials":1,"ambiguity":null}'
 # shellcheck source=../shared-gh-request-state.sh
 source "${SCRIPT_DIR}/../shared-gh-request-state.sh"
 rate_reset=$(($(date +%s) + 3600))
@@ -165,6 +172,8 @@ grep -q 'Dispatch alive: true' "$output"
 grep -q 'Worker terminal events: 4' "$output"
 grep -q 'dispatch_backoff_skipped' "$output"
 grep -q 'GraphQL budget:' "$output"
+grep -q 'REST admission:' "$output"
+grep -q 'Policy holds:' "$output"
 grep -q 'Top pre-launch blockers:' "$output"
 if ! grep -q 'Dispatch API blocked by GraphQL: false' "$output"; then
 	printf 'FAIL expected unblocked GraphQL dispatch state:\n%s\n' "$(<"$output")" >&2
@@ -195,6 +204,17 @@ jq -e '.worker_outcomes.canary_failed == 1' "$json_output" >/dev/null
 jq -e '.graphql_budget.skipped_low_count == 1' "$json_output" >/dev/null
 jq -e '.graphql_budget.force_rest_reads_count == 1' "$json_output" >/dev/null
 jq -e '.dispatch_api_blocked == false' "$json_output" >/dev/null
+jq -e '.graphql_budget_status | startswith("OK:")' "$json_output" >/dev/null
+jq -e '.rest_admission.availability == "observed" and .rest_admission.evidence_state == "read_incomplete"' "$json_output" >/dev/null
+jq -e '.rest_admission.deferred_by == "local_admission" and .rest_admission.request_attempted == false' "$json_output" >/dev/null
+jq -e '.rest_admission.deferral_count == 2 and .rest_admission.progress_block_count == 1 and .rest_admission.unit_block_count == 1' "$json_output" >/dev/null
+jq -e '.rest_admission.blocked_modes == {"unknown":1} and .rest_admission.last_observed_at != null' "$json_output" >/dev/null
+jq -e '.rest_admission.source == "pulse-stats" and .rest_admission.window_seconds == 900' "$json_output" >/dev/null
+jq -e '.rest_admission.transport.state == "available" and .rest_admission.transport.remaining == 462 and .rest_admission.transport.source == "local_response_headers"' "$json_output" >/dev/null
+jq -e '.rest_admission.remote_rejection_observed == false and .rest_admission.authentication_failure_inferred == false' "$json_output" >/dev/null
+jq -e '.policy_holds.active_in_window == true and .policy_holds.count == 1' "$json_output" >/dev/null
+jq -e '.policy_holds.source == "pulse-stats" and .policy_holds.window_seconds == 900 and .policy_holds.last_observed_at != null' "$json_output" >/dev/null
+jq -e '.zero_worker_underutilization.github_read_complete == false and .zero_worker_underutilization.github_read_status == "incomplete"' "$json_output" >/dev/null
 jq -e '.graphql_budget.reserve_mode_count == 1' "$json_output" >/dev/null
 jq -e '.graphql_budget.deferred_stage_count == 2' "$json_output" >/dev/null
 jq -e '.graphql_budget.deferred_stages.dashboard_freshness_check == 1' "$json_output" >/dev/null
@@ -300,6 +320,9 @@ mkdir -p "$missing_dir"
 missing_json="$TMP_DIR/missing-cycle-state.json"
 "$HELPER" --log-dir "$missing_dir" --repo-path "$PWD" --window 15m --json >"$missing_json"
 jq -e '.cycle_state.availability == "unavailable"' "$missing_json" >/dev/null
+jq -e '.rest_admission.availability == "observed" and .rest_admission.evidence_state == "unknown"
+  and .rest_admission.transport.state == "available"' "$missing_json" >/dev/null
+jq -e '.zero_worker_underutilization.github_read_complete == null and .zero_worker_underutilization.github_read_status == "unknown"' "$missing_json" >/dev/null
 
 jq '.cycle_state.heartbeat_at = ((now - 1800) | todateiso8601)' \
 	"$TMP_DIR/pulse-health.json" >"$missing_dir/pulse-health.json"


### PR DESCRIPTION
## Summary

Expose current-window REST admission deferrals and policy-gate holds alongside independent typed REST transport and GraphQL evidence; preserve unknown versus incomplete read state without inferring authentication failure.



## Files Changed

.agents/scripts/pulse-current-state-helper.sh, .agents/scripts/pulse-current-state.py, .agents/scripts/tests/test-pulse-current-state-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified through the source current-state helper on live local Pulse evidence; python3 -m py_compile .agents/scripts/pulse-current-state.py; test-pulse-current-state-helper.sh; test-pulse-current-state-guardrails.sh (23 passed); test-pulse-cycle-state-contract.sh (19 passed); linters-local.sh --changed

Resolves #31772


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.357 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-sol spent 12m and 168,492 tokens on this as a headless worker.