### PR TITLE
t18428: plan Dependabot PR lifecycle convergence

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1356,6 +1356,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18421 Add guarded Wasabi object storage integration with beta MCP boundary #auto-dispatch #feat #tier:standard #interactive ~3h blocked-by:t18418 ref:GH#31688 logged:2026-09-09 -> [todo/tasks/t18421-brief.md] pr:#31719 completed:2026-09-10
 
+- [>] t18428 Fix Dependabot PR lifecycle convergence #priority:high #type:bug #interactive #tier:thinking ref:GH#31795 started:2026-09-11 -> [todo/tasks/t18428-brief.md]
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/todo/tasks/t18428-brief.md
+++ b/todo/tasks/t18428-brief.md
@@ -1,0 +1,106 @@
+<!-- aidevops:brief-schema=v2 -->
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2026 Marcus Quinn -->
+# t18428: Fix Dependabot PR lifecycle convergence
+
+## Pre-flight
+
+- [x] Memory recall: `Dependabot Pulse worker intake source PR lifecycle crypto approval policy hold` → 3 hits; prior guidance requires exact-head authenticity, fail-closed authority, and source-terminal completion.
+- [x] Discovery pass: 7 recent commits touched the target files; no related open implementation PR was found.
+- [x] File refs verified: four implementation/test files are present at current `origin/main`.
+- [x] Tier: `tier:thinking` — the change touches Pulse's self-hosting dispatch and authorization path.
+- [x] Seeded draft PR decision recorded: skipped because the owning interactive session is implementing and verifying the fix directly.
+
+## Origin
+
+- **Created:** 2026-09-11
+- **Session:** OpenCode interactive session
+- **Created by:** ai-interactive with maintainer authorization
+- **Conversation context:** Investigation found five open Dependabot PRs that Pulse could classify but did not converge. Three had merged worker replacements while their source PRs remained open; one authentic update waited on cryptographic authority without actionable intake; one bot branch contained a human-authored commit.
+
+## What
+
+Make Dependabot handling converge without weakening the existing trust boundary:
+
+- Route an authentic, allowlisted Dependabot update that lacks independent current-head maintainer authority through the existing worker-intake lifecycle.
+- Close an exact-head source Dependabot PR when a completed worker intake has a verified merged replacement, even when the policy hold was not represented by a `needs-maintainer-review` label.
+- Never create a duplicate intake when completed-intake evidence already exists but cannot yet prove a merged replacement.
+- Keep modified or otherwise unauthentic bot branches fail-closed and classify verified non-Dependabot commit authorship for actionable maintainer review.
+
+## Why
+
+The current author gate returns immediately for authentic Dependabot PRs without cryptographic approval. That bypasses the only reconciliation path capable of creating worker intake or closing a superseded source PR. The source-close path also requires an NMR label that the affected policy-held PRs do not carry, so completed replacement work remains stranded.
+
+## Tier
+
+**Selected tier:** `tier:thinking`
+
+**Tier rationale:** This edits the self-hosting worker-dispatch path and exact-head authorization classification. Security invariants are decided, but regression evidence must prove no authority bypass or unauthenticated write.
+
+## PR Conventions
+
+This is a leaf issue. The implementation PR must use the repository's closing-keyword convention for GH#31795.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** The primary interactive session owns implementation through merge and release.
+- **Status:** `not-created`
+- **Freshness evidence:** Rebased onto current `origin/main`; live affected PR state and source functions revalidated on 2026-09-11.
+- **Verification run:** Prework discovery and focused source inspection complete; implementation checks pending.
+- **Stale-assumption warning:** Revalidate if another PR changes the author gate, intake marker, or source-close evidence contract.
+
+## How (Approach)
+
+### Files to Modify
+
+- EDIT: `.agents/scripts/pulse-merge.sh`
+- EDIT: `.agents/scripts/pulse-dependabot-intake.sh`
+- EDIT: `.agents/scripts/trusted-dependabot-lib.sh`
+- EDIT: `.agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh`
+- EDIT: `.agents/scripts/tests/test-pulse-dependabot-intake.sh`
+- EDIT: `.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh`
+
+### Complete Write Surface
+
+No other production files are expected. Reuse `_pm_gate_route_ineligible_author`, `_pulse_route_dependabot_pr_to_worker_issue`, `_pulse_dependabot_close_superseded_source_pr`, `_trusted_dependabot_snapshot_is_authentic`, `gh_pr_edit_safe`, and `_gh_idempotent_comment` rather than adding a parallel lifecycle.
+
+### Implementation Steps
+
+1. Send authentic Dependabot policy holds through the existing route helper after cryptographic authority fails.
+2. Reconcile completed intake before creating a new issue, requiring exact source head and a different verified merged replacement but not a redundant NMR label.
+3. Record typed authentication failure reasons and classify exact-head commit-author mismatch separately from unavailable or ambiguous evidence.
+4. For that verified mismatch only, add a maintainer-review hold and one marker-deduplicated explanatory PR comment; all unknown failures remain write-free.
+5. Extend focused tests for positive convergence and negative fail-closed behavior.
+
+### Hazards and Compatibility
+
+- Ordinary GitHub approvals must never substitute for cryptographic authority.
+- Unknown, paginated, stale-head, or unavailable snapshots must not trigger a GitHub write.
+- A completed issue without a verified merged closer must not cause source closure or duplicate intake.
+- Source closure must remain same-repository, exact-head, and replacement-provenance bound.
+- Existing explicit NMR holds without completed replacement evidence remain preserved.
+
+### Verification Before Dispatch
+
+```bash
+.agents/scripts/tests/test-pulse-dependabot-intake.sh
+.agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh
+.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+.agents/scripts/linters-local.sh --changed
+```
+
+## Acceptance Criteria
+
+- [ ] Authentic allowlisted Dependabot without crypto authority calls the intake/reconciliation route and remains unmergeable.
+- [ ] Completed worker intake plus verified merged replacement closes the unchanged source PR without requiring NMR metadata.
+- [ ] Completed intake without verified replacement fails closed and does not create a duplicate issue.
+- [ ] A human-authored commit on an otherwise genuine Dependabot PR produces a deduplicated actionable maintainer hold.
+- [ ] Unknown authenticity failures remain write-free.
+- [ ] Focused tests and changed-file lint pass.
+- [ ] The fix is merged, released, deployed, and observed converging the affected live PRs.
+
+## Rollback
+
+Revert the implementation PR. This restores policy-only holding and disables the new reconciliation/classification paths without altering stored credentials or repository history.


### PR DESCRIPTION
## Planning publication

- Publishes TODO.md and todo/ planning-file changes through a PR because main does not accept direct planning pushes.
- Source branch at helper invocation: feature/auto-20260911-195049.
- Commit message: plan: add Dependabot PR lifecycle convergence.

## Task and issue manifest

<!-- aidevops:planning-publication:v1 id=179dff83d5d9bf0d9e9f62e54f8713794b3017a0 -->
<!-- aidevops:planning-task:v1 task=t18428 issue=31795 -->
- For #31795

## Security and architecture guardrails

- This PR does not update .task-counter.
- Task IDs still come from claim-task-id.sh CAS allocation on a branch that permits atomic counter pushes.
- Do not replace counter allocation with a PR-backed counter update; PR review is not an atomic ID lock.

## Merge note

- Merge this planning-only PR before expecting pulse or issue-sync to see the TODO/todo changes.
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.358 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 2m and 70,954 tokens on this with the user in an interactive session.