### PR TITLE
t18430: pin OpenCode GitHub Action to v1.18.30

### DIFF
--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -289,7 +289,7 @@ jobs:
             }
       
       - name: Run OpenCode Agent
-        uses: anomalyco/opencode/github@774cc7c1914e4329eefde5a669f938b0cf566661 # v1.18.26
+        uses: anomalyco/opencode/github@3104c1428ec91f809e5ab86631300de41eb6952e # v1.18.30
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/TODO.md
+++ b/TODO.md
@@ -1362,6 +1362,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 ## In Progress
 
+- [ ] t18430 Update OpenCode GitHub Action pin to v1.18.30 #auto-dispatch #dependencies #github_actions #interactive #tier:simple ref:GH#31828 started:2026-09-12
+
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22
 
 - [x] t2686 fix: quality-debt NMR trap — broaden trust bar (admin collaborators) + extend NMR sig detector to recognise source:review-feedback marker/label so auto_approve_maintainer_issues can clear NMR applied by quality-feedback-helper.sh. Stranded 10 issues on exampleorg/examplerepo (#2572-#2578, #2583-#2585) authored by alex-solovyev (admin). Aligns with pulse-merge t2411/t2449 trust bar. #bugfix #pulse #quality-debt ~2h ref:GH#20299 #auto-dispatch #interactive started:2026-04-21 pr:#20304 completed:2026-04-21


### PR DESCRIPTION
## Summary

Replace the stale v1.18.29 Dependabot proposal with a direct full-SHA pin from v1.18.26 to current stable v1.18.30.



## Files Changed

.github/workflows/opencode-agent.yml, TODO.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — actionlint passed; changed-file linters passed; upstream v1.18.30 tag resolves to 3104c1428ec91f809e5ab86631300de41eb6952e; closeout evidence bundle 23e0f74ca100a607d2a4613f3a6abc8b6f7f811c206cdee05dff4dcf1df9cae3 is clean.

Resolves #31828


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.363 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 17m and 184,908 tokens on this with the user in an interactive session.