### PR TITLE
t18430: record OpenCode pin completion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1362,7 +1362,7 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 ## In Progress
 
-- [ ] t18430 Update OpenCode GitHub Action pin to v1.18.30 #auto-dispatch #dependencies #github_actions #interactive #tier:simple ref:GH#31828 started:2026-09-12
+- [x] t18430 Update OpenCode GitHub Action pin to v1.18.30 #auto-dispatch #dependencies #github_actions #interactive #tier:simple ref:GH#31828 started:2026-09-12 pr:#31829 completed:2026-09-12
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22
 


### PR DESCRIPTION
## Summary

Mark t18430 complete in TODO.md with the merged implementation PR and completion date.



## Files Changed

TODO.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Changed-file linters passed; git diff --check passed; closeout evidence bundle 8a51abf823a51d75e792b47fdeaeb992c8cf17f23bcd2887fe85a36fe5d257cb is clean; proof PR #31829 is merged.

For #31828


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.363 plugin for [OpenCode](https://opencode.ai) v1.18.30 with gpt-5.6-sol spent 35m and 213,413 tokens on this with the user in an interactive session.