### PR TITLE
GH#31785: omit untracked bundle absolute paths

### DIFF
--- a/.agents/scripts/review-evidence-helper.sh
+++ b/.agents/scripts/review-evidence-helper.sh
@@ -178,7 +178,7 @@ _review_is_binary_untracked() {
 	local repo_root="$1"
 	local path="$2"
 	local numstat=""
-	numstat=$(git -C "$repo_root" diff --no-index --numstat -- /dev/null "$repo_root/$path" 2>/dev/null || true)
+	numstat=$(git -C "$repo_root" diff --no-index --numstat -- /dev/null "$path" 2>/dev/null || true)
 	[[ "$numstat" == $'-\t-\t'* ]]
 }
 
@@ -310,7 +310,7 @@ _review_write_local() {
 		while IFS= read -r -d '' untracked_file; do
 			[[ -z "$untracked_file" ]] && continue
 			if ! _review_binary_path_recorded "$untracked_file"; then
-				git -C "$repo_root" diff --no-index --no-ext-diff -- /dev/null "$repo_root/$untracked_file" || true
+				git -C "$repo_root" diff --no-index --no-ext-diff -- /dev/null "$untracked_file" || true
 			fi
 		done < <(git -C "$repo_root" ls-files --others --exclude-standard -z)
 		printf '```\n'

--- a/.agents/scripts/tests/test-review-evidence-helper.sh
+++ b/.agents/scripts/tests/test-review-evidence-helper.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HELPER="${SCRIPT_DIR}/../review-evidence-helper.sh"
-TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/review-evidence-test.XXXXXX")"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/private-review-evidence-fixture.XXXXXX")"
+TEST_ROOT_BASENAME="$(basename "$TEST_ROOT")"
 GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
 
 git() {
@@ -96,6 +97,7 @@ fi
 if grep -Fq "$TEST_ROOT" "$LOCAL_BUNDLE"; then
 	fail 'bundle exposed host test path'
 fi
+assert_not_contains "$LOCAL_BUNDLE" "$TEST_ROOT_BASENAME" 'bundle exposed host test path basename'
 
 git -C "$REPO" add tracked.txt untracked.txt
 git -C "$REPO" add tracked.bin untracked.bin


### PR DESCRIPTION
## Summary

Normalized no-index untracked diffs to repository-relative paths and covered private-looking fixture paths.



## Files Changed

.agents/scripts/review-evidence-helper.sh, .agents/scripts/tests/test-review-evidence-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-review-evidence-helper.sh; shellcheck .agents/scripts/review-evidence-helper.sh .agents/scripts/tests/test-review-evidence-helper.sh

Resolves #31785


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.357 plugin for [OpenCode](https://opencode.ai) v1.18.22 with gpt-5.6-terra spent 46m and 178,605 tokens on this as a headless worker.