### PR TITLE
fix: preserve merge evidence and image errors

### DIFF
--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -82,7 +82,7 @@ function oauthHeaders(auth) {
   };
 }
 
-function terminalSseError(event) {
+async function enforceTerminalSseEvent(reader, event) {
   if (!TERMINAL_SSE_EVENT_TYPES.has(event.type)) return null;
   const providerError = event.error || event.response?.error || event.response?.incomplete_details || {};
   const defaultError = TERMINAL_SSE_DEFAULT_ERRORS.get(event.type) || {};
@@ -93,35 +93,40 @@ function terminalSseError(event) {
   const error = new Error(`OpenAI oauth image request failed${detail ? `: ${detail}` : `: ${event.type}`}.`);
   error.code = redactProviderDetail(code);
   error.eventType = event.type;
-  return error;
+  await cancelSseReader(reader);
+  throw error;
 }
 
-function parseSseBlock(block) {
+async function parseSseBlock(reader, block) {
   const data = block
     .split(/\r?\n/)
     .filter((line) => line.startsWith("data:"))
     .map((line) => line.slice(5).trimStart())
     .join("\n");
-  if (!data || data === "[DONE]") return { result: "", error: null };
+  if (!data || data === "[DONE]") return "";
+  let event;
   try {
-    const event = JSON.parse(data);
-    if (
-      event.type === "response.output_item.done"
-      && event.item?.type === "image_generation_call"
-      && typeof event.item.result === "string"
-    ) {
-      return { result: event.item.result, error: null };
-    }
-    if (event.type === "response.completed" && Array.isArray(event.response?.output)) {
-      const image = event.response.output.find(
-        (item) => item?.type === "image_generation_call" && typeof item.result === "string",
-      );
-      if (image?.result) return { result: image.result, error: null };
-    }
-    return { result: "", error: terminalSseError(event) };
+    event = Object(JSON.parse(data));
   } catch {
-    return { result: "", error: null };
+    return "";
   }
+  let result = "";
+  if (
+    event.type === "response.output_item.done"
+    && event.item?.type === "image_generation_call"
+    && typeof event.item.result === "string"
+  ) {
+    result = event.item.result;
+  }
+  if (event.type === "response.completed" && Array.isArray(event.response?.output)) {
+    const image = event.response.output.find(
+      (item) => item?.type === "image_generation_call" && typeof item.result === "string",
+    );
+    result = image?.result || "";
+  }
+  if (result) return result;
+  await enforceTerminalSseEvent(reader, event);
+  return "";
 }
 
 function takeNextSseBlock(pending) {
@@ -143,12 +148,8 @@ async function consumeSseBlocks(reader, pending) {
       await cancelSseReader(reader);
       throw new Error("OAuth image event exceeded the safe event-stream limit.");
     }
-    const parsed = parseSseBlock(next.block);
-    if (parsed.error) {
-      await cancelSseReader(reader);
-      throw parsed.error;
-    }
-    if (parsed.result) return { pending, result: parsed.result };
+    const result = await parseSseBlock(reader, next.block);
+    if (result) return { pending, result };
   }
   return { pending, result: "" };
 }
@@ -187,9 +188,8 @@ export async function parseImageSse(stream) {
     );
     if (done) break;
   }
-  const finalEvent = parseSseBlock(pending);
-  if (finalEvent.error) throw finalEvent.error;
-  if (finalEvent.result) return finalEvent.result;
+  const finalResult = await parseSseBlock(reader, pending);
+  if (finalResult) return finalResult;
   throw new Error("OAuth image response did not contain a completed image.");
 }
 

--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -22,6 +22,12 @@ const TERMINAL_SSE_EVENT_TYPES = new Set([
   "response.incomplete",
   "response.completed",
 ]);
+const TERMINAL_SSE_DEFAULT_ERRORS = new Map([
+  ["response.completed", {
+    code: "image_missing",
+    message: "provider completed the response without an image result",
+  }],
+]);
 
 async function withImageRequestTimeout(operation) {
   const controller = new AbortController();
@@ -94,12 +100,10 @@ function completedImageResult(event) {
 function terminalSseError(event) {
   if (!TERMINAL_SSE_EVENT_TYPES.has(event.type)) return null;
   const providerError = event.error || event.response?.error || event.response?.incomplete_details || {};
-  let code = [providerError.code, providerError.type, providerError.reason, event.code].find(Boolean) || "";
-  let message = providerError.message || event.message || "";
-  if (event.type === "response.completed" && !code && !message) {
-    code = "image_missing";
-    message = "provider completed the response without an image result";
-  }
+  const defaultError = TERMINAL_SSE_DEFAULT_ERRORS.get(event.type) || {};
+  const code = [providerError.code, providerError.type, providerError.reason, event.code, defaultError.code]
+    .find(Boolean) || "";
+  const message = [providerError.message, event.message, defaultError.message].find(Boolean) || "";
   const detail = [code, message].filter(Boolean).map(redactProviderDetail).join(": ");
   const error = new Error(`OpenAI oauth image request failed${detail ? `: ${detail}` : `: ${event.type}`}.`);
   error.code = redactProviderDetail(code);

--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -82,21 +82,6 @@ function oauthHeaders(auth) {
   };
 }
 
-function completedImageResult(event) {
-  if (
-    event.type === "response.output_item.done"
-    && event.item?.type === "image_generation_call"
-    && typeof event.item.result === "string"
-  ) {
-    return event.item.result;
-  }
-  if (event.type !== "response.completed" || !Array.isArray(event.response?.output)) return "";
-  const image = event.response.output.find(
-    (item) => item?.type === "image_generation_call" && typeof item.result === "string",
-  );
-  return image?.result || "";
-}
-
 function terminalSseError(event) {
   if (!TERMINAL_SSE_EVENT_TYPES.has(event.type)) return null;
   const providerError = event.error || event.response?.error || event.response?.incomplete_details || {};
@@ -120,8 +105,19 @@ function parseSseBlock(block) {
   if (!data || data === "[DONE]") return { result: "", error: null };
   try {
     const event = JSON.parse(data);
-    const result = completedImageResult(event);
-    if (result) return { result, error: null };
+    if (
+      event.type === "response.output_item.done"
+      && event.item?.type === "image_generation_call"
+      && typeof event.item.result === "string"
+    ) {
+      return { result: event.item.result, error: null };
+    }
+    if (event.type === "response.completed" && Array.isArray(event.response?.output)) {
+      const image = event.response.output.find(
+        (item) => item?.type === "image_generation_call" && typeof item.result === "string",
+      );
+      if (image?.result) return { result: image.result, error: null };
+    }
     return { result: "", error: terminalSseError(event) };
   } catch {
     return { result: "", error: null };

--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -94,7 +94,7 @@ function completedImageResult(event) {
 function terminalSseError(event) {
   if (!TERMINAL_SSE_EVENT_TYPES.has(event.type)) return null;
   const providerError = event.error || event.response?.error || event.response?.incomplete_details || {};
-  let code = providerError.code || providerError.type || providerError.reason || event.code || "";
+  let code = [providerError.code, providerError.type, providerError.reason, event.code].find(Boolean) || "";
   let message = providerError.message || event.message || "";
   if (event.type === "response.completed" && !code && !message) {
     code = "image_missing";

--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -16,6 +16,12 @@ const MAX_SSE_TOTAL_BYTES = 128 * 1024 * 1024;
 const MAX_API_RESPONSE_BYTES = 96 * 1024 * 1024;
 const MAX_ERROR_RESPONSE_BYTES = 64 * 1024;
 const IMAGE_REQUEST_TIMEOUT_MS = 180_000;
+const TERMINAL_SSE_EVENT_TYPES = new Set([
+  "error",
+  "response.failed",
+  "response.incomplete",
+  "response.completed",
+]);
 
 async function withImageRequestTimeout(operation) {
   const controller = new AbortController();
@@ -70,26 +76,52 @@ function oauthHeaders(auth) {
   };
 }
 
+function completedImageResult(event) {
+  if (
+    event.type === "response.output_item.done"
+    && event.item?.type === "image_generation_call"
+    && typeof event.item.result === "string"
+  ) {
+    return event.item.result;
+  }
+  if (event.type !== "response.completed" || !Array.isArray(event.response?.output)) return "";
+  const image = event.response.output.find(
+    (item) => item?.type === "image_generation_call" && typeof item.result === "string",
+  );
+  return image?.result || "";
+}
+
+function terminalSseError(event) {
+  if (!TERMINAL_SSE_EVENT_TYPES.has(event.type)) return null;
+  const providerError = event.error || event.response?.error || event.response?.incomplete_details || {};
+  let code = providerError.code || providerError.type || providerError.reason || event.code || "";
+  let message = providerError.message || event.message || "";
+  if (event.type === "response.completed" && !code && !message) {
+    code = "image_missing";
+    message = "provider completed the response without an image result";
+  }
+  const detail = [code, message].filter(Boolean).map(redactProviderDetail).join(": ");
+  const error = new Error(`OpenAI oauth image request failed${detail ? `: ${detail}` : `: ${event.type}`}.`);
+  error.code = redactProviderDetail(code);
+  error.eventType = event.type;
+  return error;
+}
+
 function parseSseBlock(block) {
   const data = block
     .split(/\r?\n/)
     .filter((line) => line.startsWith("data:"))
     .map((line) => line.slice(5).trimStart())
     .join("\n");
-  if (!data || data === "[DONE]") return "";
+  if (!data || data === "[DONE]") return { result: "", error: null };
   try {
     const event = JSON.parse(data);
-    if (
-      event.type === "response.output_item.done"
-      && event.item?.type === "image_generation_call"
-      && typeof event.item.result === "string"
-    ) {
-      return event.item.result;
-    }
+    const result = completedImageResult(event);
+    if (result) return { result, error: null };
+    return { result: "", error: terminalSseError(event) };
   } catch {
-    return "";
+    return { result: "", error: null };
   }
-  return "";
 }
 
 function takeNextSseBlock(pending) {
@@ -111,8 +143,12 @@ async function consumeSseBlocks(reader, pending) {
       await cancelSseReader(reader);
       throw new Error("OAuth image event exceeded the safe event-stream limit.");
     }
-    const result = parseSseBlock(next.block);
-    if (result) return { pending, result };
+    const parsed = parseSseBlock(next.block);
+    if (parsed.error) {
+      await cancelSseReader(reader);
+      throw parsed.error;
+    }
+    if (parsed.result) return { pending, result: parsed.result };
   }
   return { pending, result: "" };
 }
@@ -151,8 +187,9 @@ export async function parseImageSse(stream) {
     );
     if (done) break;
   }
-  const finalResult = parseSseBlock(pending);
-  if (finalResult) return finalResult;
+  const finalEvent = parseSseBlock(pending);
+  if (finalEvent.error) throw finalEvent.error;
+  if (finalEvent.result) return finalEvent.result;
   throw new Error("OAuth image response did not contain a completed image.");
 }
 

--- a/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-request.mjs
@@ -9,25 +9,14 @@ const CODEX_RESPONSES_ENDPOINT = "https://chatgpt.com/backend-api/codex/response
 const OPENAI_IMAGES_GENERATE_ENDPOINT = "https://api.openai.com/v1/images/generations";
 const OPENAI_IMAGES_EDIT_ENDPOINT = "https://api.openai.com/v1/images/edits";
 import { readFileSync } from "node:fs";
+import { parseImageSse, redactProviderDetail } from "./gpt-image-sse.mjs";
+
+export { parseImageSse };
 
 const MODEL_ROUTING_TABLE = new URL("../../configs/model-routing-table.json", import.meta.url);
-const MAX_SSE_BUFFER_CHARS = 96 * 1024 * 1024;
-const MAX_SSE_TOTAL_BYTES = 128 * 1024 * 1024;
 const MAX_API_RESPONSE_BYTES = 96 * 1024 * 1024;
 const MAX_ERROR_RESPONSE_BYTES = 64 * 1024;
 const IMAGE_REQUEST_TIMEOUT_MS = 180_000;
-const TERMINAL_SSE_EVENT_TYPES = new Set([
-  "error",
-  "response.failed",
-  "response.incomplete",
-  "response.completed",
-]);
-const TERMINAL_SSE_DEFAULT_ERRORS = new Map([
-  ["response.completed", {
-    code: "image_missing",
-    message: "provider completed the response without an image result",
-  }],
-]);
 
 async function withImageRequestTimeout(operation) {
   const controller = new AbortController();
@@ -80,117 +69,6 @@ function oauthHeaders(auth) {
     originator: "opencode",
     Accept: "text/event-stream",
   };
-}
-
-async function enforceTerminalSseEvent(reader, event) {
-  if (!TERMINAL_SSE_EVENT_TYPES.has(event.type)) return null;
-  const providerError = event.error || event.response?.error || event.response?.incomplete_details || {};
-  const defaultError = TERMINAL_SSE_DEFAULT_ERRORS.get(event.type) || {};
-  const code = [providerError.code, providerError.type, providerError.reason, event.code, defaultError.code]
-    .find(Boolean) || "";
-  const message = [providerError.message, event.message, defaultError.message].find(Boolean) || "";
-  const detail = [code, message].filter(Boolean).map(redactProviderDetail).join(": ");
-  const error = new Error(`OpenAI oauth image request failed${detail ? `: ${detail}` : `: ${event.type}`}.`);
-  error.code = redactProviderDetail(code);
-  error.eventType = event.type;
-  await cancelSseReader(reader);
-  throw error;
-}
-
-async function parseSseBlock(reader, block) {
-  const data = block
-    .split(/\r?\n/)
-    .filter((line) => line.startsWith("data:"))
-    .map((line) => line.slice(5).trimStart())
-    .join("\n");
-  if (!data || data === "[DONE]") return "";
-  let event;
-  try {
-    event = Object(JSON.parse(data));
-  } catch {
-    return "";
-  }
-  let result = "";
-  if (
-    event.type === "response.output_item.done"
-    && event.item?.type === "image_generation_call"
-    && typeof event.item.result === "string"
-  ) {
-    result = event.item.result;
-  }
-  if (event.type === "response.completed" && Array.isArray(event.response?.output)) {
-    const image = event.response.output.find(
-      (item) => item?.type === "image_generation_call" && typeof item.result === "string",
-    );
-    result = image?.result || "";
-  }
-  if (result) return result;
-  await enforceTerminalSseEvent(reader, event);
-  return "";
-}
-
-function takeNextSseBlock(pending) {
-  const delimiter = pending.match(/\r?\n\r?\n/);
-  if (!delimiter || delimiter.index === undefined) return null;
-  const end = delimiter.index + delimiter[0].length;
-  return { block: pending.slice(0, delimiter.index), rest: pending.slice(end) };
-}
-
-async function cancelSseReader(reader) {
-  await reader.cancel().catch(() => {});
-}
-
-async function consumeSseBlocks(reader, pending) {
-  let next;
-  while ((next = takeNextSseBlock(pending))) {
-    pending = next.rest;
-    if (next.block.length > MAX_SSE_BUFFER_CHARS) {
-      await cancelSseReader(reader);
-      throw new Error("OAuth image event exceeded the safe event-stream limit.");
-    }
-    const result = await parseSseBlock(reader, next.block);
-    if (result) return { pending, result };
-  }
-  return { pending, result: "" };
-}
-
-async function enforceSseLimit(reader, exceeded, message) {
-  if (!exceeded) return;
-  await cancelSseReader(reader);
-  throw new Error(message);
-}
-
-export async function parseImageSse(stream) {
-  if (!stream?.getReader) throw new Error("OAuth image response did not include an event stream.");
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  let pending = "";
-  let totalBytes = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    totalBytes += value?.byteLength || 0;
-    await enforceSseLimit(
-      reader,
-      totalBytes > MAX_SSE_TOTAL_BYTES,
-      "OAuth image response exceeded the safe event-stream limit.",
-    );
-    pending += decoder.decode(value || new Uint8Array(), { stream: !done });
-    const consumed = await consumeSseBlocks(reader, pending);
-    pending = consumed.pending;
-    if (consumed.result) {
-      await cancelSseReader(reader);
-      return consumed.result;
-    }
-    await enforceSseLimit(
-      reader,
-      pending.length > MAX_SSE_BUFFER_CHARS,
-      "OAuth image response exceeded the safe event-stream limit.",
-    );
-    if (done) break;
-  }
-  const finalResult = await parseSseBlock(reader, pending);
-  if (finalResult) return finalResult;
-  throw new Error("OAuth image response did not contain a completed image.");
 }
 
 export async function requestOAuthImage(auth, args, images, fetchImpl) {
@@ -284,14 +162,6 @@ export async function requestApiImage(auth, args, images, fetchImpl) {
     if (typeof base64 !== "string" || !base64) throw new Error("OpenAI Images API response did not contain an image.");
     return { response, base64 };
   });
-}
-
-function redactProviderDetail(value) {
-  return String(value || "")
-    .replace(/Bearer\s+\S+/gi, "Bearer [REDACTED]")
-    .replace(/\bsk-[A-Za-z0-9_-]+\b/g, "[REDACTED]")
-    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED]")
-    .slice(0, 300);
 }
 
 export async function imageRequestError(response, mode) {

--- a/.agents/plugins/opencode-aidevops/gpt-image-sse.mjs
+++ b/.agents/plugins/opencode-aidevops/gpt-image-sse.mjs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const MAX_SSE_BUFFER_CHARS = 96 * 1024 * 1024;
+const MAX_SSE_TOTAL_BYTES = 128 * 1024 * 1024;
+const TERMINAL_SSE_EVENT_TYPES = new Set([
+  "error",
+  "response.failed",
+  "response.incomplete",
+  "response.completed",
+]);
+const TERMINAL_SSE_DEFAULT_ERRORS = new Map([
+  ["response.completed", {
+    code: "image_missing",
+    message: "provider completed the response without an image result",
+  }],
+]);
+
+export function redactProviderDetail(value) {
+  return String(value || "")
+    .replace(/Bearer\s+\S+/gi, "Bearer [REDACTED]")
+    .replace(/\bsk-[A-Za-z0-9_-]+\b/g, "[REDACTED]")
+    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED]")
+    .slice(0, 300);
+}
+
+async function enforceTerminalSseEvent(reader, event) {
+  if (!TERMINAL_SSE_EVENT_TYPES.has(event.type)) return null;
+  const providerError = event.error || event.response?.error || event.response?.incomplete_details || {};
+  const defaultError = TERMINAL_SSE_DEFAULT_ERRORS.get(event.type) || {};
+  const code = [providerError.code, providerError.type, providerError.reason, event.code, defaultError.code]
+    .find(Boolean) || "";
+  const message = [providerError.message, event.message, defaultError.message].find(Boolean) || "";
+  const detail = [code, message].filter(Boolean).map(redactProviderDetail).join(": ");
+  const error = new Error(`OpenAI oauth image request failed${detail ? `: ${detail}` : `: ${event.type}`}.`);
+  error.code = redactProviderDetail(code);
+  error.eventType = event.type;
+  await cancelSseReader(reader);
+  throw error;
+}
+
+async function parseSseBlock(reader, block) {
+  const data = block
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trimStart())
+    .join("\n");
+  if (!data || data === "[DONE]") return "";
+  let event;
+  try {
+    event = Object(JSON.parse(data));
+  } catch {
+    return "";
+  }
+  let result = "";
+  if (
+    event.type === "response.output_item.done"
+    && event.item?.type === "image_generation_call"
+    && typeof event.item.result === "string"
+  ) {
+    result = event.item.result;
+  }
+  if (event.type === "response.completed" && Array.isArray(event.response?.output)) {
+    const image = event.response.output.find(
+      (item) => item?.type === "image_generation_call" && typeof item.result === "string",
+    );
+    result = image?.result || "";
+  }
+  if (result) return result;
+  await enforceTerminalSseEvent(reader, event);
+  return "";
+}
+
+function takeNextSseBlock(pending) {
+  const delimiter = pending.match(/\r?\n\r?\n/);
+  if (!delimiter || delimiter.index === undefined) return null;
+  const end = delimiter.index + delimiter[0].length;
+  return { block: pending.slice(0, delimiter.index), rest: pending.slice(end) };
+}
+
+async function cancelSseReader(reader) {
+  await reader.cancel().catch(() => {});
+}
+
+async function consumeSseBlocks(reader, pending) {
+  let next;
+  while ((next = takeNextSseBlock(pending))) {
+    pending = next.rest;
+    if (next.block.length > MAX_SSE_BUFFER_CHARS) {
+      await cancelSseReader(reader);
+      throw new Error("OAuth image event exceeded the safe event-stream limit.");
+    }
+    const result = await parseSseBlock(reader, next.block);
+    if (result) return { pending, result };
+  }
+  return { pending, result: "" };
+}
+
+async function enforceSseLimit(reader, exceeded, message) {
+  if (!exceeded) return;
+  await cancelSseReader(reader);
+  throw new Error(message);
+}
+
+export async function parseImageSse(stream) {
+  if (!stream?.getReader) throw new Error("OAuth image response did not include an event stream.");
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let pending = "";
+  let totalBytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    totalBytes += value?.byteLength || 0;
+    await enforceSseLimit(
+      reader,
+      totalBytes > MAX_SSE_TOTAL_BYTES,
+      "OAuth image response exceeded the safe event-stream limit.",
+    );
+    pending += decoder.decode(value || new Uint8Array(), { stream: !done });
+    const consumed = await consumeSseBlocks(reader, pending);
+    pending = consumed.pending;
+    if (consumed.result) {
+      await cancelSseReader(reader);
+      return consumed.result;
+    }
+    await enforceSseLimit(
+      reader,
+      pending.length > MAX_SSE_BUFFER_CHARS,
+      "OAuth image response exceeded the safe event-stream limit.",
+    );
+    if (done) break;
+  }
+  const finalResult = await parseSseBlock(reader, pending);
+  if (finalResult) return finalResult;
+  throw new Error("OAuth image response did not contain a completed image.");
+}

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt-image-request.mjs
@@ -28,6 +28,70 @@ describe("GPT image provider requests", () => {
     assert.equal(await parseImageSse(splitStream(event, 17)), IMAGE_RESULT);
   });
 
+  test("surfaces bounded redacted provider details from terminal SSE failures", async () => {
+    const exposedBearer = "Bearer provider-secret";
+    const exposedKey = "sk-provider-secret";
+    const event = `data: ${JSON.stringify({
+      type: "response.failed",
+      response: {
+        error: {
+          code: "content_policy_violation",
+          message: `Request denied for ${exposedBearer} and ${exposedKey} ${"x".repeat(500)}`,
+        },
+      },
+    })}\n\n`;
+    await assert.rejects(
+      parseImageSse(splitStream(event, 23)),
+      (error) => {
+        assert.equal(error.code, "content_policy_violation");
+        assert.equal(error.eventType, "response.failed");
+        assert.match(error.message, /content_policy_violation/);
+        assert.match(error.message, /\[REDACTED\]/);
+        assert.equal(error.message.includes("provider-secret"), false);
+        assert.ok(error.message.length < 400);
+        return true;
+      },
+    );
+  });
+
+  test("surfaces response.incomplete reasons", async () => {
+    const event = `data: ${JSON.stringify({
+      type: "response.incomplete",
+      response: { incomplete_details: { reason: "content_filter" } },
+    })}\n\n`;
+    await assert.rejects(parseImageSse(splitStream(event, 8)), /content_filter/);
+  });
+
+  test("diagnoses a completed response that contains no generated image", async () => {
+    const event = `data: ${JSON.stringify({
+      type: "response.completed",
+      response: { output: [] },
+    })}\n\n`;
+    await assert.rejects(parseImageSse(splitStream(event, 11)), /image_missing/);
+  });
+
+  test("does not retry a terminal SSE provider failure with another model", async () => {
+    let calls = 0;
+    const event = `data: ${JSON.stringify({
+      type: "error",
+      code: "server_error",
+      message: "generation failed",
+    })}\n\n`;
+    await assert.rejects(
+      requestOAuthImage(
+        { accessToken: "[redacted-credential]" },
+        { prompt: "draw a test", quality: "auto", size: "auto", format: "png" },
+        [],
+        async () => {
+          calls += 1;
+          return new Response(event, { status: 200 });
+        },
+      ),
+      /server_error: generation failed/,
+    );
+    assert.equal(calls, 1);
+  });
+
   test("builds the OAuth hosted-tool request with references", async () => {
     let captured;
     const event = `data: ${JSON.stringify({

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -430,6 +430,64 @@ _pmrc_snapshot_log_failure() {
 	return 0
 }
 
+_pmrc_snapshot_retry_timeout_seconds() {
+	local timeout_seconds="${AIDEVOPS_PULSE_MERGE_SNAPSHOT_RETRY_TIMEOUT_SECONDS:-10}"
+	local deadline=0 candidate="" now_epoch="" remaining_seconds=""
+	[[ "$timeout_seconds" =~ ^[0-9]+$ && "$timeout_seconds" -ge 1 && "$timeout_seconds" -le 30 ]] || timeout_seconds=10
+	for candidate in "${_PMP_MERGE_PASS_DEADLINE_EPOCH:-0}" "${AIDEVOPS_GH_DEADLINE_EPOCH:-0}"; do
+		[[ "$candidate" =~ ^[0-9]+$ && "$candidate" -gt 0 ]] || continue
+		[[ "$deadline" -eq 0 || "$candidate" -lt "$deadline" ]] && deadline="$candidate"
+	done
+	if [[ "$deadline" -gt 0 ]]; then
+		now_epoch=$(date +%s) || return 1
+		remaining_seconds=$((deadline - now_epoch - 1))
+		[[ "$remaining_seconds" -ge 1 ]] || return 1
+		[[ "$remaining_seconds" -lt "$timeout_seconds" ]] && timeout_seconds="$remaining_seconds"
+	fi
+	printf '%s' "$timeout_seconds"
+	return 0
+}
+
+_pmrc_snapshot_checks_with_retry() {
+	local repo_slug="$1"
+	local head_sha="$2"
+	local checks_json="" snapshot_rc=0 retry_timeout=""
+	local retry_delay="${AIDEVOPS_PULSE_MERGE_SNAPSHOT_RETRY_DELAY_SECONDS:-1}"
+
+	checks_json=$(_pmrc_snapshot_checks_json "$repo_slug" "$head_sha") || snapshot_rc=$?
+	if [[ "$snapshot_rc" -eq 0 ]]; then
+		printf '%s\n' "$checks_json"
+		return 0
+	fi
+	[[ "$snapshot_rc" -eq 75 || "$snapshot_rc" -eq 124 ]] || return "$snapshot_rc"
+	retry_timeout=$(_pmrc_snapshot_retry_timeout_seconds) || return "$snapshot_rc"
+	[[ "$retry_delay" =~ ^[0-9]+$ && "$retry_delay" -le 5 ]] || retry_delay=1
+	echo "[pulse-merge] pre-merge snapshot: transient check-set read rc=${snapshot_rc} for head ${head_sha:0:12} in ${repo_slug}; retrying once with ${retry_timeout}s timeout" >>"$LOGFILE"
+	[[ "$retry_delay" -eq 0 ]] || sleep "$retry_delay"
+
+	snapshot_rc=0
+	checks_json=$(AIDEVOPS_GH_READ_TIMEOUT="$retry_timeout" \
+		_pmrc_snapshot_checks_json "$repo_slug" "$head_sha") || snapshot_rc=$?
+	[[ "$snapshot_rc" -eq 0 ]] || return "$snapshot_rc"
+	printf '%s\n' "$checks_json"
+	return 0
+}
+
+_pmrc_prioritize_snapshot_retry() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local snapshot_rc="$3"
+	local unavailable="unavailable"
+	local queue_action="$unavailable"
+	if declare -F _pulse_merge_queue_defer >/dev/null 2>&1; then
+		queue_action=$(_pulse_merge_queue_defer "$repo_slug" "$pr_number" 2>>"$LOGFILE") || queue_action="$unavailable"
+	elif declare -F _pulse_merge_queue_enqueue >/dev/null 2>&1; then
+		queue_action=$(_pulse_merge_queue_enqueue "$repo_slug" "$pr_number" 2>>"$LOGFILE") || queue_action="$unavailable"
+	fi
+	echo "[pulse-merge] pre-merge snapshot: transient exact-head read exhausted for PR #${pr_number} in ${repo_slug} (rc=${snapshot_rc}); merge remains blocked and next-cycle priority is preserved (retry_hint=${queue_action})" >>"$LOGFILE"
+	return 0
+}
+
 _pmrc_record_preflight_check_mismatch() {
 	if declare -F gh_record_efficiency_evidence >/dev/null 2>&1; then
 		gh_record_efficiency_evidence guardrails.required_check_merge_preflight_mismatches 1 2>/dev/null || true
@@ -549,15 +607,18 @@ _pmrc_snapshot_checks_json() {
 	local head_sha="$2"
 	local runs_pages="" statuses_json="" checks_json=""
 
+	local read_rc=0
 	runs_pages=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/check-runs?per_page=100" \
-		--paginate --slurp 2>/dev/null) || {
+		--paginate --slurp 2>/dev/null) || read_rc=$?
+	if [[ "$read_rc" -ne 0 ]]; then
 		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_HEAD_PREFIX}${head_sha:0:12}" "check-runs fetch"
-		return 1
-	}
-	statuses_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/status" 2>/dev/null) || {
+		return "$read_rc"
+	fi
+	statuses_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/status" 2>/dev/null) || read_rc=$?
+	if [[ "$read_rc" -ne 0 ]]; then
 		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_HEAD_PREFIX}${head_sha:0:12}" "commit-status fetch"
-		return 1
-	}
+		return "$read_rc"
+	fi
 	# Stream API documents over stdin instead of passing large check-run payloads
 	# through --argjson, which can exceed the OS per-argument limit (GH#28164).
 	checks_json=$(printf '%s\n%s\n' "$runs_pages" "$statuses_json" |
@@ -1065,10 +1126,15 @@ _pulse_merge_preflight_snapshot_gate() {
 		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "required-context lookup"
 		return 1
 	}
-	checks_json=$(_pmrc_snapshot_checks_json "$repo_slug" "$current_head_sha") || {
+	local snapshot_rc=0
+	checks_json=$(_pmrc_snapshot_checks_with_retry "$repo_slug" "$current_head_sha") || snapshot_rc=$?
+	if [[ "$snapshot_rc" -ne 0 ]]; then
 		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
+		if [[ "$snapshot_rc" -eq 75 || "$snapshot_rc" -eq 124 ]]; then
+			_pmrc_prioritize_snapshot_retry "$repo_slug" "$pr_number" "$snapshot_rc"
+		fi
 		return 1
-	}
+	fi
 	if declare -F _pmp_record_same_pass_check_evidence >/dev/null 2>&1; then
 		_pmp_record_same_pass_check_evidence "$repo_slug" "$current_head_sha" "$checks_json" || true
 	fi

--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -1447,8 +1447,9 @@ gh_pr_check_status_rest() {
 #
 # Output (stdout): JSON array of normalised check entries:
 #   [{"name":"...","conclusion":"success|failure|null","status":"..."}, ...]
-#   Empty array "[]" on missing args / API error.
-# Returns: 0 always
+#   Empty array "[]" on missing args or when no checks are recorded.
+# Returns: 0=usable JSON, 75=read deferred, 124=read timed out,
+#          other non-zero=API/parse failure
 #######################################
 gh_pr_check_runs_rest() {
 	local slug="$1"
@@ -1461,17 +1462,18 @@ gh_pr_check_runs_rest() {
 
 	# 1. Modern check-runs (GitHub Actions / GitHub Apps) — AUTHORITATIVE.
 	# Almost all check signal in modern repos lives here. If this endpoint
-	# fails, we emit empty so callers can fail-closed; /status alone is
+	# fails, preserve the typed failure so callers can fail closed while
+	# distinguishing retryable admission deferrals/timeouts; /status alone is
 	# insufficient signal for branch-protection gating.
-	local runs=""
+	local runs="" runs_rc=0
 	runs=$(_gh_checks_api_read "repos/${slug}/commits/${sha}/check-runs" --paginate \
-		--jq '[.check_runs[]? | {name, conclusion, status}]' 2>/dev/null) || runs=""
+		--jq '[.check_runs[]? | {name, conclusion, status}]' 2>/dev/null) || runs_rc=$?
+	[[ "$runs_rc" -eq 0 ]] || return "$runs_rc"
 
 	if [[ -z "$runs" ]]; then
-		# /check-runs unreachable or empty output — emit empty so callers
-		# distinguish "fetch failed" from "no checks recorded".
-		echo ""
-		return 0
+		# A successful API read must emit JSON. Empty stdout is indeterminate,
+		# never equivalent to the valid no-checks payload `[]`.
+		return 1
 	fi
 
 	# 2. Legacy combined status (third-party CI services, repo statuses) —
@@ -1509,15 +1511,15 @@ gh_pr_check_runs_rest() {
 	# Concatenate possibly-multi-page check-runs output, then merge with
 	# normalised statuses. `jq -s 'add'` flattens into a single array.
 	# /status failure here is non-fatal: /check-runs already succeeded.
-	local merged=""
+	local merged="" merge_rc=0
 	if [[ -n "$statuses" ]]; then
-		merged=$(printf '%s\n%s' "$runs" "$statuses" | jq -s 'add // []' 2>/dev/null) || merged=""
+		merged=$(printf '%s\n%s' "$runs" "$statuses" | jq -s 'add // []' 2>/dev/null) || merge_rc=$?
 	else
-		merged=$(printf '%s' "$runs" | jq -s 'add // []' 2>/dev/null) || merged=""
+		merged=$(printf '%s' "$runs" | jq -s 'add // []' 2>/dev/null) || merge_rc=$?
 	fi
-	[[ -n "$merged" ]] || merged="[]"
+	[[ "$merge_rc" -eq 0 && -n "$merged" ]] || return 1
 
-	echo "$merged"
+	printf '%s\n' "$merged"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -28,8 +28,11 @@ TESTS_RUN=0
 TESTS_FAILED=0
 EVIDENCE_LOG="${TEST_ROOT}/efficiency-evidence.log"
 RULES_ATTRIBUTION_LOG="${TEST_ROOT}/rules-attribution.log"
+SNAPSHOT_READ_COUNT_FILE="${TEST_ROOT}/snapshot-read-count"
+SNAPSHOT_RETRY_QUEUE_LOG="${TEST_ROOT}/snapshot-retry-queue.log"
 : >"$EVIDENCE_LOG"
 : >"$RULES_ATTRIBUTION_LOG"
+: >"$SNAPSHOT_RETRY_QUEUE_LOG"
 
 gh_record_efficiency_evidence() {
 	local name="$1"
@@ -51,6 +54,22 @@ _pmrc_gh_read() {
 
 	[[ "$command" == "gh" && "$subcommand" == "api" ]] || return 1
 	case "${SNAPSHOT_MODE}:${endpoint}" in
+	"check_runs_deferred:"*check-runs*)
+		return 75
+		;;
+	"check_runs_timeout:"*check-runs*)
+		return 124
+		;;
+	"check_runs_deferred_then_success:"*check-runs* | "check_runs_timeout_then_success:"*check-runs*)
+		local read_count=0
+		[[ -f "$SNAPSHOT_READ_COUNT_FILE" ]] && read_count=$(<"$SNAPSHOT_READ_COUNT_FILE")
+		read_count=$((read_count + 1))
+		printf '%s\n' "$read_count" >"$SNAPSHOT_READ_COUNT_FILE"
+		if [[ "$read_count" -eq 1 ]]; then
+			[[ "$SNAPSHOT_MODE" == "check_runs_deferred_then_success" ]] && return 75
+			return 124
+		fi
+		;;
 	"pr_fetch_error:repos/owner/repo/pulls/7" | "check_runs_error:"*check-runs* | \
 		"status_error:"*commits/sha-reviewed/status* | "reviews_error:"*pulls/7/reviews* | \
 		"issue_comments_error:"*issues/7/comments* | "inline_comments_error:"*pulls/7/comments*)
@@ -66,6 +85,12 @@ _pmrc_gh_read() {
 	esac
 	"$@"
 	return $?
+}
+
+_pulse_merge_queue_defer() {
+	printf '%s/%s\n' "$1" "$2" >>"$SNAPSHOT_RETRY_QUEUE_LOG"
+	printf 'queued\n'
+	return 0
 }
 
 _required_contexts_for_default_branch() {
@@ -257,6 +282,8 @@ assert_gate() {
 	local rc=0
 	SNAPSHOT_MODE="$mode"
 	: >"$LOGFILE"
+	: >"$SNAPSHOT_READ_COUNT_FILE"
+	: >"$SNAPSHOT_RETRY_QUEUE_LOG"
 	_pulse_merge_preflight_snapshot_gate owner/repo 7 sha-reviewed || rc=$?
 	TESTS_RUN=$((TESTS_RUN + 1))
 	if [[ "$rc" -eq "$expected_rc" ]]; then
@@ -265,6 +292,53 @@ assert_gate() {
 	fi
 	printf 'FAIL %s (expected rc=%s, actual rc=%s)\n' "$description" "$expected_rc" "$rc"
 	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_snapshot_transient_retry_cases() {
+	local read_count=""
+	AIDEVOPS_PULSE_MERGE_SNAPSHOT_RETRY_DELAY_SECONDS=0
+	export AIDEVOPS_PULSE_MERGE_SNAPSHOT_RETRY_DELAY_SECONDS
+	_PMP_MERGE_PASS_DEADLINE_EPOCH=$(($(date +%s) + 30))
+
+	assert_gate "admission-deferred exact-head snapshot recovers on one bounded retry" \
+		check_runs_deferred_then_success 0
+	read_count=$(<"$SNAPSHOT_READ_COUNT_FILE")
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$read_count" -eq 2 ]] && grep -qF "retrying once" "$LOGFILE"; then
+		printf 'PASS admission deferral used exactly one audited retry\n'
+	else
+		printf 'FAIL admission deferral retry count/log (count=%s)\n' "$read_count"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+
+	assert_gate "timed-out exact-head snapshot recovers on one bounded retry" \
+		check_runs_timeout_then_success 0
+
+	assert_gate_blocker "repeated transient snapshot failure keeps merge blocked" \
+		check_runs_deferred 1 "$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$(grep -cF 'owner/repo/7' "$SNAPSHOT_RETRY_QUEUE_LOG" || true)" -eq 1 ]] &&
+		grep -qF "next-cycle priority is preserved" "$LOGFILE"; then
+		printf 'PASS exhausted transient retry preserves next-cycle priority\n'
+	else
+		printf 'FAIL exhausted transient retry did not preserve next-cycle priority\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+
+	_PMP_MERGE_PASS_DEADLINE_EPOCH=$(date +%s)
+	assert_gate_blocker "expired merge-pass deadline suppresses same-cycle retry" \
+		check_runs_timeout_then_success 1 "$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$(<"$SNAPSHOT_READ_COUNT_FILE")" -eq 1 ]] &&
+		[[ "$(grep -cF 'owner/repo/7' "$SNAPSHOT_RETRY_QUEUE_LOG" || true)" -eq 1 ]]; then
+		printf 'PASS deadline exhaustion blocks retry and preserves next-cycle priority\n'
+	else
+		printf 'FAIL deadline exhaustion retried or lost next-cycle priority\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+
+	unset _PMP_MERGE_PASS_DEADLINE_EPOCH AIDEVOPS_PULSE_MERGE_SNAPSHOT_RETRY_DELAY_SECONDS
 	return 0
 }
 
@@ -585,6 +659,7 @@ main() {
 	assert_configured_advisory_contexts_are_null_safe
 	assert_malformed_advisory_contexts_fail_closed_once
 	assert_snapshot_acquisition_failures_are_audited
+	assert_snapshot_transient_retry_cases
 	assert_gate "large paginated check payload streams without argument overflow" large_payload 0
 	assert_large_bot_activity_streams
 	assert_gate "large inline-comment payload streams through preflight" large_bot_activity 0

--- a/.agents/scripts/tests/test-shared-gh-wrappers-check-runs-outcomes.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-check-runs-outcomes.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=../shared-gh-wrappers-checks.sh
+source "${SCRIPT_DIR}/../shared-gh-wrappers-checks.sh"
+
+MOCK_CHECK_RUNS_RC=0
+MOCK_CHECK_RUNS_BODY='[]'
+MOCK_STATUS_RC=0
+MOCK_STATUS_BODY='[]'
+
+_gh_checks_api_read() {
+	local endpoint="$1"
+	if [[ "$endpoint" == */check-runs ]]; then
+		[[ "$MOCK_CHECK_RUNS_RC" -eq 0 ]] || return "$MOCK_CHECK_RUNS_RC"
+		printf '%s\n' "$MOCK_CHECK_RUNS_BODY"
+		return 0
+	fi
+	[[ "$MOCK_STATUS_RC" -eq 0 ]] || return "$MOCK_STATUS_RC"
+	printf '%s\n' "$MOCK_STATUS_BODY"
+	return 0
+}
+
+assert_outcome() {
+	local description="$1"
+	local expected_rc="$2"
+	local expected_output="$3"
+	local output="" rc=0 actual_output="" wanted_output=""
+	output=$(gh_pr_check_runs_rest owner/repo abc123) || rc=$?
+	actual_output="$output"
+	wanted_output="$expected_output"
+	if [[ -n "$expected_output" ]]; then
+		actual_output=$(printf '%s' "$output" | jq -c . 2>/dev/null) || actual_output="$output"
+		wanted_output=$(printf '%s' "$expected_output" | jq -c . 2>/dev/null) || wanted_output="$expected_output"
+	fi
+	if [[ "$rc" -ne "$expected_rc" || "$actual_output" != "$wanted_output" ]]; then
+		printf 'FAIL %s (rc=%s output=%q)\n' "$description" "$rc" "$output"
+		return 1
+	fi
+	printf 'PASS %s\n' "$description"
+	return 0
+}
+
+assert_outcome "valid empty check set is distinguishable from failure" 0 '[]'
+
+MOCK_CHECK_RUNS_RC=75
+assert_outcome "local admission deferral is preserved" 75 ''
+
+MOCK_CHECK_RUNS_RC=124
+assert_outcome "transport timeout is preserved" 124 ''
+
+MOCK_CHECK_RUNS_RC=1
+assert_outcome "ordinary API failure remains non-zero" 1 ''
+
+MOCK_CHECK_RUNS_RC=0
+MOCK_CHECK_RUNS_BODY=''
+assert_outcome "successful read with empty stdout fails closed" 1 ''
+
+MOCK_CHECK_RUNS_BODY='[{"name":"required-a","conclusion":"success","status":"completed"}]'
+MOCK_STATUS_RC=75
+assert_outcome "optional legacy-status deferral does not erase authoritative checks" 0 \
+	'[{"name":"required-a","conclusion":"success","status":"completed"}]'

--- a/.agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-checks-timeout.sh
@@ -46,6 +46,7 @@ main() {
 	trap '_run_cleanups' RETURN
 	WRAPPER_LOG="$(mktemp)"
 	export WRAPPER_LOG
+	export AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE=1
 	push_cleanup "rm -f '${WRAPPER_LOG}'"
 
 	local status


### PR DESCRIPTION
## Summary

- Preserve typed GitHub check-read outcomes so valid empty evidence cannot be confused with transient or terminal read failure.
- Retry mandatory uncached exact-head merge snapshots once within the remaining cycle deadline, then fail closed and preserve next-cycle priority.
- Surface bounded, redacted terminal OAuth image SSE failures without retrying them against another model.

Resolves #31775
Resolves #31780
Resolves #31781

## Runtime Testing

- `test-shared-gh-wrappers-check-runs-outcomes.sh`: 6 passed.
- `test-shared-gh-wrappers-checks-timeout.sh`: passed.
- `test-pulse-merge-preflight-snapshot.sh`: 106 passed.
- `test-pulse-merge-required-checks-filter.sh`: 75 passed.
- Focused GPT image provider tests: 12 passed.
- Changed-file lint: passed.
- Independent closeout review bundle `8c0f3fa3a76bbc57ff03f5430eccc7d313b0bc6b6b2241d4a26d1da86d49141a`: clean.
- Full plugin suite: 869 passed; one unrelated adapter test could not load the locally uninstalled `@opencode-ai/plugin` dependency.

## Key Decisions

- Valid `[]` remains success; exit 75 and 124 remain typed transient outcomes.
- The final merge snapshot remains uncached, exact-head, and mandatory.
- Terminal SSE provider events produce actionable redacted errors and do not enter the HTTP `model_not_found` retry path.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.357 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 48m and 552,156 tokens on this with the user in an interactive session. Overall, 2h 9m since this issue was created.
