### PR TITLE
GH#31815: require Dependabot supersession coverage

### DIFF
--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -97,9 +97,9 @@ _pulse_dependabot_completed_intake_issue() {
 }
 
 # Prove that every file in the authentic source PR's exact current diff already
-# has the same blob on the current base. This deliberately accepts exact content
-# equivalence only: ecosystem-specific "newer version" inference is ambiguous,
-# so unknown or non-identical state preserves the source PR.
+# has the same Git entry on the current default branch. This deliberately accepts
+# exact content and mode equivalence only. Ecosystem-specific "newer version"
+# inference is ambiguous, so unknown or non-identical state preserves the source.
 _pulse_dependabot_source_content_on_base() {
 	local pr_number="$1"
 	local repo_slug="$2"
@@ -108,35 +108,47 @@ _pulse_dependabot_source_content_on_base() {
 	local snapshot_values=""
 	local snapshot_head=""
 	local base_head=""
+	local base_ref=""
+	local default_branch=""
 	local changed_files=""
 	local file_count=""
 	local paths=""
 	local path=""
 	local source_tree=""
 	local base_tree=""
-	local source_blob=""
-	local base_blob=""
+	local source_entry=""
+	local base_entry=""
 
 	_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON="evidence-unavailable"
 	_PULSE_DEPENDABOT_SUPERSESSION_BASE_HEAD=""
+	_PULSE_DEPENDABOT_SUPERSESSION_BASE_REF=""
 	snapshot=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json headRefOid,baseRefOid,changedFiles,files 2>/dev/null) || return 2
+		--json headRefOid,baseRefOid,baseRefName,changedFiles,files 2>/dev/null) || return 2
 	snapshot_values=$(printf '%s' "$snapshot" | jq -er '
-		[.headRefOid, .baseRefOid] as $refs
+		[.headRefOid, .baseRefOid, .baseRefName] as $refs
 		| (.changedFiles | numbers) as $changed
 		| (.files | arrays) as $files
-		| if (($refs | map(select(strings and length > 0)) | length) == 2) and ($changed >= 0)
-		  then [$refs[0], $refs[1], ($changed | tostring), ($files | length | tostring)] | @tsv
+		| if (($refs | map(select(strings and length > 0)) | length) == 3) and ($changed >= 0)
+		  then [$refs[0], $refs[1], $refs[2], ($changed | tostring), ($files | length | tostring)] | @tsv
 		  else error("invalid Dependabot coverage snapshot")
 		  end' 2>/dev/null) || return 2
-	IFS=$'\t' read -r snapshot_head base_head changed_files file_count <<<"$snapshot_values"
+	IFS=$'\t' read -r snapshot_head base_head base_ref changed_files file_count <<<"$snapshot_values"
 	[[ "$snapshot_head" == "$expected_head_sha" && "$file_count" == "$changed_files" ]] || return 2
+	default_branch=$(gh api -X GET "repos/${repo_slug}" \
+		--jq '.default_branch | strings | select(length > 0)' 2>/dev/null) || return 2
+	[[ "$base_ref" == "$default_branch" ]] || return 2
 	_PULSE_DEPENDABOT_SUPERSESSION_BASE_HEAD="$base_head"
+	_PULSE_DEPENDABOT_SUPERSESSION_BASE_REF="$base_ref"
 	if [[ "$changed_files" -eq 0 ]]; then
 		_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON="no-remaining-source-diff"
 		return 0
 	fi
-	paths=$(printf '%s' "$snapshot" | jq -er '.files[] | .path | strings | select(length > 0)' 2>/dev/null) || return 2
+	paths=$(printf '%s' "$snapshot" | jq -er '
+		.changedFiles as $changed
+		| [.files[] | (.path | strings) as $path
+			| select(.changeType == "ADDED" or .changeType == "MODIFIED") | $path] as $paths
+		| if (($paths | length) == $changed) and (($paths | unique | length) == $changed)
+		  then $paths[] else error("unsupported or duplicate Dependabot diff path") end' 2>/dev/null) || return 2
 
 	source_tree=$(gh api -X GET "repos/${repo_slug}/git/trees/${expected_head_sha}" \
 		-f recursive=1 2>/dev/null) || return 2
@@ -150,13 +162,13 @@ _pulse_dependabot_source_content_on_base() {
 		"" | /* | ../* | */../* | */..) return 2 ;;
 		esac
 		[[ "$path" != *$'\r'* ]] || return 2
-		source_blob=$(printf '%s' "$source_tree" | jq -er --arg path "$path" \
-			'[.tree[] | select(.path == $path and .type == "blob")] | if length == 1 then .[0].sha else error("source blob unavailable") end' 2>/dev/null) || return 2
-		base_blob=$(printf '%s' "$base_tree" | jq -er --arg path "$path" \
-			'[.tree[] | select(.path == $path and .type == "blob")] | if length == 1 then .[0].sha else error("base blob unavailable") end' 2>/dev/null) || return 2
-		if [[ "$source_blob" != "$base_blob" ]]; then
-			_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON="base-content-mismatch"
-			echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: merged replacement does not reproduce current source content for ${path}; preserving source" >>"$LOGFILE"
+		source_entry=$(printf '%s' "$source_tree" | jq -er --arg path "$path" \
+			'[.tree[] | select(.path == $path and .type == "blob")] | if length == 1 then .[0] | [.sha, .mode, .type] | @tsv else error("source entry unavailable") end' 2>/dev/null) || return 2
+		base_entry=$(printf '%s' "$base_tree" | jq -er --arg path "$path" \
+			'[.tree[] | select(.path == $path and .type == "blob")] | if length == 1 then .[0] | [.sha, .mode, .type] | @tsv else error("base entry unavailable") end' 2>/dev/null) || return 2
+		if [[ "$source_entry" != "$base_entry" ]]; then
+			_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON="base-entry-mismatch"
+			echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: merged replacement does not reproduce current source entry for ${path}; preserving source" >>"$LOGFILE"
 			return 1
 		fi
 	done <<<"$paths"
@@ -179,6 +191,7 @@ _pulse_dependabot_close_superseded_source_pr() {
 	local final_state=""
 	local final_head=""
 	local final_base_head=""
+	local final_base_ref=""
 	local close_comment=""
 	local coverage_rc=0
 
@@ -186,6 +199,7 @@ _pulse_dependabot_close_superseded_source_pr() {
 	_PULSE_DEPENDABOT_SUPERSEDING_PR=""
 	_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON=""
 	_PULSE_DEPENDABOT_SUPERSESSION_BASE_HEAD=""
+	_PULSE_DEPENDABOT_SUPERSESSION_BASE_REF=""
 	intake_issue=$(_pulse_dependabot_completed_intake_issue "$pr_number" "$repo_slug" "$marker") || return 2
 	[[ "$intake_issue" =~ ^[0-9]+$ ]] || return 1
 	_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE="$intake_issue"
@@ -203,12 +217,14 @@ _pulse_dependabot_close_superseded_source_pr() {
 	fi
 
 	final_json=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json state,headRefOid,baseRefOid,labels 2>/dev/null) || return 2
+		--json state,headRefOid,baseRefOid,baseRefName,labels 2>/dev/null) || return 2
 	final_state=$(printf '%s' "$final_json" | jq -r '.state // ""' 2>/dev/null) || return 2
 	final_head=$(printf '%s' "$final_json" | jq -r '.headRefOid // ""' 2>/dev/null) || return 2
 	final_base_head=$(printf '%s' "$final_json" | jq -r '.baseRefOid // ""' 2>/dev/null) || return 2
+	final_base_ref=$(printf '%s' "$final_json" | jq -r '.baseRefName // ""' 2>/dev/null) || return 2
 	[[ "$final_state" == "OPEN" && "$final_head" == "$expected_head_sha" &&
-		"$final_base_head" == "$_PULSE_DEPENDABOT_SUPERSESSION_BASE_HEAD" ]] || return 2
+		"$final_base_head" == "$_PULSE_DEPENDABOT_SUPERSESSION_BASE_HEAD" &&
+		"$final_base_ref" == "$_PULSE_DEPENDABOT_SUPERSESSION_BASE_REF" ]] || return 2
 
 	if [[ "${DRY_RUN:-0}" == "1" ]]; then
 		echo "[pulse-dependabot-intake] DRY-RUN: PR #${pr_number} in ${repo_slug} would close as superseded by merged PR #${superseding_pr} for completed intake #${intake_issue}" >>"$LOGFILE"
@@ -218,7 +234,7 @@ _pulse_dependabot_close_superseded_source_pr() {
 	close_comment="<!-- aidevops:dependabot-source-superseded intake=${intake_issue} replacement=${superseding_pr} -->
 Closing this Dependabot source PR as superseded: generated worker intake #${intake_issue} is terminal and was closed by verified merged replacement PR #${superseding_pr}.
 
-The external-authority policy prevented unsafe automatic merge while the replacement converged. Pulse revalidated the authentic source head and proved that the current base exactly contains every file from the source dependency update immediately before this close.
+The external-authority policy prevented unsafe automatic merge while the replacement converged. Pulse revalidated the authentic source head and proved that the current default branch exactly contains every file entry from the source dependency update immediately before this close.
 
 _Closed by deterministic Dependabot lifecycle reconciliation (GH#30478)._"
 	if ! gh_pr_close_safe "$pr_number" --repo "$repo_slug" --comment "$close_comment" >/dev/null 2>&1; then

--- a/.agents/scripts/pulse-dependabot-intake.sh
+++ b/.agents/scripts/pulse-dependabot-intake.sh
@@ -96,8 +96,77 @@ _pulse_dependabot_completed_intake_issue() {
 	return $?
 }
 
+# Prove that every file in the authentic source PR's exact current diff already
+# has the same blob on the current base. This deliberately accepts exact content
+# equivalence only: ecosystem-specific "newer version" inference is ambiguous,
+# so unknown or non-identical state preserves the source PR.
+_pulse_dependabot_source_content_on_base() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="$3"
+	local snapshot=""
+	local snapshot_values=""
+	local snapshot_head=""
+	local base_head=""
+	local changed_files=""
+	local file_count=""
+	local paths=""
+	local path=""
+	local source_tree=""
+	local base_tree=""
+	local source_blob=""
+	local base_blob=""
+
+	_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON="evidence-unavailable"
+	_PULSE_DEPENDABOT_SUPERSESSION_BASE_HEAD=""
+	snapshot=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+		--json headRefOid,baseRefOid,changedFiles,files 2>/dev/null) || return 2
+	snapshot_values=$(printf '%s' "$snapshot" | jq -er '
+		[.headRefOid, .baseRefOid] as $refs
+		| (.changedFiles | numbers) as $changed
+		| (.files | arrays) as $files
+		| if (($refs | map(select(strings and length > 0)) | length) == 2) and ($changed >= 0)
+		  then [$refs[0], $refs[1], ($changed | tostring), ($files | length | tostring)] | @tsv
+		  else error("invalid Dependabot coverage snapshot")
+		  end' 2>/dev/null) || return 2
+	IFS=$'\t' read -r snapshot_head base_head changed_files file_count <<<"$snapshot_values"
+	[[ "$snapshot_head" == "$expected_head_sha" && "$file_count" == "$changed_files" ]] || return 2
+	_PULSE_DEPENDABOT_SUPERSESSION_BASE_HEAD="$base_head"
+	if [[ "$changed_files" -eq 0 ]]; then
+		_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON="no-remaining-source-diff"
+		return 0
+	fi
+	paths=$(printf '%s' "$snapshot" | jq -er '.files[] | .path | strings | select(length > 0)' 2>/dev/null) || return 2
+
+	source_tree=$(gh api -X GET "repos/${repo_slug}/git/trees/${expected_head_sha}" \
+		-f recursive=1 2>/dev/null) || return 2
+	base_tree=$(gh api -X GET "repos/${repo_slug}/git/trees/${base_head}" \
+		-f recursive=1 2>/dev/null) || return 2
+	printf '%s' "$source_tree" | jq -e '(.truncated == false) and (.tree | arrays | true)' >/dev/null 2>&1 || return 2
+	printf '%s' "$base_tree" | jq -e '(.truncated == false) and (.tree | arrays | true)' >/dev/null 2>&1 || return 2
+
+	while IFS= read -r path; do
+		case "$path" in
+		"" | /* | ../* | */../* | */..) return 2 ;;
+		esac
+		[[ "$path" != *$'\r'* ]] || return 2
+		source_blob=$(printf '%s' "$source_tree" | jq -er --arg path "$path" \
+			'[.tree[] | select(.path == $path and .type == "blob")] | if length == 1 then .[0].sha else error("source blob unavailable") end' 2>/dev/null) || return 2
+		base_blob=$(printf '%s' "$base_tree" | jq -er --arg path "$path" \
+			'[.tree[] | select(.path == $path and .type == "blob")] | if length == 1 then .[0].sha else error("base blob unavailable") end' 2>/dev/null) || return 2
+		if [[ "$source_blob" != "$base_blob" ]]; then
+			_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON="base-content-mismatch"
+			echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: merged replacement does not reproduce current source content for ${path}; preserving source" >>"$LOGFILE"
+			return 1
+		fi
+	done <<<"$paths"
+	_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON="exact-source-content-on-base"
+	return 0
+}
+
 # Close an authentic policy-held source PR only when its generated worker intake is
-# terminal and a different same-repository PR verifiably merged to close it.
+# terminal, a different same-repository PR verifiably merged to close it, and the
+# current base exactly contains every file from the source dependency update.
 # Missing, truncated, stale-head, or unavailable evidence preserves the hold.
 _pulse_dependabot_close_superseded_source_pr() {
 	local pr_number="$1"
@@ -109,10 +178,14 @@ _pulse_dependabot_close_superseded_source_pr() {
 	local final_json=""
 	local final_state=""
 	local final_head=""
+	local final_base_head=""
 	local close_comment=""
+	local coverage_rc=0
 
 	_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE=""
 	_PULSE_DEPENDABOT_SUPERSEDING_PR=""
+	_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON=""
+	_PULSE_DEPENDABOT_SUPERSESSION_BASE_HEAD=""
 	intake_issue=$(_pulse_dependabot_completed_intake_issue "$pr_number" "$repo_slug" "$marker") || return 2
 	[[ "$intake_issue" =~ ^[0-9]+$ ]] || return 1
 	_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE="$intake_issue"
@@ -121,14 +194,22 @@ _pulse_dependabot_close_superseded_source_pr() {
 	superseding_pr=$(_psh_find_merged_closer_for_closed_issue \
 		"$repo_slug" "$intake_issue" "$pr_number" 2>/dev/null) || return 2
 	[[ "$superseding_pr" =~ ^[0-9]+$ && "$superseding_pr" != "$pr_number" ]] || return 2
+	_PULSE_DEPENDABOT_SUPERSEDING_PR="$superseding_pr"
+	_pulse_dependabot_source_content_on_base \
+		"$pr_number" "$repo_slug" "$expected_head_sha" || coverage_rc=$?
+	if [[ "$coverage_rc" -ne 0 ]]; then
+		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: merged replacement PR #${superseding_pr} lacks exact source-content coverage (${_PULSE_DEPENDABOT_SUPERSESSION_COVERAGE_REASON:-unknown}); preserving source" >>"$LOGFILE"
+		return 2
+	fi
 
 	final_json=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json state,headRefOid,labels 2>/dev/null) || return 2
+		--json state,headRefOid,baseRefOid,labels 2>/dev/null) || return 2
 	final_state=$(printf '%s' "$final_json" | jq -r '.state // ""' 2>/dev/null) || return 2
 	final_head=$(printf '%s' "$final_json" | jq -r '.headRefOid // ""' 2>/dev/null) || return 2
-	[[ "$final_state" == "OPEN" && "$final_head" == "$expected_head_sha" ]] || return 2
+	final_base_head=$(printf '%s' "$final_json" | jq -r '.baseRefOid // ""' 2>/dev/null) || return 2
+	[[ "$final_state" == "OPEN" && "$final_head" == "$expected_head_sha" &&
+		"$final_base_head" == "$_PULSE_DEPENDABOT_SUPERSESSION_BASE_HEAD" ]] || return 2
 
-	_PULSE_DEPENDABOT_SUPERSEDING_PR="$superseding_pr"
 	if [[ "${DRY_RUN:-0}" == "1" ]]; then
 		echo "[pulse-dependabot-intake] DRY-RUN: PR #${pr_number} in ${repo_slug} would close as superseded by merged PR #${superseding_pr} for completed intake #${intake_issue}" >>"$LOGFILE"
 		return 0
@@ -137,7 +218,7 @@ _pulse_dependabot_close_superseded_source_pr() {
 	close_comment="<!-- aidevops:dependabot-source-superseded intake=${intake_issue} replacement=${superseding_pr} -->
 Closing this Dependabot source PR as superseded: generated worker intake #${intake_issue} is terminal and was closed by verified merged replacement PR #${superseding_pr}.
 
-The external-authority policy prevented unsafe automatic merge while the replacement converged. Pulse revalidated the authentic source head immediately before this close.
+The external-authority policy prevented unsafe automatic merge while the replacement converged. Pulse revalidated the authentic source head and proved that the current base exactly contains every file from the source dependency update immediately before this close.
 
 _Closed by deterministic Dependabot lifecycle reconciliation (GH#30478)._"
 	if ! gh_pr_close_safe "$pr_number" --repo "$repo_slug" --comment "$close_comment" >/dev/null 2>&1; then
@@ -199,7 +280,11 @@ _pulse_dependabot_preflight_route() {
 	fi
 	[[ "$reconcile_rc" -eq 1 ]] && return 0
 	if [[ "${_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE:-}" =~ ^[0-9]+$ ]]; then
-		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: completed intake #${_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE} has no verified merged replacement; preserving source without duplicate intake" >>"$LOGFILE"
+		if [[ "${_PULSE_DEPENDABOT_SUPERSEDING_PR:-}" =~ ^[0-9]+$ ]]; then
+			echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: completed intake #${_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE} replacement #${_PULSE_DEPENDABOT_SUPERSEDING_PR} lacks verified dependency-content coverage; preserving source without duplicate intake" >>"$LOGFILE"
+		else
+			echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: completed intake #${_PULSE_DEPENDABOT_COMPLETED_INTAKE_ISSUE} has no verified merged replacement; preserving source without duplicate intake" >>"$LOGFILE"
+		fi
 	else
 		echo "[pulse-dependabot-intake] PR #${pr_number} in ${repo_slug}: completed-intake reconciliation evidence unavailable; preserving source without duplicate intake" >>"$LOGFILE"
 	fi

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -13,11 +13,12 @@ CLOSED_ISSUE_LIST_FAIL=0
 AUTHENTIC=1
 AUTH_FAILURE_REASON="snapshot-unavailable"
 PR_LABELS=""
-PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[{"name":"needs-maintainer-review"}]}'
+PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","labels":[{"name":"needs-maintainer-review"}]}'
 PR_SCOPE_JSON='{"headRefOid":"head-current","files":[{"path":"package.json"},{"path":"bun.lock"}]}'
-PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","changedFiles":2,"files":[{"path":"package.json"},{"path":"bun.lock"}]}'
-SOURCE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","sha":"lock-updated"}]}'
-BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","sha":"lock-updated"}]}'
+PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","changedFiles":2,"files":[{"path":"package.json","changeType":"MODIFIED"},{"path":"bun.lock","changeType":"MODIFIED"}]}'
+SOURCE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","mode":"100644","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","mode":"100644","sha":"lock-updated"}]}'
+BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","mode":"100644","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","mode":"100644","sha":"lock-updated"}]}'
+DEFAULT_BRANCH="main"
 TREE_READ_FAIL=0
 PR_VIEW_FAIL=0
 SUPERSEDING_PR=""
@@ -65,11 +66,11 @@ gh_issue_list() {
 
 gh_pr_view() {
 	[[ "$PR_VIEW_FAIL" -eq 0 ]] || return 1
-	if [[ " $* " == *" --json headRefOid,baseRefOid,changedFiles,files "* ]]; then
+	if [[ " $* " == *" --json headRefOid,baseRefOid,baseRefName,changedFiles,files "* ]]; then
 		printf '%s\n' "$PR_COVERAGE_JSON"
 	elif [[ " $* " == *" --json headRefOid,files "* ]]; then
 		printf '%s\n' "$PR_SCOPE_JSON"
-	elif [[ " $* " == *" --json state,headRefOid,baseRefOid,labels "* ]]; then
+	elif [[ " $* " == *" --json state,headRefOid,baseRefOid,baseRefName,labels "* ]]; then
 		printf '%s\n' "$PR_FINAL_JSON"
 	else
 		printf '%s\n' "$PR_LABELS"
@@ -82,6 +83,7 @@ gh() {
 	case " $* " in
 	*"/git/trees/head-current "*) printf '%s\n' "$SOURCE_TREE_JSON" ;;
 	*"/git/trees/base-current "*) printf '%s\n' "$BASE_TREE_JSON" ;;
+	*" repos/owner/repo --jq "*) printf '%s\n' "$DEFAULT_BRANCH" ;;
 	*) return 1 ;;
 	esac
 	return 0
@@ -307,7 +309,7 @@ test_closes_policy_held_source_after_verified_replacement() {
 	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
 	AUTHENTIC=1
 	PR_LABELS=""
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","labels":[]}'
 	PR_VIEW_FAIL=0
 	SUPERSEDING_PR="99"
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
@@ -329,14 +331,14 @@ test_policy_only_replacement_preserves_source() {
 	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
 	AUTHENTIC=1
 	PR_LABELS=""
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[]}'
-	BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","sha":"manifest-old"},{"path":"bun.lock","type":"blob","sha":"lock-old"}]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","labels":[]}'
+	BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","mode":"100644","sha":"manifest-old"},{"path":"bun.lock","type":"blob","mode":"100644","sha":"lock-old"}]}'
 	SUPERSEDING_PR="99"
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
 	[[ "$route_rc" -eq 6 && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
 	assert_file_contains "policy-only replacement preserves source" "$LOGFILE" \
 		"replacement #99 lacks verified dependency-content coverage; preserving source"
-	BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","sha":"lock-updated"}]}'
+	BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","mode":"100644","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","mode":"100644","sha":"lock-updated"}]}'
 	CLOSED_ISSUES_JSON="[]"
 	SUPERSEDING_PR=""
 	return 0
@@ -364,11 +366,56 @@ test_malformed_coverage_snapshot_preserves_source() {
 
 	rm -f "${TEST_ROOT}/pr-close-args"
 	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
-	PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","changedFiles":2,"files":[{"path":"package.json"}]}'
+	PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","changedFiles":2,"files":[{"path":"package.json","changeType":"MODIFIED"}]}'
 	SUPERSEDING_PR="99"
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
 	[[ "$route_rc" -eq 6 && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
-	PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","changedFiles":2,"files":[{"path":"package.json"},{"path":"bun.lock"}]}'
+	PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","changedFiles":2,"files":[{"path":"package.json","changeType":"MODIFIED"},{"path":"bun.lock","changeType":"MODIFIED"}]}'
+	CLOSED_ISSUES_JSON="[]"
+	SUPERSEDING_PR=""
+	return 0
+}
+
+test_mode_mismatch_preserves_source() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/pr-close-args"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","mode":"100755","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","mode":"100644","sha":"lock-updated"}]}'
+	SUPERSEDING_PR="99"
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 6 && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","mode":"100644","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","mode":"100644","sha":"lock-updated"}]}'
+	CLOSED_ISSUES_JSON="[]"
+	SUPERSEDING_PR=""
+	return 0
+}
+
+test_duplicate_diff_path_preserves_source() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/pr-close-args"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","changedFiles":2,"files":[{"path":"package.json","changeType":"MODIFIED"},{"path":"package.json","changeType":"MODIFIED"}]}'
+	SUPERSEDING_PR="99"
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 6 && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","changedFiles":2,"files":[{"path":"package.json","changeType":"MODIFIED"},{"path":"bun.lock","changeType":"MODIFIED"}]}'
+	CLOSED_ISSUES_JSON="[]"
+	SUPERSEDING_PR=""
+	return 0
+}
+
+test_non_default_base_ref_preserves_source() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/pr-close-args"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"release","changedFiles":2,"files":[{"path":"package.json","changeType":"MODIFIED"},{"path":"bun.lock","changeType":"MODIFIED"}]}'
+	SUPERSEDING_PR="99"
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 6 && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","changedFiles":2,"files":[{"path":"package.json","changeType":"MODIFIED"},{"path":"bun.lock","changeType":"MODIFIED"}]}'
 	CLOSED_ISSUES_JSON="[]"
 	SUPERSEDING_PR=""
 	return 0
@@ -382,7 +429,7 @@ test_completed_intake_without_replacement_does_not_duplicate() {
 	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
 	AUTHENTIC=1
 	PR_LABELS=""
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","labels":[]}'
 	SUPERSEDING_PR=""
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
 	[[ "$route_rc" -eq 6 ]] || return 1
@@ -452,13 +499,13 @@ test_preserves_hold_when_source_head_drifted() {
 	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
 	AUTHENTIC=1
 	PR_LABELS="needs-maintainer-review"
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-changed","baseRefOid":"base-current","labels":[{"name":"needs-maintainer-review"}]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-changed","baseRefOid":"base-current","baseRefName":"main","labels":[{"name":"needs-maintainer-review"}]}'
 	SUPERSEDING_PR="99"
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
 	[[ "$route_rc" -eq 6 ]] || return 1
 	[[ ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
 	CLOSED_ISSUES_JSON="[]"
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[{"name":"needs-maintainer-review"}]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","labels":[{"name":"needs-maintainer-review"}]}'
 	PR_LABELS=""
 	SUPERSEDING_PR=""
 	return 0
@@ -469,11 +516,11 @@ test_preserves_source_when_base_drifts_after_coverage() {
 
 	rm -f "${TEST_ROOT}/pr-close-args"
 	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-changed","labels":[]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-changed","baseRefName":"main","labels":[]}'
 	SUPERSEDING_PR="99"
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
 	[[ "$route_rc" -eq 6 && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[{"name":"needs-maintainer-review"}]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","baseRefName":"main","labels":[{"name":"needs-maintainer-review"}]}'
 	CLOSED_ISSUES_JSON="[]"
 	SUPERSEDING_PR=""
 	return 0
@@ -617,6 +664,9 @@ main() {
 	test_policy_only_replacement_preserves_source
 	test_unavailable_coverage_evidence_preserves_source
 	test_malformed_coverage_snapshot_preserves_source
+	test_mode_mismatch_preserves_source
+	test_duplicate_diff_path_preserves_source
+	test_non_default_base_ref_preserves_source
 	test_completed_intake_without_replacement_does_not_duplicate
 	test_unavailable_completion_lookup_does_not_duplicate
 	test_preserves_hold_when_terminal_issue_has_no_merged_replacement

--- a/.agents/scripts/tests/test-pulse-dependabot-intake.sh
+++ b/.agents/scripts/tests/test-pulse-dependabot-intake.sh
@@ -13,8 +13,12 @@ CLOSED_ISSUE_LIST_FAIL=0
 AUTHENTIC=1
 AUTH_FAILURE_REASON="snapshot-unavailable"
 PR_LABELS=""
-PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[{"name":"needs-maintainer-review"}]}'
+PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[{"name":"needs-maintainer-review"}]}'
 PR_SCOPE_JSON='{"headRefOid":"head-current","files":[{"path":"package.json"},{"path":"bun.lock"}]}'
+PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","changedFiles":2,"files":[{"path":"package.json"},{"path":"bun.lock"}]}'
+SOURCE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","sha":"lock-updated"}]}'
+BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","sha":"lock-updated"}]}'
+TREE_READ_FAIL=0
 PR_VIEW_FAIL=0
 SUPERSEDING_PR=""
 
@@ -61,13 +65,25 @@ gh_issue_list() {
 
 gh_pr_view() {
 	[[ "$PR_VIEW_FAIL" -eq 0 ]] || return 1
-	if [[ " $* " == *" --json headRefOid,files "* ]]; then
+	if [[ " $* " == *" --json headRefOid,baseRefOid,changedFiles,files "* ]]; then
+		printf '%s\n' "$PR_COVERAGE_JSON"
+	elif [[ " $* " == *" --json headRefOid,files "* ]]; then
 		printf '%s\n' "$PR_SCOPE_JSON"
-	elif [[ " $* " == *" --json state,headRefOid,labels "* ]]; then
+	elif [[ " $* " == *" --json state,headRefOid,baseRefOid,labels "* ]]; then
 		printf '%s\n' "$PR_FINAL_JSON"
 	else
 		printf '%s\n' "$PR_LABELS"
 	fi
+	return 0
+}
+
+gh() {
+	[[ "$1" == "api" && "$TREE_READ_FAIL" -eq 0 ]] || return 1
+	case " $* " in
+	*"/git/trees/head-current "*) printf '%s\n' "$SOURCE_TREE_JSON" ;;
+	*"/git/trees/base-current "*) printf '%s\n' "$BASE_TREE_JSON" ;;
+	*) return 1 ;;
+	esac
 	return 0
 }
 
@@ -291,7 +307,7 @@ test_closes_policy_held_source_after_verified_replacement() {
 	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
 	AUTHENTIC=1
 	PR_LABELS=""
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[]}'
 	PR_VIEW_FAIL=0
 	SUPERSEDING_PR="99"
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
@@ -305,6 +321,59 @@ test_closes_policy_held_source_after_verified_replacement() {
 	return 0
 }
 
+test_policy_only_replacement_preserves_source() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/create-args" "${TEST_ROOT}/pr-close-args"
+	OPEN_ISSUES_JSON="[]"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	AUTHENTIC=1
+	PR_LABELS=""
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[]}'
+	BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","sha":"manifest-old"},{"path":"bun.lock","type":"blob","sha":"lock-old"}]}'
+	SUPERSEDING_PR="99"
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 6 && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	assert_file_contains "policy-only replacement preserves source" "$LOGFILE" \
+		"replacement #99 lacks verified dependency-content coverage; preserving source"
+	BASE_TREE_JSON='{"truncated":false,"tree":[{"path":"package.json","type":"blob","sha":"manifest-updated"},{"path":"bun.lock","type":"blob","sha":"lock-updated"}]}'
+	CLOSED_ISSUES_JSON="[]"
+	SUPERSEDING_PR=""
+	return 0
+}
+
+test_unavailable_coverage_evidence_preserves_source() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/pr-close-args"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	TREE_READ_FAIL=1
+	SUPERSEDING_PR="99"
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 6 && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	assert_file_contains "unavailable coverage evidence preserves source" "$LOGFILE" \
+		"lacks exact source-content coverage (evidence-unavailable); preserving source"
+	TREE_READ_FAIL=0
+	CLOSED_ISSUES_JSON="[]"
+	SUPERSEDING_PR=""
+	return 0
+}
+
+test_malformed_coverage_snapshot_preserves_source() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/pr-close-args"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","changedFiles":2,"files":[{"path":"package.json"}]}'
+	SUPERSEDING_PR="99"
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 6 && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	PR_COVERAGE_JSON='{"headRefOid":"head-current","baseRefOid":"base-current","changedFiles":2,"files":[{"path":"package.json"},{"path":"bun.lock"}]}'
+	CLOSED_ISSUES_JSON="[]"
+	SUPERSEDING_PR=""
+	return 0
+}
+
 test_completed_intake_without_replacement_does_not_duplicate() {
 	local route_rc=0
 
@@ -313,7 +382,7 @@ test_completed_intake_without_replacement_does_not_duplicate() {
 	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
 	AUTHENTIC=1
 	PR_LABELS=""
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[]}'
 	SUPERSEDING_PR=""
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
 	[[ "$route_rc" -eq 6 ]] || return 1
@@ -383,14 +452,29 @@ test_preserves_hold_when_source_head_drifted() {
 	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
 	AUTHENTIC=1
 	PR_LABELS="needs-maintainer-review"
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-changed","labels":[{"name":"needs-maintainer-review"}]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-changed","baseRefOid":"base-current","labels":[{"name":"needs-maintainer-review"}]}'
 	SUPERSEDING_PR="99"
 	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
 	[[ "$route_rc" -eq 6 ]] || return 1
 	[[ ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
 	CLOSED_ISSUES_JSON="[]"
-	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","labels":[{"name":"needs-maintainer-review"}]}'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[{"name":"needs-maintainer-review"}]}'
 	PR_LABELS=""
+	SUPERSEDING_PR=""
+	return 0
+}
+
+test_preserves_source_when_base_drifts_after_coverage() {
+	local route_rc=0
+
+	rm -f "${TEST_ROOT}/pr-close-args"
+	CLOSED_ISSUES_JSON='[{"number":42,"body":"<!-- aidevops:dependabot-pr-intake repo=owner/repo pr=30038 -->","labels":[{"name":"origin:worker"},{"name":"status:done"},{"name":"solved:worker"}]}]'
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-changed","labels":[]}'
+	SUPERSEDING_PR="99"
+	_pulse_route_dependabot_pr_to_worker_issue "30038" "owner/repo" "app/dependabot" "head-current" "policy-ineligible" || route_rc=$?
+	[[ "$route_rc" -eq 6 && ! -e "${TEST_ROOT}/pr-close-args" ]] || return 1
+	PR_FINAL_JSON='{"state":"OPEN","headRefOid":"head-current","baseRefOid":"base-current","labels":[{"name":"needs-maintainer-review"}]}'
+	CLOSED_ISSUES_JSON="[]"
 	SUPERSEDING_PR=""
 	return 0
 }
@@ -530,11 +614,15 @@ main() {
 	test_classifies_human_modified_bot_branch
 	test_preserves_explicit_maintainer_hold
 	test_closes_policy_held_source_after_verified_replacement
+	test_policy_only_replacement_preserves_source
+	test_unavailable_coverage_evidence_preserves_source
+	test_malformed_coverage_snapshot_preserves_source
 	test_completed_intake_without_replacement_does_not_duplicate
 	test_unavailable_completion_lookup_does_not_duplicate
 	test_preserves_hold_when_terminal_issue_has_no_merged_replacement
 	test_preserves_hold_without_worker_solution_attribution
 	test_preserves_hold_when_source_head_drifted
+	test_preserves_source_when_base_drifts_after_coverage
 	test_dry_run_reports_supersession_without_close
 	test_fails_closed_when_hold_state_is_unavailable
 	test_dry_run_has_no_write


### PR DESCRIPTION
## Summary

- Prevent deterministic lifecycle reconciliation from closing an authentic Dependabot source when a merged intake replacement only changed policy or CI behavior.
- Bind closure to the exact source head and current base, require a complete non-truncated file snapshot, and prove identical blobs for every source diff path.
- Fail closed on head or base drift, incomplete file pagination, unavailable trees, malformed evidence, or content mismatch.

## Files Changed

- `.agents/scripts/pulse-dependabot-intake.sh`
- `.agents/scripts/tests/test-pulse-dependabot-intake.sh`

## Runtime Testing

- **Risk level:** High because this guards automatic source-PR closure.
- `bash -n` on both changed shell files.
- `shellcheck` on both changed shell files.
- `.agents/scripts/tests/test-pulse-dependabot-intake.sh`.
- `.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh`: 37 tests passed.
- `.agents/scripts/linters-local.sh --changed`.
- Live evidence: PR #31657 source and base workflow blobs differ, so the new exact-content guard refuses supersession.

Resolves #31815

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.362 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 5h 53m and 2,453,449 tokens on this with the user in an interactive session.