### PR TITLE
GH#31794: reconcile durable release lane finalization

### DIFF
--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -1131,6 +1131,7 @@ release_lane_finalize() {
 	local source_pr="$2"
 	local receipt="$3"
 	local state_json=""
+	local write_rc=0
 	[[ -n "$_AIDEVOPS_RELEASE_LANE_TOKEN" ]] || return 1
 	release_lane_read "$repo" || return 1
 	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
@@ -1139,8 +1140,25 @@ release_lane_finalize() {
 	state_json=$(jq -c --arg receipt "$receipt" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
 		'.active=false | .phase="terminal" | .terminal_receipt=$receipt | .updated_at=$now' \
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
-	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD"
-	return $?
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || write_rc=$?
+	if [[ "$write_rc" -ne 0 ]]; then
+		# A compare-and-swap write can reach GitHub before its transport reports an
+		# error. Re-read the exact terminal state so a durable publication does not
+		# become a false reconciliation failure.
+		if release_lane_read "$repo" && jq -e --argjson source_pr "$source_pr" \
+			--arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" --arg receipt "$receipt" '
+			.active == false and .source_pr == $source_pr and .operation_token == $token
+			and .phase == "terminal" and .terminal_receipt == $receipt
+		' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null; then
+			printf 'RELEASE_LANE_FINALIZE_RECONCILED source_pr=%s receipt=%s write_exit=%s\n' \
+				"$source_pr" "$receipt" "$write_rc" >&2
+			return 0
+		fi
+		printf 'RELEASE_LANE_FINALIZE_FAILED source_pr=%s receipt=%s write_exit=%s\n' \
+			"$source_pr" "$receipt" "$write_rc" >&2
+		return "$write_rc"
+	fi
+	return 0
 }
 
 #aidevops:trust-boundary

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -545,4 +545,25 @@ printf 'PASS failed aggregate and reconcile temporary checkouts are still cleane
 )
 printf 'PASS pending reconciliation persists its verified discovered tag\n'
 
+(
+	cd "$ROOT/repo/linked-branch"
+	export PATH="$ROOT/bin:/usr/bin:/bin"
+	export GIT_CALL_LOG="$ROOT/git.log" FAKE_REPO_ROOT="$ROOT/repo"
+	export AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees"
+	source "$SCRIPT_DIR/full-loop-release-helper.sh" help >/dev/null
+	_AIDEVOPS_RELEASE_LANE_TOKEN="fixture-token"
+	_AIDEVOPS_RELEASE_LANE_HEAD="fixture-head"
+	lane_state='{"active":true,"source_pr":42,"phase":"remote-publication","terminal_receipt":null,"operation_token":"fixture-token"}'
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$lane_state"
+		return 0
+	}
+	_release_lane_write() {
+		lane_state='{"active":false,"source_pr":42,"phase":"terminal","terminal_receipt":"published","operation_token":"fixture-token"}'
+		return 1
+	}
+	release_lane_finalize test/repo 42 published || exit 1
+)
+printf 'PASS terminal lane writes reconcile durable state after transport uncertainty\n'
+
 exit 0


### PR DESCRIPTION
## Summary

Re-read the exact terminal release lane after a transport-error write, preserving failure when the durable state cannot be verified.



## Files Changed

.agents/scripts/release-lane-helper.sh, .agents/scripts/tests/test-full-loop-release-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-full-loop-release-helper.sh; bash .agents/scripts/tests/test-full-loop-release-reconcile.sh; shellcheck .agents/scripts/release-lane-helper.sh .agents/scripts/tests/test-full-loop-release-helper.sh

Resolves #31794


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.359 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 5m and 97,650 tokens on this as a headless worker.