### PR TITLE
GH#31789: isolate Qlty label refreshes

### DIFF
--- a/.agents/scripts/tests/test-workflow-cascade-lint.sh
+++ b/.agents/scripts/tests/test-workflow-cascade-lint.sh
@@ -389,6 +389,7 @@ test_real_nmr_hold_workflow() {
 
 test_real_qlty_regression_mitigated() {
 	local qlty_file=".github/workflows/qlty-regression.yml"
+	local refresh_file=".github/workflows/qlty-regression-ratchet-refresh.yml"
 	if [ ! -f "$qlty_file" ]; then
 		print_result "real: qlty-regression.yml NOT flagged (cancel disabled)" 1 "file not found"
 		return 0
@@ -400,10 +401,16 @@ test_real_qlty_regression_mitigated() {
 	if [[ $rc -ne 0 ]]; then
 		failed=1
 	fi
-	if ! grep -Fq "github.event.action == 'labeled' && github.event.label.name != 'ratchet-bump'" "$qlty_file"; then
+	if ! grep -Fq "types: [opened, synchronize, reopened]" "$qlty_file" || \
+		grep -Fq "types: [opened, synchronize, reopened, labeled]" "$qlty_file"; then
 		failed=1
 	fi
-	if ! grep -Fq "'Qlty Regression Gate (label ignored)' || 'Qlty Regression Gate'" "$qlty_file"; then
+	if ! grep -Fq "workflow_call:" "$qlty_file" || ! grep -Fqx "    name: Qlty Regression Gate" "$qlty_file"; then
+		failed=1
+	fi
+	if [ ! -f "$refresh_file" ] || ! grep -Fq "types: [labeled]" "$refresh_file" || \
+		! grep -Fq "github.event.label.name == 'ratchet-bump'" "$refresh_file" || \
+		! grep -Fq "uses: ./.github/workflows/qlty-regression.yml" "$refresh_file"; then
 		failed=1
 	fi
 	print_result "real: qlty-regression.yml NOT flagged (cancel disabled)" "$failed" "exit=$rc output=$output"

--- a/.github/workflows/qlty-regression-ratchet-refresh.yml
+++ b/.github/workflows/qlty-regression-ratchet-refresh.yml
@@ -1,0 +1,18 @@
+name: Qlty Regression Ratchet Refresh
+
+# GH#31789: Keep ratchet-triggered refreshes out of the protected workflow.
+# A separate workflow identity prevents unrelated label suites from replacing
+# the required Qlty Regression Gate association on the PR head.
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  refresh:
+    if: github.event.label.name == 'ratchet-bump'
+    uses: ./.github/workflows/qlty-regression.yml
+    secrets: inherit

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -17,18 +17,12 @@ env:
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
-    # t2220/t3403/GH#31746: suppress required-check cascades on label events.
-    # `gh pr create --label "a,b,c,d"` fires one `labeled` event per label
-    # after the initial `opened`; each event can trigger a new run. When this
-    # workflow used `cancel-in-progress: true`, label runs cancelled the
-    # in-flight required check before job-level guards could skip them. Docs-only
-    # PRs observed 15+ cancelled runs per workflow, which `gh pr checks`
-    # then surfaces as `fail` (it displays `cancelled` conclusions as
-    # `fail` in its TSV output). Keep the workflow trigger unconditional so a
-    # `ratchet-bump` label can refresh the gate. Unrelated label events use a
-    # distinct non-required summary name below, preventing duplicate required
-    # contexts while `detect-scope` avoids the expensive Qlty scan.
+    # GH#31789: Required workflow runs must not receive `labeled` events.
+    # GitHub can select a later label-only suite for required-check association,
+    # leaving a successful exact-head verdict permanently "expected". The
+    # ratchet-bump refresh is isolated in qlty-regression-ratchet-refresh.yml.
+    types: [opened, synchronize, reopened]
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -204,7 +198,7 @@ jobs:
           exit 1
 
   required-check:
-    name: "${{ github.event.action == 'labeled' && github.event.label.name != 'ratchet-bump' && 'Qlty Regression Gate (label ignored)' || 'Qlty Regression Gate' }}"
+    name: Qlty Regression Gate
     runs-on: ubuntu-latest
     needs: [detect-scope, qlty-diff]
     if: always()


### PR DESCRIPTION
## Summary

Isolated ratchet-bump refreshes in a reusable caller so unrelated labels never create suites for the protected Qlty workflow.



## Files Changed

.agents/scripts/tests/test-workflow-cascade-lint.sh, .github/workflows/qlty-regression-ratchet-refresh.yml, .github/workflows/qlty-regression.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — bash .agents/scripts/tests/test-workflow-cascade-lint.sh; shellcheck .agents/scripts/tests/test-workflow-cascade-lint.sh; GitHub Actions YAML pre-commit validation

Resolves #31789


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.357 plugin for [OpenCode](https://opencode.ai) v1.18.29 with gpt-5.6-terra spent 13m and 211,056 tokens on this as a headless worker.
