### PR TITLE
t18428: mark task complete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1356,7 +1356,7 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18421 Add guarded Wasabi object storage integration with beta MCP boundary #auto-dispatch #feat #tier:standard #interactive ~3h blocked-by:t18418 ref:GH#31688 logged:2026-09-09 -> [todo/tasks/t18421-brief.md] pr:#31719 completed:2026-09-10
 
-- [>] t18428 Fix Dependabot PR lifecycle convergence #priority:high #type:bug #interactive #tier:thinking ref:GH#31795 started:2026-09-11 -> [todo/tasks/t18428-brief.md]
+- [x] t18428 Fix Dependabot PR lifecycle convergence #priority:high #type:bug #interactive #tier:thinking ref:GH#31795 started:2026-09-11 -> [todo/tasks/t18428-brief.md] pr:#31798 completed:2026-09-11
 
 ## In Progress
 


### PR DESCRIPTION
## Planning publication

- Publishes TODO.md and todo/ planning-file changes through a PR because main does not accept direct planning pushes.
- Source branch at helper invocation: feature/auto-20260911-211537.
- Commit message: plan: t18428 → done.

## Task and issue manifest

<!-- aidevops:planning-publication:v1 id=098bfda8591f5c387efcf4e0027896b2379ab674 -->
<!-- aidevops:planning-task:v1 task=t18428 issue=31795 -->
- For #31795

## Security and architecture guardrails

- This PR does not update .task-counter.
- Task IDs still come from claim-task-id.sh CAS allocation on a branch that permits atomic counter pushes.
- Do not replace counter allocation with a PR-backed counter update; PR review is not an atomic ID lock.

## Merge note

- Merge this planning-only PR before expecting pulse or issue-sync to see the TODO/todo changes.
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.361 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 1h 35m and 807,018 tokens on this with the user in an interactive session.