### PR TITLE
t18428: converge Dependabot PR lifecycle

### DIFF
--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -96,7 +96,7 @@ _pulse_dependabot_completed_intake_issue() {
 	return $?
 }
 
-# Close an authentic held source PR only when its generated worker intake is
+# Close an authentic policy-held source PR only when its generated worker intake is
 # terminal and a different same-repository PR verifiably merged to close it.
 # Missing, truncated, stale-head, or unavailable evidence preserves the hold.
 _pulse_dependabot_close_superseded_source_pr() {
@@ -109,26 +109,25 @@ _pulse_dependabot_close_superseded_source_pr() {
 	local final_json=""
 	local final_state=""
 	local final_head=""
-	local final_labels=""
 	local close_comment=""
 
-	declare -F _psh_find_merged_closer_for_closed_issue >/dev/null 2>&1 || return 1
-	declare -F gh_pr_close_safe >/dev/null 2>&1 || return 1
-	intake_issue=$(_pulse_dependabot_completed_intake_issue "$pr_number" "$repo_slug" "$marker") || return 1
+	_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE=""
+	_PULSE_DEPENDABOT_SUPERSEDING_PR=""
+	intake_issue=$(_pulse_dependabot_completed_intake_issue "$pr_number" "$repo_slug" "$marker") || return 2
 	[[ "$intake_issue" =~ ^[0-9]+$ ]] || return 1
+	_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE="$intake_issue"
+	declare -F _psh_find_merged_closer_for_closed_issue >/dev/null 2>&1 || return 2
+	declare -F gh_pr_close_safe >/dev/null 2>&1 || return 2
 	superseding_pr=$(_psh_find_merged_closer_for_closed_issue \
-		"$repo_slug" "$intake_issue" "$pr_number" 2>/dev/null) || return 1
-	[[ "$superseding_pr" =~ ^[0-9]+$ && "$superseding_pr" != "$pr_number" ]] || return 1
+		"$repo_slug" "$intake_issue" "$pr_number" 2>/dev/null) || return 2
+	[[ "$superseding_pr" =~ ^[0-9]+$ && "$superseding_pr" != "$pr_number" ]] || return 2
 
 	final_json=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json state,headRefOid,labels 2>/dev/null) || return 1
-	final_state=$(printf '%s' "$final_json" | jq -r '.state // ""' 2>/dev/null) || return 1
-	final_head=$(printf '%s' "$final_json" | jq -r '.headRefOid // ""' 2>/dev/null) || return 1
-	final_labels=$(printf '%s' "$final_json" | jq -r '[.labels[]?.name] | join(",")' 2>/dev/null) || return 1
-	[[ "$final_state" == "OPEN" && "$final_head" == "$expected_head_sha" ]] || return 1
-	[[ ",${final_labels}," == *",needs-maintainer-review,"* ]] || return 1
+		--json state,headRefOid,labels 2>/dev/null) || return 2
+	final_state=$(printf '%s' "$final_json" | jq -r '.state // ""' 2>/dev/null) || return 2
+	final_head=$(printf '%s' "$final_json" | jq -r '.headRefOid // ""' 2>/dev/null) || return 2
+	[[ "$final_state" == "OPEN" && "$final_head" == "$expected_head_sha" ]] || return 2
 
-	_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE="$intake_issue"
 	_PULSE_DEPENDABOT_SUPERSEDING_PR="$superseding_pr"
 	if [[ "${DRY_RUN:-0}" == "1" ]]; then
 		echo "[pulse-dependabot-intake] DRY-RUN: PR #${pr_number} in ${repo_slug} would close as superseded by merged PR #${superseding_pr} for completed intake #${intake_issue}" >>"$LOGFILE"
@@ -138,18 +137,73 @@ _pulse_dependabot_close_superseded_source_pr() {
 	close_comment="<!-- aidevops:dependabot-source-superseded intake=${intake_issue} replacement=${superseding_pr} -->
 Closing this Dependabot source PR as superseded: generated worker intake #${intake_issue} is terminal and was closed by verified merged replacement PR #${superseding_pr}.
 
-The explicit maintainer hold prevented unsafe automatic merge while the replacement converged. Pulse revalidated the source head and hold immediately before this close.
+The external-authority policy prevented unsafe automatic merge while the replacement converged. Pulse revalidated the authentic source head immediately before this close.
 
 _Closed by deterministic Dependabot lifecycle reconciliation (GH#30478)._"
 	if ! gh_pr_close_safe "$pr_number" --repo "$repo_slug" --comment "$close_comment" >/dev/null 2>&1; then
 		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: verified replacement PR #${superseding_pr}, but source close failed" >>"$LOGFILE"
-		return 1
+		return 2
 	fi
 	if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
 		_pulse_merge_invalidate_pr_list_cache "$repo_slug" "closed superseded Dependabot source PR #${pr_number}"
 	fi
 	echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: closed as superseded by merged PR #${superseding_pr} for completed intake #${intake_issue}" >>"$LOGFILE"
 	return 0
+}
+
+# Classify the one authenticity failure that is both exact-head verified and
+# actionable without guessing: a genuine Dependabot PR whose commit set contains
+# a commit not authored by Dependabot. Unknown snapshot failures remain write-free.
+_pulse_dependabot_mark_modified_source_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="$3"
+	local marker="<!-- aidevops:dependabot-modified-source head=${expected_head_sha} -->"
+	local body=""
+
+	declare -F _gh_idempotent_comment >/dev/null 2>&1 || return 1
+	declare -F gh_pr_edit_safe >/dev/null 2>&1 || return 1
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		echo "[pulse-dependabot-intake] DRY-RUN: PR #${pr_number} in ${repo_slug} would receive an actionable maintainer hold for non-Dependabot commit authorship" >>"$LOGFILE"
+		return 0
+	fi
+	body="${marker}
+Pulse verified this PR's GitHub Bot identity, same-repository head, and exact head SHA, but the current commit set contains non-Dependabot commit authorship. Automated merge and worker intake remain blocked because a modified bot branch cannot be treated as an authentic Dependabot update.
+
+Maintainer action: inspect the added commits, then either close and recreate the update from Dependabot or use the repository's existing current-head maintainer approval workflow after accepting the modified branch."
+	_gh_idempotent_comment "$pr_number" "$repo_slug" "$marker" "$body" "pr" || return 1
+	gh_pr_edit_safe "$pr_number" --repo "$repo_slug" \
+		--add-label "needs-maintainer-review" >/dev/null 2>&1 || return 1
+	echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: exact-head bot branch contains non-Dependabot commit authorship; added actionable maintainer hold" >>"$LOGFILE"
+	return 0
+}
+
+_pulse_dependabot_preflight_route() {
+	local pr_number="$1" repo_slug="$2" pr_author="$3" expected_head_sha="$4" marker="$5"
+	local reconcile_rc=0
+
+	#aidevops:trust-boundary — only a typed failure reached after exact-head Bot,
+	# repository, and source-head verification may trigger a maintainer hold write.
+	if ! _is_authentic_dependabot_pr "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha"; then
+		if [[ "${_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON:-}" == "commit-author-mismatch" ]] &&
+			_pulse_dependabot_mark_modified_source_pr "$pr_number" "$repo_slug" "$expected_head_sha"; then
+			return 5
+		fi
+		return 1
+	fi
+	if _pulse_dependabot_close_superseded_source_pr \
+		"$pr_number" "$repo_slug" "$expected_head_sha" "$marker"; then
+		return 4
+	else
+		reconcile_rc=$?
+	fi
+	[[ "$reconcile_rc" -eq 1 ]] && return 0
+	if [[ "${_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE:-}" =~ ^[0-9]+$ ]]; then
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: completed intake #${_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE} has no verified merged replacement; preserving source without duplicate intake" >>"$LOGFILE"
+	else
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: completed-intake reconciliation evidence unavailable; preserving source without duplicate intake" >>"$LOGFILE"
+	fi
+	return 6
 }
 
 # Return 0 when the source PR carries an explicit maintainer-review hold,
@@ -280,6 +334,7 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 	local issue_output=""
 	local lock_dir=""
 	local hold_rc=0
+	local preflight_rc=0
 	local scope_lines=""
 
 	case "$reason" in
@@ -296,14 +351,12 @@ _pulse_route_dependabot_pr_to_worker_issue() {
 		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: existing worker issue ${existing_url}" >>"$LOGFILE"
 		return 0
 	fi
-	_is_authentic_dependabot_pr "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha" || return 1
+	_pulse_dependabot_preflight_route \
+		"$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha" "$marker" || preflight_rc=$?
+	[[ "$preflight_rc" -eq 0 ]] || return "$preflight_rc"
 	_pulse_dependabot_pr_has_maintainer_hold "$pr_number" "$repo_slug" || hold_rc=$?
 	case "$hold_rc" in
 	0)
-		if _pulse_dependabot_close_superseded_source_pr \
-			"$pr_number" "$repo_slug" "$expected_head_sha" "$marker"; then
-			return 4
-		fi
 		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: preserving explicit needs-maintainer-review hold; no worker issue created" >>"$LOGFILE"
 		return 3
 		;;

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -491,12 +491,14 @@ _pm_gate_author_trust() {
 			# #aidevops:trust-boundary — verified provenance and dependency
 			# allowlisting establish authenticity, not collaborator authority.
 			# Dependabot remains external and may proceed only with independent,
-			# current-head maintainer approval. Do not route a policy-only hold to
-			# repair intake: there is no code or dependency defect to repair.
+			# current-head maintainer approval. A policy-only hold still enters the
+			# Dependabot lifecycle router so existing replacement work can converge
+			# or a tightly scoped maintainer-briefed intake can be created.
 			if _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$expected_head_sha"; then
 				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — verified Dependabot author ${pr_author} remains external but has current-head maintainer crypto-approval, proceeding" >>"$LOGFILE"
 			else
-				echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — verified Dependabot author ${pr_author} remains external and lacks current-head maintainer crypto-approval; preserving policy hold without repair intake" >>"$LOGFILE"
+				echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — verified Dependabot author ${pr_author} remains external and lacks current-head maintainer crypto-approval; entering lifecycle reconciliation" >>"$LOGFILE"
+				_pm_gate_route_ineligible_author "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha"
 				return 1
 			fi
 		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$expected_head_sha"; then
@@ -522,6 +524,8 @@ _pm_gate_route_ineligible_author() {
 			echo "[pulse-wrapper] Merge pass: closed superseded Dependabot source PR #${pr_number} in ${repo_slug} after verified replacement PR #${_PULSE_DEPENDABOT_SUPERSEDING_PR:-unknown} (GH#30478)" >>"$LOGFILE"
 		fi
 		;;
+	5) echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — exact-head Dependabot source contains non-Dependabot commit authorship; actionable maintainer hold applied" >>"$LOGFILE" ;;
+	6) echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — completed Dependabot intake lacks verified replacement evidence; preserving source without duplicate intake" >>"$LOGFILE" ;;
 	*) echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE" ;;
 	esac
 	return 0

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -9,7 +9,9 @@ INTAKE_SCRIPT="${SCRIPT_DIR}/../pulse-dependabot-intake.sh"
 TEST_ROOT=""
 OPEN_ISSUES_JSON="[]"
 CLOSED_ISSUES_JSON="[]"
+CLOSED_ISSUE_LIST_FAIL=0
 AUTHENTIC=1
+AUTH_FAILURE_REASON="snapshot-unavailable"
 PR_LABELS=""
 PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[{"name":"needs-maintainer-review"}]}'
 PR_SCOPE_JSON='{"headRefOid":"head-current","files":[{"path":"package.json"},{"path":"bun.lock"}]}'
@@ -36,15 +38,20 @@ _is_authentic_dependabot_pr() {
 	local repo_slug="$2"
 	local pr_author="$3"
 	local expected_head_sha="$4"
-	[[ "$AUTHENTIC" -eq 1 && "$pr_number" == "30038" && "$repo_slug" == "owner/repo" &&
-		"$pr_author" == "app/dependabot" && "$expected_head_sha" == "head-current" ]]
-	return $?
+	if [[ "$AUTHENTIC" -eq 1 && "$pr_number" == "30038" && "$repo_slug" == "owner/repo" &&
+		"$pr_author" == "app/dependabot" && "$expected_head_sha" == "head-current" ]]; then
+		_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON=""
+		return 0
+	fi
+	_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON="$AUTH_FAILURE_REASON"
+	return 1
 }
 
 gh_issue_list() {
 	local args=" $* "
 	printf '%s\n' "$*" >>"${TEST_ROOT}/issue-list-args"
 	if [[ "$args" == *" --state closed "* ]]; then
+		[[ "$CLOSED_ISSUE_LIST_FAIL" -eq 0 ]] || return 1
 		printf '%s\n' "$CLOSED_ISSUES_JSON"
 	else
 		printf '%s\n' "$OPEN_ISSUES_JSON"
@@ -76,6 +83,16 @@ _psh_find_merged_closer_for_closed_issue() {
 
 gh_pr_close_safe() {
 	printf '%s\n' "$@" >"${TEST_ROOT}/pr-close-args"
+	return 0
+}
+
+gh_pr_edit_safe() {
+	printf '%s\n' "$@" >"${TEST_ROOT}/pr-edit-args"
+	return 0
+}
+
+_gh_idempotent_comment() {
+	printf '%s\n' "$@" >"${TEST_ROOT}/idempotent-comment-args"
 	return 0
 }
 
@@ -217,14 +234,36 @@ test_saturated_target_lookup_blocks_dispatch() {
 }
 
 test_rejects_unverified_author() {
-	rm -f "${TEST_ROOT}/create-args"
+	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/pr-edit-args" "${TEST_ROOT}/idempotent-comment-args"
 	OPEN_ISSUES_JSON="[]"
 	AUTHENTIC=0
+	AUTH_FAILURE_REASON="snapshot-unavailable"
 	if _pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible"; then
 		return 1
 	fi
-	[[ ! -e "${TEST_ROOT}/create-args" ]]
+	[[ ! -e "${TEST_ROOT}/create-args" && ! -e "${TEST_ROOT}/pr-edit-args" &&
+		! -e "${TEST_ROOT}/idempotent-comment-args" ]]
 	return $?
+}
+
+test_classifies_human_modified_bot_branch() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/pr-edit-args" "${TEST_ROOT}/idempotent-comment-args"
+	OPEN_ISSUES_JSON="[]"
+	AUTHENTIC=0
+	AUTH_FAILURE_REASON="commit-author-mismatch"
+	_pulse_route_dependabot_pr_to_worker_issue \
+		"30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 5 ]] || return 1
+	[[ ! -e "${TEST_ROOT}/create-args" ]] || return 1
+	assert_file_contains "modified bot branch receives maintainer hold" \
+		"${TEST_ROOT}/pr-edit-args" "needs-maintainer-review"
+	assert_file_contains "modified bot branch receives actionable explanation" \
+		"${TEST_ROOT}/idempotent-comment-args" "non-Dependabot commit authorship"
+	AUTHENTIC=1
+	AUTH_FAILURE_REASON="snapshot-unavailable"
+	return 0
 }
 
 test_preserves_explicit_maintainer_hold() {
@@ -244,15 +283,15 @@ test_preserves_explicit_maintainer_hold() {
 	return 0
 }
 
-test_closes_held_source_after_verified_replacement() {
+test_closes_policy_held_source_after_verified_replacement() {
 	local route_rc=0
 
 	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/pr-close-args"
 	OPEN_ISSUES_JSON="[]"
 	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
 	AUTHENTIC=1
-	PR_LABELS="needs-maintainer-review"
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[{"name":"needs-maintainer-review"}]}'
+	PR_LABELS=""
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[]}'
 	PR_VIEW_FAIL=0
 	SUPERSEDING_PR="99"
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
@@ -266,6 +305,41 @@ test_closes_held_source_after_verified_replacement() {
 	return 0
 }
 
+test_completed_intake_without_replacement_does_not_duplicate() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/pr-close-args"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	AUTHENTIC=1
+	PR_LABELS=""
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[]}'
+	SUPERSEDING_PR=""
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 6 ]] || return 1
+	[[ ! -e "${TEST_ROOT}/create-args" && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	assert_file_contains "completed intake without replacement fails closed" \
+		"$LOGFILE" "completed intake #42 has no verified merged replacement; preserving source without duplicate intake"
+	CLOSED_ISSUES_JSON="[]"
+	return 0
+}
+
+test_unavailable_completion_lookup_does_not_duplicate() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/create-args"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUE_LIST_FAIL=1
+	AUTHENTIC=1
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 6 ]] || return 1
+	[[ ! -e "${TEST_ROOT}/create-args" ]] || return 1
+	assert_file_contains "unavailable completion evidence fails closed" \
+		"$LOGFILE" "completed-intake reconciliation evidence unavailable; preserving source without duplicate intake"
+	CLOSED_ISSUE_LIST_FAIL=0
+	return 0
+}
+
 test_preserves_hold_when_terminal_issue_has_no_merged_replacement() {
 	local route_rc=0
 
@@ -276,7 +350,7 @@ test_preserves_hold_when_terminal_issue_has_no_merged_replacement() {
 	PR_LABELS="needs-maintainer-review"
 	SUPERSEDING_PR=""
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
-	[[ "$route_rc" -eq 3 ]] || return 1
+	[[ "$route_rc" -eq 6 ]] || return 1
 	[[ ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
 	CLOSED_ISSUES_JSON="[]"
 	PR_LABELS=""
@@ -312,7 +386,7 @@ test_preserves_hold_when_source_head_drifted() {
 	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-changed","labels":[{"name":"needs-maintainer-review"}]}'
 	SUPERSEDING_PR="99"
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
-	[[ "$route_rc" -eq 3 ]] || return 1
+	[[ "$route_rc" -eq 6 ]] || return 1
 	[[ ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
 	CLOSED_ISSUES_JSON="[]"
 	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[{"name":"needs-maintainer-review"}]}'
@@ -453,8 +527,11 @@ main() {
 	printf 'PASS existing intake is idempotent\n'
 	test_rejects_unverified_author
 	printf 'PASS unverified authors fail closed\n'
+	test_classifies_human_modified_bot_branch
 	test_preserves_explicit_maintainer_hold
-	test_closes_held_source_after_verified_replacement
+	test_closes_policy_held_source_after_verified_replacement
+	test_completed_intake_without_replacement_does_not_duplicate
+	test_unavailable_completion_lookup_does_not_duplicate
 	test_preserves_hold_when_terminal_issue_has_no_merged_replacement
 	test_preserves_hold_without_worker_solution_attribution
 	test_preserves_hold_when_source_head_drifted

--- a/.agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh
+++ b/.agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh
@@ -167,11 +167,12 @@ FIXTURE_CRYPTO_APPROVED=0
 : >"$DEPENDABOT_ROUTE_CALLS"
 : >"$LOGFILE"
 result=$(run_gate head-current 'dependabot[bot]')
-if [[ "$result" -eq 1 ]] && [[ ! -s "$DEPENDABOT_ROUTE_CALLS" ]] &&
+if [[ "$result" -eq 1 ]] &&
+	grep -qF "950 owner/repo dependabot[bot] head-current policy-ineligible" "$DEPENDABOT_ROUTE_CALLS" &&
 	grep -qF "remains external and lacks current-head maintainer crypto-approval" "$LOGFILE"; then
-	print_result "verified Dependabot without independent authority stops without repair intake" 0
+	print_result "verified Dependabot without independent authority enters lifecycle reconciliation" 0
 else
-	print_result "verified Dependabot without independent authority stops without repair intake" 1 \
+	print_result "verified Dependabot without independent authority enters lifecycle reconciliation" 1 \
 		"rc=${result} route=$(cat "$DEPENDABOT_ROUTE_CALLS") log=$(cat "$LOGFILE")"
 fi
 

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -388,6 +388,25 @@ test_spoofed_author_fails() {
 	return 0
 }
 
+test_human_commit_sets_actionable_auth_failure() {
+	local pr_json=""
+
+	write_pr_fixture "dependabot" "alex" "requirements-lock.txt" "SUCCESS"
+	pr_json=$(<"${TEST_ROOT}/pr.json")
+	if _trusted_dependabot_snapshot_is_authentic \
+		"$pr_json" "owner/repo" "dependabot[bot]" "head-current"; then
+		print_result "human-modified Dependabot branch fails authenticity" 1 "Unexpected authentic result"
+		return 0
+	fi
+	if [[ "${_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON:-}" == "commit-author-mismatch" ]]; then
+		print_result "human-modified Dependabot branch exposes typed failure" 0
+		return 0
+	fi
+	print_result "human-modified Dependabot branch exposes typed failure" 1 \
+		"reason=${_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON:-empty}"
+	return 0
+}
+
 test_dependabot_login_with_user_type_fails() {
 	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
 	jq '.data.repository.pullRequest.author.__typename = "User"' \
@@ -735,6 +754,7 @@ main() {
 	test_trusted_dependabot_rejects_paginated_snapshot
 	test_trusted_dependabot_rejects_incomplete_snapshot
 	test_spoofed_author_fails
+	test_human_commit_sets_actionable_auth_failure
 	test_dependabot_login_with_user_type_fails
 	test_security_failure_fails
 	test_non_dependency_file_fails

--- a/.agents/scripts/trusted-dependabot-lib.sh
+++ b/.agents/scripts/trusted-dependabot-lib.sh
@@ -16,6 +16,7 @@ _TRUSTED_DEPENDABOT_LAST_PR_JSON=""
 _TRUSTED_DEPENDABOT_LAST_REPO=""
 _TRUSTED_DEPENDABOT_LAST_PR=""
 _TRUSTED_DEPENDABOT_LAST_HEAD=""
+_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON=""
 
 _td_gh_read() {
 	local rc=0
@@ -283,10 +284,14 @@ _trusted_dependabot_snapshot_is_authentic() {
 	local snapshot_head=""
 	local bad_commits=""
 
+	_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON="invalid-input"
 	[[ -n "$pr_json" && "$pr_json" != "null" && -n "$repo_slug" && -n "$expected_head_sha" ]] || return 1
 	case "$pr_author" in
 	dependabot\[bot\] | app/dependabot | "") ;;
-	*) return 1 ;;
+	*)
+		_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON="unsupported-pr-author"
+		return 1
+		;;
 	esac
 
 	api_author=$(printf '%s' "$pr_json" | jq -r '.author.login // ""' 2>/dev/null) || return 1
@@ -296,11 +301,24 @@ _trusted_dependabot_snapshot_is_authentic() {
 	snapshot_head=$(printf '%s' "$pr_json" | jq -r '.headRefOid // ""' 2>/dev/null) || return 1
 	#aidevops:trust-boundary — worker intake and merge trust share this exact-head
 	# GitHub Bot, repository ownership, and commit-authorship verification.
-	[[ "$api_author_type" == "Bot" && "$api_author" == "dependabot" ]] || return 1
-	[[ "$head_owner" == "$repo_owner" && "$head_repo" == "$repo_slug" ]] || return 1
-	[[ "$snapshot_head" == "$expected_head_sha" ]] || return 1
+	if [[ "$api_author_type" != "Bot" || "$api_author" != "dependabot" ]]; then
+		_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON="bot-identity-mismatch"
+		return 1
+	fi
+	if [[ "$head_owner" != "$repo_owner" || "$head_repo" != "$repo_slug" ]]; then
+		_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON="repository-ownership-mismatch"
+		return 1
+	fi
+	if [[ "$snapshot_head" != "$expected_head_sha" ]]; then
+		_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON="head-mismatch"
+		return 1
+	fi
 	bad_commits=$(printf '%s' "$pr_json" | jq '[.commits[]? | select([.authors[]?.login] | index("dependabot[bot]") | not)] | length' 2>/dev/null) || return 1
-	[[ "$bad_commits" == "0" ]] || return 1
+	if [[ "$bad_commits" != "0" ]]; then
+		_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON="commit-author-mismatch"
+		return 1
+	fi
+	_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON=""
 	return 0
 }
 
@@ -318,6 +336,7 @@ _is_authentic_dependabot_pr() {
 		&& -n "$_TRUSTED_DEPENDABOT_LAST_PR_JSON" ]]; then
 		pr_json="$_TRUSTED_DEPENDABOT_LAST_PR_JSON"
 	else
+		_TRUSTED_DEPENDABOT_AUTH_FAILURE_REASON="snapshot-unavailable"
 		pr_json=$(_trusted_dependabot_pr_json_graphql "$pr_number" "$repo_slug" auth) || return 1
 		_TRUSTED_DEPENDABOT_LAST_PR_JSON="$pr_json"
 		_TRUSTED_DEPENDABOT_LAST_REPO="$repo_slug"


### PR DESCRIPTION
## Summary

Route exact-head authentic Dependabot policy holds through the existing worker lifecycle, close source PRs after verified merged replacements without depending on NMR metadata, suppress duplicate intake when completion evidence is incomplete, and classify human-modified bot branches for maintainer review.



## Files Changed

.agents/scripts/pulse-dependabot-intake.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-dependabot-intake.sh, .agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, .agents/scripts/trusted-dependabot-lib.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Focused intake, author-gate, and trusted-Dependabot regression scripts passed; ShellCheck passed for all six changed shell files; linters-local.sh --changed passed including Bash 3.2, portability, secret, complexity, and nesting gates.

Resolves #31795


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.359 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 51s and 32,028 tokens on this with the user in an interactive session.