### PR TITLE
t18429: plan task-completion compatibility fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1358,6 +1358,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18428 Fix Dependabot PR lifecycle convergence #priority:high #type:bug #interactive #tier:thinking ref:GH#31795 started:2026-09-11 -> [todo/tasks/t18428-brief.md] pr:#31798 completed:2026-09-11
 
+- [ ] t18429 Fix in-progress task completion and planning PR title compatibility #auto-dispatch #bug #framework #priority:high ref:GH#31805
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Planning publication

- Publishes TODO.md and todo/ planning-file changes through a PR because main does not accept direct planning pushes.
- Source branch at helper invocation: feature/auto-20260911-214151.
- Commit message: plan: add t18429.

## Task and issue manifest

<!-- aidevops:planning-publication:v1 id=e14e4bf286b72f6779a41c51f0021fc061698329 -->
<!-- aidevops:planning-task:v1 task=t18429 issue=31805 -->
- For #31805

## Security and architecture guardrails

- This PR does not update .task-counter.
- Task IDs still come from claim-task-id.sh CAS allocation on a branch that permits atomic counter pushes.
- Do not replace counter allocation with a PR-backed counter update; PR review is not an atomic ID lock.

## Merge note

- Merge this planning-only PR before expecting pulse or issue-sync to see the TODO/todo changes.
<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.361 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 2h 1m and 1,066,447 tokens on this with the user in an interactive session.