### PR TITLE
GH#31811: stream redacted secret command output

### DIFF
--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -203,18 +203,23 @@ if not secret_values:
     raise SystemExit("redaction values were empty")
 
 marker = b"[REDACTED]"
-maximum_length = len(secret_values[0])
 output = sys.stdout.buffer
 pending = b""
 
 def redact_available(data, final=False):
-    keep = 0 if final else maximum_length - 1
     pieces = []
-    while len(data) > keep:
+    while data:
         match = next((value for value in secret_values if data.startswith(value)), None)
         if match is not None:
+            if not final and any(
+                len(value) > len(match) and value.startswith(data)
+                for value in secret_values
+            ):
+                break
             pieces.append(marker)
             data = data[len(match):]
+        elif not final and any(value.startswith(data) for value in secret_values):
+            break
         else:
             pieces.append(data[:1])
             data = data[1:]
@@ -228,7 +233,7 @@ def redact_available(data, final=False):
     return data
 
 while True:
-    chunk = sys.stdin.buffer.read(65536)
+    chunk = sys.stdin.buffer.read1(65536)
     if not chunk:
         break
     pending = redact_available(pending + chunk)

--- a/.agents/scripts/tests/test-secret-helper.sh
+++ b/.agents/scripts/tests/test-secret-helper.sh
@@ -419,6 +419,84 @@ test_run_redacts_sed_significant_literal_values() {
 	return 0
 }
 
+test_run_streams_safe_output_before_child_exit() {
+	setup
+	trap 'teardown' RETURN
+	export AIDEVOPS_TEST_SECRET='PUBLIC_READY_MARKER_IS_A_LONG_SECRET_VALUE'
+	local result=""
+
+	result=$(
+		HOME="$TEST_DIR/home" HELPER_UNDER_TEST="$HELPER" python3 - <<'PY'
+import os
+import select
+import subprocess
+import sys
+
+program = (
+    'import sys, time; '
+    'sys.stdout.write("PUBLIC_READY_MARKER\\n"); '
+    'sys.stdout.flush(); '
+    'time.sleep(2)'
+)
+process = subprocess.Popen(
+    [
+        "bash",
+        os.environ["HELPER_UNDER_TEST"],
+        "REDACTION_KEY",
+        "--",
+        sys.executable,
+        "-c",
+        program,
+    ],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+try:
+    readable = bool(select.select([process.stdout], [], [], 1.0)[0])
+    line = process.stdout.readline() if readable else b""
+    child_still_running = process.poll() is None
+    process.wait(timeout=4)
+    if readable and line == b"PUBLIC_READY_MARKER\n" and child_still_running and process.returncode == 0:
+        print("ok")
+    else:
+        print("failed")
+finally:
+    if process.poll() is None:
+        process.kill()
+        process.wait()
+PY
+	)
+
+	if [[ "$result" == "ok" ]]; then
+		print_result "run streams safe output while child remains alive" 0
+	else
+		print_result "run streams safe output while child remains alive" 1 "Expected marker before child exit"
+	fi
+	return 0
+}
+
+test_run_redacts_overlapping_secrets_split_across_writes() {
+	setup
+	trap 'teardown' RETURN
+	export AIDEVOPS_TEST_SECRET='split-boundary-fixture-value'
+	mkdir -p "$TEST_DIR/home/.config/aidevops"
+	cat >"$TEST_DIR/home/.config/aidevops/credentials.sh" <<'EOF'
+export SHORT_REDACTION_KEY="split-boundary"
+EOF
+	chmod 600 "$TEST_DIR/home/.config/aidevops/credentials.sh"
+	local output=""
+
+	output=$(HOME="$TEST_DIR/home" bash "$HELPER" run python3 -c \
+		'import os, sys, time; value = os.environ["REDACTION_KEY"]; short = os.environ["SHORT_REDACTION_KEY"]; sys.stdout.write("safe:" + short); sys.stdout.flush(); time.sleep(0.05); sys.stdout.write(value[len(short):] + ":done\n"); sys.stdout.flush()')
+
+	if [[ "$output" == "safe:[REDACTED]:done" && "$output" != *"$AIDEVOPS_TEST_SECRET"* ]]; then
+		print_result "run redacts overlapping secrets split across writes" 0
+	else
+		print_result "run redacts overlapping secrets split across writes" 1 "Expected one marker without fixture disclosure"
+	fi
+	return 0
+}
+
 test_run_fails_closed_when_redactor_cannot_start() {
 	setup
 	trap 'teardown' RETURN
@@ -453,6 +531,8 @@ main() {
 	test_fallback_set_creates_credentials_store
 	test_concurrent_fallback_sets_preserve_all_credentials
 	test_run_redacts_sed_significant_literal_values
+	test_run_streams_safe_output_before_child_exit
+	test_run_redacts_overlapping_secrets_split_across_writes
 	test_run_fails_closed_when_redactor_cannot_start
 	test_multiline_gopass_injection_preserves_embedded_newlines
 	test_inventory_is_names_only_deterministic_json


### PR DESCRIPTION
## Summary

Make secret-wrapped child output observable while the child remains alive, retaining only unresolved secret prefixes across reads.



## Files Changed

.agents/scripts/secret-helper.sh, .agents/scripts/tests/test-secret-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: secret-helper regression suite 14/14; live marker observed before child exit; overlapping split-write secrets redacted; ShellCheck, shfmt, secretlint, portability, complexity, and changed-file lint passed

Resolves #31811


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.362 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 29m and 522,376 tokens on this with the user in an interactive session.
