### PR TITLE
GH#31812: redact indirect credential records

### DIFF
--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -73,6 +73,8 @@ PEM_REDACTION_TOKEN = "[redacted-private-key]"
 PEM_BEGIN_MARKER = "-----BEGIN "
 PEM_KEY_SUFFIX = "PRIVATE KEY-----"
 PEM_LABEL_PATTERN = re.compile(r"^[A-Z0-9 ]*$")
+IDENTIFIER_FIELD_NAMES = {"KEY", "NAME", "VARIABLE"}
+VALUE_FIELD_NAMES = {"VALUE"}
 PLACEHOLDER_VALUES = {
     "",
     "***",
@@ -120,6 +122,16 @@ def is_placeholder_value(value: str) -> bool:
 def preserves_sensitive_value(value) -> bool:
     """Keep absence and explicit string placeholders under sensitive keys."""
     return value is None or (isinstance(value, str) and is_placeholder_value(value))
+
+
+def is_identifier_field_name(name: str) -> bool:
+    """Return whether a field identifies the name of a sibling value."""
+    return normalize_field_name(name) in IDENTIFIER_FIELD_NAMES
+
+
+def is_value_field_name(name: str) -> bool:
+    """Return whether a field holds the value named by a sibling identifier."""
+    return normalize_field_name(name) in VALUE_FIELD_NAMES
 
 
 def redact_named_assignment(match: re.Match) -> str:
@@ -191,18 +203,74 @@ def scrub_credentials(text: str) -> tuple[str, int]:
 def scrub_value(value):
     """Recursively scrub credentials from any JSON-serialisable value."""
     if isinstance(value, str):
-        return scrub_credentials(value)[0]
+        parsed = parse_structured_text(value)
+        if parsed is not None:
+            parsed_value, stringify = parsed
+            scrubbed, count = scrub_value(parsed_value)
+            if count:
+                return stringify(scrubbed), count
+        return scrub_credentials(value)
     if isinstance(value, dict):
         scrubbed = {}
+        count = 0
+        has_sensitive_identifier = any(
+            is_identifier_field_name(key)
+            and isinstance(nested, str)
+            and is_sensitive_field_name(nested)
+            for key, nested in value.items()
+        )
         for key, nested in value.items():
             if is_sensitive_field_name(key) and not preserves_sensitive_value(nested):
                 scrubbed[key] = REDACTION_TOKEN
+                count += 1
+            elif has_sensitive_identifier and is_value_field_name(key) and not preserves_sensitive_value(nested):
+                scrubbed[key] = REDACTION_TOKEN
+                count += 1
             else:
-                scrubbed[key] = scrub_value(nested)
-        return scrubbed
+                scrubbed[key], nested_count = scrub_value(nested)
+                count += nested_count
+        return scrubbed, count
     if isinstance(value, list):
-        return [scrub_value(item) for item in value]
-    return value
+        scrubbed = []
+        count = 0
+        for item in value:
+            nested, nested_count = scrub_value(item)
+            scrubbed.append(nested)
+            count += nested_count
+        return scrubbed, count
+    return value, 0
+
+
+def parse_structured_text(value: str):
+    """Parse a complete JSON document or independently bounded NDJSON records."""
+    if not value.strip():
+        return None
+    try:
+        parsed = json.loads(value)
+        if not isinstance(parsed, (dict, list)):
+            return None
+        return parsed, lambda scrubbed: json.dumps(scrubbed, separators=(",", ":"))
+    except json.JSONDecodeError:
+        pass
+
+    lines = value.splitlines()
+    if not lines:
+        return None
+    parsed = []
+    for line in lines:
+        if not line.strip():
+            parsed.append(None)
+            continue
+        try:
+            record = json.loads(line)
+            if not isinstance(record, (dict, list)):
+                return None
+            parsed.append(record)
+        except json.JSONDecodeError:
+            return None
+    return parsed, lambda scrubbed: "\n".join(
+        "" if record is None else json.dumps(record, separators=(",", ":")) for record in scrubbed
+    )
 
 
 def main() -> None:
@@ -217,25 +285,14 @@ def main() -> None:
 
     tool_response = data.get("tool_response", "")
 
-    # Fast path: no known prefix, private key, or named assignment in the payload.
-    if (
-        not CREDENTIAL_PATTERN.search(raw)
-        and PEM_BEGIN_MARKER not in raw
-        and not NAMED_CREDENTIAL_ASSIGNMENT_PATTERN.search(raw)
-    ):
-        return
-
     # Scrub the tool_response field (may be str or nested JSON object).
     if isinstance(tool_response, str):
-        scrubbed, count = scrub_credentials(tool_response)
+        scrubbed, count = scrub_value(tool_response)
         if count == 0:
             return
     elif isinstance(tool_response, (dict, list)):
-        scrubbed = scrub_value(tool_response)
-        # Re-serialise to detect if anything actually changed.
-        original_json = json.dumps(tool_response, ensure_ascii=False)
-        scrubbed_json = json.dumps(scrubbed, ensure_ascii=False)
-        if original_json == scrubbed_json:
+        scrubbed, count = scrub_value(tool_response)
+        if count == 0:
             return
     else:
         return

--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -302,15 +302,10 @@ def main() -> None:
     tool_response = data.get("tool_response", "")
 
     # Scrub the tool_response field (may be str or nested JSON object).
-    if isinstance(tool_response, str):
-        scrubbed, count = scrub_value(tool_response)
-        if count == 0:
-            return
-    elif isinstance(tool_response, (dict, list)):
-        scrubbed, count = scrub_value(tool_response)
-        if count == 0:
-            return
-    else:
+    if not isinstance(tool_response, (str, dict, list)):
+        return
+    scrubbed, count = scrub_value(tool_response)
+    if count == 0:
         return
 
     elapsed_ms = (time.monotonic_ns() - start_ns) / 1_000_000

--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -264,19 +264,22 @@ def scrub_sequence(value: list):
 
 def parse_structured_text(value: str):
     """Parse complete JSON or independent NDJSON records for recursive scrubbing."""
-    if not value.strip():
-        return None
     parsed = parse_json_document(value)
     if parsed is not None:
         return parsed, lambda scrubbed: json.dumps(scrubbed, separators=(",", ":"))
     records = []
     for line in value.splitlines():
         record = parse_json_document(line) if line.strip() else None
-        if record is None and line.strip():
-            return None
-        records.append(record)
+        records.append(line if record is None and line.strip() else record)
+    if not any(isinstance(record, (dict, list)) for record in records):
+        return None
     return records, lambda scrubbed: "\n".join(
-        "" if record is None else json.dumps(record, separators=(",", ":")) for record in scrubbed
+        ""
+        if record is None
+        else record
+        if isinstance(record, str)
+        else json.dumps(record, separators=(",", ":"))
+        for record in scrubbed
     )
 
 

--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -48,6 +48,8 @@ import re
 import sys
 import time
 
+from structured_text_parser import parse_structured_text
+
 # Regex mirrors shared-constants.sh scrub_credentials sed pattern exactly.
 # Group 1: token prefix family (one of the 10 families).
 # Suffix: 10+ alphanumeric / dash / underscore chars (token body).
@@ -260,36 +262,6 @@ def scrub_sequence(value: list):
         scrubbed.append(nested)
         count += nested_count
     return scrubbed, count
-
-
-def parse_structured_text(value: str):
-    """Parse complete JSON or independent NDJSON records for recursive scrubbing."""
-    parsed = parse_json_document(value)
-    if parsed is not None:
-        return parsed, lambda scrubbed: json.dumps(scrubbed, separators=(",", ":"))
-    records = []
-    for line in value.splitlines():
-        record = parse_json_document(line) if line.strip() else None
-        records.append(line if record is None and line.strip() else record)
-    if not any(isinstance(record, (dict, list)) for record in records):
-        return None
-    return records, lambda scrubbed: "\n".join(
-        ""
-        if record is None
-        else record
-        if isinstance(record, str)
-        else json.dumps(record, separators=(",", ":"))
-        for record in scrubbed
-    )
-
-
-def parse_json_document(value: str):
-    """Return JSON containers and leave scalar or invalid values unparsed."""
-    try:
-        parsed = json.loads(value)
-    except json.JSONDecodeError:
-        return None
-    return parsed if isinstance(parsed, (dict, list)) else None
 
 
 def main() -> None:

--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -203,74 +203,90 @@ def scrub_credentials(text: str) -> tuple[str, int]:
 def scrub_value(value):
     """Recursively scrub credentials from any JSON-serialisable value."""
     if isinstance(value, str):
-        parsed = parse_structured_text(value)
-        if parsed is not None:
-            parsed_value, stringify = parsed
-            scrubbed, count = scrub_value(parsed_value)
-            if count:
-                return stringify(scrubbed), count
-        return scrub_credentials(value)
+        return scrub_text_value(value)
     if isinstance(value, dict):
-        scrubbed = {}
-        count = 0
-        has_sensitive_identifier = any(
-            is_identifier_field_name(key)
-            and isinstance(nested, str)
-            and is_sensitive_field_name(nested)
-            for key, nested in value.items()
-        )
-        for key, nested in value.items():
-            if is_sensitive_field_name(key) and not preserves_sensitive_value(nested):
-                scrubbed[key] = REDACTION_TOKEN
-                count += 1
-            elif has_sensitive_identifier and is_value_field_name(key) and not preserves_sensitive_value(nested):
-                scrubbed[key] = REDACTION_TOKEN
-                count += 1
-            else:
-                scrubbed[key], nested_count = scrub_value(nested)
-                count += nested_count
-        return scrubbed, count
+        return scrub_mapping(value)
     if isinstance(value, list):
-        scrubbed = []
-        count = 0
-        for item in value:
-            nested, nested_count = scrub_value(item)
-            scrubbed.append(nested)
-            count += nested_count
-        return scrubbed, count
+        return scrub_sequence(value)
     return value, 0
 
 
+def scrub_text_value(value: str):
+    """Scrub plain text or recursively scrub an embedded structured payload."""
+    parsed = parse_structured_text(value)
+    if parsed is None:
+        return scrub_credentials(value)
+    parsed_value, stringify = parsed
+    scrubbed, count = scrub_value(parsed_value)
+    return (stringify(scrubbed), count) if count else scrub_credentials(value)
+
+
+def scrub_mapping(value: dict):
+    """Scrub sensitive fields and their sibling value records."""
+    has_sensitive_identifier = has_sensitive_identifier_field(value)
+    scrubbed = {}
+    count = 0
+    for key, nested in value.items():
+        if should_redact_field(key, nested, has_sensitive_identifier):
+            scrubbed[key] = REDACTION_TOKEN
+            count += 1
+        else:
+            scrubbed[key], nested_count = scrub_value(nested)
+            count += nested_count
+    return scrubbed, count
+
+
+def has_sensitive_identifier_field(value: dict) -> bool:
+    """Return whether a record's name field identifies a sensitive value."""
+    return any(
+        is_identifier_field_name(key) and isinstance(nested, str) and is_sensitive_field_name(nested)
+        for key, nested in value.items()
+    )
+
+
+def should_redact_field(key, value, has_sensitive_identifier: bool) -> bool:
+    """Return whether a field is directly or indirectly credential-bearing."""
+    return not preserves_sensitive_value(value) and (
+        is_sensitive_field_name(key) or (has_sensitive_identifier and is_value_field_name(key))
+    )
+
+
+def scrub_sequence(value: list):
+    """Scrub each independent list entry and accumulate its redaction count."""
+    scrubbed = []
+    count = 0
+    for item in value:
+        nested, nested_count = scrub_value(item)
+        scrubbed.append(nested)
+        count += nested_count
+    return scrubbed, count
+
+
 def parse_structured_text(value: str):
-    """Parse a complete JSON document or independently bounded NDJSON records."""
+    """Parse complete JSON or independent NDJSON records for recursive scrubbing."""
     if not value.strip():
         return None
-    try:
-        parsed = json.loads(value)
-        if not isinstance(parsed, (dict, list)):
-            return None
+    parsed = parse_json_document(value)
+    if parsed is not None:
         return parsed, lambda scrubbed: json.dumps(scrubbed, separators=(",", ":"))
-    except json.JSONDecodeError:
-        pass
-
-    lines = value.splitlines()
-    if not lines:
-        return None
-    parsed = []
-    for line in lines:
-        if not line.strip():
-            parsed.append(None)
-            continue
-        try:
-            record = json.loads(line)
-            if not isinstance(record, (dict, list)):
-                return None
-            parsed.append(record)
-        except json.JSONDecodeError:
+    records = []
+    for line in value.splitlines():
+        record = parse_json_document(line) if line.strip() else None
+        if record is None and line.strip():
             return None
-    return parsed, lambda scrubbed: "\n".join(
+        records.append(record)
+    return records, lambda scrubbed: "\n".join(
         "" if record is None else json.dumps(record, separators=(",", ":")) for record in scrubbed
     )
+
+
+def parse_json_document(value: str):
+    """Return JSON containers and leave scalar or invalid values unparsed."""
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, (dict, list)) else None
 
 
 def main() -> None:

--- a/.agents/hooks/structured_text_parser.py
+++ b/.agents/hooks/structured_text_parser.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Structured text parsing for transcript scrub hooks."""
+
+import json
+
+
+def parse_structured_text(value: str):
+    """Parse complete JSON or independent NDJSON records for recursive scrubbing."""
+    parsed = _parse_json_document(value)
+    if parsed is not None:
+        return parsed, lambda scrubbed: json.dumps(scrubbed, separators=(",", ":"))
+    records = []
+    for line in value.splitlines():
+        record = _parse_json_document(line) if line.strip() else None
+        records.append(line if record is None and line.strip() else record)
+    if not any(isinstance(record, (dict, list)) for record in records):
+        return None
+    return records, lambda scrubbed: "\n".join(_stringify_record(record) for record in scrubbed)
+
+
+def _parse_json_document(value: str):
+    """Return JSON containers and leave scalar or invalid values unparsed."""
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, (dict, list)) else None
+
+
+def _stringify_record(record) -> str:
+    """Serialize one parsed record or preserve one raw NDJSON line."""
+    if record is None:
+        return ""
+    if isinstance(record, str):
+        return record
+    return json.dumps(record, separators=(",", ":"))

--- a/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
@@ -3,7 +3,7 @@
 
 /** Credential transcript scrubbing shared by OpenCode post-tool hooks. */
 
-import { parseStructuredText } from "./credential-structured-text.mjs";
+import { parseStructuredText } from "./structured-text-parser.mjs";
 
 const CREDENTIAL_PATTERN =
   /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;

--- a/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
@@ -3,6 +3,8 @@
 
 /** Credential transcript scrubbing shared by OpenCode post-tool hooks. */
 
+import { parseStructuredText } from "./credential-structured-text.mjs";
+
 const CREDENTIAL_PATTERN =
   /(^|[^A-Za-z0-9_-])(sk-|GOCSPX-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
 const NAMED_CREDENTIAL_ASSIGNMENT_PATTERN =
@@ -134,102 +136,63 @@ function scrubPlainCredentials(text) {
 
 export function scrubCredentials(text) {
   const parsed = parseStructuredText(text);
-  if (parsed) {
-    const scrubbed = scrubValue(parsed.value);
-    if (scrubbed.count > 0) {
-      return { scrubbed: parsed.stringify(scrubbed.value), count: scrubbed.count };
-    }
-  }
-  return scrubPlainCredentials(text);
+  const scrubbed = parsed && scrubValue(parsed.value);
+  return scrubbed?.count > 0
+    ? { scrubbed: parsed.stringify(scrubbed.value), count: scrubbed.count }
+    : scrubPlainCredentials(text);
 }
 
 function scrubValue(value) {
-  if (typeof value === "string") {
-    const parsed = parseStructuredText(value);
-    if (parsed) {
-      const scrubbed = scrubValue(parsed.value);
-      if (scrubbed.count > 0) {
-        return { value: parsed.stringify(scrubbed.value), count: scrubbed.count };
-      }
-    }
-    const { scrubbed, count } = scrubCredentials(value);
-    return { value: scrubbed, count };
-  }
-  if (Array.isArray(value)) {
-    let total = 0;
-    const result = value.map((item) => {
-      const { value: scrubbed, count } = scrubValue(item);
-      total += count;
-      return scrubbed;
-    });
-    return { value: result, count: total };
-  }
-  if (value !== null && typeof value === "object") {
-    let total = 0;
-    const result = {};
-    const hasSensitiveIdentifier = Object.entries(value).some(
-      ([key, nestedValue]) =>
-        isIdentifierFieldName(key) && typeof nestedValue === "string" && isSensitiveFieldName(nestedValue),
-    );
-    for (const [key, nestedValue] of Object.entries(value)) {
-      if (isSensitiveFieldName(key) && !preservesSensitiveValue(nestedValue)) {
-        result[key] = REDACTION_TOKEN;
-        total++;
-        continue;
-      }
-      if (hasSensitiveIdentifier && isValueFieldName(key) && !preservesSensitiveValue(nestedValue)) {
-        result[key] = REDACTION_TOKEN;
-        total++;
-        continue;
-      }
-      const { value: scrubbed, count } = scrubValue(nestedValue);
-      result[key] = scrubbed;
-      total += count;
-    }
-    return { value: result, count: total };
-  }
+  if (typeof value === "string") return scrubTextValue(value);
+  if (Array.isArray(value)) return scrubSequence(value);
+  if (value !== null && typeof value === "object") return scrubMapping(value);
   return { value, count: 0 };
 }
 
-function parseStructuredText(value) {
-  const text = value.trim();
-  if (!text) return null;
-  try {
-    const parsed = JSON.parse(text);
-    if (parsed !== null && typeof parsed === "object") {
-      return { value: parsed, stringify: (scrubbed) => JSON.stringify(scrubbed) };
-    }
-    return null;
-  } catch {
-    // A complete JSON document is not required for tool output; try NDJSON below.
-  }
+function scrubTextValue(value) {
+  const parsed = parseStructuredText(value);
+  const scrubbed = parsed && scrubValue(parsed.value);
+  return scrubbed?.count > 0
+    ? { value: parsed.stringify(scrubbed.value), count: scrubbed.count }
+    : renameScrubbedText(value);
+}
 
-  const lines = value.split(/(\r?\n)/);
-  const parsed = [];
-  let records = 0;
-  for (let index = 0; index < lines.length; index += 2) {
-    const line = lines[index];
-    if (!line.trim()) {
-      parsed.push(null);
-      continue;
-    }
-    try {
-      const record = JSON.parse(line);
-      if (record === null || typeof record !== "object") return null;
-      parsed.push(record);
-      records++;
-    } catch {
-      return null;
-    }
-  }
-  if (records === 0) return null;
-  return {
-    value: parsed,
-    stringify: (scrubbed) =>
-      scrubbed
-        .map((record, index) => (record === null ? lines[index * 2] : JSON.stringify(record)))
-        .join("\n"),
-  };
+function renameScrubbedText(value) {
+  const { scrubbed, count } = scrubCredentials(value);
+  return { value: scrubbed, count };
+}
+
+function scrubSequence(value) {
+  return value.reduce(
+    (result, item) => {
+      const scrubbed = scrubValue(item);
+      result.value.push(scrubbed.value);
+      result.count += scrubbed.count;
+      return result;
+    },
+    { value: [], count: 0 },
+  );
+}
+
+function scrubMapping(value) {
+  const hasSensitiveIdentifier = Object.entries(value).some(
+    ([key, nestedValue]) =>
+      isIdentifierFieldName(key) && typeof nestedValue === "string" && isSensitiveFieldName(nestedValue),
+  );
+  return Object.entries(value).reduce((result, [key, nestedValue]) => {
+    const scrubbed = shouldRedactField(key, nestedValue, hasSensitiveIdentifier)
+      ? { value: REDACTION_TOKEN, count: 1 }
+      : scrubValue(nestedValue);
+    result.value[key] = scrubbed.value;
+    result.count += scrubbed.count;
+    return result;
+  }, { value: {}, count: 0 });
+}
+
+function shouldRedactField(key, value, hasSensitiveIdentifier) {
+  return !preservesSensitiveValue(value) && (
+    isSensitiveFieldName(key) || (hasSensitiveIdentifier && isValueFieldName(key))
+  );
 }
 
 /** Scrub credentials from any JSON-serialisable tool output. */

--- a/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-output-scrub.mjs
@@ -27,6 +27,8 @@ const PLACEHOLDER_VALUES = new Set([
 
 export const REDACTION_TOKEN = "[redacted-credential]";
 export const PEM_REDACTION_TOKEN = "[redacted-private-key]";
+const IDENTIFIER_FIELD_NAMES = new Set(["KEY", "NAME", "VARIABLE"]);
+const VALUE_FIELD_NAMES = new Set(["VALUE"]);
 
 function scrubPrivateKeys(text) {
   const chunks = [];
@@ -91,6 +93,14 @@ function preservesSensitiveValue(value) {
   return value == null || (typeof value === "string" && isPlaceholderValue(value));
 }
 
+function isIdentifierFieldName(name) {
+  return IDENTIFIER_FIELD_NAMES.has(normalizeFieldName(name));
+}
+
+function isValueFieldName(name) {
+  return VALUE_FIELD_NAMES.has(normalizeFieldName(name));
+}
+
 function redactAssignedValue(value) {
   if (isPlaceholderValue(value)) return value;
   const quote = value.at(0);
@@ -102,7 +112,7 @@ function redactAssignedValue(value) {
 }
 
 /** Scrub known token prefixes and unknown-format values under sensitive names. */
-export function scrubCredentials(text) {
+function scrubPlainCredentials(text) {
   const { scrubbed: pemScrubbed, count: pemCount } = scrubPrivateKeys(text);
   let count = pemCount;
   const namedScrubbed = pemScrubbed.replace(
@@ -122,8 +132,26 @@ export function scrubCredentials(text) {
   return { scrubbed, count };
 }
 
+export function scrubCredentials(text) {
+  const parsed = parseStructuredText(text);
+  if (parsed) {
+    const scrubbed = scrubValue(parsed.value);
+    if (scrubbed.count > 0) {
+      return { scrubbed: parsed.stringify(scrubbed.value), count: scrubbed.count };
+    }
+  }
+  return scrubPlainCredentials(text);
+}
+
 function scrubValue(value) {
   if (typeof value === "string") {
+    const parsed = parseStructuredText(value);
+    if (parsed) {
+      const scrubbed = scrubValue(parsed.value);
+      if (scrubbed.count > 0) {
+        return { value: parsed.stringify(scrubbed.value), count: scrubbed.count };
+      }
+    }
     const { scrubbed, count } = scrubCredentials(value);
     return { value: scrubbed, count };
   }
@@ -139,8 +167,17 @@ function scrubValue(value) {
   if (value !== null && typeof value === "object") {
     let total = 0;
     const result = {};
+    const hasSensitiveIdentifier = Object.entries(value).some(
+      ([key, nestedValue]) =>
+        isIdentifierFieldName(key) && typeof nestedValue === "string" && isSensitiveFieldName(nestedValue),
+    );
     for (const [key, nestedValue] of Object.entries(value)) {
       if (isSensitiveFieldName(key) && !preservesSensitiveValue(nestedValue)) {
+        result[key] = REDACTION_TOKEN;
+        total++;
+        continue;
+      }
+      if (hasSensitiveIdentifier && isValueFieldName(key) && !preservesSensitiveValue(nestedValue)) {
         result[key] = REDACTION_TOKEN;
         total++;
         continue;
@@ -152,6 +189,47 @@ function scrubValue(value) {
     return { value: result, count: total };
   }
   return { value, count: 0 };
+}
+
+function parseStructuredText(value) {
+  const text = value.trim();
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed !== null && typeof parsed === "object") {
+      return { value: parsed, stringify: (scrubbed) => JSON.stringify(scrubbed) };
+    }
+    return null;
+  } catch {
+    // A complete JSON document is not required for tool output; try NDJSON below.
+  }
+
+  const lines = value.split(/(\r?\n)/);
+  const parsed = [];
+  let records = 0;
+  for (let index = 0; index < lines.length; index += 2) {
+    const line = lines[index];
+    if (!line.trim()) {
+      parsed.push(null);
+      continue;
+    }
+    try {
+      const record = JSON.parse(line);
+      if (record === null || typeof record !== "object") return null;
+      parsed.push(record);
+      records++;
+    } catch {
+      return null;
+    }
+  }
+  if (records === 0) return null;
+  return {
+    value: parsed,
+    stringify: (scrubbed) =>
+      scrubbed
+        .map((record, index) => (record === null ? lines[index * 2] : JSON.stringify(record)))
+        .join("\n"),
+  };
 }
 
 /** Scrub credentials from any JSON-serialisable tool output. */

--- a/.agents/plugins/opencode-aidevops/structured-text-parser.mjs
+++ b/.agents/plugins/opencode-aidevops/structured-text-parser.mjs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/** Parse complete JSON containers without treating scalars as structured output. */
+function parseJsonContainer(text) {
+  try {
+    const value = JSON.parse(text);
+    return value !== null && typeof value === "object" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse complete JSON or independent NDJSON records while preserving separators. */
+export function parseStructuredText(value) {
+  const document = parseJsonContainer(value.trim());
+  if (document !== null) {
+    return { value: document, stringify: (scrubbed) => JSON.stringify(scrubbed) };
+  }
+
+  const parts = value.split(/(\r?\n)/);
+  const records = [];
+  let recordCount = 0;
+  for (let index = 0; index < parts.length; index += 2) {
+    const line = parts[index];
+    if (!line.trim()) {
+      records.push(null);
+      continue;
+    }
+    const record = parseJsonContainer(line);
+    if (record === null) return null;
+    records.push(record);
+    recordCount++;
+  }
+  if (recordCount === 0) return null;
+
+  return {
+    value: records,
+    stringify: (scrubbed) =>
+      scrubbed
+        .map((record, index) => {
+          const line = record === null ? parts[index * 2] : JSON.stringify(record);
+          return `${line}${parts[index * 2 + 1] ?? ""}`;
+        })
+        .join(""),
+  };
+}

--- a/.agents/plugins/opencode-aidevops/structured-text-parser.mjs
+++ b/.agents/plugins/opencode-aidevops/structured-text-parser.mjs
@@ -28,9 +28,8 @@ export function parseStructuredText(value) {
       continue;
     }
     const record = parseJsonContainer(line);
-    if (record === null) return null;
-    records.push(record);
-    recordCount++;
+    records.push(record ?? line);
+    if (record !== null) recordCount++;
   }
   if (recordCount === 0) return null;
 
@@ -39,7 +38,8 @@ export function parseStructuredText(value) {
     stringify: (scrubbed) =>
       scrubbed
         .map((record, index) => {
-          const line = record === null ? parts[index * 2] : JSON.stringify(record);
+          const line =
+            record === null ? parts[index * 2] : typeof record === "string" ? record : JSON.stringify(record);
           return `${line}${parts[index * 2 + 1] ?? ""}`;
         })
         .join(""),

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -137,6 +137,11 @@ describe("credential transcript scrub boundary", () => {
       `${JSON.stringify({ ...record, value: REDACTION_TOKEN })}\n${JSON.stringify({ key: "REGION", value: "eu-west" })}`,
       1,
     );
+    assertScrub(
+      `malformed-before\r\n${JSON.stringify(record)}\r\nmalformed-after`,
+      `malformed-before\r\n${JSON.stringify({ ...record, value: REDACTION_TOKEN })}\r\nmalformed-after`,
+      1,
+    );
   });
 
   test("toolExecuteAfter redacts sibling credential records without cross-record bleed", async () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs
@@ -129,6 +129,42 @@ describe("credential transcript scrub boundary", () => {
     assertScrub("MONKEY_TOKENIZER=enabled", "MONKEY_TOKENIZER=enabled", 0);
   });
 
+  test("redacts sibling credential records in structured JSON and NDJSON", () => {
+    const record = { key: "SYNTHETIC_API_KEY", value: "opaque-synthetic-value-1234567890", enabled: true };
+    assertScrub(JSON.stringify(record), JSON.stringify({ ...record, value: REDACTION_TOKEN }), 1);
+    assertScrub(
+      `${JSON.stringify(record)}\n${JSON.stringify({ key: "REGION", value: "eu-west" })}`,
+      `${JSON.stringify({ ...record, value: REDACTION_TOKEN })}\n${JSON.stringify({ key: "REGION", value: "eu-west" })}`,
+      1,
+    );
+  });
+
+  test("toolExecuteAfter redacts sibling credential records without cross-record bleed", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "aidevops-sibling-credential-scrub-"));
+    const output = {
+      output: {
+        stdout: JSON.stringify([
+          { name: "SYNTHETIC_API_KEY", value: "opaque-synthetic-value-1234567890" },
+          { variable: "REGION", value: "eu-west" },
+          { key: "API_TOKEN", value: "[redacted-credential]" },
+        ]),
+      },
+      metadata: {},
+    };
+
+    try {
+      const hooks = createQualityHooks({ scriptsDir: tempDir, logsDir: tempDir });
+      await hooks.toolExecuteAfter({ tool: "test", callID: "" }, output);
+      assert.deepEqual(JSON.parse(output.output.stdout), [
+        { name: "SYNTHETIC_API_KEY", value: REDACTION_TOKEN },
+        { variable: "REGION", value: "eu-west" },
+        { key: "API_TOKEN", value: "[redacted-credential]" },
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("scans adversarial 10KB named-field input within the performance budget", () => {
     const input = "A ".repeat(5_000);
     const runs = 100;

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -31,6 +31,7 @@ HOOKS_DIR="$HOME/.aidevops/hooks"
 HOOK_SCRIPT="$HOOKS_DIR/git_safety_guard.py"
 POST_HOOK_SCRIPT="$HOOKS_DIR/mcp_task_post_hook.py"
 CREDENTIAL_SCRUB_SCRIPT="$HOOKS_DIR/credential-transcript-scrub.py"
+STRUCTURED_TEXT_PARSER_SCRIPT="$HOOKS_DIR/structured_text_parser.py"
 SECRET_READ_GUARD_SCRIPT="$HOOKS_DIR/secret_file_read_guard.py"
 COMPLEXITY_ADVISORY_SCRIPT="$HOOKS_DIR/complexity_advisory_pre_edit.py"
 CLAUDE_SETTINGS="$HOME/.claude/settings.json"
@@ -670,6 +671,8 @@ install_hook() {
 	source_post_hook=$(find_source_hook "mcp_task_post_hook.py") || return 1
 	local source_credential_scrub_hook
 	source_credential_scrub_hook=$(find_source_hook "credential-transcript-scrub.py") || return 1
+	local source_structured_text_parser
+	source_structured_text_parser=$(find_source_hook "structured_text_parser.py") || return 1
 	local source_secret_read_guard_hook
 	source_secret_read_guard_hook=$(find_source_hook "secret_file_read_guard.py") || return 1
 	local source_complexity_advisory_hook
@@ -694,6 +697,8 @@ install_hook() {
 	cp "$source_credential_scrub_hook" "$CREDENTIAL_SCRUB_SCRIPT"
 	chmod +x "$CREDENTIAL_SCRUB_SCRIPT"
 	print_success "Installed $CREDENTIAL_SCRUB_SCRIPT"
+	cp "$source_structured_text_parser" "$STRUCTURED_TEXT_PARSER_SCRIPT"
+	print_success "Installed $STRUCTURED_TEXT_PARSER_SCRIPT"
 	cp "$source_secret_read_guard_hook" "$SECRET_READ_GUARD_SCRIPT"
 	chmod +x "$SECRET_READ_GUARD_SCRIPT"
 	print_success "Installed $SECRET_READ_GUARD_SCRIPT"

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -388,6 +388,22 @@ else
 fi
 printf '  Note: subprocess launch adds ~50ms Python startup; in-process cost shown above.\n'
 
+SIBLING_PAYLOAD='{"tool_response":"[{\"key\":\"SYNTHETIC_API_KEY\",\"value\":\"opaque-synthetic-value-1234567890\"},{\"name\":\"REGION\",\"value\":\"eu-west\"}]"}'
+output_sibling=$(run_hook "$SIBLING_PAYLOAD")
+if echo "$output_sibling" | python3 -c "import json,sys; response=json.loads(json.load(sys.stdin)['tool_response']); assert response == [{'key':'SYNTHETIC_API_KEY','value':'[redacted-credential]'},{'name':'REGION','value':'eu-west'}]" 2>/dev/null; then
+	pass "30. JSON sibling credential records scrubbed without cross-record bleed"
+else
+	fail "30. JSON sibling credential records scrubbed without cross-record bleed — got: $output_sibling"
+fi
+
+NDJSON_SIBLING_PAYLOAD='{"tool_response":"{\"variable\":\"SYNTHETIC_API_KEY\",\"value\":\"opaque-synthetic-value-1234567890\"}\n{\"key\":\"REGION\",\"value\":\"eu-west\"}"}'
+output_ndjson_sibling=$(run_hook "$NDJSON_SIBLING_PAYLOAD")
+if echo "$output_ndjson_sibling" | python3 -c "import json,sys; response=json.load(sys.stdin)['tool_response'].splitlines(); assert [json.loads(record) for record in response] == [{'variable':'SYNTHETIC_API_KEY','value':'[redacted-credential]'},{'key':'REGION','value':'eu-west'}]" 2>/dev/null; then
+	pass "31. NDJSON sibling credential records scrubbed"
+else
+	fail "31. NDJSON sibling credential records scrubbed — got: $output_ndjson_sibling"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 printf '\n'

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -404,6 +404,14 @@ else
 	fail "31. NDJSON sibling credential records scrubbed — got: $output_ndjson_sibling"
 fi
 
+MIXED_NDJSON_PAYLOAD='{"tool_response":"malformed-before\n{\"key\":\"SYNTHETIC_API_KEY\",\"value\":\"opaque-synthetic-value-1234567890\"}\nmalformed-after"}'
+output_mixed_ndjson=$(run_hook "$MIXED_NDJSON_PAYLOAD")
+if echo "$output_mixed_ndjson" | python3 -c "import json,sys; response=json.load(sys.stdin)['tool_response'].splitlines(); assert response[0] == 'malformed-before' and response[2] == 'malformed-after'; assert json.loads(response[1]) == {'key':'SYNTHETIC_API_KEY','value':'[redacted-credential]'}" 2>/dev/null; then
+	pass "32. Valid NDJSON records remain scrubbed beside malformed records"
+else
+	fail "32. Valid NDJSON records remain scrubbed beside malformed records — got: $output_mixed_ndjson"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 printf '\n'

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -341,7 +341,7 @@ else
 	fail "27. Performance: ${BENCH_MS}ms per 10KB in-process exceeds 5ms budget"
 fi
 
-NAMED_BENCH_MS=$(python3 -c "
+NAMED_BENCH_MS=$(PYTHONPATH="$HOOKS_DIR" python3 -c "
 import runpy, time
 
 scrub_credentials = runpy.run_path('$HOOK_SCRIPT')['scrub_credentials']
@@ -364,7 +364,7 @@ else
 	fail "28. Named-field performance: ${NAMED_BENCH_MS}ms per 10KB exceeds 5ms budget"
 fi
 
-PEM_BENCH_MS=$(python3 -c "
+PEM_BENCH_MS=$(PYTHONPATH="$HOOKS_DIR" python3 -c "
 import runpy, time
 
 scrub_credentials = runpy.run_path('$HOOK_SCRIPT')['scrub_credentials']


### PR DESCRIPTION
Resolves #31812

Redacts values in structured sibling `key`/`name`/`variable` credential records for OpenCode and Claude Code transcript hooks while preserving non-secret metadata, placeholders, and record isolation.

## Runtime Testing

- `node --test .agents/plugins/opencode-aidevops/tests/test-credential-scrub.mjs` — 25 tests passed, including the production post-tool hook path.
- `bash .agents/scripts/tests/test-credential-transcript-scrub.sh` — 47 assertions passed, including JSON, NDJSON, malformed adjacent records, and the existing per-10KB performance checks.
- `.agents/scripts/linters-local.sh --changed` — passed, including ShellCheck and secretlint.

## Review

- Independent critical-risk closeout review: clean on the final local evidence bundle.

## Decisions

- Parse complete JSON and each valid NDJSON record independently so malformed adjacent lines cannot suppress sibling-field redaction or cause cross-record correlation.
- Keep structured-text parsing in small runtime-local helper modules; the Claude Code installer deploys its Python helper alongside the hook.
- Use neutral helper filenames because the repository intentionally ignores `*credential*` paths.

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.362 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-terra spent 22m and 66,567 tokens on this with the user in an interactive session.